### PR TITLE
Unified model→backend router + real GGUF correctness fixes (ZINC, FLM, GenericBackend)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,44 @@ if(ROCWMMA_FOUND)
 endif()
 target_sources(rocm_cpp PRIVATE src/prefill_dispatcher.cpp)
 
+# -- libzinc : ZINC GPU backend (github.com/zolotukhin/zinc, forked at
+#    /home/$USER/zinc — a genuinely separate project, NOT the stale vendored
+#    copy under engine/gpu in this repo). Built via its own C ABI shim
+#    (src/c_abi.zig in that checkout) into a shared library, linked into
+#    backend_zinc.cpp below. ------------------------------------------------
+set(ZINC_REPO_DIR "$ENV{HOME}/zinc" CACHE PATH "Path to the ZINC checkout")
+# zinc's build.zig currently requires Zig 0.15.x specifically (build.zig.zon:
+# minimum_zig_version 0.15.2) — newer 0.16+ toolchains hit real build.zig API
+# breaks (e.g. b.graph.env_map moved). Prefer a pinned 0.15.2 toolchain over
+# whatever `zig` resolves to on PATH, since that's commonly a newer version
+# via package managers that auto-track a "latest" channel.
+find_program(ZIG_0_15_EXECUTABLE zig
+    HINTS "$ENV{HOME}/.local/zig-0.15.2"
+    NO_DEFAULT_PATH)
+if(NOT ZIG_0_15_EXECUTABLE)
+    find_program(ZIG_0_15_EXECUTABLE zig)
+endif()
+set(ZINC_ENABLED FALSE)
+if(ZIG_0_15_EXECUTABLE AND EXISTS "${ZINC_REPO_DIR}/build.zig")
+    set(ZINC_ENABLED TRUE)
+    set(ZINC_LIB "${ZINC_REPO_DIR}/zig-out/lib/libzinc.so")
+    # zinc's full `zig build` also builds unrelated, currently-broken training
+    # shader targets (missing .comp source files, pre-existing and unrelated
+    # to inference/libzinc.so) that make the overall command exit nonzero even
+    # when libzinc.so itself built fine. Don't propagate that unrelated
+    # failure — just verify the one artifact we actually need exists after.
+    add_custom_command(
+        OUTPUT "${ZINC_LIB}"
+        COMMAND sh -c "'${ZIG_0_15_EXECUTABLE}' build -Doptimize=ReleaseFast; test -f '${ZINC_LIB}'"
+        WORKING_DIRECTORY "${ZINC_REPO_DIR}"
+        DEPENDS "${ZINC_REPO_DIR}/src/c_abi.zig" "${ZINC_REPO_DIR}/build.zig"
+        COMMENT "Building libzinc.so from ${ZINC_REPO_DIR} (zig build)"
+        VERBATIM)
+    add_custom_target(zinc_lib DEPENDS "${ZINC_LIB}")
+else()
+    message(STATUS "ZINC backend disabled: need a Zig 0.15.x toolchain and a checkout at ${ZINC_REPO_DIR} (git clone https://github.com/zolotukhin/zinc)")
+endif()
+
 # -- libbackend_manager : Pure C++ backend abstraction layer (no HIP) ---------
 add_library(backend_manager STATIC
     src/backend_factory.cpp
@@ -227,14 +265,24 @@ add_library(backend_manager STATIC
     src/backend_plugin.cpp
     src/backend_cpu.cpp
     src/backend_generic.cpp
+    src/backend_flm.cpp
+    src/simple_tokenizer.cpp
     src/model_discovery.cpp)
 target_include_directories(backend_manager PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 target_include_directories(backend_manager PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
-target_link_libraries(backend_manager PUBLIC dl)
+target_link_libraries(backend_manager PUBLIC dl rocm_cpp)
 target_compile_options(backend_manager PRIVATE -O3 -Wall -Wno-unused-result -std=c++17)
+
+if(ZINC_ENABLED)
+    target_sources(backend_manager PRIVATE src/backend_zinc.cpp)
+    add_dependencies(backend_manager zinc_lib)
+    target_link_libraries(backend_manager PUBLIC "${ZINC_LIB}")
+else()
+    target_compile_definitions(backend_manager PRIVATE ZINC_DISABLED=1)
+endif()
 
 set(RCPP_HIP_SOURCES ${RCPP_SOURCES} src/prefill_dispatcher.cpp)
 list(FILTER RCPP_HIP_SOURCES INCLUDE REGEX "\\.hip$|prefill_dispatcher\\.cpp$")
@@ -440,12 +488,16 @@ add_executable(unified_server
     src/backend_hip.cpp
     src/zaya_engine.cpp
     src/backend_npu.cpp
-    src/backend_generic.cpp)
+    src/backend_generic.cpp
+    src/model_router.cpp
+    src/backend_flm.cpp)
 set_source_files_properties(src/backend_hip.cpp PROPERTIES LANGUAGE HIP)
 set_source_files_properties(src/zaya_engine.cpp PROPERTIES LANGUAGE HIP)
 set_source_files_properties(src/backend_generic.cpp PROPERTIES LANGUAGE CXX)
 set_source_files_properties(tools/unified_server.cpp PROPERTIES LANGUAGE CXX)
 set_source_files_properties(src/backend_npu.cpp PROPERTIES LANGUAGE CXX)
+set_source_files_properties(src/model_router.cpp PROPERTIES LANGUAGE CXX)
+set_source_files_properties(src/backend_flm.cpp PROPERTIES LANGUAGE CXX)
 target_include_directories(unified_server PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
@@ -461,6 +513,11 @@ target_link_libraries(unified_server PRIVATE
     rocm_cpp hip::host hip::device)
 target_link_options(unified_server PRIVATE -rdynamic)
 set_target_properties(unified_server PROPERTIES HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
+if(ZINC_ENABLED)
+    set_target_properties(unified_server PROPERTIES
+        INSTALL_RPATH "${ZINC_REPO_DIR}/zig-out/lib"
+        BUILD_RPATH "${ZINC_REPO_DIR}/zig-out/lib")
+endif()
 
 add_custom_target(zaya_agent ALL
     DEPENDS unified_server
@@ -476,6 +533,11 @@ add_executable(backend_demo tools/backend_demo.cpp)
 target_include_directories(backend_demo PRIVATE src/)
 target_compile_options(backend_demo PRIVATE -O3 -Wall -Wno-unused-result -std=c++17)
 target_link_libraries(backend_demo PRIVATE backend_manager dl)
+if(ZINC_ENABLED)
+    set_target_properties(backend_demo PROPERTIES
+        INSTALL_RPATH "${ZINC_REPO_DIR}/zig-out/lib"
+        BUILD_RPATH "${ZINC_REPO_DIR}/zig-out/lib")
+endif()
 
 add_executable(bitnet_tui tools/bitnet_tui.cpp)
 target_link_libraries(bitnet_tui PRIVATE

--- a/include/backend_manager.h
+++ b/include/backend_manager.h
@@ -43,6 +43,9 @@ struct BackendInfo {
     float score;               // benchmark score (ms/token, 0 = untested)
     bool available;            // detected at startup
     bool functional;           // passed health check
+    bool auto_selectable = true; // false = never tried by init()'s auto-loop or
+                                  // select_best() (see docs/GEMM-KERNEL-CORRECTNESS-CONFIRMED.md);
+                                  // true manual opt-in needs on-demand lazy init, not yet built
     uint64_t total_inferences; // lifetime counter
     uint64_t failed_inferences;
     double cumulative_ms;      // total inference time in ms
@@ -92,6 +95,11 @@ public:
     void discover();
     /// Initialize the selected backend(s) and load weights
     bool init(const ModelConfig& cfg, const std::string& weights_dir);
+    /// Same, but try backend ids in `preferred_ids` order first (falling back to
+    /// normal priority order for anything not in the list, or if all preferred
+    /// ids fail). Empty preferred_ids behaves exactly like the two-arg overload.
+    bool init(const ModelConfig& cfg, const std::string& weights_dir,
+              const std::vector<std::string>& preferred_ids);
     /// Destroy all backends
     void destroy();
 
@@ -157,6 +165,10 @@ private:
     // Internal backend lifecycle (GPU/NPU via dlsym, CPU linked in)
     Backend* create_instance_rt(const BackendInfo& info);
     void destroy_instance(BackendInfo& info);
+    // Shared by both init() overloads: try backends_[order[i]] in sequence.
+    // Caller must hold mtx_.
+    bool init_in_order(const ModelConfig& cfg, const std::string& weights_dir,
+                        const std::vector<size_t>& order);
 
     // Try next backend in fallback chain
     bool failover();

--- a/include/common.h
+++ b/include/common.h
@@ -13,6 +13,9 @@ enum class BackendType : uint8_t {
     GENERIC = 6,
     ZAMBA2 = 7,   // Zamba2 hybrid Mamba2+attention (CPU ref)
     ZAMBA2_GPU = 8, // Zamba2 with HIP acceleration
+    ZINC_GPU = 9,   // General GGUF backend via engine/gpu (ZINC), multi-arch/multi-quant
+    NPU_FLM = 10,   // NPU inference via FastFlowLM subprocess (in-process kernels are broken, see docs/GEMM-KERNEL-CORRECTNESS-CONFIRMED.md)
+    Q4NX_FUSION = 11, // Q4NX format via engine/fusion, forced cpu_only policy
 };
 
 inline const char* backend_name(BackendType t) {
@@ -22,11 +25,24 @@ inline const char* backend_name(BackendType t) {
         case BackendType::NPU_XRT: return "NPU XDNA (XRT)";
         case BackendType::CPU_AVX512: return "CPU AVX-512";
         case BackendType::CPU_SCALAR: return "CPU (scalar)";
+        case BackendType::GENERIC: return "Generic CPU (GGUF)";
         case BackendType::ZAMBA2: return "Zamba2 (Mamba2 CPU)";
         case BackendType::ZAMBA2_GPU: return "Zamba2 (Mamba2 GPU)";
+        case BackendType::ZINC_GPU: return "ZINC GPU (Vulkan, multi-arch)";
+        case BackendType::NPU_FLM: return "NPU via FastFlowLM";
+        case BackendType::Q4NX_FUSION: return "Q4NX Fusion (CPU)";
         default: return "none";
     }
 }
+
+enum class ModelFormat : uint8_t {
+    UNKNOWN = 0,
+    GGUF = 1,
+    H1B = 2,
+    Q4NX = 3,
+    SAFETENSORS = 4,
+    RAW_BIN = 5,
+};
 
 struct ModelConfig {
     int hidden            = 2048;
@@ -59,4 +75,9 @@ struct ModelConfig {
     std::string model_path;
     std::string weights_dir;
     std::string lora_path;   // optional .lora file for adapter merge
+
+    ModelFormat format = ModelFormat::UNKNOWN;
+    std::string architecture;   // e.g. "llama", "qwen2", "qwen3", "gemma", "phi3", "zaya1" — from
+                                 // general.architecture (GGUF) or format-specific header, NOT model_name
+    std::string quantization;   // best-effort, e.g. "Q4_K_M", "Q8_0", "F16", "ternary"
 };

--- a/include/model_router.h
+++ b/include/model_router.h
@@ -1,0 +1,24 @@
+#pragma once
+// model_router.h — model -> backend selection.
+//
+// Given a discovered ModelConfig, decides which Backend(s) (by BackendManager
+// id, in preference order) should try to handle it. This is a static table in
+// the spirit of engine/fusion/arch_registry.zig's architecture registry,
+// ported to C++: it only decides ORDER, reusing BackendManager's existing
+// try-until-one-succeeds init loop (see BackendManager::init's preferred_ids
+// overload) rather than introducing a new selection primitive.
+//
+// npu_xrt is deliberately never returned here — its GEMM kernels are confirmed
+// broken (docs/GEMM-KERNEL-CORRECTNESS-CONFIRMED.md) and it stays manual-opt-in
+// only (see BackendInfo::auto_selectable in backend_manager.h).
+
+#include "common.h"
+#include <string>
+#include <vector>
+
+struct BackendRoute {
+    std::vector<std::string> backend_ids_in_order;
+    std::string reason; // human-readable, for logging
+};
+
+BackendRoute select_backend_route(const ModelConfig& cfg);

--- a/include/q4nx_reader.h
+++ b/include/q4nx_reader.h
@@ -1,0 +1,150 @@
+#pragma once
+// q4nx_reader.h — shared reader for the Q4NX model format.
+//
+// Q4NX uses a safetensors-style container: 8-byte little-endian header length,
+// then a JSON header mapping tensor name -> {dtype, shape, data_offsets}, then
+// raw tensor data. There is no top-level architecture/config field — dimensions
+// and architecture must be derived from tensor names/shapes (matching how
+// engine/fusion/model_data.zig's deriveConfig() works).
+
+#include "common.h"
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+// ── Q4NX model reader ──
+// Reads float32 weights from the mmap'd model file by JSON key lookup.
+// The model file is an indexed format: JSON header with data_offsets, then
+// raw float32 weight data at those offsets.
+struct Q4nxReader {
+    const char* data = nullptr;
+    size_t size = 0;
+
+    bool open(const std::string& path) {
+        int fd = ::open(path.c_str(), O_RDONLY);
+        if (fd < 0) { perror("Q4NX: open model"); return false; }
+        struct stat st;
+        fstat(fd, &st);
+        data = (const char*)mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+        size = st.st_size;
+        ::close(fd);  // global POSIX close, not the member function
+        if (data == MAP_FAILED) { perror("Q4NX: mmap model"); data = nullptr; return false; }
+        return true;
+    }
+
+    void close() {
+        if (data && size > 0) { munmap((void*)data, size); data = nullptr; size = 0; }
+    }
+
+    // Find data offset for a JSON key in the model header
+    // Uses standard C string search instead of GNU memmem extension.
+    uint64_t find_offset(const char* key) const {
+        if (!data || !key) return 0;
+        size_t kl = strlen(key);
+        if (kl == 0) return 0;
+        const char* p = data;
+        const char* e = data + (size > 65536 ? 65536 : size); // header within first 64KB
+        while (p + kl <= e) {
+            // Find first character match
+            const char* q = (const char*)memchr(p, key[0], e - p);
+            if (!q || q + kl > e) return 0;
+            // Check full key match
+            if (memcmp(q, key, kl) == 0) {
+                if (q > data && *(q - 1) == '"' && *(q + kl) == '"') {
+                    const char* o = strstr(q, "\"data_offsets\"");
+                    if (o) {
+                        const char* a = strchr(o, '[');
+                        if (a) return strtoull(a + 1, NULL, 10);
+                    }
+                }
+                p = q + 1;
+            } else {
+                p = q + 1;
+            }
+        }
+        return 0;
+    }
+
+    // Read float32 array at offset into a vector
+    std::vector<float> read_floats(uint64_t offset, size_t count) const {
+        std::vector<float> v;
+        if (!data || offset == 0 || offset + count * 4 > size) return v;
+        v.resize(count);
+        memcpy(v.data(), data + offset, count * sizeof(float));
+        return v;
+    }
+};
+
+// Best-effort metadata extraction for model discovery: dims from the embedding
+// tensor's shape, layer count from the highest "model.layers.N." index seen,
+// quantization from the embedding tensor's dtype string, architecture from the
+// filename (Q4NX has no self-describing architecture field — same convention
+// engine/fusion's model_tag already relies on).
+inline bool read_q4nx_metadata(const std::string& path, ModelConfig& cfg) {
+    Q4nxReader r;
+    if (!r.open(path)) return false;
+    if (r.size < 16) { r.close(); return false; }
+
+    uint64_t hdr_len = 0;
+    memcpy(&hdr_len, r.data, 8);
+    if (hdr_len == 0 || 8 + hdr_len > r.size || hdr_len > (r.size > 65536 ? 65536 : r.size)) {
+        r.close();
+        return false; // not a Q4NX/safetensors-style header
+    }
+    std::string header(r.data + 8, (size_t)hdr_len);
+
+    // Embedding tensor gives [vocab, hidden] and dtype.
+    auto find_shape_after = [&](const std::string& needle, int& a, int& b) -> bool {
+        auto pos = header.find(needle);
+        if (pos == std::string::npos) return false;
+        auto shape_pos = header.find("\"shape\":[", pos);
+        if (shape_pos == std::string::npos) return false;
+        shape_pos += strlen("\"shape\":[");
+        return sscanf(header.c_str() + shape_pos, "%d,%d", &a, &b) == 2;
+    };
+    int vocab = 0, hidden = 0;
+    if (find_shape_after("\"model.embed_tokens.weight\"", vocab, hidden) ||
+        find_shape_after("\"lm_head.weight\"", vocab, hidden)) {
+        cfg.vocab = cfg.vocab_size = vocab;
+        cfg.hidden = cfg.hidden_size = hidden;
+    }
+
+    // Layer count: highest "model.layers.N." index + 1.
+    int max_layer = -1;
+    size_t search = 0;
+    const std::string marker = "\"model.layers.";
+    while ((search = header.find(marker, search)) != std::string::npos) {
+        int n = atoi(header.c_str() + search + marker.size());
+        if (n > max_layer) max_layer = n;
+        search += marker.size();
+    }
+    if (max_layer >= 0) cfg.n_layers = cfg.num_layers = max_layer + 1;
+
+    // Quantization: dtype of the first tensor found.
+    auto dtype_pos = header.find("\"dtype\":\"");
+    if (dtype_pos != std::string::npos) {
+        dtype_pos += strlen("\"dtype\":\"");
+        auto end = header.find('"', dtype_pos);
+        if (end != std::string::npos) cfg.quantization = header.substr(dtype_pos, end - dtype_pos);
+    }
+
+    // Architecture: best-effort from filename (no self-describing field in Q4NX).
+    // Split on '-'/'_' only, not digits — real GGUF architecture tags keep the
+    // version digit as part of the name (e.g. "qwen3", "zaya1"), so match that.
+    auto slash = path.find_last_of('/');
+    auto dot = path.find_last_of('.');
+    std::string base = path.substr(slash + 1, (dot == std::string::npos ? path.size() : dot) - slash - 1);
+    auto sep = base.find_first_of("-_");
+    cfg.architecture = sep == std::string::npos ? base : base.substr(0, sep);
+    cfg.model_name = base;
+    cfg.model_path = path;
+    cfg.format = ModelFormat::Q4NX;
+
+    r.close();
+    return true;
+}

--- a/include/simple_tokenizer.h
+++ b/include/simple_tokenizer.h
@@ -1,0 +1,122 @@
+#pragma once
+// simple_tokenizer.h — shared tokenizer wrapper, extracted from
+// tools/unified_server.cpp so backends that need to bridge token IDs to text
+// (e.g. FlmBackend, which talks to an external text-only subprocess) can use
+// the exact same vocabulary as the rest of the server. Uses the RCPP BPE
+// tokenizer (.htok) when available, falls back to ASCII/UTF-8 byte
+// passthrough when not — behavior unchanged from the original inline struct.
+
+#include "rocm_cpp/tokenizer.h"
+#include <string>
+#include <vector>
+#include <cstdio>
+
+struct SimpleTokenizer {
+    int bos_id = 2;
+    int eos_id = 1;
+    bool use_bpe = false;
+    rcpp_tokenizer_t* bpe_tok = nullptr;
+
+    bool load(const std::string& vocab_path) {
+        if (vocab_path.size() >= 5 && vocab_path.substr(vocab_path.size() - 5) == ".htok") {
+            rcpp_tokenizer_t* tok = nullptr;
+            rcpp_status_t st = rcpp_tokenizer_load(vocab_path.c_str(), &tok);
+            if (st == RCPP_OK && tok) {
+                bpe_tok = tok;
+                use_bpe = true;
+                bos_id = rcpp_tokenizer_bos_id(bpe_tok);
+                eos_id = rcpp_tokenizer_eos_id(bpe_tok);
+                fprintf(stderr, "Loaded BPE tokenizer from %s (BOS=%d, EOS=%d)\n",
+                        vocab_path.c_str(), bos_id, eos_id);
+                return true;
+            }
+            fprintf(stderr, "Failed to load BPE tokenizer from %s\n", vocab_path.c_str());
+        }
+        fprintf(stderr, "No .htok at %s — using fallback ASCII tokenizer\n", vocab_path.c_str());
+        return false;
+    }
+
+    ~SimpleTokenizer() {
+        if (bpe_tok) rcpp_tokenizer_free(bpe_tok);
+    }
+
+    std::vector<int> encode(const std::string& text) {
+        if (use_bpe && bpe_tok) {
+            std::vector<int> r(4096);
+            size_t out_n = 0;
+            rcpp_status_t st = rcpp_tokenizer_encode(bpe_tok, text.c_str(), text.size(),
+                                                      1, r.data(), r.size(), &out_n);
+            if (st == RCPP_OK && out_n > 0) {
+                r.resize(out_n);
+                return r;
+            }
+            return {bos_id};
+        }
+        // Fallback: ASCII + UTF-8 byte passthrough
+        std::vector<int> r = {bos_id};
+        for (unsigned char c : text) {
+            if (c >= 32 && c <= 126)
+                r.push_back((int)c + 100);
+            else if (c != 0)
+                r.push_back((int)c + 200);
+        }
+        return r;
+    }
+
+    /// Encode with per-token log-probabilities (for cascade strategy).
+    /// Returns token IDs and fills logprobs_out with corresponding logprobs.
+    std::vector<int> encode_with_logprobs(const std::string& text,
+                                           std::vector<double>& logprobs_out) {
+        logprobs_out.clear();
+        if (use_bpe && bpe_tok) {
+            std::vector<int> r(4096);
+            std::vector<double> lp(4096);
+            size_t out_n = 0;
+            rcpp_status_t st = rcpp_tokenizer_encode_with_logprobs(
+                bpe_tok, text.c_str(), text.size(),
+                1, r.data(), lp.data(), r.size(), &out_n);
+            if (st == RCPP_OK && out_n > 0) {
+                r.resize(out_n);
+                logprobs_out.assign(lp.begin(), lp.begin() + out_n);
+                return r;
+            }
+            return {bos_id};
+        }
+        // Fallback: encode without logprobs
+        auto tokens = encode(text);
+        logprobs_out.resize(tokens.size(), -1.0);
+        return tokens;
+    }
+
+    std::string decode(const std::vector<int>& tokens) {
+        if (use_bpe && bpe_tok) {
+            std::string r(4096, '\0');
+            size_t out_len = 0;
+            rcpp_status_t st = rcpp_tokenizer_decode(bpe_tok, tokens.data(), tokens.size(),
+                                                      r.data(), r.size(), &out_len);
+            if (st == RCPP_OK && out_len > 0) {
+                r.resize(out_len);
+                return r;
+            }
+            return "";
+        }
+        // Fallback: ASCII + UTF-8 byte passthrough
+        std::string r;
+        for (int v : tokens) {
+            if (v == bos_id || v == eos_id) continue;
+            if (v > 100 && v < 200)
+                r += (char)(v - 100);
+            else if (v > 200 && v < 456)
+                r += (char)(v - 200);
+            else {
+                r += '['; r += std::to_string(v); r += ']';
+            }
+        }
+        return r;
+    }
+};
+
+// Shared global instance — defined once in tools/unified_server.cpp, used
+// there and by any backend (e.g. FlmBackend) that needs to bridge token IDs
+// to text using the exact same vocabulary the rest of the server uses.
+extern SimpleTokenizer g_tokenizer;

--- a/include/simple_tokenizer.h
+++ b/include/simple_tokenizer.h
@@ -2,20 +2,73 @@
 // simple_tokenizer.h — shared tokenizer wrapper, extracted from
 // tools/unified_server.cpp so backends that need to bridge token IDs to text
 // (e.g. FlmBackend, which talks to an external text-only subprocess) can use
-// the exact same vocabulary as the rest of the server. Uses the RCPP BPE
-// tokenizer (.htok) when available, falls back to ASCII/UTF-8 byte
-// passthrough when not — behavior unchanged from the original inline struct.
+// the exact same vocabulary as the rest of the server.
+//
+// Three tokenizer sources, in priority order:
+//   1. ZINC's GGUF-native BPE tokenizer (load_from_gguf) — reads the real
+//      vocab embedded in the active model's own GGUF file, so arbitrary
+//      downloaded models get correct tokenization with no extra files
+//      needed. Requires the ZINC integration (see CMakeLists.txt
+//      ZINC_ENABLED) — falls through when unavailable.
+//   2. RCPP BPE tokenizer (.htok) — the project's own Zaya-specific format.
+//   3. ASCII/UTF-8 byte passthrough — last-resort fallback, degrades badly
+//      for real vocabularies (kept only so the server never hard-fails).
 
 #include "rocm_cpp/tokenizer.h"
 #include <string>
 #include <vector>
 #include <cstdio>
+#include <cstdint>
+#include <cstddef>
+
+#ifndef ZINC_DISABLED
+extern "C" {
+    void* zinc_tokenizer_init(const char* gguf_path);
+    void zinc_tokenizer_destroy(void* state);
+    uint32_t zinc_tokenizer_bos_id(void* state);
+    uint32_t zinc_tokenizer_eos_id(void* state);
+    long long zinc_tokenizer_encode(void* state, const char* text, uint32_t* out_ids, size_t out_cap);
+    long long zinc_tokenizer_decode(void* state, const uint32_t* ids, size_t n_ids, char* out_buf, size_t out_cap);
+}
+#endif
 
 struct SimpleTokenizer {
     int bos_id = 2;
     int eos_id = 1;
     bool use_bpe = false;
     rcpp_tokenizer_t* bpe_tok = nullptr;
+    bool use_gguf_native = false;
+#ifndef ZINC_DISABLED
+    void* gguf_tok_state = nullptr;
+#endif
+
+    // Try loading the real tokenizer embedded in a GGUF file (ZINC's native
+    // BPE tokenizer). Returns false (leaving any existing tokenizer state
+    // untouched) if ZINC isn't built in, the path isn't a GGUF file, or it
+    // has no embedded vocab — caller should keep using whatever was loaded
+    // before, not treat this as fatal.
+    bool load_from_gguf(const std::string& gguf_path) {
+#ifndef ZINC_DISABLED
+        if (gguf_path.size() < 5 || gguf_path.substr(gguf_path.size() - 5) != ".gguf")
+            return false;
+        void* st = zinc_tokenizer_init(gguf_path.c_str());
+        if (!st) {
+            fprintf(stderr, "SimpleTokenizer: no usable embedded vocab in %s\n", gguf_path.c_str());
+            return false;
+        }
+        unload_gguf_native();
+        gguf_tok_state = st;
+        use_gguf_native = true;
+        bos_id = (int)zinc_tokenizer_bos_id(st);
+        eos_id = (int)zinc_tokenizer_eos_id(st);
+        fprintf(stderr, "Loaded GGUF-native tokenizer from %s (BOS=%d, EOS=%d)\n",
+                gguf_path.c_str(), bos_id, eos_id);
+        return true;
+#else
+        (void)gguf_path;
+        return false;
+#endif
+    }
 
     bool load(const std::string& vocab_path) {
         if (vocab_path.size() >= 5 && vocab_path.substr(vocab_path.size() - 5) == ".htok") {
@@ -36,11 +89,27 @@ struct SimpleTokenizer {
         return false;
     }
 
+    void unload_gguf_native() {
+#ifndef ZINC_DISABLED
+        if (gguf_tok_state) { zinc_tokenizer_destroy(gguf_tok_state); gguf_tok_state = nullptr; }
+#endif
+        use_gguf_native = false;
+    }
+
     ~SimpleTokenizer() {
         if (bpe_tok) rcpp_tokenizer_free(bpe_tok);
+        unload_gguf_native();
     }
 
     std::vector<int> encode(const std::string& text) {
+#ifndef ZINC_DISABLED
+        if (use_gguf_native && gguf_tok_state) {
+            std::vector<uint32_t> r(4096);
+            long long n = zinc_tokenizer_encode(gguf_tok_state, text.c_str(), r.data(), r.size());
+            if (n > 0) return std::vector<int>(r.begin(), r.begin() + n);
+            return {bos_id};
+        }
+#endif
         if (use_bpe && bpe_tok) {
             std::vector<int> r(4096);
             size_t out_n = 0;
@@ -82,13 +151,23 @@ struct SimpleTokenizer {
             }
             return {bos_id};
         }
-        // Fallback: encode without logprobs
+        // Fallback (also used for GGUF-native, which has no logprob API):
+        // encode without logprobs
         auto tokens = encode(text);
         logprobs_out.resize(tokens.size(), -1.0);
         return tokens;
     }
 
     std::string decode(const std::vector<int>& tokens) {
+#ifndef ZINC_DISABLED
+        if (use_gguf_native && gguf_tok_state) {
+            std::vector<uint32_t> ids(tokens.begin(), tokens.end());
+            std::string r(8192, '\0');
+            long long n = zinc_tokenizer_decode(gguf_tok_state, ids.data(), ids.size(), r.data(), r.size());
+            if (n >= 0) { r.resize(n); return r; }
+            return "";
+        }
+#endif
         if (use_bpe && bpe_tok) {
             std::string r(4096, '\0');
             size_t out_len = 0;
@@ -116,7 +195,8 @@ struct SimpleTokenizer {
     }
 };
 
-// Shared global instance — defined once in tools/unified_server.cpp, used
-// there and by any backend (e.g. FlmBackend) that needs to bridge token IDs
-// to text using the exact same vocabulary the rest of the server uses.
+// Shared global instance — defined once in src/simple_tokenizer.cpp, used
+// by unified_server.cpp and by any backend (e.g. FlmBackend) that needs to
+// bridge token IDs to text using the exact same vocabulary the rest of the
+// server uses.
 extern SimpleTokenizer g_tokenizer;

--- a/src/backend.h
+++ b/src/backend.h
@@ -71,6 +71,13 @@ extern "C" Backend* create_hip_backend();
 // ── NPU backend ──
 Backend* create_npu_backend();
 
+// ── NPU via FastFlowLM subprocess (see docs/GEMM-KERNEL-CORRECTNESS-CONFIRMED.md
+// for why this exists instead of the in-process NPU kernels) ──
+extern "C" Backend* create_flm_backend();
+
+// ── ZINC backend (general GGUF, multi-arch/multi-quant, via libzinc.so) ──
+Backend* create_zinc_backend();
+
 // ── Zamba2 backend ──
 Backend* create_zamba2_backend();
 

--- a/src/backend_flm.cpp
+++ b/src/backend_flm.cpp
@@ -1,0 +1,311 @@
+// backend_flm.cpp — NPU inference via the FastFlowLM (FLM) subprocess.
+//
+// The project's own in-process NPU GEMM kernels are confirmed producing wrong
+// output on real hardware (docs/GEMM-KERNEL-CORRECTNESS-CONFIRMED.md) — this
+// backend exists specifically to give NPU-class models a *working* path while
+// that's unresolved, by shelling out to AMD's FastFlowLM (github.com/amd/fastflowlm)
+// instead. Ported from the prototype at tests/backends/backend_npu_flm.cpp
+// (InferenceBackend interface, toy char-offset "tokenizer") to the canonical
+// Backend interface with real tokenizer bridging via the shared g_tokenizer
+// (include/simple_tokenizer.h) — same vocabulary the rest of the server uses,
+// so FLM's text output round-trips through re-tokenization correctly.
+//
+// Known architectural compromise, not a bug: FLM has no per-token logits API,
+// only a whole-turn text REPL. This backend queries FLM for a fresh completion
+// every time it sees new (non-self-generated) token content, and streams the
+// re-tokenized response back one real token at a time. That means it re-queries
+// once per prompt token during prefill (each such call's return value is
+// discarded by the caller anyway — see tools/unified_server.cpp's
+// generate_completion() prefill loop) rather than once per turn. Correct, but
+// not maximally efficient; a natural follow-up is widening the Backend
+// interface with an explicit prefill/decode boundary so this can query FLM
+// exactly once per turn instead.
+
+#include "backend.h"
+#include "backend_detect.h"
+#include "simple_tokenizer.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cctype>
+#include <string>
+#include <vector>
+#include <chrono>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/select.h>
+#include <fcntl.h>
+#include <signal.h>
+
+struct FlmBackend : Backend {
+    std::string flm_bin_ = "/opt/fastflowlm/bin/flm";
+    std::string model_tag_ = "qwen3:0.6b";
+    int ready_timeout_s_ = 45;
+    int query_timeout_ms_ = 120000;
+
+    pid_t pid_ = -1;
+    int stdin_fd_ = -1, stdout_fd_ = -1, stderr_fd_ = -1;
+
+    // Per-turn state
+    std::vector<int> prompt_tokens_;
+    std::vector<int> response_tokens_;
+    size_t response_pos_ = 0;
+    int last_returned_ = -1;
+
+    FlmBackend() { type = BackendType::NPU_FLM; name = "NPU via FastFlowLM"; }
+    ~FlmBackend() override { destroy(); }
+
+    bool find_flm_bin() {
+        if (access(flm_bin_.c_str(), X_OK) == 0) return true;
+        flm_bin_ = "/usr/bin/flm";
+        return access(flm_bin_.c_str(), X_OK) == 0;
+    }
+
+    // FLM only serves its own bundled Qwen3 catalog, keyed by size tag —
+    // not a general GGUF engine. Only route qwen3-architecture models here
+    // (see model_router.h); this mapping picks the closest shipped size.
+    static std::string tag_for_hidden(int hidden) {
+        if (hidden <= 1024) return "qwen3:0.6b";
+        if (hidden <= 1536) return "qwen3:1.7b";
+        if (hidden <= 2560) return "qwen3:4b";
+        return "qwen3:8b";
+    }
+
+    bool init(const ModelConfig& model_cfg, const std::string& weights_dir) override {
+        (void)weights_dir;
+        cfg = model_cfg;
+        destroy();
+
+        if (cfg.architecture != "qwen3") {
+            fprintf(stderr, "FLM: architecture '%s' not in FLM's catalog (qwen3 only)\n",
+                    cfg.architecture.c_str());
+            return false;
+        }
+        if (!has_npu()) { fprintf(stderr, "FLM: no XDNA NPU detected\n"); return false; }
+        if (!find_flm_bin()) { fprintf(stderr, "FLM: flm binary not found\n"); return false; }
+
+        model_tag_ = tag_for_hidden(cfg.hidden);
+        fprintf(stderr, "FLM: launching %s...\n", model_tag_.c_str());
+
+        int to_child[2], from_child[2], err_child[2];
+        if (pipe(to_child) || pipe(from_child) || pipe(err_child)) return false;
+
+        pid_ = fork();
+        if (pid_ == 0) {
+            dup2(to_child[0], STDIN_FILENO);
+            dup2(from_child[1], STDOUT_FILENO);
+            dup2(err_child[1], STDERR_FILENO);
+            close(to_child[0]); close(to_child[1]);
+            close(from_child[0]); close(from_child[1]);
+            close(err_child[0]); close(err_child[1]);
+            execl(flm_bin_.c_str(), "flm", "run", model_tag_.c_str(), nullptr);
+            _exit(1);
+        }
+        close(to_child[0]); close(from_child[1]); close(err_child[1]);
+        stdin_fd_ = to_child[1];
+        stdout_fd_ = from_child[0];
+        stderr_fd_ = err_child[0];
+
+        // Wait for the ">>> " prompt — model load takes several seconds.
+        std::string buf; char c;
+        auto t0 = std::chrono::steady_clock::now();
+        bool ready = false;
+        while (std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::steady_clock::now() - t0).count() < ready_timeout_s_) {
+            fd_set fds; FD_ZERO(&fds); FD_SET(stdout_fd_, &fds);
+            struct timeval tv = {1, 0};
+            if (select(stdout_fd_ + 1, &fds, nullptr, nullptr, &tv) > 0) {
+                if (read(stdout_fd_, &c, 1) > 0) {
+                    buf += c;
+                    if (buf.size() >= 4 && buf.substr(buf.size() - 4) == ">>> ") { ready = true; break; }
+                }
+            }
+        }
+        // Drain stderr for visibility (FLM prints load progress there).
+        char drain[4096];
+        for (;;) {
+            fd_set fds; FD_ZERO(&fds); FD_SET(stderr_fd_, &fds);
+            struct timeval tv = {0, 0};
+            if (select(stderr_fd_ + 1, &fds, nullptr, nullptr, &tv) <= 0) break;
+            int n = read(stderr_fd_, drain, sizeof(drain) - 1);
+            if (n <= 0) break;
+            drain[n] = 0;
+            fprintf(stderr, "%s", drain);
+        }
+        if (!ready) { fprintf(stderr, "FLM: init timeout\n"); destroy(); return false; }
+
+        initialized = true;
+        fprintf(stderr, "FLM: ready (%s)\n", model_tag_.c_str());
+        return true;
+    }
+
+    bool reset() override {
+        prompt_tokens_.clear();
+        response_tokens_.clear();
+        response_pos_ = 0;
+        last_returned_ = -1;
+        return true;
+    }
+
+    // FLM's REPL interleaves the real answer with "[FLM] ..." progress/log
+    // lines (some ANSI-colored) and repeats the answer a second time under
+    // a "[FLM]  Model RAW Output:" marker. Extract just the first clean,
+    // non-"[FLM]" span of text — everything from after the leading log
+    // lines up to the next "[FLM]" line (real behavior verified by
+    // capturing raw output directly: `flm run <tag>` piped input/output).
+    static std::string strip_ansi(const std::string& s) {
+        std::string out;
+        out.reserve(s.size());
+        for (size_t i = 0; i < s.size(); i++) {
+            if ((unsigned char)s[i] == 0x1b && i + 1 < s.size() && s[i + 1] == '[') {
+                size_t j = i + 2;
+                while (j < s.size() && !isalpha((unsigned char)s[j])) j++;
+                i = j; // skip terminating letter too (loop's ++ advances past it)
+                continue;
+            }
+            out += s[i];
+        }
+        return out;
+    }
+
+    static std::string extract_answer(const std::string& raw) {
+        std::string clean = strip_ansi(raw);
+        std::vector<std::string> lines;
+        size_t start = 0;
+        for (size_t i = 0; i <= clean.size(); i++) {
+            if (i == clean.size() || clean[i] == '\n') {
+                lines.push_back(clean.substr(start, i - start));
+                start = i + 1;
+            }
+        }
+        std::string answer;
+        bool collecting = false;
+        for (auto& line : lines) {
+            bool is_log = line.rfind("[FLM]", 0) == 0;
+            if (is_log) {
+                if (collecting) break; // hit the "Model RAW Output:" duplicate — stop
+                continue;              // still in the leading log lines — skip
+            }
+            if (line.empty() && !collecting) continue; // skip blank lines before the answer starts
+            collecting = true;
+            if (!answer.empty()) answer += '\n';
+            answer += line;
+        }
+        while (!answer.empty() && (answer.back() == '\n' || answer.back() == ' '))
+            answer.pop_back();
+        return answer;
+    }
+
+    // Whole-turn text exchange over the ">>> "-delimited REPL.
+    std::string query_flm(const std::string& prompt) {
+        std::string req = prompt + "\n";
+        if (write(stdin_fd_, req.c_str(), req.size()) < 0) return "";
+
+        std::string resp;
+        char c;
+        auto t0 = std::chrono::steady_clock::now();
+        while (std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - t0).count() < query_timeout_ms_) {
+            fd_set fds; FD_ZERO(&fds); FD_SET(stdout_fd_, &fds);
+            struct timeval tv = {1, 0};
+            if (select(stdout_fd_ + 1, &fds, nullptr, nullptr, &tv) > 0) {
+                if (read(stdout_fd_, &c, 1) > 0) {
+                    resp += c;
+                    if (resp.size() >= 4 && resp.substr(resp.size() - 4) == ">>> ") break;
+                }
+            } else break;
+        }
+        if (resp.size() >= 4 && resp.substr(resp.size() - 4) == ">>> ")
+            resp = resp.substr(0, resp.size() - 4);
+        // Drop the echoed input line (REPL echoes what was piped to it).
+        auto nl = resp.find('\n');
+        if (nl != std::string::npos) resp = resp.substr(nl + 1);
+        return extract_answer(resp);
+    }
+
+    bool forward(int, float*) override { return false; } // no hidden states — use generate()
+    bool lm_head(const float*, float*, int*) override { return false; } // use generate()
+
+    int generate(int token_id) override {
+        if (!initialized) return -1;
+
+        if (token_id == last_returned_ && !response_tokens_.empty()) {
+            // Continuing to drain an already-computed response.
+            if (response_pos_ < response_tokens_.size()) {
+                last_returned_ = response_tokens_[response_pos_++];
+                return last_returned_;
+            }
+            last_returned_ = g_tokenizer.eos_id;
+            return last_returned_;
+        }
+
+        // New prompt content (prefill, or the boundary token before decode
+        // begins — see the file-level comment for why we can't tell which).
+        prompt_tokens_.push_back(token_id);
+        std::string prompt = g_tokenizer.decode(prompt_tokens_);
+        if (prompt.empty()) prompt = " ";
+
+        // Every distinct new-token call would otherwise re-query FLM, which
+        // both wastes round-trips AND pollutes FLM's own session context with
+        // discarded partial-prompt exchanges before the real one. Under a
+        // real BPE tokenizer each token is already word/subword-sized, so
+        // this is a minor inefficiency — but under the char-level ASCII
+        // fallback (verified: with no .htok available, each character is
+        // its own token) it becomes a query storm, one per character, that
+        // measurably degrades answer quality. Mitigate by only actually
+        // querying at a word/punctuation boundary (or if nothing has been
+        // queried yet this turn) — cuts query count roughly to one per word
+        // instead of one per token, without needing a prefill/decode signal
+        // the Backend interface doesn't provide.
+        char last_ch = prompt.empty() ? ' ' : prompt.back();
+        bool at_boundary = last_ch == ' ' || last_ch == '\n' || ispunct((unsigned char)last_ch);
+        if (!at_boundary && !response_tokens_.empty()) {
+            // Mid-word continuation of a prompt we've already queried once —
+            // keep the previous answer as our best guess rather than
+            // re-querying (avoids the storm; the final boundary call before
+            // decode will produce the real, complete-prompt answer).
+            last_returned_ = response_tokens_[0];
+            return last_returned_;
+        }
+
+        std::string text = query_flm(prompt);
+        response_tokens_ = g_tokenizer.encode(text);
+        response_pos_ = 0;
+        if (response_tokens_.empty()) { last_returned_ = g_tokenizer.eos_id; return last_returned_; }
+        last_returned_ = response_tokens_[response_pos_++];
+        return last_returned_;
+    }
+
+    void destroy() override {
+        if (pid_ > 0) {
+            const char* exit_cmd = "/exit\n";
+            if (stdin_fd_ >= 0) write(stdin_fd_, exit_cmd, strlen(exit_cmd));
+            usleep(200000);
+            if (stdin_fd_ >= 0) close(stdin_fd_);
+            if (stdout_fd_ >= 0) close(stdout_fd_);
+            if (stderr_fd_ >= 0) close(stderr_fd_);
+            kill(pid_, SIGTERM);
+            usleep(200000);
+            kill(pid_, SIGKILL);
+            waitpid(pid_, nullptr, WNOHANG);
+            pid_ = -1;
+        }
+        stdin_fd_ = stdout_fd_ = stderr_fd_ = -1;
+        initialized = false;
+    }
+
+    float benchmark(int tokens) override {
+        if (!initialized) return -1.0f;
+        reset();
+        auto t0 = std::chrono::high_resolution_clock::now();
+        int tok = g_tokenizer.bos_id;
+        for (int i = 0; i < tokens; i++) tok = generate(tok);
+        float ms = std::chrono::duration<float, std::milli>(
+            std::chrono::high_resolution_clock::now() - t0).count();
+        return tokens > 0 ? ms / tokens : 0.0f;
+    }
+
+    bool can_infer() const override { return initialized; }
+};
+
+extern "C" Backend* create_flm_backend() { return new FlmBackend(); }

--- a/src/backend_generic.cpp
+++ b/src/backend_generic.cpp
@@ -321,7 +321,7 @@ struct GenericBackend : Backend {
     struct LayerW { size_t wq, wk, wv, wo, w1, w2, w3, rms_attn, rms_ffn; };
     std::vector<LayerW> layers;
 
-    GenericBackend() { type = BackendType::CPU_AVX512; name = "Generic CPU (AVX-512)"; }
+    GenericBackend() { type = BackendType::GENERIC; name = "Generic CPU (GGUF)"; }
 
     void load_weights(const std::string& base) {
         // Weights stored as flat float vectors: model_layers_N_name.bin

--- a/src/backend_generic.cpp
+++ b/src/backend_generic.cpp
@@ -317,8 +317,14 @@ struct GenericBackend : Backend {
     int pos = 0;
     std::vector<float> logits_buf;
 
-    // Per-layer weight indices
-    struct LayerW { size_t wq, wk, wv, wo, w1, w2, w3, rms_attn, rms_ffn; };
+    // Per-layer weight indices. bq/bk/bv are optional QKV biases (Qwen2 and
+    // some other architectures use biased attention projections, unlike
+    // Llama) — SIZE_MAX means "not present in this model", distinct from a
+    // legitimate index 0 into flat_weights.
+    struct LayerW {
+        size_t wq, wk, wv, wo, w1, w2, w3, rms_attn, rms_ffn;
+        size_t bq = SIZE_MAX, bk = SIZE_MAX, bv = SIZE_MAX;
+    };
     std::vector<LayerW> layers;
 
     GenericBackend() { type = BackendType::GENERIC; name = "Generic CPU (GGUF)"; }
@@ -451,7 +457,19 @@ struct GenericBackend : Backend {
             flat_weights.insert(flat_weights.end(), buf.begin(), buf.end());
             return idx;
         };
-        
+        // Like load_tensor, but returns SIZE_MAX (not 0) when the tensor
+        // simply isn't present — for genuinely optional tensors (QKV bias),
+        // where "absent" and "present at index 0" must stay distinguishable.
+        auto load_tensor_optional = [&](const std::string& name, size_t expected) -> size_t {
+            std::vector<float> buf;
+            size_t n = 0;
+            if (!read_gguf_tensor(path, name, buf, &n)) return SIZE_MAX;
+            if (n != expected) { fprintf(stderr, "  %s: expected %zu, got %zu\n", name.c_str(), expected, n); return SIZE_MAX; }
+            size_t idx = flat_weights.size();
+            flat_weights.insert(flat_weights.end(), buf.begin(), buf.end());
+            return idx;
+        };
+
         for (int i = 0; i < L; i++) {
             std::string p = "blk." + std::to_string(i) + ".";
             LayerW lw;
@@ -464,7 +482,15 @@ struct GenericBackend : Backend {
             lw.w1 = load_tensor(p + "ffn_gate.weight", FF*H);
             lw.w2 = load_tensor(p + "ffn_up.weight", FF*H);
             lw.w3 = load_tensor(p + "ffn_down.weight", H*FF);
+            lw.bq = load_tensor_optional(p + "attn_q.bias", NH*HD);
+            lw.bk = load_tensor_optional(p + "attn_k.bias", NKV*HD);
+            lw.bv = load_tensor_optional(p + "attn_v.bias", NKV*HD);
             layers[i] = lw;
+        }
+        {
+            int with_bias = 0;
+            for (auto& lw : layers) if (lw.bq != SIZE_MAX) with_bias++;
+            if (with_bias > 0) printf("Generic: %d/%d layers have biased QKV projections\n", with_bias, L);
         }
         
         printf("Generic: loaded %zu layers, embed=%zu, final_norm=%zu\n",
@@ -492,22 +518,34 @@ struct GenericBackend : Backend {
         for (int i = 0; i < n; i++) o[i] = x[i] * r * w[i];
     }
 
+    // NeoX-style (half-split) RoPE — the convention GGUF/llama.cpp-family
+    // models (Llama, Qwen, Mistral, ...) actually use: pairs element i with
+    // i+rot_dim/2, not adjacent elements (i, i+1). Cross-checked against
+    // ZINC's shaders (src/shaders/rope_fused.comp and siblings, all
+    // independently confirm half_rot = rope_dim/2 pairing) since ZINC is
+    // independently verified to produce coherent output on these same
+    // models — this file's previous adjacent-pair version was the GPT-J
+    // convention, wrong for this model family, and produced incoherent
+    // (real-vocabulary but semantically scrambled) output as a result.
     static void rope(float* q, float* k, int pos, int n_heads, int n_kv, int hd, int rot_dim, float theta) {
+        int half = rot_dim / 2;
         for (int h = 0; h < n_heads; h++) {
-            for (int d = 0; d < rot_dim; d += 2) {
-                float freq = pos / powf(theta, d / (float)rot_dim);
-                float cosv = cosf(freq), sinv = sinf(freq);
-                int i0 = h * hd + d, i1 = h * hd + d + 1;
+            for (int i = 0; i < half; i++) {
+                float freq = 1.0f / powf(theta, (2.0f * i) / (float)rot_dim);
+                float t = pos * freq;
+                float cosv = cosf(t), sinv = sinf(t);
+                int i0 = h * hd + i, i1 = h * hd + i + half;
                 float q0 = q[i0], q1 = q[i1];
                 q[i0] = q0 * cosv - q1 * sinv;
                 q[i1] = q0 * sinv + q1 * cosv;
             }
         }
         for (int h = 0; h < n_kv; h++) {
-            for (int d = 0; d < rot_dim; d += 2) {
-                float freq = pos / powf(theta, d / (float)rot_dim);
-                float cosv = cosf(freq), sinv = sinf(freq);
-                int i0 = h * hd + d, i1 = h * hd + d + 1;
+            for (int i = 0; i < half; i++) {
+                float freq = 1.0f / powf(theta, (2.0f * i) / (float)rot_dim);
+                float t = pos * freq;
+                float cosv = cosf(t), sinv = sinf(t);
+                int i0 = h * hd + i, i1 = h * hd + i + half;
                 float k0 = k[i0], k1 = k[i1];
                 k[i0] = k0 * cosv - k1 * sinv;
                 k[i1] = k0 * sinv + k1 * cosv;
@@ -576,6 +614,12 @@ struct GenericBackend : Backend {
             matmul(q.data(), x2.data(), w(l.wq), NH*HD, H);
             matmul(k.data(), x2.data(), w(l.wk), NKV*HD, H);
             matmul(v.data(), x2.data(), w(l.wv), NKV*HD, H);
+
+            // Optional QKV bias (Qwen2 and others use biased attention
+            // projections; absent for architectures like Llama).
+            if (l.bq != SIZE_MAX) { float* b = w(l.bq); for (int i = 0; i < NH*HD; i++) q[i] += b[i]; }
+            if (l.bk != SIZE_MAX) { float* b = w(l.bk); for (int i = 0; i < NKV*HD; i++) k[i] += b[i]; }
+            if (l.bv != SIZE_MAX) { float* b = w(l.bv); for (int i = 0; i < NKV*HD; i++) v[i] += b[i]; }
 
             // RoPE
             rope(q.data(), k.data(), pos, NH, NKV, HD, rot_dim, theta);

--- a/src/backend_manager.cpp
+++ b/src/backend_manager.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <thread>
 #include <chrono>
+#include <unistd.h>
 
 // ── Backend priority by tier ──
 static int tier_priority(BackendTier t) {
@@ -50,6 +51,10 @@ void BackendManager::discover() {
         info.priority = tier_priority(info.tier) + 50;
         info.available = has_npu();
         info.functional = false;  // needs init to confirm
+        // Compiled INT8 GEMM kernels are confirmed producing wrong output on real
+        // hardware (docs/GEMM-KERNEL-CORRECTNESS-CONFIRMED.md) — never auto-select
+        // until that's resolved. NPU inference goes through the FLM backend instead.
+        info.auto_selectable = false;
         info.score = 0;
         info.total_inferences = 0;
         info.failed_inferences = 0;
@@ -57,6 +62,54 @@ void BackendManager::discover() {
         info.instance = nullptr;
         info.plugin_handle = nullptr;
         printf("  %-25s %s\n", "NPU XDNA (XRT)", info.available ? "✅ detected" : "❌ not available");
+        backends_.push_back(info);
+    }
+
+    // 1b. NPU via FastFlowLM subprocess — the actually-correct NPU path while
+    // npu_xrt's in-process kernels remain broken (see docs/GEMM-KERNEL-CORRECTNESS-CONFIRMED.md).
+    {
+        BackendInfo info;
+        info.id = "npu_flm";
+        info.type = BackendType::NPU_FLM;
+        info.tier = BackendTier::T1_ACCELERATOR;
+        info.description = "NPU via FastFlowLM";
+        info.priority = tier_priority(info.tier) + 40;
+        bool flm_bin = access("/opt/fastflowlm/bin/flm", X_OK) == 0 ||
+                       access("/usr/bin/flm", X_OK) == 0;
+        info.available = has_npu() && flm_bin;
+        info.functional = false;
+        info.score = 0;
+        info.total_inferences = 0;
+        info.failed_inferences = 0;
+        info.cumulative_ms = 0;
+        info.instance = nullptr;
+        info.plugin_handle = nullptr;
+        printf("  %-25s %s\n", "NPU via FastFlowLM", info.available ? "✅ detected" : "❌ not available");
+        backends_.push_back(info);
+    }
+
+    // 1c. ZINC GPU — general GGUF, multi-architecture/multi-quant (see model_router.h;
+    // this is the default GPU path for non-Zaya, non-qwen3 GGUF models).
+    {
+        BackendInfo info;
+        info.id = "zinc_gpu";
+        info.type = BackendType::ZINC_GPU;
+        info.tier = BackendTier::T2_GPU;
+        info.description = "ZINC GPU (Vulkan, multi-arch)";
+        info.priority = tier_priority(info.tier) + 40;
+#ifdef ZINC_DISABLED
+        info.available = false;
+#else
+        info.available = has_vulkan() || has_hip_gpu();
+#endif
+        info.functional = false;
+        info.score = 0;
+        info.total_inferences = 0;
+        info.failed_inferences = 0;
+        info.cumulative_ms = 0;
+        info.instance = nullptr;
+        info.plugin_handle = nullptr;
+        printf("  %-25s %s\n", "ZINC GPU (Vulkan)", info.available ? "✅ detected" : "❌ not available");
         backends_.push_back(info);
     }
 
@@ -140,6 +193,29 @@ void BackendManager::discover() {
         backends_.push_back(info);
     }
 
+    // 6. CPU generic — general-purpose GGUF backend (Llama/Mistral/Qwen2/Gemma/Phi),
+    // unlike cpu_avx512/cpu_scalar (CPUBackend) which only accept the hardcoded
+    // Zaya1-8B dims. Always available; the router (model_router.h) is what actually
+    // prefers this for non-Zaya models — see select_backend_route().
+    {
+        BackendInfo info;
+        info.id = "cpu_generic";
+        info.type = BackendType::GENERIC;
+        info.tier = BackendTier::T3_CPU;
+        info.description = "Generic CPU (GGUF)";
+        info.priority = tier_priority(info.tier) + 20;
+        info.available = true;  // always
+        info.functional = false;
+        info.score = 0;
+        info.total_inferences = 0;
+        info.failed_inferences = 0;
+        info.cumulative_ms = 0;
+        info.instance = nullptr;
+        info.plugin_handle = nullptr;
+        printf("  %-25s %s\n", "CPU Generic (GGUF)", "✅ always available");
+        backends_.push_back(info);
+    }
+
     // Rack 'em
     rank_backends();
     active_idx_ = 0;
@@ -159,9 +235,46 @@ bool BackendManager::init(const ModelConfig& cfg, const std::string& weights_dir
         return false;
     }
 
-    // Try each backend in priority order until one initializes
-    for (auto& info : backends_) {
-        if (!info.available) continue;
+    std::vector<size_t> order(backends_.size());
+    for (size_t i = 0; i < order.size(); i++) order[i] = i;
+    return init_in_order(cfg, weights_dir, order);
+}
+
+bool BackendManager::init(const ModelConfig& cfg, const std::string& weights_dir,
+                           const std::vector<std::string>& preferred_ids) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    cfg_ = cfg;
+    weights_dir_ = weights_dir;
+
+    if (backends_.empty()) {
+        fprintf(stderr, "BackendManager: no backends discovered. Run discover() first.\n");
+        return false;
+    }
+
+    // Preferred ids first (in the order given), then everything else in the
+    // usual priority order. Unknown preferred ids are silently skipped.
+    std::vector<size_t> order;
+    std::vector<bool> used(backends_.size(), false);
+    for (const auto& id : preferred_ids) {
+        for (size_t i = 0; i < backends_.size(); i++) {
+            if (!used[i] && backends_[i].id == id) {
+                order.push_back(i);
+                used[i] = true;
+                break;
+            }
+        }
+    }
+    for (size_t i = 0; i < backends_.size(); i++) if (!used[i]) order.push_back(i);
+
+    return init_in_order(cfg, weights_dir, order);
+}
+
+bool BackendManager::init_in_order(const ModelConfig& cfg, const std::string& weights_dir,
+                                    const std::vector<size_t>& order) {
+    // Try each backend in the given order until one initializes.
+    for (size_t idx : order) {
+        auto& info = backends_[idx];
+        if (!info.available || !info.auto_selectable) continue;
 
         printf("BackendManager: trying %s (%s)...\n", info.id.c_str(), info.description.c_str());
         // Try to create via dlsym (GPU/NPU backends live in librocm_cpp.so or standalone)
@@ -187,7 +300,7 @@ bool BackendManager::init(const ModelConfig& cfg, const std::string& weights_dir
             initialized_ = true;
             // Set active_idx_ to this backend so generate() works immediately
             // without requiring the caller to manually call select_backend() (#fix #17).
-            active_idx_ = &info - backends_.data();
+            active_idx_ = idx;
             printf("  → ✅ initialized successfully\n");
 
             // Create monitor entry
@@ -217,7 +330,7 @@ bool BackendManager::select_best() {
             float best_score = 1e30f;
             for (size_t i = 0; i < backends_.size(); i++) {
                 auto& b = backends_[i];
-                if (!b.available || !b.functional) continue;
+                if (!b.available || !b.functional || !b.auto_selectable) continue;
                 if (b.score > 0 && b.score < best_score) {
                     best_score = b.score;
                     best_idx = i;
@@ -226,7 +339,7 @@ bool BackendManager::select_best() {
             // If no backend has a score, fall back to first available+functional
             if (best_idx == backends_.size()) {
                 for (size_t i = 0; i < backends_.size(); i++) {
-                    if (backends_[i].available && backends_[i].functional) {
+                    if (backends_[i].available && backends_[i].functional && backends_[i].auto_selectable) {
                         best_idx = i;
                         break;
                     }
@@ -244,7 +357,7 @@ bool BackendManager::select_best() {
         case SelectionStrategy::LOWEST_POWER: {
             // Pick the highest-priority available+functional backend (NPU > GPU > CPU)
             for (size_t i = 0; i < backends_.size(); i++) {
-                if (backends_[i].available && backends_[i].functional) {
+                if (backends_[i].available && backends_[i].functional && backends_[i].auto_selectable) {
                     active_idx_ = i;
                     return true;
                 }
@@ -257,7 +370,7 @@ bool BackendManager::select_best() {
             size_t start = (active_idx_ + 1) % backends_.size();
             for (size_t i = 0; i < backends_.size(); i++) {
                 size_t idx = (start + i) % backends_.size();
-                if (backends_[idx].available && backends_[idx].functional) {
+                if (backends_[idx].available && backends_[idx].functional && backends_[idx].auto_selectable) {
                     active_idx_ = idx;
                     return true;
                 }
@@ -937,6 +1050,16 @@ Backend* BackendManager::create_instance_rt(const BackendInfo& info) {
         case BackendType::CPU_AVX512:
         case BackendType::CPU_SCALAR:
             return create_cpu_backend();
+        case BackendType::GENERIC:
+            return create_generic_backend();
+        case BackendType::NPU_FLM:
+            return create_flm_backend();
+        case BackendType::ZINC_GPU:
+#ifdef ZINC_DISABLED
+            return nullptr;
+#else
+            return create_zinc_backend();
+#endif
         default:
             return nullptr;
     }

--- a/src/backend_npu.cpp
+++ b/src/backend_npu.cpp
@@ -14,6 +14,7 @@
 //   NPU_XCLBIN_DIR   — xclbin directory (passed through to worker)
 
 #include "backend.h"
+#include "q4nx_reader.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -29,69 +30,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <signal.h>
-
-// ── Q4NX model reader ──
-// Reads float32 weights from the mmap'd model file by JSON key lookup.
-// The model file is an indexed format: JSON header with data_offsets, then
-// raw float32 weight data at those offsets.
-struct Q4nxReader {
-    const char* data = nullptr;
-    size_t size = 0;
-
-    bool open(const std::string& path) {
-        int fd = ::open(path.c_str(), O_RDONLY);
-        if (fd < 0) { perror("NPU: open model"); return false; }
-        struct stat st;
-        fstat(fd, &st);
-        data = (const char*)mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
-        size = st.st_size;
-        ::close(fd);  // global POSIX close, not the member function
-        if (data == MAP_FAILED) { perror("NPU: mmap model"); data = nullptr; return false; }
-        return true;
-    }
-
-    void close() {
-        if (data && size > 0) { munmap((void*)data, size); data = nullptr; size = 0; }
-    }
-
-    // Find data offset for a JSON key in the model header
-    // Uses standard C string search instead of GNU memmem extension.
-    uint64_t find_offset(const char* key) const {
-        if (!data || !key) return 0;
-        size_t kl = strlen(key);
-        if (kl == 0) return 0;
-        const char* p = data;
-        const char* e = data + (size > 65536 ? 65536 : size); // header within first 64KB
-        while (p + kl <= e) {
-            // Find first character match
-            const char* q = (const char*)memchr(p, key[0], e - p);
-            if (!q || q + kl > e) return 0;
-            // Check full key match
-            if (memcmp(q, key, kl) == 0) {
-                if (q > data && *(q - 1) == '"' && *(q + kl) == '"') {
-                    const char* o = strstr(q, "\"data_offsets\"");
-                    if (o) {
-                        const char* a = strchr(o, '[');
-                        if (a) return strtoull(a + 1, NULL, 10);
-                    }
-                }
-                p = q + 1;
-            } else {
-                p = q + 1;
-            }
-        }
-        return 0;
-    }
-
-    // Read float32 array at offset into a vector
-    std::vector<float> read_floats(uint64_t offset, size_t count) const {
-        std::vector<float> v;
-        if (!data || offset == 0 || offset + count * 4 > size) return v;
-        v.resize(count);
-        memcpy(v.data(), data + offset, count * sizeof(float));
-        return v;
-    }
-};
 
 // ── Math helpers (CPU fallback ops) ──
 static constexpr float EPS = 1e-6f;

--- a/src/backend_zinc.cpp
+++ b/src/backend_zinc.cpp
@@ -1,0 +1,153 @@
+// backend_zinc.cpp — general-purpose GGUF backend via ZINC (engine/gpu),
+// the multi-architecture, multi-quant Vulkan compute engine. Unlike
+// zaya_engine's hand-tuned HIP kernels (hardcoded to one architecture), ZINC
+// derives its runtime config from GGUF metadata itself — no dims rejection
+// needed here, matching that generality.
+//
+// ZINC is a genuinely separate open-source project (github.com/zolotukhin/zinc,
+// forked to bong-water-water-bong/zinc — see /home/bcloud/zinc, NOT the stale
+// vendored copy at engine/gpu inside this repo). This backend links against
+// libzinc.so, built from that fork's src/c_abi.zig (a thin C ABI shim added
+// there, mirroring zaya_engine.h's opaque-state init/generate/destroy
+// convention — no changes to ZINC's own compute internals).
+//
+// The C ABI exposes a single fused generate call (prompt text in, response
+// text out) rather than per-token stepping — ZINC's own compute.forward.generate()
+// already does a real batched prefill + full decode loop in one call, and
+// text is the only safe boundary since ZINC's native tokenizer vocabulary
+// (derived per-model from each GGUF's own embedded vocab) won't generally
+// match whatever tokenizer produced the token IDs Backend::generate() receives.
+// So, like backend_flm.cpp, this bridges token IDs <-> text via g_tokenizer,
+// batching queries at word/punctuation boundaries rather than one interior
+// call per prompt token. Unlike FLM (an external subprocess with its own
+// persistent conversational state), each zinc_generate_text() call is a
+// fresh, stateless computation over exactly the tokens passed in — so the
+// FLM backend's context-pollution problem doesn't apply here; redundant
+// calls during prefill accumulation are pure wasted compute, not a
+// correctness bug.
+
+#include "backend.h"
+#include "simple_tokenizer.h"
+#include <cstdio>
+#include <cstring>
+#include <cctype>
+#include <string>
+#include <vector>
+#include <chrono>
+
+extern "C" {
+    void* zinc_init(const char* gguf_path);
+    void zinc_destroy(void* state);
+    long long zinc_generate_text(void* state, const char* prompt_text, unsigned int max_tokens,
+                                  char* out_buf, size_t out_cap);
+}
+
+struct ZincBackend : Backend {
+    void* zinc_state_ = nullptr;
+
+    std::vector<int> prompt_tokens_;
+    std::vector<int> response_tokens_;
+    size_t response_pos_ = 0;
+    int last_returned_ = -1;
+
+    ZincBackend() { type = BackendType::ZINC_GPU; name = "ZINC GPU (Vulkan, multi-arch)"; }
+    ~ZincBackend() override { destroy(); }
+
+    bool init(const ModelConfig& model_cfg, const std::string& weights_dir) override {
+        (void)weights_dir;
+        cfg = model_cfg;
+        destroy();
+
+        if (cfg.model_path.empty() ||
+            (cfg.format != ModelFormat::GGUF && cfg.format != ModelFormat::H1B)) {
+            fprintf(stderr, "ZINC: no GGUF model path available\n");
+            return false;
+        }
+
+        printf("ZINC: loading %s...\n", cfg.model_path.c_str());
+        zinc_state_ = zinc_init(cfg.model_path.c_str());
+        if (!zinc_state_) {
+            fprintf(stderr, "ZINC: zinc_init failed (model load or Vulkan init error — see stderr above)\n");
+            return false;
+        }
+        initialized = true;
+        printf("ZINC: ready\n");
+        return true;
+    }
+
+    bool reset() override {
+        prompt_tokens_.clear();
+        response_tokens_.clear();
+        response_pos_ = 0;
+        last_returned_ = -1;
+        return true;
+    }
+
+    bool forward(int, float*) override { return false; } // no hidden states — use generate()
+    bool lm_head(const float*, float*, int*) override { return false; } // use generate()
+
+    int generate(int token_id) override {
+        if (!initialized) return -1;
+
+        if (token_id == last_returned_ && !response_tokens_.empty()) {
+            if (response_pos_ < response_tokens_.size()) {
+                last_returned_ = response_tokens_[response_pos_++];
+                return last_returned_;
+            }
+            last_returned_ = g_tokenizer.eos_id;
+            return last_returned_;
+        }
+
+        prompt_tokens_.push_back(token_id);
+        std::string prompt = g_tokenizer.decode(prompt_tokens_);
+        if (prompt.empty()) prompt = " ";
+
+        // Batch queries at word/punctuation boundaries rather than every
+        // token (see file header) — pure perf optimization here, not a
+        // correctness requirement like it was for FlmBackend.
+        char last_ch = prompt.back();
+        bool at_boundary = last_ch == ' ' || last_ch == '\n' || ispunct((unsigned char)last_ch);
+        if (!at_boundary && !response_tokens_.empty()) {
+            last_returned_ = response_tokens_[0];
+            return last_returned_;
+        }
+
+        static thread_local std::vector<char> out_buf(1 << 20); // 1MB
+        long long n = zinc_generate_text(zinc_state_, prompt.c_str(), 64,
+                                          out_buf.data(), out_buf.size());
+        if (n < 0) {
+            fprintf(stderr, "ZINC: generate failed (code %lld)\n", n);
+            last_returned_ = g_tokenizer.eos_id;
+            return last_returned_;
+        }
+        std::string text(out_buf.data(), (size_t)n);
+        response_tokens_ = g_tokenizer.encode(text);
+        response_pos_ = 0;
+        if (response_tokens_.empty()) { last_returned_ = g_tokenizer.eos_id; return last_returned_; }
+        last_returned_ = response_tokens_[response_pos_++];
+        return last_returned_;
+    }
+
+    void destroy() override {
+        if (zinc_state_) {
+            zinc_destroy(zinc_state_);
+            zinc_state_ = nullptr;
+        }
+        initialized = false;
+    }
+
+    float benchmark(int tokens) override {
+        if (!initialized) return -1.0f;
+        reset();
+        auto t0 = std::chrono::high_resolution_clock::now();
+        int tok = g_tokenizer.bos_id;
+        for (int i = 0; i < tokens; i++) tok = generate(tok);
+        float ms = std::chrono::duration<float, std::milli>(
+            std::chrono::high_resolution_clock::now() - t0).count();
+        return tokens > 0 ? ms / tokens : 0.0f;
+    }
+
+    bool can_infer() const override { return initialized; }
+};
+
+Backend* create_zinc_backend() { return new ZincBackend(); }

--- a/src/gguf_loader.cpp
+++ b/src/gguf_loader.cpp
@@ -291,14 +291,15 @@ rcpp_status_t rcpp_bitnet_load_gguf(const char* path, rcpp_bitnet_model_t* out_m
         };
         // Select target pointers based on weight format
         // BST format writes to bst_*_packed_dev, standard writes to *_packed_dev
-        auto lw = [&](const std::string& gn, void** std_ptr, void** bst_ptr, int r, int c) {
+        auto lw = [&](const std::string& gn, void** std_ptr, void** bst_ptr, int r, int c) -> rcpp_status_t {
             std::vector<float> data;
-            if (!reader.read_tensor(gn, data)) return;
+            if (!reader.read_tensor(gn, data)) return RCPP_OK;
             std::vector<_Float16> f16(data.size());
             for (size_t i = 0; i < data.size(); ++i) f16[i] = (_Float16)data[i];
             void** target = reader.has_bst_tensor ? bst_ptr : std_ptr;
             HIP_CHECK(hipMalloc(target, f16.size() * sizeof(_Float16)));
             HIP_CHECK(hipMemcpy(*target, f16.data(), f16.size() * sizeof(_Float16), hipMemcpyHostToDevice));
+            return RCPP_OK;
         };
         lw(prefix("input_layernorm.weight"), &layer.input_norm_dev, &layer.input_norm_dev, hidden_size, 1);
         lw(prefix("post_attention_layernorm.weight"), &layer.post_attn_norm_dev, &layer.post_attn_norm_dev, hidden_size, 1);

--- a/src/model_discovery.cpp
+++ b/src/model_discovery.cpp
@@ -2,8 +2,11 @@
 // and read their headers to populate ModelConfig without loading full weights.
 
 #include "model_discovery.h"
+#include "q4nx_reader.h"
 #include <cstdio>
 #include <cstring>
+#include <cmath>
+#include <limits>
 #include <dirent.h>
 #include <sys/stat.h>
 
@@ -11,6 +14,32 @@
 // Reads just enough of a GGUF file to extract architecture + dimensions.
 // The GGUF spec: magic(4) + version(4) + tensor_count(8) + metadata_kv_count(8)
 // Then kv pairs: key_length(8) + key_data + value_type(4) + value_data
+
+// Best-effort mapping of GGUF's general.file_type (ggml_ftype) to a human-readable
+// quantization tag. Not exhaustive — covers the common cases, falls back to a
+// numbered "unknown" tag for anything else rather than silently guessing.
+static std::string ggml_ftype_name(uint32_t ft) {
+    switch (ft) {
+        case 0:  return "F32";
+        case 1:  return "F16";
+        case 2:  return "Q4_0";
+        case 3:  return "Q4_1";
+        case 7:  return "Q8_0";
+        case 8:  return "Q5_0";
+        case 9:  return "Q5_1";
+        case 10: return "Q2_K";
+        case 11: return "Q3_K_S";
+        case 12: return "Q3_K_M";
+        case 13: return "Q3_K_L";
+        case 14: return "Q4_K_S";
+        case 15: return "Q4_K_M";
+        case 16: return "Q5_K_S";
+        case 17: return "Q5_K_M";
+        case 18: return "Q6_K";
+        case 32: return "BF16";
+        default: return "unknown(" + std::to_string(ft) + ")";
+    }
+}
 
 static bool read_gguf_metadata(const std::string& path, ModelConfig& cfg) {
     FILE* f = fopen(path.c_str(), "rb");
@@ -41,6 +70,7 @@ static bool read_gguf_metadata(const std::string& path, ModelConfig& cfg) {
         cfg.head_dim = hs / n_heads;
         cfg.max_seq_len = max_seq ? max_seq : 2048;
         cfg.model_path = path;
+        cfg.format = ModelFormat::H1B;
         // Derive name from filename
         auto slash = path.find_last_of('/');
         auto dot = path.find_last_of('.');
@@ -67,6 +97,7 @@ static bool read_gguf_metadata(const std::string& path, ModelConfig& cfg) {
     cfg.rope_theta = 10000.0f;
     cfg.rms_norm_eps = 1e-6f;
     cfg.model_path = path;
+    cfg.format = ModelFormat::GGUF;
     auto slash = path.find_last_of('/');
     auto dot = path.find_last_of('.');
     cfg.model_name = path.substr(slash + 1, dot - slash - 1);
@@ -103,13 +134,14 @@ static bool read_gguf_metadata(const std::string& path, ModelConfig& cfg) {
         };
 
         std::string key(key_buf);
-        if (key == "general.architecture") { 
-            cfg.model_name = read_str(); 
-            // Build architecture-specific key prefix for later checks
+        if (key == "general.architecture") {
+            // Keep separate from model_name (general.name), which commonly appears
+            // later in the same file and would otherwise clobber this value.
+            cfg.architecture = read_str();
         }
         else if (key == "general.name") { cfg.model_name = read_str(); }
         else if (key == "tokenizer.ggml.model") { /* ignore */ }
-        else if (key == "general.file_type") { /* ignore */ }
+        else if (key == "general.file_type") { cfg.quantization = ggml_ftype_name(read_u32()); }
         else {
             // Check for dimension keys (architecture-agnostic by checking suffixes)
             auto ends_with = [&](const std::string& s) -> bool {
@@ -194,7 +226,7 @@ std::vector<ModelConfig> discover_models(const std::string& dir) {
         auto dot = name.find_last_of('.');
         if (dot == std::string::npos) continue;
         std::string ext = name.substr(dot);
-        if (ext != ".gguf" && ext != ".h1b" && ext != ".safetensors" && ext != ".bin") continue;
+        if (ext != ".gguf" && ext != ".h1b" && ext != ".safetensors" && ext != ".bin" && ext != ".q4nx") continue;
 
         std::string full = dir + "/" + name;
         struct stat st;
@@ -204,10 +236,13 @@ std::vector<ModelConfig> discover_models(const std::string& dir) {
         bool ok = false;
         if (ext == ".gguf") ok = read_gguf_metadata(full, cfg);
         else if (ext == ".h1b") ok = read_gguf_metadata(full, cfg);
+        else if (ext == ".q4nx") ok = read_q4nx_metadata(full, cfg);
         else if (ext == ".bin") {
             // .bin files: use the directory name as model name, Zaya defaults
             cfg.model_name = dir.substr(dir.find_last_of('/') + 1);
             cfg.model_path = full;
+            cfg.format = ModelFormat::RAW_BIN;
+            cfg.architecture = "zaya1";
             cfg.hidden = cfg.hidden_size = 2048;
             cfg.n_layers = cfg.num_layers = 40;
             cfg.n_heads = cfg.num_heads = cfg.num_attention_heads = 8;
@@ -222,9 +257,12 @@ std::vector<ModelConfig> discover_models(const std::string& dir) {
 
         if (ok) {
             models.push_back(cfg);
-            printf("  📦 %-30s %d layers, %d hidden, %d heads%s\n",
+            printf("  📦 %-30s %d layers, %d hidden, %d heads%s — %s/%s/%s\n",
                    cfg.model_name.c_str(), cfg.n_layers, cfg.hidden, cfg.n_heads,
-                   cfg.n_kv_heads != cfg.n_heads ? " (GQA)" : "");
+                   cfg.n_kv_heads != cfg.n_heads ? " (GQA)" : "",
+                   ext.c_str(),
+                   cfg.architecture.empty() ? "?" : cfg.architecture.c_str(),
+                   cfg.quantization.empty() ? "?" : cfg.quantization.c_str());
         }
     }
     closedir(d);
@@ -349,11 +387,25 @@ bool read_gguf_tensor(const std::string& path, const std::string& tensor_name,
     output.resize(target->n);
     fseek(f, target->data_off, SEEK_SET);
     
-    // Helper: read fp16 from file
+    // Helper: read fp16 from file. Handles subnormals correctly — the naive
+    // "rebias the exponent bits" trick silently produces wrong values when
+    // exp==0 (subnormal), which real quantization scale factors do hit in
+    // practice (verified: a real Q6_K super-block scale in a downloaded
+    // model was off by ~2.3x from the naive conversion until this fix).
     auto rd_f16 = [&]() -> float {
         uint16_t h; fread(&h, 2, 1, f);
-        uint32_t f32 = ((h & 0x8000)<<16) | ((((h>>10)&0x1f)-15+127)<<23) | ((h&0x3ff)<<13);
-        float r; memcpy(&r, &f32, 4); return r;
+        int sign = (h & 0x8000) ? -1 : 1;
+        int exp = (h >> 10) & 0x1F;
+        int mant = h & 0x3FF;
+        float val;
+        if (exp == 0) {
+            val = std::ldexp((float)mant, -24); // subnormal (incl. zero): mant * 2^-24
+        } else if (exp == 0x1F) {
+            val = mant ? std::numeric_limits<float>::quiet_NaN() : std::numeric_limits<float>::infinity();
+        } else {
+            val = std::ldexp((float)(mant | 0x400), exp - 25); // (1.mant) * 2^(exp-15-10)
+        }
+        return sign * val;
     };
 
     switch (target->dtype) {
@@ -413,24 +465,77 @@ bool read_gguf_tensor(const std::string& path, const std::string& tensor_name,
             }
             break;
         }
-        case 12: { // Q4_K: 256 elems, 144 bytes/block
+        case 12: { // Q4_K: 256-elem superblock, 144 bytes: d(2) + dmin(2) + scales[12] + qs[128]
+            // Reference layout: ggml's block_q4_K / get_scale_min_k4 (llama.cpp ggml-quants.c).
+            // Sub-block (32-elem) scale/min are 6-bit values packed across 12 bytes; qs holds
+            // 4-bit quants, low/high nibble = elements [0..32)/[32..64) of each 64-elem pair.
             uint64_t nb = (target->n + 255) / 256;
             for (uint64_t b = 0; b < nb; b++) {
-                // Q4_K: 2 bytes scale + 2 bytes min + 128 bytes q4 + 12 bytes scales? 
-                // Just skip this block and zero-fill for now
-                fseek(f, 144, SEEK_CUR);
-                for (int j = 0; j < 256 && b*256+j < target->n; j++)
-                    output[b*256+j] = 0.0f;
+                float d = rd_f16();
+                float dmin = rd_f16();
+                uint8_t scales[12]; fread(scales, 1, 12, f);
+                uint8_t qs[128]; fread(qs, 1, 128, f);
+
+                auto get_scale_min = [&](int j, uint8_t& sc, uint8_t& m) {
+                    if (j < 4) {
+                        sc = scales[j] & 63;
+                        m = scales[j + 4] & 63;
+                    } else {
+                        sc = (uint8_t)((scales[j + 4] & 0xF) | ((scales[j - 4] >> 6) << 4));
+                        m = (uint8_t)((scales[j + 4] >> 4) | ((scales[j] >> 6) << 4));
+                    }
+                };
+
+                size_t base = b * 256;
+                int is = 0;
+                const uint8_t* q = qs;
+                for (int off = 0; off < 256; off += 64) {
+                    uint8_t sc, m;
+                    get_scale_min(is + 0, sc, m);
+                    float d1 = d * sc, m1 = dmin * m;
+                    get_scale_min(is + 1, sc, m);
+                    float d2 = d * sc, m2 = dmin * m;
+                    for (int l = 0; l < 32 && base + off + l < target->n; l++)
+                        output[base + off + l] = d1 * (q[l] & 0xF) - m1;
+                    for (int l = 0; l < 32 && base + off + 32 + l < target->n; l++)
+                        output[base + off + 32 + l] = d2 * (q[l] >> 4) - m2;
+                    q += 32;
+                    is += 2;
+                }
             }
             break;
         }
-        case 14: { // Q6_K: 256 elems, 210 bytes/block
+        case 14: { // Q6_K: 256-elem superblock, 210 bytes: ql[128] + qh[64] + scales[16] + d(2)
+            // Reference layout: ggml's block_q6_K (llama.cpp ggml-quants.c). 6-bit quants:
+            // low 4 bits from ql, high 2 bits from qh; 16 signed 8-bit per-16-elem scales.
             uint64_t nb = (target->n + 255) / 256;
             for (uint64_t b = 0; b < nb; b++) {
-                // Q6_K: skip block, zero-fill
-                fseek(f, 210, SEEK_CUR);
-                for (int j = 0; j < 256 && b*256+j < target->n; j++)
-                    output[b*256+j] = 0.0f;
+                uint8_t ql[128]; fread(ql, 1, 128, f);
+                uint8_t qh[64]; fread(qh, 1, 64, f);
+                int8_t scales[16]; fread(scales, 1, 16, f);
+                float d = rd_f16();
+
+                size_t base = b * 256;
+                const uint8_t* qlp = ql;
+                const uint8_t* qhp = qh;
+                const int8_t* sc = scales;
+                for (int n = 0; n < 256; n += 128) {
+                    for (int l = 0; l < 32; l++) {
+                        int is = l / 16;
+                        int8_t q1 = (int8_t)((qlp[l] & 0xF) | (((qhp[l] >> 0) & 3) << 4)) - 32;
+                        int8_t q2 = (int8_t)((qlp[l + 32] & 0xF) | (((qhp[l] >> 2) & 3) << 4)) - 32;
+                        int8_t q3 = (int8_t)((qlp[l] >> 4) | (((qhp[l] >> 4) & 3) << 4)) - 32;
+                        int8_t q4 = (int8_t)((qlp[l + 32] >> 4) | (((qhp[l] >> 6) & 3) << 4)) - 32;
+                        size_t i1 = base + n + l, i2 = base + n + l + 32, i3 = base + n + l + 64, i4 = base + n + l + 96;
+                        if (i1 < target->n) output[i1] = d * sc[is + 0] * q1;
+                        if (i2 < target->n) output[i2] = d * sc[is + 2] * q2;
+                        if (i3 < target->n) output[i3] = d * sc[is + 4] * q3;
+                        if (i4 < target->n) output[i4] = d * sc[is + 6] * q4;
+                    }
+                    qlp += 64;
+                    qhp += 32;
+                    sc += 8;
+                }
             }
             break;
         }

--- a/src/model_discovery.cpp
+++ b/src/model_discovery.cpp
@@ -416,41 +416,61 @@ bool read_gguf_tensor(const std::string& path, const std::string& tensor_name,
             break;
         }
         case 2: { // Q4_0: 32 elems, 2 bytes scale + 16 bytes nibbles = 18 bytes/block
+            // ggml's block_q4_0 de-interleaves nibbles into two halves, NOT
+            // sequential (j, j+1, j+2...): output[j] is qs[j]'s low nibble,
+            // output[j+16] is qs[j]'s high nibble (see dequantize_row_q4_0
+            // in ggml-quants.c). Verified against the independent `gguf`
+            // Python reference (bit-exact) for Q4_K/Q6_K — same verification
+            // needed here caught this was using the wrong pattern.
             uint64_t nb = (target->n + 31) / 32;
             for (uint64_t b = 0; b < nb; b++) {
                 float scale = rd_f16();
                 uint8_t q[16]; fread(q, 1, 16, f);
-                for (int j = 0; j < 32 && b*32+j < target->n; j++) {
-                    int8_t v = (j&1) ? (q[j>>1]>>4) : (q[j>>1]&0xf);
-                    output[b*32+j] = (v - 8) * scale;
+                for (int j = 0; j < 16; j++) {
+                    size_t i0 = b*32+j, i1 = b*32+j+16;
+                    if (i0 < target->n) output[i0] = ((int)(q[j] & 0xF) - 8) * scale;
+                    if (i1 < target->n) output[i1] = ((int)(q[j] >> 4) - 8) * scale;
                 }
             }
             break;
         }
-        case 6: { // Q5_0: 32 elems, 2 bytes scale + 16 bytes ql + 4 bytes qh = 22 bytes/block
+        case 6: { // Q5_0: 32 elems, 2 bytes scale + 4 bytes qh + 16 bytes qs = 22 bytes/block
+            // Same de-interleaved low/high split as Q4_0, plus a 5th bit from
+            // qh (read as one little-endian u32, bit j for the low half,
+            // bit j+16 for the high half — see dequantize_row_q5_0).
             uint64_t nb = (target->n + 31) / 32;
             for (uint64_t b = 0; b < nb; b++) {
                 float d = rd_f16();
-                uint8_t ql[16]; fread(ql, 1, 16, f);
-                uint8_t qh[4]; fread(qh, 1, 4, f);
-                for (int j = 0; j < 32 && b*32+j < target->n; j++) {
-                    uint8_t lo = (ql[j/2] >> (4*(j%2))) & 0xF;
-                    uint8_t hi = (qh[j/8] >> (j%8)) & 1;
-                    output[b*32+j] = (float)((int)(lo | (hi << 4)) - 16) * d;
+                uint8_t qh_bytes[4]; fread(qh_bytes, 1, 4, f);
+                uint32_t qh; memcpy(&qh, qh_bytes, 4);
+                uint8_t qs[16]; fread(qs, 1, 16, f);
+                for (int j = 0; j < 16; j++) {
+                    uint8_t xh_0 = (uint8_t)(((qh >> j) << 4) & 0x10);
+                    uint8_t xh_1 = (uint8_t)((qh >> (j + 12)) & 0x10);
+                    int32_t x0 = (int32_t)((qs[j] & 0xF) | xh_0) - 16;
+                    int32_t x1 = (int32_t)((qs[j] >> 4) | xh_1) - 16;
+                    size_t i0 = b*32+j, i1 = b*32+j+16;
+                    if (i0 < target->n) output[i0] = x0 * d;
+                    if (i1 < target->n) output[i1] = x1 * d;
                 }
             }
             break;
         }
-        case 7: { // Q5_1: 32 elems, 2 bytes d + 2 bytes m + 4 bytes qh + 16 bytes ql = 24 bytes/block
+        case 7: { // Q5_1: 32 elems, 2 bytes d + 2 bytes m + 4 bytes qh + 16 bytes qs = 24 bytes/block
             uint64_t nb = (target->n + 31) / 32;
             for (uint64_t b = 0; b < nb; b++) {
                 float d = rd_f16(); float m = rd_f16();
-                uint8_t qh[4]; fread(qh, 1, 4, f);
-                uint8_t ql[16]; fread(ql, 1, 16, f);
-                for (int j = 0; j < 32 && b*32+j < target->n; j++) {
-                    int lo = (ql[j/2] >> (4*(j%2))) & 0xF;
-                    int hi = (qh[j/8] >> (j%8)) & 1;
-                    output[b*32+j] = (float)((lo | (hi << 4)) - 16) * d + m;
+                uint8_t qh_bytes[4]; fread(qh_bytes, 1, 4, f);
+                uint32_t qh; memcpy(&qh, qh_bytes, 4);
+                uint8_t qs[16]; fread(qs, 1, 16, f);
+                for (int j = 0; j < 16; j++) {
+                    uint8_t xh_0 = (uint8_t)(((qh >> j) << 4) & 0x10);
+                    uint8_t xh_1 = (uint8_t)((qh >> (j + 12)) & 0x10);
+                    int32_t x0 = (int32_t)((qs[j] & 0xF) | xh_0);
+                    int32_t x1 = (int32_t)((qs[j] >> 4) | xh_1);
+                    size_t i0 = b*32+j, i1 = b*32+j+16;
+                    if (i0 < target->n) output[i0] = x0 * d + m;
+                    if (i1 < target->n) output[i1] = x1 * d + m;
                 }
             }
             break;

--- a/src/model_router.cpp
+++ b/src/model_router.cpp
@@ -1,0 +1,30 @@
+#include "model_router.h"
+
+// Phase 2: two rules. (a) exact Zaya1-8B dims (the only architecture the
+// hand-tuned HIP/CPU kernels understand) keeps today's behavior unchanged.
+// (b) everything else GGUF/H1B-shaped goes to cpu_generic, the one backend
+// that actually parses arbitrary llama.cpp-style tensor layouts. Q4NX/ZINC
+// routing is added in later phases (see docs/plans — Phase 3/4/5) as those
+// backends land; until then a Q4NX model simply has no route here and falls
+// through to BackendManager's normal (all-fail) behavior, which is honest
+// given no working backend exists for it yet.
+static bool is_exact_zaya_dims(const ModelConfig& cfg) {
+    return cfg.hidden == 2048 && cfg.n_layers == 40 && cfg.n_heads == 8 &&
+           cfg.n_kv_heads == 2 && cfg.head_dim == 128 && cfg.vocab == 262272;
+}
+
+BackendRoute select_backend_route(const ModelConfig& cfg) {
+    if (is_exact_zaya_dims(cfg)) {
+        return {{"hip_gpu", "cpu_scalar"}, "exact Zaya1-8B dims — hand-tuned kernel path"};
+    }
+    if (cfg.architecture == "qwen3") {
+        // FLM only serves its own bundled Qwen3 catalog (see backend_flm.cpp's
+        // tag_for_hidden) — cpu_generic as fallback if FLM/NPU isn't available
+        // or the exact size isn't a good match.
+        return {{"npu_flm", "cpu_generic"}, "qwen3 architecture — FastFlowLM NPU path"};
+    }
+    if (cfg.format == ModelFormat::GGUF || cfg.format == ModelFormat::H1B) {
+        return {{"zinc_gpu", "cpu_generic"}, "GGUF/H1B model — ZINC GPU, generic CPU fallback"};
+    }
+    return {{}, "no route for this format yet — falling back to default priority order"};
+}

--- a/src/simple_tokenizer.cpp
+++ b/src/simple_tokenizer.cpp
@@ -1,0 +1,8 @@
+// simple_tokenizer.cpp — single definition point for the shared g_tokenizer
+// instance declared in include/simple_tokenizer.h. Lives in the
+// backend_manager static lib so every target that links it (unified_server,
+// backend_demo, ...) gets the symbol, regardless of whether that target
+// actually loads/uses a real tokenizer.
+#include "simple_tokenizer.h"
+
+SimpleTokenizer g_tokenizer;

--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -23,7 +23,8 @@
 #include "backend_plugin.h"
 #include "backend.h"
 #include "model_discovery.h"
-#include "rocm_cpp/tokenizer.h"
+#include "model_router.h"
+#include "simple_tokenizer.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -64,112 +65,9 @@ static AgentWatchdog* g_watchdog = nullptr;
 // ── Tokenizer: uses RCPP BPE tokenizer (.htok) when available, falls back
 // to SimpleTokenizer (ASCII + UTF-8 byte passthrough) when not.
 // The RCPP tokenizer is linked via librocm_cpp and reads .htok binary format.
-struct SimpleTokenizer {
-    int bos_id = 2;
-    int eos_id = 1;
-    bool use_bpe = false;
-    rcpp_tokenizer_t* bpe_tok = nullptr;
-
-    bool load(const std::string& vocab_path) {
-        if (vocab_path.size() >= 5 && vocab_path.substr(vocab_path.size() - 5) == ".htok") {
-            rcpp_tokenizer_t* tok = nullptr;
-            rcpp_status_t st = rcpp_tokenizer_load(vocab_path.c_str(), &tok);
-            if (st == RCPP_OK && tok) {
-                bpe_tok = tok;
-                use_bpe = true;
-                bos_id = rcpp_tokenizer_bos_id(bpe_tok);
-                eos_id = rcpp_tokenizer_eos_id(bpe_tok);
-                fprintf(stderr, "Loaded BPE tokenizer from %s (BOS=%d, EOS=%d)\n",
-                        vocab_path.c_str(), bos_id, eos_id);
-                return true;
-            }
-            fprintf(stderr, "Failed to load BPE tokenizer from %s\n", vocab_path.c_str());
-        }
-        fprintf(stderr, "No .htok at %s — using fallback ASCII tokenizer\n", vocab_path.c_str());
-        return false;
-    }
-
-    ~SimpleTokenizer() {
-        if (bpe_tok) rcpp_tokenizer_free(bpe_tok);
-    }
-
-    std::vector<int> encode(const std::string& text) {
-        if (use_bpe && bpe_tok) {
-            std::vector<int> r(4096);
-            size_t out_n = 0;
-            rcpp_status_t st = rcpp_tokenizer_encode(bpe_tok, text.c_str(), text.size(),
-                                                      1, r.data(), r.size(), &out_n);
-            if (st == RCPP_OK && out_n > 0) {
-                r.resize(out_n);
-                return r;
-            }
-            return {bos_id};
-        }
-        // Fallback: ASCII + UTF-8 byte passthrough
-        std::vector<int> r = {bos_id};
-        for (unsigned char c : text) {
-            if (c >= 32 && c <= 126)
-                r.push_back((int)c + 100);
-            else if (c != 0)
-                r.push_back((int)c + 200);
-        }
-        return r;
-    }
-
-    /// Encode with per-token log-probabilities (for cascade strategy).
-    /// Returns token IDs and fills logprobs_out with corresponding logprobs.
-    std::vector<int> encode_with_logprobs(const std::string& text,
-                                           std::vector<double>& logprobs_out) {
-        logprobs_out.clear();
-        if (use_bpe && bpe_tok) {
-            std::vector<int> r(4096);
-            std::vector<double> lp(4096);
-            size_t out_n = 0;
-            rcpp_status_t st = rcpp_tokenizer_encode_with_logprobs(
-                bpe_tok, text.c_str(), text.size(),
-                1, r.data(), lp.data(), r.size(), &out_n);
-            if (st == RCPP_OK && out_n > 0) {
-                r.resize(out_n);
-                logprobs_out.assign(lp.begin(), lp.begin() + out_n);
-                return r;
-            }
-            return {bos_id};
-        }
-        // Fallback: encode without logprobs
-        auto tokens = encode(text);
-        logprobs_out.resize(tokens.size(), -1.0);
-        return tokens;
-    }
-
-    std::string decode(const std::vector<int>& tokens) {
-        if (use_bpe && bpe_tok) {
-            std::string r(4096, '\0');
-            size_t out_len = 0;
-            rcpp_status_t st = rcpp_tokenizer_decode(bpe_tok, tokens.data(), tokens.size(),
-                                                      r.data(), r.size(), &out_len);
-            if (st == RCPP_OK && out_len > 0) {
-                r.resize(out_len);
-                return r;
-            }
-            return "";
-        }
-        // Fallback: ASCII + UTF-8 byte passthrough
-        std::string r;
-        for (int v : tokens) {
-            if (v == bos_id || v == eos_id) continue;
-            if (v > 100 && v < 200)
-                r += (char)(v - 100);
-            else if (v > 200 && v < 456)
-                r += (char)(v - 200);
-            else {
-                r += '['; r += std::to_string(v); r += ']';
-            }
-        }
-        return r;
-    }
-};
-
-static SimpleTokenizer g_tokenizer;
+// SimpleTokenizer itself lives in include/simple_tokenizer.h; g_tokenizer is
+// defined once in src/simple_tokenizer.cpp (part of backend_manager) so any
+// backend that needs it (e.g. FlmBackend) can link against the same instance.
 
 // ── Signal handler ──
 static void handle_sigint(int) {
@@ -656,7 +554,7 @@ int main(int argc, char** argv) {
     // Phase 2.5: Scan for model files
     printf("\n── Model Discovery ──\n");
     static std::vector<ModelConfig> discovered = discover_models(g_weights_dir);
-    static ModelConfig current_cfg = default_model_config();
+    static ModelConfig current_cfg = discovered.empty() ? default_model_config() : discovered.front();
     for (auto& m : discovered) {
         printf("  ✓  %s (%s)\n", m.model_name.c_str(), m.model_path.c_str());
     }
@@ -667,7 +565,9 @@ int main(int argc, char** argv) {
     // Phase 3: Initialize
     printf("\n── Initialize ──\n");
     ModelConfig cfg = current_cfg;
-    bool inited = mgr.init(cfg, g_weights_dir);
+    BackendRoute route = select_backend_route(cfg);
+    printf("  Router: %s\n", route.reason.c_str());
+    bool inited = mgr.init(cfg, g_weights_dir, route.backend_ids_in_order);
     if (inited) {
         // Ensure active_idx_ points to the initialized backend
         // (init() returns true but doesn't update active_idx_)
@@ -826,7 +726,8 @@ int main(int argc, char** argv) {
                     printf("[model] switching to %s (%d layers, %d hidden)\n",
                            dm.model_name.c_str(), dm.n_layers, dm.hidden);
                     current_cfg = dm;
-                    mgr.init(current_cfg, g_weights_dir);
+                    BackendRoute swrt = select_backend_route(current_cfg);
+                    mgr.init(current_cfg, g_weights_dir, swrt.backend_ids_in_order);
                     break;
                 }
             }

--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -565,6 +565,11 @@ int main(int argc, char** argv) {
     // Phase 3: Initialize
     printf("\n── Initialize ──\n");
     ModelConfig cfg = current_cfg;
+    // Prefer the model's own embedded GGUF vocab over the fixed .htok/ASCII
+    // tokenizer loaded above — correct per-model tokenization matters as
+    // much as backend routing for arbitrary (non-Zaya) models. Falls back
+    // silently (keeps whatever tokenizer was already loaded) if unavailable.
+    g_tokenizer.load_from_gguf(cfg.model_path);
     BackendRoute route = select_backend_route(cfg);
     printf("  Router: %s\n", route.reason.c_str());
     bool inited = mgr.init(cfg, g_weights_dir, route.backend_ids_in_order);
@@ -726,6 +731,7 @@ int main(int argc, char** argv) {
                     printf("[model] switching to %s (%d layers, %d hidden)\n",
                            dm.model_name.c_str(), dm.n_layers, dm.hidden);
                     current_cfg = dm;
+                    g_tokenizer.load_from_gguf(current_cfg.model_path);
                     BackendRoute swrt = select_backend_route(current_cfg);
                     mgr.init(current_cfg, g_weights_dir, swrt.backend_ids_in_order);
                     break;


### PR DESCRIPTION
## Summary

`unified_server` previously ran the hardcoded Zaya1-8B config regardless of what was actually in the weights directory. This wires model discovery into the server for real and adds a routing layer that picks the right backend per model, so an arbitrary dropped-in GGUF/Q4NX model now actually works — live-verified end to end, not just structurally routed.

**Three commits:**

1. **`feat: unified model→backend router, real GGUF Q4_K/Q6_K dequant, ZINC+FLM backends`**
   - `ModelConfig` gains format/architecture/quantization fields; fixed a bug where `general.architecture` was getting clobbered by `general.name` in the same GGUF file.
   - `npu_xrt` gated out of all auto-selection (`docs/GEMM-KERNEL-CORRECTNESS-CONFIRMED.md` — confirmed producing wrong output).
   - Wired in `GenericBackend` (`cpu_generic`) — previously dead code, compiled but never instantiated.
   - New `backend_flm.cpp`: real NPU inference via the FastFlowLM subprocess, ported from a test-only prototype to the canonical `Backend` interface with real tokenizer bridging.
   - New `backend_zinc.cpp` + `libzinc.so` integration: general multi-arch/multi-quant GPU inference via the separate ZINC project. Live-verified ~140 tok/s real GPU inference.
   - `Q4_K`/`Q6_K` dequantization were literal zero-fill stubs — implemented for real, verified bit-exact against an independent reference.
   - Fixed a latent FP16 subnormal-handling bug shared by every quant format in the GGUF loader.

2. **`feat: real per-model tokenizer via ZINC's GGUF-native BPE`**
   - Every text-quality issue traced back to one root cause: no real per-model tokenizer. Reused ZINC's already-proven GGUF-native BPE tokenizer instead of writing a new one.
   - Live result: `zinc_gpu` produces fully coherent English on a real downloaded model instead of garbled/bracket-notation output.

3. **`fix: GenericBackend forward-pass bugs (RoPE convention, QKV bias, Q4_0/Q5_0/Q5_1)`**
   - Found via systematic numerical diffing against an independent reference (dumped real intermediate tensor values, compared against numpy + the `gguf` Python package).
   - RoPE was using the wrong rotation convention (GPT-J-style instead of the NeoX half-split GGUF models actually use).
   - QKV bias (Qwen2 uses biased attention projections) was never loaded or applied.
   - `Q4_0`/`Q5_0`/`Q5_1` dequantization used the wrong nibble de-interleaving order.
   - End result: `cpu_generic` now produces genuinely coherent output too, matching `zinc_gpu`.

## Test plan

- [x] Full clean build (`cmake --build build --target unified_server backend_demo`) passes
- [x] `npu_xrt` confirmed never auto-selected in `backend_demo`'s discovery/init log
- [x] Real GGUF model → discovered → routed → `zinc_gpu` → coherent completion via `/v1/chat/completions`
- [x] Same model → `cpu_generic` → coherent completion (previously garbled)
- [x] Q4_K/Q6_K/Q5_0 dequantization verified bit-exact (max abs diff `0.0`) against the independent `gguf` Python reference
- [x] Existing Zaya default flow unaffected (`hip_gpu`/`cpu_scalar` still reject non-Zaya configs as before)

Note: `zinc_gpu`/`libzinc.so` build support requires a pinned Zig 0.15.2 toolchain and a separate ZINC checkout — the build gracefully falls back (`ZINC_DISABLED`) when unavailable, so this doesn't block CI on runners without that setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
