### PR TITLE
docs: add Health Checks section to app-integration guide

### DIFF
--- a/docs/app-integration.md
+++ b/docs/app-integration.md
@@ -70,6 +70,26 @@ endpoints such as `/v1/images/generations`, `/v1/images/edits`,
 `/v1/audio/speech`, `/v1/audio/transcriptions`, and `/v1/chat/completions` for
 vision.
 
+## Health Checks
+
+Each service exposes a `/health` endpoint. Poll these before sending inference requests to verify the stack is up.
+
+| Service | URL | Expected response |
+|---------|-----|-------------------|
+| 1bit-proxy | `http://127.0.0.1:13306/health` | `{"status":"ok"}` |
+| Lemonade (lemond) | `http://127.0.0.1:13305/health` | `{"status":"ok", ...}` |
+| FastFlowLM (NPU) | `http://127.0.0.1:52625/health` | `{"status":"ok"}` |
+
+Quick shell check:
+
+```bash
+curl -sf http://127.0.0.1:13306/health | jq .status   # proxy
+curl -sf http://127.0.0.1:13305/health | jq .status   # lemond
+curl -sf http://127.0.0.1:52625/health | jq .status   # flm (if NPU lane active)
+```
+
+`1bit status` runs all three checks and prints a summary.
+
 ## Security
 
 These endpoints are local developer services by default. Do not expose them directly to the internet. Put authentication, TLS, and an explicit reverse proxy policy in front of any remote access.

--- a/docs/app-integration.md
+++ b/docs/app-integration.md
@@ -72,23 +72,23 @@ vision.
 
 ## Health Checks
 
-Each service exposes a `/health` endpoint. Poll these before sending inference requests to verify the stack is up.
+Use these endpoints to verify the stack is up before sending inference requests.
 
 | Service | URL | Expected response |
 |---------|-----|-------------------|
-| 1bit-proxy | `http://127.0.0.1:13306/health` | `{"status":"ok"}` |
-| Lemonade (lemond) | `http://127.0.0.1:13305/health` | `{"status":"ok", ...}` |
+| 1bit-proxy | `http://127.0.0.1:13306/health` | `{"ok":true,...}` |
+| Lemonade (lemond) | `http://127.0.0.1:13305/api/v1/health` | `{"status":"ok",...}` |
 | FastFlowLM (NPU) | `http://127.0.0.1:52625/health` | `{"status":"ok"}` |
 
-Quick shell check:
+Quick shell check (HTTP 200 = service is up):
 
 ```bash
-curl -sf http://127.0.0.1:13306/health | jq .status   # proxy
-curl -sf http://127.0.0.1:13305/health | jq .status   # lemond
-curl -sf http://127.0.0.1:52625/health | jq .status   # flm (if NPU lane active)
+curl -sf http://127.0.0.1:13306/health | jq .ok          # proxy → true
+curl -sf http://127.0.0.1:13305/api/v1/health | jq .status  # lemond → "ok"
+curl -sf http://127.0.0.1:52625/health >/dev/null && echo ok  # flm
 ```
 
-`1bit status` runs all three checks and prints a summary.
+`1bit status` summarizes all three services: lemond via `/v1/models`, flm via process detection, and proxy via `/health`.
 
 ## Security
 


### PR DESCRIPTION
## Summary

- Adds a Health Checks section to `docs/app-integration.md`
- The doc covered base URLs and routing but said nothing about verifying services before sending requests
- Documents `/health` endpoints for proxy (:13306), lemond (:13305), and FastFlowLM (:52625)
- Includes a quick `curl` one-liner and notes that `1bit status` covers all three

## Test plan

- [x] Doc renders correctly in markdown preview
- [x] URLs match the ports documented elsewhere in `app-integration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)