### PR TITLE
fix(proxy): bind 0.0.0.0 so LAN clients can reach it

### DIFF
--- a/packaging/binary/proxy.ts
+++ b/packaging/binary/proxy.ts
@@ -71,9 +71,13 @@ function pickTarget(modelId: string | undefined): string {
 export async function startProxy(): Promise<void> {
   await refreshModels();
 
+  // Bind all interfaces so the proxy is reachable from the LAN, not just
+  // localhost. Set PROXY_HOST=127.0.0.1 to restore loopback-only.
+  const PROXY_HOST = process.env.PROXY_HOST || "0.0.0.0";
+
   const server = Bun.serve({
     port: PROXY_PORT,
-    hostname: "127.0.0.1",
+    hostname: PROXY_HOST,
     // 30 min idle for long completions.
     idleTimeout: 0,
     async fetch(req) {
@@ -181,7 +185,9 @@ export async function startProxy(): Promise<void> {
   const flmCount = Array.from(modelCache.byId.values()).filter(
     (m) => m.backend === "flm",
   ).length;
-  console.log(`[1bit-proxy] listening on http://127.0.0.1:${server.port}`);
+  console.log(
+    `[1bit-proxy] listening on http://${PROXY_HOST}:${server.port}`,
+  );
   console.log(
     `[1bit-proxy]   lemond: ${LEMOND_URL}  (${lemondCount} models)`,
   );


### PR DESCRIPTION
## Summary
- \`packaging/binary/proxy.ts\` was hard-coded to \`hostname: \"127.0.0.1\"\`, so the proxy was loopback-only and unreachable from any non-localhost client.
- Default bind is now \`0.0.0.0\`. Set \`PROXY_HOST=127.0.0.1\` env var to restore loopback-only.

## Why this is safe right now
Main's \`proxy.ts\` only forwards to \`lemond\` (Lemonade Server, :13305) and \`flm\` (FastFlowLM) and exposes the OpenAI \`/v1/*\` surface. There are no mutating control-plane routes (no \`pacman\` / \`systemctl\` shells). Exposing this on the LAN just gives other devices the OpenAI-compatible endpoint.

If a control plane lands later, the recommendation is to either gate mutating routes with auth, or split them onto a separate loopback-only listener.

## Test plan
- [ ] \`bun packaging/binary/proxy.ts\` — verify it logs \`listening on http://0.0.0.0:\$PORT\`
- [ ] From another device on the LAN: \`curl http://<host-ip>:\$PORT/v1/models\` — should return the model list
- [ ] \`PROXY_HOST=127.0.0.1 bun packaging/binary/proxy.ts\` — verify loopback-only fallback still works
- [ ] CI green