### PR TITLE
fix: address CodeRabbit findings (25 fixed / 2 deferred / 3 rejected of 30)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,7 @@ Thanks for sending a patch. A few ground rules from CLAUDE.md:
 - [ ] **Rule A** — no Python at runtime (scripts on a dev box are fine; services / HTTP paths stay Rust).
 - [ ] **Rule B** — all new kernels live under `rocm-cpp/` (C++20 / HIP); FFI'd through `1bit-hip`.
 - [ ] **Rule C** — no new hipBLAS calls on the runtime path.
-- [ ] **Rule D** — Rust 1.86 / edition 2024 (no `rust-version` bump without a reason).
+- [ ] **Rule D** — Rust 1.88+ / edition 2024 (no `rust-version` bump without a reason).
 
 ## Tests
 

--- a/1bit-site/assets/style.css
+++ b/1bit-site/assets/style.css
@@ -1122,7 +1122,6 @@ p code,
 li code,
 td code {
   overflow-wrap: anywhere;
-  word-break: break-word;
 }
 
 .data-table,

--- a/1bit-site/blog/index.html
+++ b/1bit-site/blog/index.html
@@ -23,7 +23,7 @@
   <ul class="posts">
     <li>
       <span class="date">2026-04-28</span> &middot;
-      <a href="/docs/benchmarks.html#stack-green-2026-04-28">Historical benchmark — both lanes green</a>
+      <a href="/#bench">Historical benchmark — both lanes green</a>
       <p class="muted">Historical local run: one Lemonade endpoint, two compute lanes (iGPU <code>llamacpp:rocm</code> + NPU <code>flm:npu</code>), on Linux. Current public repair docs now start with toolbox-backed Strix Halo llama.cpp and keep the single control plane as roadmap work.</p>
     </li>
   </ul>

--- a/1bit-site/index.html
+++ b/1bit-site/index.html
@@ -170,7 +170,7 @@ http://127.0.0.1:13305/api/v1
 # FastFlowLM direct: optional NPU runtime
 http://127.0.0.1:52625/v1</code></pre>
   <p>Use <code>:13305</code> direct when testing the active backend. Use the proxy when one OpenAI-compatible client should keep the same base URL while the backend changes from toolbox llama.cpp to native Lemonade or optional FLM routing.</p>
-  <p class="muted">This follows Lemonade's app model: local apps integrate by configuring an OpenAI-compatible base URL. Lemonade's own docs cover the API surface and app guides at <a href="https://lemonade-server.ai/docs/api/" rel="noopener">lemonade-server.ai/docs/api/</a> and <a href="https://lemonade-server.ai/docs/server/apps/" rel="noopener">/docs/server/apps/</a>.</p>
+  <p class="muted">This follows Lemonade's app model: local apps integrate by configuring an OpenAI-compatible base URL. Lemonade's own docs cover the API surface at <a href="https://lemonade-server.ai/docs/api/" rel="noopener">lemonade-server.ai/docs/api/</a>.</p>
   <div class="scroll-x">
   <table class="data-table">
     <thead><tr><th>App</th><th>Base URL</th><th>Why</th></tr></thead>

--- a/1bit-site/robots.txt
+++ b/1bit-site/robots.txt
@@ -24,5 +24,3 @@ Disallow: /join/
 Disallow: /donate/
 Disallow: /blog/2026-04-23-streaming-service/
 Disallow: /blog/2026-04-23-lossless-audio/
-
-Sitemap: https://1bit.systems/sitemap.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,11 @@ second.
   native runtimes, and model hot paths. Open WebUI is allowed only as an
   isolated secondary UI behind the OpenAI-compatible endpoint.
 - **Rule B: C++20 for kernels.** HIP code belongs in `rocm-cpp/`.
+  *Only applies on the archived branch `archive/cpp-tower-2026-04-27`;
+  the live tree intentionally has no `rocm-cpp/` tower (see What NOT to
+  do below).*
 - **Rule C: hipBLAS is banned in the runtime path.** Port kernels to
