### PR TITLE
fix(site): publish unique visitors instead of CI-inflated clone counts

### DIFF
--- a/.github/workflows/traffic-badge.yml
+++ b/.github/workflows/traffic-badge.yml
@@ -1,129 +1,72 @@
-name: Traffic Badge
+name: Audience Badge
 on:
   schedule:
     - cron: '0 6 * * *'   # daily at 6AM UTC
   workflow_dispatch:       # manual trigger
+
+# Publishes a unique-visitor badge from the GitHub traffic API.
+#
+# Deliberately NOT clone-based: Actions checkouts count as clones, and because
+# each hosted runner is a fresh VM they count as *unique* cloners too. Clone
+# counts therefore track our own CI volume, not adoption. Views/uniques are not
+# inflated that way, so they are what we publish.
 
 jobs:
   badge:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: read
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch traffic + stars
+      - name: Fetch traffic views + stars
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # === Full clone data (last 14 days) ===
-          CLONE_DATA=$(gh api repos/${{ github.repository }}/traffic/clones)
-          TOTAL_CLONES=$(echo "$CLONE_DATA" | jq '.count')
-          TOTAL_UNIQUE=$(echo "$CLONE_DATA" | jq '.uniques')
-          DAILY_COUNT=$(echo "$CLONE_DATA" | jq '.clones[-1].count')
-          DAILY_UNIQUE=$(echo "$CLONE_DATA" | jq '.clones[-1].uniques')
-          DAILY_DATE=$(echo "$CLONE_DATA" | jq -r '.clones[-1].timestamp[:10]')
-          PREV_COUNT=$(echo "$CLONE_DATA" | jq '.clones[-2].count // 0')
-          PREV_DATE=$(echo "$CLONE_DATA" | jq -r '.clones[-2].timestamp[:10] // "unknown"')
+          set -euo pipefail
 
-          # === Stars ===
+          VIEW_DATA=$(gh api repos/${{ github.repository }}/traffic/views)
+          UNIQUE_VISITORS=$(echo "$VIEW_DATA" | jq '.uniques')
+          TOTAL_VIEWS=$(echo "$VIEW_DATA" | jq '.count')
+
           STARS=$(gh api repos/${{ github.repository }} --jq '.stargazers_count')
           FORKS=$(gh api repos/${{ github.repository }} --jq '.forks_count')
 
-          # === Trend ===
-          if [ "$PREV_COUNT" -gt 0 ] 2>/dev/null; then
-            PCT_CHANGE=$(echo "scale=1; (($DAILY_COUNT - $PREV_COUNT) / $PREV_COUNT) * 100" | bc 2>/dev/null || echo "0")
-            if [ "$(echo "$PCT_CHANGE > 0" | bc 2>/dev/null)" = "1" ]; then
-              TREND="▲ +${PCT_CHANGE}%"
-              TREND_COLOR="brightgreen"
-            elif [ "$(echo "$PCT_CHANGE < 0" | bc 2>/dev/null)" = "1" ]; then
-              TREND="▼ ${PCT_CHANGE}%"
-              TREND_COLOR="red"
-            else
-              TREND="— 0%"
-              TREND_COLOR="yellow"
-            fi
-          else
-            TREND="—"
-            TREND_COLOR="blue"
+          if   [ "$UNIQUE_VISITORS" -ge 500 ]; then COLOR="brightgreen"
+          elif [ "$UNIQUE_VISITORS" -ge 100 ]; then COLOR="green"
+          elif [ "$UNIQUE_VISITORS" -ge 25  ]; then COLOR="yellowgreen"
+          else COLOR="yellow"
           fi
 
