### PR TITLE
fix(release): drop composablekernel-dev to fix apt 'held broken packages' (#100)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,32 +12,20 @@ jobs:
   server:
     name: Build release (Rust server + HIP kernels)
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    container: rocm/dev-ubuntu-24.04:7.2.4
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v5
-      - name: Install build deps + ROCm
+      # The stock ubuntu-24.04 runner's apt ROCm 7.2 repo is broken on noble
+      # (rocm-dev/hip-dev/composablekernel-dev all hit "held broken packages" — #100),
+      # so the release builds inside the official AMD ROCm image instead. That
+      # image ships /opt/rocm (HIP + amdclang), which CMakeLists.txt auto-detects
+      # via its system-ROCm fallback (L52-57). No apt ROCm install => no conflict.
+      # CK is optional in the build (skips ck_gemm.cpp if composable_kernel not found).
+      - name: Install build tools (git cmake ninja)
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq cmake ninja-build build-essential
-          wget -qO - https://repo.radeon.com/rocm/rocm.gpg.key \
-            | sudo gpg --dearmor -o /etc/apt/keyrings/rocm.gpg
-          # Use noble (Ubuntu 24.04) repo — jammy (22.04) repos may have
-          # missing or incompatible packages on the ubuntu-24.04 runner.
-          cat <<'ROCM_APT' | sudo tee /etc/apt/sources.list.d/rocm.list
-          deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/7.2 noble main
-          deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/graphics/7.2/ubuntu noble main
-          ROCM_APT
-          # composablekernel-dev dropped: optional (CMakeLists builds ck_gemm.cpp
-          # only if composable_kernel FOUND; release targets link hip::*, not CK
-          # — see CMakeLists L136-145,174-175,286,295). It was the apt conflict
-          # source ("held broken packages" on noble). Restore CK via pip TheRock
-          # SDK (rocm[devel,libraries]) if the CK GEMM path is needed later.
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq rocm-dev hip-dev
-
-      # ── Kernel engine (HIP/C++): librocm_cpp.so + bitnet_decode ──
-      # This is the actual inference engine. The Rust server below is a proxy
-      # that spawns `bitnet_decode --server`, so the release must ship both.
+          apt-get update -qq
+          apt-get install -y -qq git cmake ninja-build build-essential
+      - uses: actions/checkout@v5
       - name: Build HIP kernels + decode server
         run: |
           cmake -B build -G Ninja -DCMAKE_HIP_ARCHITECTURES=gfx1151

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
   server:
     name: Build release (Rust server + HIP kernels)
     runs-on: ubuntu-24.04
-    container: rocm/dev-ubuntu-24.04:7.2.4
-    timeout-minutes: 45
+    container: rocm/dev-ubuntu-24.04:7.2.4-complete   # complete = all ROCm libs (rocwmma/CK/rocBLAS) so headers like rocwmma/rocwmma.hpp resolve
+    timeout-minutes: 60
     steps:
       # The stock ubuntu-24.04 runner's apt ROCm 7.2 repo is broken on noble
       # (rocm-dev/hip-dev/composablekernel-dev all hit "held broken packages" — #100),

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:    # manual runs (branch builds) — Create Release is guarded to tag-only so no junk release is published
 
 permissions:
   contents: write
@@ -26,8 +27,13 @@ jobs:
           deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/7.2 noble main
           deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/graphics/7.2/ubuntu noble main
           ROCM_APT
+          # composablekernel-dev dropped: optional (CMakeLists builds ck_gemm.cpp
+          # only if composable_kernel FOUND; release targets link hip::*, not CK
+          # — see CMakeLists L136-145,174-175,286,295). It was the apt conflict
+          # source ("held broken packages" on noble). Restore CK via pip TheRock
+          # SDK (rocm[devel,libraries]) if the CK GEMM path is needed later.
           sudo apt-get update -qq
-          sudo apt-get install -y -qq rocm-dev hip-dev composablekernel-dev
+          sudo apt-get install -y -qq rocm-dev hip-dev
 
       # ── Kernel engine (HIP/C++): librocm_cpp.so + bitnet_decode ──
       # This is the actual inference engine. The Rust server below is a proxy
@@ -76,6 +82,7 @@ jobs:
           tar czf 1bit-linux-x86_64.tar.gz -C dist .
 
       - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')   # only on real tag pushes; skip manual workflow_dispatch runs
         uses: softprops/action-gh-release@v2
         with:
           files: 1bit-linux-x86_64.tar.gz


### PR DESCRIPTION
Fixes #100.

## Root cause
The `v2026.07.13-npu-consolidation` release build ([run 29290751109](https://github.com/bong-water-water-bong/1bit-systems/actions/runs/29290751109)) failed at `Install build deps + ROCm` with `E: Unable to correct problems, you have held broken packages` on the **ubuntu-24.04 noble** runner. The previous release (`v2026.07.08-ternary-npu`) succeeded with the identical step 5 days ago → an environment regression, not a code change (PRs #97/#98 only touched `npu-infer/`, which is not in the build path).

## Fix
1. **Drop `composablekernel-dev`** from the apt install — the heaviest dep and the conflict source. It is **optional**: `CMakeLists.txt` builds `ck_gemm.cpp` only `if(composable_kernel_FOUND)`, else uses the standalone prefill path (L136–145, 174–175). Release targets (`rocm_cpp`, `bitnet_decode`, `bench_prefill_variants`) link `hip::host`/`hip::device`, **not CK** (L286, 295) → shipped binaries are unaffected. Build degrades gracefully.
2. **Add `workflow_dispatch:`** so `release.yml` can be validated on a branch.
3. **Guard `Create Release`** with `if: startsWith(github.ref, 'refs/tags/')` so a manual `workflow_dispatch` run builds/packages but does **not** publish a junk release.

## Validation
I'll trigger a manual `workflow_dispatch` run of `release.yml` on this branch. `Create Release` will be skipped (guard) so nothing is published. If the HIP/C++ + Rust build & package succeed green → merge → re-tag `v2026.07.13-npu-consolidation` at new `main` → the real tag-push run publishes `1bit-linux-x86_64.tar.gz`.

## Restoring CK later (not in this PR)
If the CK GEMM path is wanted in releases again, install via the project's recommended **pip TheRock SDK** (`pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ rocm[devel,libraries]`) — `CMakeLists.txt` already detects that first (L5–62) and it provides CK without the broken apt repo.