-  `rocm-cpp/` instead.
+  `rocm-cpp/` instead. *Same scope as Rule B — archive-branch only.*
 - **Rule D: Rust 1.88+, edition 2024.** Bump with a reason.
 - **Rule E: NPU has two lanes.** FastFlowLM is the live XDNA serving
   lane. Custom NPU kernels are IRON author-time → MLIR-AIE → Peano →

--- a/benchmarks/bench-1bit-pile.sh
+++ b/benchmarks/bench-1bit-pile.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # bench-1bit-pile.sh — sweep llama-bench across the ternary/sub-2-bit pile
-# Output: /home/bcloud/claude output/bench-1bit-<DATE>.json (one JSON object per model)
+# Output: $OUT_DIR/bench-1bit-<DATE>.json (one JSON object per model)
 set -uo pipefail
 
 LLAMA_BENCH="${LLAMA_BENCH:-/home/bcloud/.cache/lemonade/bin/llamacpp/vulkan/llama-bench}"
 PILE_ROOT="${PILE_ROOT:-/home/bcloud/halo-ai/models/ternary-test}"
-OUT_DIR="${OUT_DIR:-/home/bcloud/claude output}"
+OUT_DIR="${OUT_DIR:-$HOME/claude-output}"
 TS="$(date +%Y%m%d-%H%M%S)"
 JSON_OUT="${OUT_DIR}/bench-1bit-${TS}.json"
 LOG_OUT="${OUT_DIR}/bench-1bit-${TS}.log"
@@ -42,7 +42,7 @@ for entry in "${ENTRIES[@]}"; do
         continue
     fi
 
-    SIZE_MB="$(($(stat -c%s "${GGUF}") / (1024 * 1024)))"
+    SIZE_MB="$(($(wc -c < "${GGUF}") / (1024 * 1024)))"
     echo "=== ${LABEL} (${SIZE_MB} MB) ===" | tee -a "${LOG_OUT}"
 
     # llama-bench JSON output. -p 512 (prompt-eval), -n 128 (gen), -r 2 (reps).
@@ -57,9 +57,13 @@ for entry in "${ENTRIES[@]}"; do
     # Each invocation prints one JSON array. Tag with our label.
     if [[ ${FIRST} -eq 0 ]]; then echo "," >> "${JSON_OUT}"; fi
     FIRST=0
-    {
-        echo "{\"label\":\"${LABEL}\",\"gguf\":\"${GGUF}\",\"size_mb\":${SIZE_MB},\"results\":${RAW}}"
-    } >> "${JSON_OUT}"
+    jq -n \
+        --arg label "${LABEL}" \
+        --arg gguf  "${GGUF}" \
+        --argjson size_mb "${SIZE_MB}" \
+        --argjson results "${RAW}" \
+        '{label:$label, gguf:$gguf, size_mb:$size_mb, results:$results}' \
+        >> "${JSON_OUT}"
 
     echo "${RAW}" | tee -a "${LOG_OUT}"
 done

--- a/benchmarks/data/ppl-cross-arch-20260422.json
+++ b/benchmarks/data/ppl-cross-arch-20260422.json
@@ -3,16 +3,16 @@
   "timestamp": "2026-04-22",
   "purpose": "Cross-arch numerical parity verification: gfx1151 (Strix Halo iGPU) vs gfx1201 (RX 9070 XT RDNA4 dGPU) on identical model + dataset + harness",
   "model": {
-    "path": "/home/bcloud/1bit-halo-models/models/halo-1bit-2b.h1b",
+    "path": "~/1bit-halo-models/models/halo-1bit-2b.h1b",
     "md5": "6a234ff78fa5da4eb60befa744de693e",
-    "tokenizer": "/home/bcloud/1bit-halo-models/models/halo-1bit-2b.htok",
+    "tokenizer": "~/1bit-halo-models/models/halo-1bit-2b.htok",
     "weight_format": "HALO_V2 2bpw int8-act",
     "arch": "bitnet",
     "hs": 2560, "is": 6912, "L": 30, "nh": 20, "nkv": 5, "hd": 128, "vocab": 128256,
     "rope_theta": 500000.0, "rms_norm_eps": 1.0e-05
   },
   "dataset": {
-    "path": "/home/bcloud/1bit-halo-models/datasets/wikitext-103-test.txt",
+    "path": "~/1bit-halo-models/datasets/wikitext-103-test.txt",
     "md5": "c9a4cfee58e432486273b1126541e347",
     "bytes": 1281033
   },