-          # === Daily badge color ===
-          if [ "$DAILY_COUNT" -ge 500 ]; then DAILY_COLOR="brightgreen"
-          elif [ "$DAILY_COUNT" -ge 100 ]; then DAILY_COLOR="green"
-          elif [ "$DAILY_COUNT" -ge 10 ]; then DAILY_COLOR="yellowgreen"
-          else DAILY_COLOR="yellow"
-          fi
-
-          # === Clones:stars ratio color ===
-          TOTAL_RATIO=$(echo "scale=0; $TOTAL_CLONES / $STARS" | bc 2>/dev/null || echo "$TOTAL_CLONES")
-          UNIQUE_RATIO=$(echo "scale=0; $TOTAL_UNIQUE / $STARS" | bc 2>/dev/null || echo "$TOTAL_UNIQUE")
-          if [ "$TOTAL_RATIO" -ge 100 ]; then RATIO_COLOR="brightgreen"
-          elif [ "$TOTAL_RATIO" -ge 50 ]; then RATIO_COLOR="green"
-          elif [ "$TOTAL_RATIO" -ge 20 ]; then RATIO_COLOR="yellowgreen"
-          else RATIO_COLOR="yellow"
-          fi
-
-          # Renamed exist badges
-          cat > site/traffic-badge.json << EOF
+          cat > site/visitors.json << EOF
           {
             "schemaVersion": 1,
-            "label": "clones",
-            "message": "${TOTAL_CLONES} (${TOTAL_UNIQUE} unique)",
-            "color": "${RATIO_COLOR}",
+            "label": "unique visitors (14d)",
+            "message": "${UNIQUE_VISITORS}",
+            "color": "${COLOR}",
             "cacheSeconds": 86400
           }
           EOF
 
-          # Daily clones badge — the bragging right
-          cat > site/daily-clones.json << EOF
+          cat > site/audience.json << EOF
           {
-            "schemaVersion": 1,
-            "label": "clones today",
-            "message": "${DAILY_COUNT}",
-            "color": "${DAILY_COLOR}",
-            "cacheSeconds": 86400
+            "unique_visitors_14d": ${UNIQUE_VISITORS},
+            "views_14d": ${TOTAL_VIEWS},
+            "stars": ${STARS},
+            "forks": ${FORKS},
+            "updated": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           }
           EOF
 
-          # Daily clones with unique + trend
-          cat > site/daily-clones-full.json << EOF
-          {
-            "schemaVersion": 1,
-            "label": "clones ${DAILY_DATE}",
-            "message": "${DAILY_COUNT} (${DAILY_UNIQUE} unique) ${TREND}",
-            "color": "${DAILY_COLOR}",
-            "cacheSeconds": 86400,
-            "style": "flat-square",
-            "logoSvg": "<svg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'><circle cx='7' cy='7' r='6' fill='%2300ff00' opacity='0.3'/><circle cx='7' cy='7' r='3' fill='%2300ff00'/></svg>"
-          }
-          EOF
-
-          # Clones:stars ratio
-          cat > site/clones-stars.json << EOF
-          {
-            "schemaVersion": 1,
-            "label": "clones:stars",
-            "message": "${TOTAL_RATIO}:1 (${UNIQUE_RATIO}:1 unique)",
-            "color": "${RATIO_COLOR}",
-            "cacheSeconds": 86400
-          }
-          EOF
-
-          echo "=== Daily Clones ==="
-          echo "  $DAILY_DATE: $DAILY_COUNT clones ($DAILY_UNIQUE unique) ${TREND}"
-          echo "   Previous ($PREV_DATE): $PREV_COUNT"
-          echo ""
-          echo "=== All-time ==="
-          echo "  Total: $TOTAL_CLONES clones · $TOTAL_UNIQUE unique"
-          echo "  Ratio: $TOTAL_RATIO:1 clones:stars"
+          echo "=== Audience (14d) ==="
+          echo "  Unique visitors: $UNIQUE_VISITORS"
+          echo "  Views:           $TOTAL_VIEWS"
           echo "  Stars: $STARS · Forks: $FORKS"
 
       - name: Commit badges
         run: |
           git config user.name "CI Fix Bot"
           git config user.email "ci-fixer@bot.com"
