### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -240,6 +240,7 @@ install_cli() {
     say "Installing /usr/local/bin/1bit + proxy + omni"
     run sudo install -m 0755 "$(dirname "$0")/scripts/1bit" /usr/local/bin/1bit
     run sudo install -d /usr/local/share/1bit-systems
+    run sudo install -m 0644 "$(dirname "$0")/scripts/1bit-home.html" /usr/local/share/1bit-systems/1bit-home.html
     run sudo install -m 0644 "$(dirname "$0")/scripts/1bit-proxy.js" /usr/local/share/1bit-systems/1bit-proxy.js
     run sudo install -m 0755 "$(dirname "$0")/scripts/1bit-omni.py" /usr/local/share/1bit-systems/1bit-omni.py
     ok "1bit CLI + proxy + omni installed — try: 1bit up   or   1bit omni \"...\""


### PR DESCRIPTION
Added a line to copy the 1bit-home.html file to the 1bit-systems folder in /usr/local/share/1bit-systems

<!--
Thanks for sending a patch. A few ground rules from CLAUDE.md:

- One logical change per PR. "fix X" + "feat Y" = two PRs.
- Commit messages have a "why" line, not just a "what".
- Conventional Commits prefixes (feat / fix / perf / docs / refactor /
  build / ci / chore / test).
- `cargo test --workspace --release` must stay green.
- Any change that adds a new crate needs ≥ 3 in-crate tests.
-->

## Summary
Added a line to copy the 1bit-home.html file to the 1bit-systems folder in /usr/local/share/1bit-systems.
<!-- One-paragraph description of the change and why it's worth landing. -->

## Why
The file was missing, causing the post 1bit up launch of the browser to not load a webpage.
<!-- The motivating problem. Link issues, benchmarks, prior discussion. -->

## Change summary
Added new line.
- <!-- bullet: what changed -->
- <!-- bullet: what changed -->

## Rule check

- [x] **Rule A** — no Python at runtime (scripts on a dev box are fine; services / HTTP paths stay Rust).
- [x] **Rule B** — all new kernels live under `rocm-cpp/` (C++20 / HIP); FFI'd through `1bit-hip`.
- [x] **Rule C** — no new hipBLAS calls on the runtime path.
- [x] **Rule D** — Rust 1.86 / edition 2024 (no `rust-version` bump without a reason).

## Tests

- [ ] `cargo test --workspace --release` is green locally.
- [ ] New code ships with tests (unit, integration, or parity fixture as appropriate).
- [ ] If perf-sensitive: ran `halo bench` / `halo ppl` — numbers below.

<!-- paste benchmark diff if relevant -->

## Risk

<!-- What could go wrong after this lands? How would we find out?
     Shadow-burnin? Metric to watch on /metrics? Rollback plan? -->

## Related

<!-- Closes #, follows up on #, supersedes #, references docs/wiki/*.md -->
