### PR TITLE
fix(docs): update dead lemonade-server.ai URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ This stack stands on:
 
 - AMD GAIA: https://amd-gaia.ai/docs/quickstart
 - Lemonade Server: https://lemonade-server.ai/docs/
-- Lemonade OmniRouter: https://lemonade-server.ai/docs/omni-router/
+- Lemonade OmniRouter: https://lemonade-server.ai/docs/dev/omni-router/
 - FastFlowLM: https://fastflowlm.com/docs/
 - llama.cpp / GGUF ecosystem for iGPU GGUF benchmarking and model work.
 - ROCm, XRT, and `amdxdna` for AMD GPU/NPU runtime support.

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Useful docs:
 - GAIA quickstart: https://amd-gaia.ai/docs/quickstart
 - Lemonade docs: https://lemonade-server.ai/docs/
 - Lemonade API overview: https://lemonade-server.ai/docs/api/
-- Lemonade app integration guides: https://lemonade-server.ai/docs/server/apps/
-- Lemonade OmniRouter: https://lemonade-server.ai/docs/omni-router/
+- Lemonade app integration guides: https://lemonade-server.ai/docs/integrations/
+- Lemonade OmniRouter: https://lemonade-server.ai/docs/dev/omni-router/
 - FastFlowLM docs: https://fastflowlm.com/docs/
 - FastFlowLM server mode: https://fastflowlm.com/docs/instructions/server/
 

--- a/docs/app-integration.md
+++ b/docs/app-integration.md
@@ -78,5 +78,5 @@ These endpoints are local developer services by default. Do not expose them dire
 
 - Lemonade docs: https://lemonade-server.ai/docs/
 - Lemonade API overview: https://lemonade-server.ai/docs/api/
-- Lemonade OmniRouter docs: https://lemonade-server.ai/docs/omni-router/
-- Lemonade server configuration: https://lemonade-server.ai/docs/server/configuration/
+- Lemonade OmniRouter docs: https://lemonade-server.ai/docs/dev/omni-router/
+- Lemonade server configuration: https://lemonade-server.ai/docs/guide/configuration/

--- a/docs/omnirouter.md
+++ b/docs/omnirouter.md
@@ -81,7 +81,7 @@ FastFlowLM direct NPU lane:    http://127.0.0.1:52625/v1
 ## References
 
 - Lemonade docs: https://lemonade-server.ai/docs/
-- Lemonade OmniRouter docs: https://lemonade-server.ai/docs/omni-router/
+- Lemonade OmniRouter docs: https://lemonade-server.ai/docs/dev/omni-router/
 - Lemonade OpenAI API docs: https://lemonade-server.ai/docs/api/openai/
 - FastFlowLM docs: https://fastflowlm.com/docs/
 - FastFlowLM server docs: https://fastflowlm.com/docs/instructions/server/


### PR DESCRIPTION
## Summary

The Lemonade docs site restructured its URLs. The latest `ci` run on `main` (25709189716) failed at the `lychee` step with 6 dead-link errors across 4 markdown files; this PR fixes all 6.

| Old (404) | New (200) | Hits |
|---|---|---|
| `/docs/omni-router/` | `/docs/dev/omni-router/` | 4 |
| `/docs/server/configuration/` | `/docs/guide/configuration/` | 1 |
| `/docs/server/apps/` | `/docs/integrations/` | 1 |

Files touched: `README.md`, `CONTRIBUTING.md`, `docs/app-integration.md`, `docs/omnirouter.md`.

All 3 replacement URLs verified `HTTP 200` at PR-open time.

## Scope

Per `CLAUDE.md` "match the literal ask, default to the minimum that delivers": doc-URL fixes only. **Not** in scope:
- Issue #12 (missing `bong-water-water-bong/1bit-fastflowlm` fork) — separate concern, needs a fork-policy decision before touching `install.sh`.
- Any docs content rewriting beyond the dead URLs.

## Test plan

- [ ] `ci` workflow on this PR — should be green; specifically the `lychee` job that was red on main.
- [ ] Spot-check the rendered Markdown still reads correctly (URLs are inline link references, no anchor text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links across multiple files to reference new URL paths for OmniRouter and integration guides.
  * Reorganized upstream project references in contribution guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bong-water-water-bong/1bit-systems/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->