-          git add site/traffic-badge.json site/daily-clones.json site/daily-clones-full.json site/clones-stars.json
-          git diff --cached --quiet || git commit -m "chore: update traffic badges [skip ci]"
+          git add site/visitors.json site/audience.json
+          git diff --cached --quiet || git commit -m "chore: update audience badge [skip ci]"
           git push

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Zero Python. Your hardware.
 [![113 tok/s ROCm](https://img.shields.io/badge/113%20tok%2Fs-ROCm-ff0000.svg)](docs/wiki/performance.md)
 [![Vulkan ⭐](https://img.shields.io/badge/Vulkan-%E2%AD%90%20primary-b3802c.svg)](docs/wiki/engines.md)
 [![MIT](https://img.shields.io/badge/license-MIT-00ff00.svg)](LICENSE)
-[![clones today](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/bong-water-water-bong/1bit-systems/main/site/daily-clones.json&cacheSeconds=3600)](https://github.com/bong-water-water-bong/1bit-systems/graphs/traffic)
-[![clones:stars](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/bong-water-water-bong/1bit-systems/main/site/clones-stars.json)](https://github.com/bong-water-water-bong/1bit-systems/graphs/traffic)
+[![unique visitors (14d)](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/bong-water-water-bong/1bit-systems/main/site/visitors.json&cacheSeconds=3600)](https://github.com/bong-water-water-bong/1bit-systems/graphs/traffic)
+[![stars](https://img.shields.io/github/stars/bong-water-water-bong/1bit-systems?color=00ff88&label=stars)](https://github.com/bong-water-water-bong/1bit-systems/stargazers)
+[![forks](https://img.shields.io/github/forks/bong-water-water-bong/1bit-systems?color=12a0ed&label=forks)](https://github.com/bong-water-water-bong/1bit-systems/network/members)
 <br>
 <sub>deb · snap · docker · AUR · homebrew · ollama</sub>
 

--- a/site/audience.json
+++ b/site/audience.json
@@ -1,0 +1,7 @@
+{
+  "unique_visitors_14d": 36,
+  "views_14d": 303,
+  "stars": 9,
+  "forks": 4,
+  "updated": "2026-07-10T11:05:32Z"
+}

--- a/site/clones-stars.json
+++ b/site/clones-stars.json
@@ -1,7 +1,0 @@
-{
-  "schemaVersion": 1,
-  "label": "clones:stars",
-  "message": "6113:9 (783:9 unique)",
-  "color": "brightgreen",
-  "cacheSeconds": 86400
-}

--- a/site/daily-clones-full.json
+++ b/site/daily-clones-full.json
@@ -1,7 +1,0 @@
-{
-  "schemaVersion": 1,
-  "label": "clones 2026-07-05",
-  "message": "1102 (196 unique) ▲ +47.3%",
-  "color": "brightgreen",
-  "cacheSeconds": 86400
-}

--- a/site/daily-clones.json
+++ b/site/daily-clones.json
@@ -1,1 +1,0 @@
-{"schemaVersion": 1, "label": "clones today", "message": "1441", "color": "brightgreen", "cacheSeconds": 86400}

--- a/site/index.html
+++ b/site/index.html
@@ -217,7 +217,7 @@
           Custom HIP C++ ternary kernels on AMD Strix Halo. <strong>113 tok/s decode</strong> (8.8 ms/tok).
           <br><strong>28.4 TFlops</strong> prefill GEMM. <strong>48.5 GB/s</strong> GEMV bandwidth.
           <br><span class="nop">No hipBLAS. No Python. No cloud.</span> Your GPU. <a href="https://github.com/bong-water-water-bong/1bit/blob/main/LICENSE">MIT licensed</a>.
-          <br><span style="color:var(--green);font-weight:700;font-size:13px;">▲ <span id="daily-clones-hero">—</span> cloned today · <a href="https://github.com/bong-water-water-bong/1bit-systems/graphs/traffic" style="color:var(--blue);">6,459 total</a></span>
+          <br><span style="color:var(--green);font-weight:700;font-size:13px;">▲ <span id="visitors-hero">—</span> · <a href="https://github.com/bong-water-water-bong/1bit-systems/stargazers" style="color:var(--blue);"><span id="stars-hero">—</span> stars</a></span>
         </div>
       </blockquote>
       <div class="row" style="margin-top:18px;">
@@ -246,10 +246,10 @@
           <span class="pill info" style="font-size:10px;"><span class="dot"></span><span id="weight-read">436 MB</span>/tok</span>
           <span class="pill warn" style="font-size:10px;"><span class="dot"></span><span id="tflops">28.4 TFlops</span></span>
           <span class="pill dark" style="font-size:10px;"><span class="dot"></span><span id="fused-size2">82 MB</span> LM head</span>
-          <span class="pill ok" style="font-size:10px;"><span class="dot"></span><span id="daily-clones-count">—</span> clones today</span>
+          <span class="pill ok" style="font-size:10px;"><span class="dot"></span><span id="visitors-count">—</span> visitors (14d)</span>
         </div>
         <div style="margin-top:8px;font-size:10px;color:var(--dim);font-family:var(--mono);text-align:center;">
-          daily clones via <a href="https://github.com/bong-water-water-bong/1bit-systems/graphs/traffic" style="color:var(--blue);">GitHub traffic API</a> · updated daily
+          unique visitors via <a href="https://github.com/bong-water-water-bong/1bit-systems/graphs/traffic" style="color:var(--blue);">GitHub traffic API</a> · 14-day window · updated daily
         </div>
       </div>
     </div>
@@ -279,7 +279,7 @@
     <div class="stat"><span class="lbl caps">Weight read</span><span class="val">436 <span>MB</span></span><span class="foot"><span class="dot" style="background:var(--green)"></span>−54% vs FP16 LM head</span></div>
     <div class="stat"><span class="lbl caps">LM head</span><span class="val">82 <span>MB</span></span><span class="foot"><span class="dot" style="background:var(--pink)"></span>TQ2 packed · was 621 MB</span></div>
     <div class="stat"><span class="lbl caps">Kernel tests</span><span class="val">5/6</span><span class="foot"><span class="dot" style="background:var(--green)"></span>RoPE fp16 tolerance</span></div>
-    <div class="stat"><span class="lbl caps">Daily clones</span><span class="val"><span id="daily-clones-stat">—</span></span><span class="foot"><span class="dot" style="background:var(--green)"></span>GitHub traffic API · <span id="daily-clones-total">6,459</span> total</span></div>
+    <div class="stat"><span class="lbl caps">Unique visitors</span><span class="val"><span id="visitors-stat">—</span></span><span class="foot"><span class="dot" style="background:var(--green)"></span>GitHub traffic API · 14d · <span id="views-total">—</span> views</span></div>
   </div>
   <p style="margin-top:24px;text-align:center;"><a href="https://github.com/bong-water-water-bong/1bit/blob/main/README.md" class="btn btn-ghost btn-md" target="_blank" rel="noopener">Full benchmarks →</a></p>
 </section>
@@ -448,7 +448,7 @@
     var links=nav&&nav.querySelectorAll('a');for(var j=0;links&&j<links.length;j++){links[j].addEventListener('click',function(){ham.classList.remove('open');nav.classList.remove('open');});}
   })();
 
-  // Single source of truth: /numbers.json + /daily-clones.json
+  // Single source of truth: /numbers.json + /audience.json
   (function(){
     var N={}; // populated from numbers.json
     var el=function(id){return document.getElementById(id);};
@@ -504,13 +504,19 @@
     };
     nx.send();
 
-    // Fetch daily clones badge (separate — updates daily)
+    // Fetch audience stats (separate — updates daily)
     var cx=new XMLHttpRequest();
-    cx.open('GET','/daily-clones.json',true);
+    cx.open('GET','/audience.json',true);
     cx.onload=function(){
-      try{var d=JSON.parse(cx.responseText),m=d.message||'?';set('daily-clones-count',m);set('daily-clones-hero',m+' clones');set('daily-clones-stat',m);}catch(e){}
+      try{
+        var d=JSON.parse(cx.responseText);
+        var v=d.unique_visitors_14d,s=d.stars,w=d.views_14d;
+        set('visitors-count',v);set('visitors-stat',v);
+        set('visitors-hero',v+' unique visitors (14d)');
+        set('stars-hero',s);set('views-total',w);
+      }catch(e){}
     };
-    cx.onerror=function(){set('daily-clones-count','?');set('daily-clones-hero','? clones');set('daily-clones-stat','?');};
+    cx.onerror=function(){set('visitors-count','?');set('visitors-hero','? unique visitors (14d)');set('visitors-stat','?');set('stars-hero','?');set('views-total','?');};
     cx.send();
   })();
 </script>

--- a/site/traffic-badge.json
+++ b/site/traffic-badge.json
@@ -1,7 +1,0 @@
-{
-  "schemaVersion": 1,
-  "label": "clones",
-  "message": "6113 (783 unique)",
-  "color": "brightgreen",
-  "cacheSeconds": 86400
-}

--- a/site/visitors.json
+++ b/site/visitors.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "label": "unique visitors (14d)",
+  "message": "36",
+  "color": "yellowgreen",
+  "cacheSeconds": 86400
+}


### PR DESCRIPTION
## Problem

The README badges and the site hero were publishing clone counts as if they measured adoption. They don't.

GitHub's traffic API counts every `actions/checkout` as a clone. Because each hosted runner is a fresh VM, CI checkouts also inflate the **unique cloner** count — so "just show uniques" doesn't fix it either.

Over the last 14 days:

| Metric | Value |
|---|---|
| Clones | 6,459 (816 "unique") |
| Views | 303 (36 unique) |
| Workflow runs since Jul 1 | 806 |

The clone curve tracks CI volume, not humans: the Jul 3 dip (25 runs → 266 clones) and the Jul 5–6 peak (144/168 runs → 1,102/1,019 clones) move together. Jul 2 reported 180 "unique cloners" on a day the site had 4 unique visitors.

The site was also rendering a **hardcoded** `6,459 total` in two places.

## Fix

Clones can't be de-duplicated against CI through any API, so this replaces them rather than trying to correct them.

- `traffic-badge.yml` → **Audience Badge**: reads `traffic/views` plus stars/forks, writes `site/visitors.json` (shields endpoint) and `site/audience.json` (site data).
- `README.md`: drop `clones today` / `clones:stars`; add unique-visitors, stars, forks badges.
- `site/index.html`: hero, pill, and stat tile now show unique visitors + stars; hardcoded `6,459` removed; JS fetches `/audience.json`.
- Deleted `site/{daily-clones,daily-clones-full,clones-stars,traffic-badge}.json`.

New JSON files are seeded with live values (36 visitors / 303 views / 9 stars / 4 forks) so the site isn't broken before the first scheduled run.

## Verification

- Workflow YAML parses; steps intact.
- Every `d.<key>` the page JS reads exists in `audience.json`; `visitors.json` has the four keys shields' endpoint schema requires.
- Served `site/` locally: `/audience.json` 200, `/visitors.json` 200, `/index.html` 200, `/daily-clones.json` now 404.
- All five new element ids are declared once and wired in both the `onload` and `onerror` paths.

Not verified: the scheduled workflow hasn't run yet, and the badge images render only once `visitors.json` is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace clone-based badges with 14‑day unique visitor metrics to avoid CI-inflated counts and show real audience. Updates the workflow, README, and site UI; removes obsolete clone badge JSON.

- **Bug Fixes**
  - Workflow: renamed to Audience Badge; reads traffic views + stars/forks; writes `site/visitors.json` (Shields endpoint) and `site/audience.json`.
  - README: removed clone badges; added unique-visitors, stars, and forks badges.
  - Site: hero/pill/stat now show unique visitors (14d) + stars; removed hardcoded total; JS fetches `/audience.json`.
  - Cleanup: deleted `site/daily-clones*.json`, `site/clones-stars.json`, `site/traffic-badge.json`; seeded new JSON to avoid broken badges before first run.

<sup>Written for commit 96e09f15f0ec30d98a683dcf8f469a0f143267a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bong-water-water-bong/1bit-systems/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

