### PR TITLE
feat(ci): cargo fmt + clippy + test matrix on Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,32 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  fmt:
+    name: cargo fmt --check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Non-blocking: the existing tree has pre-existing rustfmt drift that
+    # will be cleaned up in a dedicated `style: cargo fmt` sweep. Keeping
+    # the job visible so new formatting regressions show up in PR checks;
+    # flip to `continue-on-error: false` after the sweep lands.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust 1.86 (rustfmt)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.86"
+          components: rustfmt
+
+      # rustfmt doesn't touch the build target — no cache needed.
+      - name: cargo fmt --all -- --check
+        run: cargo fmt --all -- --check
+
   test:
     name: cargo test (default features, no GPU)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -35,6 +58,7 @@ jobs:
   clippy:
     name: cargo clippy (-D warnings, no GPU crates)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -72,6 +96,7 @@ jobs:
   install-sh:
     name: install.sh syntax + CI-mode dry-run
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -91,6 +116,7 @@ jobs:
   build-appimage:
     name: build-appimage (non-blocking)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Non-blocking while the release flow / signing is wired up. Flip to
     # `continue-on-error: false` after first green run lands an artifact
     # users can actually download.


### PR DESCRIPTION
## Summary

Formalizes the CI contract for the `1bit-systems` workspace on GitHub
Actions (ubuntu-latest, Rust 1.86 pinned, default features only — no
GPU, no MLX).

Delta vs. the pre-existing `ci.yml` on `main`:

- **New `fmt` job** running `cargo fmt --all -- --check` with the
  `rustfmt` component. Marked `continue-on-error: true` for now because
  the tree has pre-existing rustfmt drift that a dedicated
  `style: cargo fmt` sweep will resolve in a follow-up. Keeping the job
  in the workflow makes new formatting regressions visible in PR checks.
- **`timeout-minutes: 30`** on every job (`fmt`, `test`, `clippy`,
  `install-sh`, `build-appimage`) — a bound in case a cache-miss release
  build wedges a runner.

Everything else (clippy `-D warnings` with `onebit-hip`/`onebit-mlx`
excluded, `cargo build --workspace --release --locked`, `cargo test
--workspace --release --locked`, the `install.sh` CI-dry-run, and the
non-blocking AppImage build) was already in place and is unchanged
beyond the timeout.

## Baseline CI health (informational)

Run locally against the tip of `bong/main` (the base of this PR):

- **`cargo test --workspace --release --locked`**: ~585 tests across
  ~30 crates. **2 pre-existing failures**, both in `onebit-power`:
  - `profiles::tests::missing_profile_is_none` — panics in
    `crates/1bit-power/src/profiles.rs:84` (toml deserializer path)
  - `profiles::tests::parses_inline_table` — panics in
    `crates/1bit-power/src/profiles.rs:73` (toml deserializer path)

  Baseline is already red on these two tests; this PR deliberately does
  **not** touch them. CI will simply gate future regressions once the
  existing failures are resolved in their own PR.
- **`cargo fmt --all -- --check`**: currently fails with multiple
  whitespace/block-style diffs in `crates/1bit-agents/bin/*.rs` and a
  few other places. That's why the `fmt` job is
  `continue-on-error: true` — keeps the signal visible without blocking
  the PR gate until the cleanup sweep lands.
- **`cargo clippy --workspace --exclude onebit-hip --exclude onebit-mlx
  --release --all-targets --no-deps --locked -- -D warnings
  -A clippy::uninlined-format-args`**: already enforced on `main` by the
  existing `clippy` job (unchanged in this PR).

## Test plan

- [ ] On push, `fmt` job runs and reports its result (expected:
      pre-existing drift, non-blocking).
- [ ] On push, `test`, `clippy`, `install-sh` jobs complete under 30
      minutes each.
- [ ] `test` surfaces exactly the 2 known `profiles.rs` failures listed
      above — no new regressions.
- [ ] `clippy` stays green (same gate as before).
- [ ] `build-appimage` continues to run non-blocking and produces the
      artifact on non-fork pushes.