### PR TITLE
Remove robots.txt from site

### DIFF
--- a/1bit-site/robots.txt
+++ b/1bit-site/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Allow: /
-Sitemap: https://1bit.systems/sitemap.xml

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Allow: /
-Sitemap: https://1bit.systems/sitemap.xml


### PR DESCRIPTION
## Summary
- Deletes `site/robots.txt` and `1bit-site/robots.txt` (source + Cloudflare Pages deploy copy)
- No robots.txt means default allow-all for every crawler, including AI bots (GPTBot, ClaudeBot, CCBot, etc.) — same net permission as the previous `Allow: /` file, but with the file gone entirely per request

## Test plan
- [ ] Merge to main to trigger the Cloudflare Pages deploy (per CLAUDE.md, site deploys from `1bit-site/` on push to main)
- [ ] Confirm `https://1bit.systems/robots.txt` 404s post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed robots.txt so the site defaults to allow-all for all crawlers, matching the previous Allow: / behavior without the file. Deleted site/robots.txt and 1bit-site/robots.txt; after deploy, https://1bit.systems/robots.txt should 404.

<sup>Written for commit bfbf155b7a63ee52ec1fd8e80afa79f0b85fcf07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bong-water-water-bong/1bit-systems/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