@@ -40,7 +40,7 @@
       "host": "ryzen",
       "arch": "gfx1201",
       "gpu": "RX 9070 XT (RDNA4, GDDR6 ~640 GB/s)",
-      "binary": "/home/bcloud/rocm-cpp/build/bitnet_decode",
+      "binary": "~/rocm-cpp/build/bitnet_decode",
       "perplexity": 11.975776,
       "mean_nll": 2.482886,
       "scored_chunks": 4095,

--- a/docs/wiki/1bit-website-spec-v2.md
+++ b/docs/wiki/1bit-website-spec-v2.md
@@ -1,5 +1,12 @@
 # 1bit.systems — Complete Website Spec (v2, 2026-04-21)
 
+> **Historical.** This file is a 2026-04-21 design/spec draft. It predates the
+> 2026-05-06 toolbox-first repair path and may overstate shipping status for
+> Lemonade, FastFlowLM, the NPU lane, and the single control plane. Current
+> public copy must follow `README.md`, `docs/toolbox-backends.md`, and
+> `docs/control-plane-roadmap.md`. See the "Historical Website Spec" note at
+> the bottom of this file for the same caveat.
+
 **Target:** WordPress install (Gutenberg blocks), calm-technical voice, local-first product presentation with a built-in wiki.
 
 **Voice:** calm technical. No memes. No 80s refs. No exclamation marks. (Per `project_brand_voice_split.md`; the meme voice stays on the GH README.)

--- a/docs/wiki/Cloudflare-Tunnel-Setup.md
+++ b/docs/wiki/Cloudflare-Tunnel-Setup.md
@@ -34,11 +34,11 @@ cloudflared tunnel login
 #      ~/.cloudflared/cert.pem
 
 # 2. Create the tunnel (returns a UUID, writes ~/.cloudflared/<UUID>.json)
-cloudflared tunnel create api-1bit systems-studio
+cloudflared tunnel create api-1bit-systems-studio
 #    → note the UUID; call it TUUID
 
 # 3. Bind the subdomain to the tunnel (creates a proxied CNAME in CF DNS)
-cloudflared tunnel route dns api-1bit systems-studio api.1bit.systems
+cloudflared tunnel route dns api-1bit-systems-studio api.1bit.systems
 ```
 
 ## Four mechanical steps (fill in UUID + enable)
@@ -115,8 +115,8 @@ realtime endpoints are not an acceptable launch state.
 
 ```bash
 systemctl --user disable --now strix-cloudflared.service
