### PR TITLE
fix(site): restore brand logo as favicon SVG

### DIFF
--- a/1bit-site/assets/logo.svg
+++ b/1bit-site/assets/logo.svg
@@ -1,15 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="1bit.systems">
-  <defs>
-    <radialGradient id="g" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#00d4ff" stop-opacity="0.45"/>
-      <stop offset="100%" stop-color="#00d4ff" stop-opacity="0"/>
-    </radialGradient>
-  </defs>
   <rect width="64" height="64" fill="#0d1117"/>
-  <circle cx="32" cy="32" r="26" fill="url(#g)"/>
-  <circle cx="32" cy="32" r="20" fill="none" stroke="#00d4ff" stroke-width="2.5"/>
-  <circle cx="32" cy="32" r="3.2" fill="#00d4ff"/>
+  <circle cx="32" cy="32" r="24" fill="none" stroke="#ff4d8d" stroke-width="2.5"/>
   <text x="32" y="40" text-anchor="middle"
-        font-family="'JetBrains Mono','SF Mono',monospace"
-        font-size="18" font-weight="700" fill="#00d4ff" letter-spacing="-0.04em">1b</text>
+        font-family="'JetBrains Mono','SF Mono','Fira Code',ui-monospace,monospace"
+        font-size="20" font-weight="800" fill="#00d4ff" letter-spacing="-0.04em">1bs</text>
 </svg>


### PR DESCRIPTION
## Summary

- `1bit-site/assets/logo.svg` was left over from the pre-rebrand scaffold (cyan ring + `1b`).
- Updated to the canonical pink-ring + cyan `1bs` mark, matching `brand-lockup.svg` and `logo.png`.
- One file changed; favicon now matches the rest of the brand identity.

## Why

The rebrand on 2026-04-25 updated `logo.png` and added `brand-lockup.svg` but missed `logo.svg`, so browser tab favicons still show the pre-rebrand mark.

## Test plan

- [ ] After deploy, browser tab icon shows pink ring + cyan `1bs` (not cyan ring + `1b`).
- [ ] Source SVG renders crisp at 16×16 and 32×32.
- [ ] No other site assets touched.