### PR TITLE
test: PR Agent on self-hosted runner (Docker ready)

### DIFF
--- a/TEST_PR_AGENT.md
+++ b/TEST_PR_AGENT.md
@@ -1,1 +1,1 @@
-# Test PR for local runner
+# PR Agent local runner test - Docker ready


### PR DESCRIPTION
Testing self-hosted PR Agent with Docker installed on strix-halo runner. OpenCode/GLM-5.2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark the self-hosted PR Agent local-runner test as Docker-ready by updating the test doc title. This confirms the Docker-based setup on the self-hosted runner is ready to use.

<sup>Written for commit f4197d25bbcae651a83675dc99aa63334eb0ec05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bong-water-water-bong/1bit-systems/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