-cloudflared tunnel route dns --overwrite-dns api-1bit systems-studio  # removes CNAME
-cloudflared tunnel delete api-1bit systems-studio
+cloudflared tunnel route dns --overwrite-dns api-1bit-systems-studio  # removes CNAME
+cloudflared tunnel delete api-1bit-systems-studio
 ```
 
 ## References

--- a/docs/wiki/Ternary-on-AIE-Pack-Plan.md
+++ b/docs/wiki/Ternary-on-AIE-Pack-Plan.md
@@ -57,7 +57,7 @@ Crossover: compute-bound at all prefill lengths we'll see. Bandwidth is not the 
 
 ## Activation path
 
-Activations flow in as int8 from a stage upstream (CPU-side quantiser or the previous layer's output). Today's 1bit-server has bf16 activations end-to-end; for NPU prefill we add:
+Activations flow in as int8 from a stage upstream (CPU-side quantiser or the previous layer's output). Today's 1bit-proxy has bf16 activations end-to-end; for NPU prefill we add:
 
 - `activation_quantise_int8(bf16 in, i8 out, bf16 scale)` — one pass before tile dispatch.
 - `activation_dequantise_bf16(i32 in, bf16 out, bf16 scale)` — one pass after tile drain.

--- a/install.sh
+++ b/install.sh
@@ -498,7 +498,7 @@ configure_optc_mitigation() {
     fi
     sudo cp -a /etc/default/limine "/etc/default/limine.pre-1bit-optc.$(date +%Y%m%d%H%M%S)"
     if ! grep -q "$flag" /etc/default/limine; then
-        sudo sed -i "/KERNEL_CMDLINE\\[default\\]/ s/\"$/ $flag\"/" /etc/default/limine
+        echo "KERNEL_CMDLINE[default]+=\" $flag\"" | sudo tee -a /etc/default/limine >/dev/null
     fi
     sudo limine-install
     warn "OPTC mitigation staged; reboot required before $flag is active"

--- a/packaging/aur/1bit-systems-bin/.SRCINFO
+++ b/packaging/aur/1bit-systems-bin/.SRCINFO
@@ -1,13 +1,10 @@
 pkgbase = 1bit-systems-bin
-	pkgdesc = Lean unified 1-bit / sub-2-bit inference engine for AMD Strix Halo (Lemonade + FastFlowLM) — single-binary build
+	pkgdesc = DEPRECATED binary packaging draft for 1bit-systems; use install.sh until refreshed
 	pkgver = 2.0.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://1bit.systems
-	install = 1bit-systems.install
 	arch = x86_64
 	license = MIT
-	depends = lemonade-server
-	depends = fastflowlm
 	depends = xrt
 	depends = xrt-plugin-amdxdna
 	depends = rocm-hip-sdk

--- a/packaging/aur/1bit-systems-git/.SRCINFO
+++ b/packaging/aur/1bit-systems-git/.SRCINFO
@@ -14,6 +14,7 @@ pkgbase = 1bit-systems-git
 	depends = python
 	provides = 1bit-systems
 	conflicts = 1bit-systems
+	conflicts = 1bit-systems-bin
 	source = 1bit-systems::git+https://github.com/bong-water-water-bong/1bit-systems.git#branch=main
 	sha256sums = SKIP
 

--- a/packaging/aur/1bit-systems-git/.SRCINFO
+++ b/packaging/aur/1bit-systems-git/.SRCINFO
@@ -1,14 +1,11 @@
 pkgbase = 1bit-systems-git
-	pkgdesc = Lean unified 1-bit / sub-2-bit inference engine for AMD Strix Halo (Lemonade + FastFlowLM)
+	pkgdesc = DEPRECATED packaging draft for 1bit-systems; use install.sh until AUR is refreshed
 	pkgver = r0.0000000
-	pkgrel = 1
+	pkgrel = 2
 	url = https://1bit.systems
-	install = 1bit-systems.install
 	arch = x86_64
 	license = MIT
 	makedepends = git
-	depends = lemonade-server
-	depends = fastflowlm
 	depends = xrt
 	depends = xrt-plugin-amdxdna
 	depends = rocm-hip-sdk

--- a/packaging/aur/1bit-systems-git/PKGBUILD
+++ b/packaging/aur/1bit-systems-git/PKGBUILD
@@ -24,7 +24,7 @@ depends=(
 makedepends=('git')
 
 provides=("$_pkgname")
-conflicts=("$_pkgname")
+conflicts=("$_pkgname" "1bit-systems-bin")
 
 source=("$_pkgname::git+https://github.com/bong-water-water-bong/1bit-systems.git#branch=main")
 sha256sums=('SKIP')

--- a/packaging/aur/1bit-systems-git/PKGBUILD
+++ b/packaging/aur/1bit-systems-git/PKGBUILD
@@ -46,7 +46,13 @@ package() {
 
   # OmniRouter loop with our 1bit defaults (Tier 2 LLM + SD-Turbo + kokoro + whisper)
   install -Dm755 scripts/1bit-omni.py "$pkgdir/usr/share/$_pkgname/1bit-omni.py"
-  install -Dm644 scripts/omni-plugins/*.json -t "$pkgdir/usr/share/$_pkgname/omni-plugins/"
+  # Defensive: skip if the omni-plugins glob has no matches (don't fail the build).
+  shopt -s nullglob
+  _omni=(scripts/omni-plugins/*.json)
+  shopt -u nullglob
+  if (( ${#_omni[@]} > 0 )); then
+    install -Dm644 "${_omni[@]}" -t "$pkgdir/usr/share/$_pkgname/omni-plugins/"
+  fi
 
   # Memlock conf — NPU + GPU buffers want unlimited
   install -Dm644 /dev/stdin "$pkgdir/etc/security/limits.d/99-1bit-systems.conf" <<'EOF'

--- a/packaging/binary/1bit.ts
+++ b/packaging/binary/1bit.ts
@@ -9,6 +9,7 @@
 
 import { spawn, spawnSync, execSync } from "node:child_process";
 import { existsSync, openSync, closeSync } from "node:fs";
+import { homedir } from "node:os";
 import { startProxy } from "./proxy.ts";
 
 const CYAN = "\x1b[0;36m";
@@ -267,11 +268,21 @@ function escapeRe(s: string): string {
 }
 
 function cmdBench(): void {
+  const home = homedir();
   const candidates = [
-    "/home/bcloud/Projects/1bit-systems/benchmarks/bench-1bit-pile.sh",
+    `${process.cwd()}/benchmarks/bench-1bit-pile.sh`,
+    `${home}/1bit-systems/benchmarks/bench-1bit-pile.sh`,
+    `${home}/Projects/1bit-systems/benchmarks/bench-1bit-pile.sh`,
+    "/usr/share/1bit-systems/benchmarks/bench-1bit-pile.sh",
+    "/usr/local/share/1bit-systems/benchmarks/bench-1bit-pile.sh",
   ];
   let script = "";
-  for (const p of candidates) if (existsSync(p)) script = p;
+  for (const p of candidates) {
+    if (existsSync(p)) {
+      script = p;
+      break;
+    }
+  }
   if (!script) die("bench script not found");
   const r = spawnSync("bash", [script], { stdio: "inherit" });
   if (r.status !== 0) process.exit(r.status || 1);

--- a/packaging/binary/1bit.ts
+++ b/packaging/binary/1bit.ts
@@ -364,7 +364,7 @@ Usage:
   1bit status            Show service status
   1bit pull <model>      Pull a model (auto-routes NPU vs GPU)
   1bit bench             Run the 1-bit / ternary pile bench
-  1bit npu [model]       Start FLM NPU server (default: $DEFAULT_NPU_MODEL)
+  1bit npu [model]       Start FLM NPU server (default: ${DEFAULT_NPU_MODEL})
   1bit webui [up|down|status]  Run Open WebUI on :3000, branded + pointed at proxy
 
 Endpoints (after \`1bit up\`):

--- a/scripts/1bit
+++ b/scripts/1bit
@@ -74,8 +74,6 @@ proxy_script() {
         echo /usr/local/share/1bit-systems/1bit-proxy.js
     elif [[ -f /usr/share/1bit-systems/1bit-proxy.js ]]; then
         echo /usr/share/1bit-systems/1bit-proxy.js
-    elif [[ -f /home/bcloud/1bit-systems/scripts/1bit-proxy.js ]]; then
-        echo /home/bcloud/1bit-systems/scripts/1bit-proxy.js
     else
         echo ""
     fi
@@ -615,7 +613,6 @@ cmd_bench() {
     self_dir="$(dirname "$(readlink -f "$0")")"
     for cand in \
         "$self_dir/../benchmarks/bench-1bit-pile.sh" \
-        /home/bcloud/1bit-systems/benchmarks/bench-1bit-pile.sh \
         /usr/local/share/1bit-systems/benchmarks/bench-1bit-pile.sh \
         /usr/share/1bit-systems/benchmarks/bench-1bit-pile.sh
     do

--- a/scripts/optc_soak_2hr.sh
+++ b/scripts/optc_soak_2hr.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 DURATION="${1:-7200}"
 CADENCE="${OPTC_CADENCE:-10}"
-OUT_DIR="${OPTC_OUT_DIR:-$HOME/claude output/optc-soak-$(date +%Y%m%d-%H%M%S)}"
+OUT_DIR="${OPTC_OUT_DIR:-$HOME/claude-output/optc-soak-$(date +%Y%m%d-%H%M%S)}"
 PATTERN='REG_WAIT.*optc35_disable_crtc|optc35_disable_crtc'
 
 mkdir -p "$OUT_DIR"


### PR DESCRIPTION
## Summary

Addresses **27 of 30** findings from a `coderabbit review --agent --base-commit <initial>` full-history audit of `main`. 3 findings deliberately rejected with reasoning; 2 deferred to release-cut / re-benchmark time.

### Critical (6/6 addressed)

- **AUR metadata desync (4):** Regenerated both `packaging/aur/1bit-systems-{git,bin}/.SRCINFO` from authoritative PKGBUILDs (drifted on `pkgrel`, `pkgdesc`, `depends`, `install=`).
- **Hardcoded `/home/bcloud` in `packaging/binary/1bit.ts cmdBench`:** Candidate list ordered dev → system; break on first match.
- **Obsolete `1bit-server` in `docs/wiki/Ternary-on-AIE-Pack-Plan.md`:** Renamed to `1bit-proxy`.

### Major (8 of 10 addressed; 2 deferred)

- `scripts/1bit` `proxy_script()` + `cmd_bench()`: dropped maintainer-specific `/home/bcloud` fallbacks (2 sites).
- AUR `-git` package now `conflicts=("$_pkgname" "1bit-systems-bin")` — symmetric with `-bin`.
- `install.sh:500` limine cmdline: switched from quoted-form `sed` (silent no-op on the actual shell-array syntax) to `KERNEL_CMDLINE[default]+=...` append, which works either way.
- `docs/wiki/Cloudflare-Tunnel-Setup.md`: `api-1bit systems-studio` → `api-1bit-systems-studio` across all 4 `cloudflared` invocations.
- `1bit-site/blog/index.html`: blog bench link points directly at `/#bench` (the previous `/docs/benchmarks.html#stack-green-2026-04-28` hit a `301!` redirect that strips the fragment, and the anchor doesn't exist on the homepage).
- `docs/wiki/1bit-website-spec-v2.md`: added top historical-status disclaimer (file already had one at the bottom).

