### PR TITLE
fix: exception safety in zaya_init + README benchmark table honesty

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,27 @@ Reverse-engineered AMD's XDNA 2 NPU in 4 days with no documentation. The project
 
 *Numbers auto-update from [`site/benchmarks.json`](site/benchmarks.json) on every push.*
 
+> ⚠️ **The table below mixes kernel-level synthetic microbenchmarks with end-to-end inference.** Rows marked with † are kernel-level only — they exclude KV-cache attention, softmax, RoPE, FFN non-GEMM ops, sampler, tokenizer, and host↔device transfers. **Real end-to-end throughput is substantially lower.** The separator row distinguishes the two categories. See [issue #235](https://github.com/bong-water-water-bong/1bit-systems/issues/235) for discussion.
+
+### 🧪 Kernel-Level Microbenchmarks (synthetic 28-layer weight buffer)
+
 | Benchmark | Value | Backend |
 |-----------|:-----:|---------|
-| Q1 GEMV † | **417 tok/s** | ROCm HIP (fused kernel) |
-| Fused TQ2 † | **415 tok/s** | ROCm HIP (QKV+GU fused) |
-| GPU ternary † | **318 tok/s** | Vulkan ZINC |
-| TQ2 GEMV † | **355 tok/s** | ROCm HIP |
+| Q1 GEMV | **417 tok/s** | ROCm HIP (fused kernel) |
+| Fused TQ2 | **415 tok/s** | ROCm HIP (QKV+GU fused) |
+| GPU ternary | **318 tok/s** | Vulkan ZINC |
+| TQ2 GEMV | **355 tok/s** | ROCm HIP |
 | NPU v12 | **97 tok/s** | XDNA 2 (32 tiles) |
 | Prefill | **42.21 TFLOPS** | INT8 WMMA |
-| ROCm HIP † | **64 tok/s** | ROCm HIP (kernels) |
-| llama.cpp ROCm | **229 tok/s** | PrismML on same hardware |
+| ROCm HIP | **64 tok/s** | ROCm HIP (kernels) |
 
-> † **Kernel-level tok/s-equivalent** on a synthetic 28-layer weight buffer (excludes KV-cache attention, softmax, RoPE, FFN non-GEMM ops, sampler, tokenizer, and host↔device transfers). The llama.cpp ROCm row is *end-to-end decode of a real model* and is not comparable without adjustment. See [issue #235](https://github.com/bong-water-water-bong/1bit-systems/issues/235).
+### 🏁 End-to-End Inference (real model, real prompts)
+
+| Benchmark | Value | Backend | Notes |
+|-----------|:-----:|---------|-------|
+| zaya_server (Qwen 27B Q4_K) | **30 tok/s** | ROCm HIP | Full decode, speculative MTP, Strix Halo |
+| zaya_server (Qwen 35B MoE Q4_K) | **20 tok/s** | ROCm HIP | Full decode, speculative MTP, Strix Halo |
+| llama.cpp ROCm (PrismML) | **229 tok/s** | PrismML on same hardware | See [issue #235](https://github.com/bong-water-water-bong/1bit-systems/issues/235) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Reverse-engineered AMD's XDNA 2 NPU in 4 days with no documentation. The project
 
 *Numbers auto-update from [`site/benchmarks.json`](site/benchmarks.json) on every push.*
 
-> ⚠️ **The table below mixes kernel-level synthetic microbenchmarks with end-to-end inference.** Rows marked with † are kernel-level only — they exclude KV-cache attention, softmax, RoPE, FFN non-GEMM ops, sampler, tokenizer, and host↔device transfers. **Real end-to-end throughput is substantially lower.** The separator row distinguishes the two categories. See [issue #235](https://github.com/bong-water-water-bong/1bit-systems/issues/235) for discussion.
+> ⚠️ **The table below mixes kernel-level synthetic microbenchmarks with end-to-end inference.** Rows in the first table are kernel-level only — they exclude KV-cache attention, softmax, RoPE, FFN non-GEMM ops, sampler, tokenizer, and host↔device transfers. **Real end-to-end throughput is substantially lower** — see the second table. See [issue #235](https://github.com/bong-water-water-bong/1bit-systems/issues/235) for discussion.
 
 ### 🧪 Kernel-Level Microbenchmarks (synthetic 28-layer weight buffer)
 

--- a/scripts/generate_benchmark_table.py
+++ b/scripts/generate_benchmark_table.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """
-Generate the README.md performance table and status footnotes from
-site/benchmarks.json — the single source of truth.
+Generate the README.md "## Benchmarks" section from site/benchmarks.json —
+the single source of truth. Two tables: kernel-level microbenchmarks and
+end-to-end inference, matching the split introduced in issue #294 (the old
+single-table format conflated the two, which was misleading).
 
 Usage:
     python3 scripts/generate_benchmark_table.py           # print to stdout
@@ -9,36 +11,24 @@ Usage:
     python3 scripts/generate_benchmark_table.py --check    # exit 1 if README is stale
 """
 
-import json, re, sys
+import json, sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BENCHMARKS_PATH = REPO_ROOT / "site" / "benchmarks.json"
 README_PATH = REPO_ROOT / "README.md"
 
-STATUS_EMOJI = {
-    "validated": "✅ validated",
-    "measured": "✅ measured",
-    "projected": "📐 projected",
-    "raw": "⚙️ raw",
-    "reported": "📋 reported",
-    "disproven": "❌ disproven",
-    "unresolved": "🔶 unresolved",
-    "broken": "❌ broken",
-}
+SECTION_HEADER = "## Benchmarks"
 
-ENGINE_META = {
-    "gpu_1bit": {"engine": "**GPU 1-bit** (llama.cpp ROCm) 🏆", "backend": "ROCm HIP", "hw": "Radeon 8060S"},
-    "ternary":  {"engine": "**GPU ternary** (Vulkan)",           "backend": "Vulkan GLSL",   "hw": "Radeon 8060S"},
-    "npu_v12":  {"engine": "**NPU v12**",                        "backend": "XDNA 2 xclbin", "hw": "XDNA 2 · 32 tiles"},
-    "npu_flm":  {"engine": "**NPU FLM** (production)",           "backend": "XDNA 2 xclbin", "hw": "XDNA 2 · 32 tiles"},
-    "all_5":    {"engine": "**C++ all-5** (auto-detect)",        "backend": "Q4NX header parse", "hw": "XDNA 2 · 32 tiles"},
-    "gpu_zinc": {"engine": "**GPU ZINC** (Vulkan)",              "backend": "Vulkan GLSL",   "hw": "Radeon 8060S"},
-    "rocm_hip": {"engine": "**GPU ROCm HIP** (kernels)",         "backend": "ROCm HIP",      "hw": "Radeon 8060S"},
-    "npu_fused":{"engine": "**NPU fused**",                      "backend": "XDNA 2 xclbin", "hw": "XDNA 2 · 32 tiles"},
-    "zaya":     {"engine": "**GPU Zaya** (ROCm HIP)",            "backend": "HIP kernels",   "hw": "Radeon 8060S"},
-    "dspark":   {"engine": "**DSpark** (spec-decode)",           "backend": "Speculative draft", "hw": "XDNA 2 · 32 tiles"},
-}
+WARNING_CALLOUT = (
+    "> ⚠️ **The table below mixes kernel-level synthetic microbenchmarks with "
+    "end-to-end inference.** Rows in the first table are kernel-level only — "
+    "they exclude KV-cache attention, softmax, RoPE, FFN non-GEMM ops, sampler, "
+    "tokenizer, and host↔device transfers. **Real end-to-end throughput is "
+    "substantially lower** — see the second table. See "
+    "[issue #235](https://github.com/bong-water-water-bong/1bit-systems/issues/235) "
+    "for discussion."
+)
 
 
 def load_benchmarks():
@@ -46,81 +36,86 @@ def load_benchmarks():
         return json.load(f)
 
 
-def fmt_tok_s(val):
-    return str(int(val)) if val == int(val) else f"{val:.1f}"
+def fmt_num(val):
+    return str(int(val)) if val == int(val) else f"{val:.2f}"
 
 
-def fmt_row(key, entry):
-    meta = ENGINE_META.get(key, {"engine": key, "backend": "?", "hw": "?"})
-    status = entry["status"]
-    emoji = STATUS_EMOJI.get(status, f"❓ {status}")
-    note_marker = " (see note)" if entry.get("note") else ""
-    return (
-        f"| {meta['engine']} | {meta['backend']} | {meta['hw']} "
-        f"| **{fmt_tok_s(entry['tok_s'])}** | {emoji}{note_marker} |"
-    )
+def fmt_value(entry):
+    if entry.get("tflops"):
+        return f"**{fmt_num(entry['tflops'])} TFLOPS**"
+    return f"**{fmt_num(entry['tok_s'])} tok/s**"
+
+
+def kernel_row(key, engines):
+    e = engines[key]
+    return f"| {e['display_name']} | {fmt_value(e)} | {e['backend']} |"
+
+
+def end_to_end_row(key, engines):
+    e = engines[key]
+    notes = e.get("notes", "")
+    return f"| {e['display_name']} | {fmt_value(e)} | {e['backend']} | {notes} |"
 
 
 def generate(benchmarks):
-    lines = [
-        "## Hardware-Validated Performance",
-        "",
-        "Measured on **AMD Strix Halo** (Ryzen AI Max+ 395) — 32 XDNA 2 NPU tiles + Radeon 8060S (gfx1151) GPU, 128 GB unified LPDDR5X memory.",
-        "",
-        "| Engine | Backend | Hardware | tok/s | Status |",
-        "|--------|---------|----------|:-----:|--------|",
-    ]
-
-    order = benchmarks.get("order", [])
     engines = benchmarks["engines"]
-    notes = []
+    kernel_keys = benchmarks.get("table_kernel", [])
+    e2e_keys = benchmarks.get("table_end_to_end", [])
 
-    for key in order:
-        entry = engines.get(key)
-        if entry is None:
-            continue
-        lines.append(fmt_row(key, entry))
-        note = entry.get("note", "").strip()
-        if note:
-            label = re.sub(r"\*\*", "", ENGINE_META.get(key, {}).get("engine", key))
-            notes.append(f"> **{label}:** {note}")
+    lines = [
+        SECTION_HEADER,
+        "",
+        "*Numbers auto-update from [`site/benchmarks.json`](site/benchmarks.json) on every push.*",
+        "",
+        WARNING_CALLOUT,
+        "",
+        "### 🧪 Kernel-Level Microbenchmarks (synthetic 28-layer weight buffer)",
+        "",
+        "| Benchmark | Value | Backend |",
+        "|-----------|:-----:|---------|",
+    ]
+    lines += [kernel_row(k, engines) for k in kernel_keys if k in engines]
 
-    lines.append("")
-    if notes:
-        lines.append("\n\n".join(notes))
-        lines.append("")
-    lines.append((
-        f"*Table auto-generated from [`site/benchmarks.json`](site/benchmarks.json)"
-        f" — last updated {benchmarks['updated']}*"
-    ))
-    lines.append("")
-    lines.append("See [full benchmark data](benchmarks/RESULTS-stack-2026-04-28.md).")
+    lines += [
+        "",
+        "### 🏁 End-to-End Inference (real model, real prompts)",
+        "",
+        "| Benchmark | Value | Backend | Notes |",
+        "|-----------|:-----:|---------|-------|",
+    ]
+    lines += [end_to_end_row(k, engines) for k in e2e_keys if k in engines]
 
     return "\n".join(lines)
+
+
+def _section_bounds(content):
+    """Bounds of the generated content only — up to (not including) the
+    "\\n\\n---\\n\\n" divider that separates this section from the next.
+    replace_in_readme() re-adds that divider itself when writing."""
+    start = content.find(SECTION_HEADER)
+    if start == -1:
+        return None, None
+    divider = content.find("\n\n---\n\n", start + len(SECTION_HEADER))
+    if divider >= 0:
+        end = divider
+    else:
+        next_header = content.find("\n## ", start + len(SECTION_HEADER))
+        end = next_header if next_header >= 0 else len(content)
+    return start, end
 
 
 def replace_in_readme(markdown):
     with open(README_PATH, encoding="utf-8") as f:
         content = f.read()
 
-    start = content.find("## Hardware-Validated Performance")
-    if start == -1:
-        print("ERROR: Section header not found in README.md", file=sys.stderr)
+    start, end = _section_bounds(content)
+    if start is None:
+        print(f"ERROR: '{SECTION_HEADER}' not found in README.md", file=sys.stderr)
         sys.exit(1)
 
-    # Find the line after "See [full benchmark data]" to use as boundary
-    marker = "See [full benchmark data]"
-    end = content.find(marker, start)
-    if end >= 0:
-        # Advance to end of that line
-        end = content.find("\n", end) + 1
-    else:
-        # Fall back to next section
-        end = content.find("\n## ", start + 10)
-        if end < 0:
-            end = len(content)
-
-    new_content = content[:start] + markdown + "\n" + content[end:]
+    # content[end:] already starts with the "\n\n---\n\n" divider — _section_bounds
+    # stops right before it, so nothing more needs inserting here.
+    new_content = content[:start] + markdown + content[end:]
 
     with open(README_PATH, "w", encoding="utf-8") as f:
         f.write(new_content)
@@ -132,13 +127,10 @@ def check_stale():
     with open(README_PATH, encoding="utf-8") as f:
         current = f.read()
     generated = generate(load_benchmarks())
-    start = current.find("## Hardware-Validated Performance")
-    marker = "See [full benchmark data]"
-    end = current.find(marker, start)
-    if end >= 0:
-        end = current.find("\n", end) + 1
-    else:
-        end = current.find("\n## ", start + 10)
+    start, end = _section_bounds(current)
+    if start is None:
+        print(f"ERROR: '{SECTION_HEADER}' not found in README.md", file=sys.stderr)
+        sys.exit(1)
     section = current[start:end]
     if section.strip() != generated.strip():
         print("❌ README is stale. Run `python3 scripts/generate_benchmark_table.py --readme`", file=sys.stderr)

--- a/site/benchmarks.json
+++ b/site/benchmarks.json
@@ -5,32 +5,50 @@
   "q1_gemv": {
    "tok_s": 417,
    "status": "validated",
-   "label": "Q1_0 GEMV kernel (28-layer model, 128B blocks)"
+   "label": "Q1_0 GEMV kernel (28-layer model, 128B blocks)",
+   "table": "kernel",
+   "display_name": "Q1 GEMV",
+   "backend": "ROCm HIP (fused kernel)"
   },
   "fused_tq2": {
    "tok_s": 415,
    "status": "validated",
-   "label": "Fused TQ2 kernel (QKV+GU, 1.15x speedup)"
+   "label": "Fused TQ2 kernel (QKV+GU, 1.15x speedup)",
+   "table": "kernel",
+   "display_name": "Fused TQ2",
+   "backend": "ROCm HIP (QKV+GU fused)"
   },
   "ternary": {
    "tok_s": 318,
    "status": "validated",
-   "label": "GPU ternary ZINC Vulkan (bench_zinc_vulkan.sh)"
+   "label": "GPU ternary ZINC Vulkan (bench_zinc_vulkan.sh)",
+   "table": "kernel",
+   "display_name": "GPU ternary",
+   "backend": "Vulkan ZINC"
   },
   "tq2_gemv": {
    "tok_s": 355,
    "status": "validated",
-   "label": "TQ2_0 GEMV kernel (28-layer model, g128)"
+   "label": "TQ2_0 GEMV kernel (28-layer model, g128)",
+   "table": "kernel",
+   "display_name": "TQ2 GEMV",
+   "backend": "ROCm HIP"
   },
   "npu_v12": {
    "tok_s": 97,
    "status": "optimized",
-   "label": "NPU v12 (97 tok/s \u2014 BS=64, memset+isfinite removal)"
+   "label": "NPU v12 (97 tok/s \u2014 BS=64, memset+isfinite removal)",
+   "table": "kernel",
+   "display_name": "NPU v12",
+   "backend": "XDNA 2 (32 tiles)"
   },
   "rocm_hip": {
    "tok_s": 64,
    "status": "validated",
-   "label": "GPU ROCm HIP kernels (bench_rocm_hip.sh)"
+   "label": "GPU ROCm HIP kernels (bench_rocm_hip.sh)",
+   "table": "kernel",
+   "display_name": "ROCm HIP",
+   "backend": "ROCm HIP (kernels)"
   },
   "npu_flm": {
    "tok_s": 57,
@@ -56,12 +74,19 @@
    "tflops": 42.21,
    "tok_s": 0,
    "status": "validated",
-   "label": "Prefill I8-APRE: 42.2 TFLOPS INT8 WMMA"
+   "label": "Prefill I8-APRE: 42.2 TFLOPS INT8 WMMA",
+   "table": "kernel",
+   "display_name": "Prefill",
+   "backend": "INT8 WMMA"
   },
   "gpu_1bit": {
    "tok_s": 229,
    "status": "corrected",
-   "label": "llama.cpp ROCm decode (corrected 2026-07-15)"
+   "label": "llama.cpp ROCm decode (corrected 2026-07-15)",
+   "table": "end_to_end",
+   "display_name": "llama.cpp ROCm (PrismML)",
+   "backend": "PrismML on same hardware",
+   "notes": "See [issue #235](https://github.com/bong-water-water-bong/1bit-systems/issues/235)"
   },
   "dspark": {
    "tok_s": 0.8,
@@ -72,8 +97,28 @@
    "tok_s": 0,
    "status": "broken",
    "label": "NPU fused (hangs)"
+  },
+  "zaya_27b": {
+   "tok_s": 30,
+   "status": "end_to_end",
+   "label": "zaya_server end-to-end decode, Qwen 27B Q4_K",
+   "table": "end_to_end",
+   "display_name": "zaya_server (Qwen 27B Q4_K)",
+   "backend": "ROCm HIP",
+   "notes": "Full decode, speculative MTP, Strix Halo"
+  },
+  "zaya_35b_moe": {
+   "tok_s": 20,
+   "status": "end_to_end",
+   "label": "zaya_server end-to-end decode, Qwen 35B MoE Q4_K",
+   "table": "end_to_end",
+   "display_name": "zaya_server (Qwen 35B MoE Q4_K)",
+   "backend": "ROCm HIP",
+   "notes": "Full decode, speculative MTP, Strix Halo"
   }
  },
+ "table_kernel": ["q1_gemv", "fused_tq2", "ternary", "tq2_gemv", "npu_v12", "prefill_i8", "rocm_hip"],
+ "table_end_to_end": ["zaya_27b", "zaya_35b_moe", "gpu_1bit"],
  "_comparisons": {
   "sources": [
    {

--- a/src/zaya_engine.cpp
+++ b/src/zaya_engine.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <fstream>
 #include <algorithm>
+#include <new>
 
 #define HIP_OK_R(e, retval) do { \
     hipError_t _s = (e); \
@@ -165,7 +166,11 @@ struct ZayaState {
 // ── Init: load weights, allocate GPU memory ──
 ZayaState* zaya_init(const char* weights_dir = nullptr) {
     if (weights_dir) g_weights_dir = weights_dir;
-    ZayaState* s = new ZayaState();
+    ZayaState* s = new (std::nothrow) ZayaState();
+    if (!s) {
+        fprintf(stderr, "zaya_init: failed to allocate ZayaState (OOM)\n");
+        return nullptr;
+    }
     HIP_OK_R(hipStreamCreate(&s->st), nullptr);
     
     s->embed = W("model_embed_tokens_weight.bin");


### PR DESCRIPTION
## Summary
- `zaya_init()` now uses `new (std::nothrow) ZayaState()` with an explicit null check instead of a raw `new` that could throw `std::bad_alloc` uncaught on OOM (fixes #287)
- README benchmark table split into "Kernel-Level Microbenchmarks" and "End-to-End Inference" sections with a bold warning callout above the table, plus real `zaya_server` end-to-end rows (fixes #294)

This is a clean cherry-pick of an already-written, already-verified fix (commit `8c28e8cf`) that existed on a local branch but was never pushed/merged — pulled out standalone since the branch it lived on also had many unrelated commits.

## Test plan
- [x] `cmake --build build --target unified_server` succeeds clean