**Deferred (2):**
- `packaging/aur/1bit-systems-bin/PKGBUILD` `sha256sums=SKIP` — `v2.0.0` doesn't exist yet (latest is `v0.1.9`); checksums get populated at release-cut time, and the PKGBUILD already documents this.
- `benchmarks/data/shadow-burnin-sample-200-20260422.jsonl` `prompt_idx 7` failure — recorded benchmark output from 2026-04-22, not a code bug; investigating requires re-running the burn-in.

### Minor (11 of 14 addressed; 3 rejected)

- `benchmarks/bench-1bit-pile.sh`: `stat -c%s` → `wc -c <` (BSD/macOS portability); per-model JSON built with `jq -n --arg/--argjson` (no more shell interpolation); default `OUT_DIR` hyphenated from `"$HOME/claude output"` → `"$HOME/claude-output"`.
- `benchmarks/data/ppl-cross-arch-20260422.json`: scrubbed 4 leaked `/home/bcloud/` paths to `~/...`. Md5s preserved; identifying username removed.
- `scripts/optc_soak_2hr.sh`: default `OPTC_OUT_DIR` hyphenated to match `claude-output`.
- `CLAUDE.md`: Rules B/C now note they apply only on the archived `archive/cpp-tower-2026-04-27` branch (the live tree's "What NOT to do" forbids reintroducing `rocm-cpp/`, so B/C were contradictory on `main`).
- `.github/PULL_REQUEST_TEMPLATE.md`: Rule D checkbox bumped to `Rust 1.88+` to match the CLAUDE.md authoritative rule.
- `1bit-site/assets/style.css`: dropped deprecated `word-break: break-word` (the adjacent `overflow-wrap: anywhere` provides the same behavior).
- `1bit-site/index.html`: removed the 404'd second Lemonade docs link (`/docs/server/apps/`); kept the working `/docs/api/` link.
- `1bit-site/robots.txt`: dropped phantom `Sitemap:` advertising a non-existent `/sitemap.xml`.
- `packaging/aur/1bit-systems-git/PKGBUILD`: guarded the `scripts/omni-plugins/*.json` install with `nullglob` so an empty directory doesn't fail the build.
- `packaging/binary/1bit.ts` `usage()`: `$DEFAULT_NPU_MODEL` → `${DEFAULT_NPU_MODEL}` so the default model name actually expands in the JS template literal.

**Rejected (3):**
- `packaging/binary/proxy.ts:78-84` and `packaging/binary/1bit.ts:294` "bind to 0.0.0.0 for README parity" — backwards: the README binds *everything* to `127.0.0.1` (see lines 28-31, 49-52, 63-71, 78-91). `proxy.ts:78-80` has an explicit comment `"Local-only by default. Set PROXY_HOST=0.0.0.0 only behind explicit authentication/TLS or a trusted LAN firewall policy."` — flipping to `0.0.0.0` would be a security regression, not parity.
- `benchmarks/bench-1bit-pile.sh:4` "add `-e` to `set -uo pipefail`" — the script uses `|| true` + explicit `continue` to skip individual missing GGUFs and keep the sweep going; `-e` would abort on the first missing model and defeat the design.

## Test plan

- [x] 14 commits, 17 files changed
- [x] `bash -n` on all touched shell files (install.sh, scripts/1bit, scripts/optc_soak_2hr.sh, bench-1bit-pile.sh, PKGBUILD)
- [x] `jq -e .` on touched JSON
- [x] CI green on previous push (shellcheck + JSON + HTML + lychee)
- [ ] CI green on this push
- [ ] `coderabbit-ai[bot]` re-reviews
- [ ] `qodo-code-review[bot]` re-reviews

Full audit log: `/tmp/cr-1bit-systems.log` — 30 findings disposition: **25 fixed, 2 deferred (release-cut / re-benchmark), 3 rejected (security default + intentional design)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected activation pipeline wording, fixed Cloudflare Tunnel CLI name, added a historical caveat, updated a blog link target, and clarified a guidance file.

* **Chores**
  * Marked AUR packages as deprecated and updated packaging metadata.
  * Safer kernel-parameter staging in installer.
  * Removed hard-coded repo fallback paths in helper scripts.
  * Adjusted robots rules and site indexing.

* **New Features**
  * Bench/CLI searches for benchmark scripts in multiple standard locations and shows runtime defaults correctly.

* **Style**
  * Improved inline code wrapping behavior in site styles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bong-water-water-bong/1bit-systems/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->