### PR TITLE
docs: recover HN post, Reddit post, and Twitter thread drafts

### DIFF
--- a/docs/hn-post.md
+++ b/docs/hn-post.md
@@ -1,77 +1,70 @@
 # Hacker News Post Draft
 
 ## Title:
-**Native ternary on AMD's NPU: 32 cores, 128/128 bit-exact, 118.9 µs — on a laptop**
+**One binary, model-agnostic across NPU + GPU + CPU, zero Python — on AMD Strix Halo**
 
 ## Body:
 
-AMD shipped the Strix Halo with a 50 TOPS NPU and 32 AIE cores. Then they
-locked sub-8-bit compute behind a proprietary runtime.
+AMD shipped the Strix Halo with a 50 TOPS NPU, a real GPU, and 128 GB of unified
+memory. The official stack only lets you use them one at a time, through
+separate proprietary or semi-proprietary tools, each tied to its own model
+format.
 
-The silicon can do 2-bit packed ternary natively. The vector units are right
-there. AMD just decided you shouldn't be allowed to use them without paying.
-
-I bought one. I got angry. I fixed it.
-
-**32-core native ternary kernel. 128/128 bit-exact. 118.9 microseconds.
-314 KB xclbin. No FastFlowLM. No proprietary anything. MIT licensed.**
+I built a single C++ binary that routes whatever GGUF model you hand it to
+whichever backend can actually run it — GPU (ROCm HIP), NPU (via FastFlowLM,
+since our own in-process NPU kernels aren't correctness-verified yet — more on
+that below), or CPU fallback. No config files, no model registry. Drop in a
+model, it works.
 
 ### What this is
 
-- **Native ternary on the NPU**: 2-bit packed weights → BF16 MAC, decoded on-the-fly
-- **128/128 bit-exact**: all-ones test = -256.0000 exactly. Not "within tolerance." EXACTLY.
-- **118.9 µs per call**: 32,768 MACs (128 rows × 256 ternary) in one dispatch
-- **314 KB xclbin**: built with open-source Chess C++ + MLIR. Zero proprietary bits.
-- **Q2_0 decoder**: cos=1.000000 vs F16. We reverse-engineered the format bit-for-bit.
+- **Model-agnostic router**: reads a GGUF/safetensors/Q4NX file's own metadata
+  (architecture, quantization, tensor shapes) and picks a backend automatically
+- **Real quant format support**: Q4_0/Q5_0/Q5_1/Q8_0/Q4_K/Q5_K/Q6_K/Q2_K/Q3_K/Q8_K/BF16,
+  each dequantizer verified bit-exact against the independent `gguf` Python
+  reference implementation — not "looks right," actually diffed
+- **A CPU reference backend** (Qwen2/Qwen3/Llama/Mistral/Gemma/Phi family,
+  including MoE routing and Qwen3's Q/K-norm) verified against an independent
+  numpy forward pass, not just "doesn't crash"
+- **Zero Python at runtime**: C++23, one binary, no pip/Docker/conda
 
-### The "wait, AMD locked that?" part
+### The honest part
 
-Ternary models store weights as {-1, 0, +1}. Bonsai-1.7B = 250 MB. Same model
-at FP16 = 3.4 GB. That's 13.6× smaller. The entire thing fits in L3 cache.
+Our own in-process NPU engine (`engine/npu/`) has a confirmed correctness bug
+in its GEMM kernels on real hardware — the numbers looked good, the output
+didn't. Rather than ship that as "NPU support," the default NPU path delegates
+to FastFlowLM (an external, already-correct subprocess) until our kernel is
+actually fixed. That's disclosed in the README, not buried in a footnote.
 
-AMD's NPU can process 4 ternary weights per byte — the AIE vector units have
-native 2-bit decode paths. But the official toolchain only exposes INT8. So
-everyone running 1-bit models on AMD NPUs has been upcasting to INT8 first,
-throwing away the whole point of ternary.
+Real, validated (not synthetic) end-to-end numbers on a Radeon 8060S + XDNA 2
+Strix Halo box:
 
-We wrote the kernel they should have shipped: `mm_ternary_32x64x128`. Decodes
-2-bit packed ternary on-the-fly. Multiplies against BF16 activations. Reduces
-via dot product. Applies per-row scale. 4× less memory traffic than INT8.
+| Path | tok/s | Status |
+|------|:-----:|--------|
+| GPU ROCm HIP (kernel-level) | 64 | validated |
+| NPU via FastFlowLM | 57 | validated |
+| GPU Vulkan (ZINC) | 22 | validated |
+| zaya_server, Qwen 27B Q4_K, real prompt | 30 | end-to-end |
+| zaya_server, Qwen 35B MoE Q4_K, real prompt | 20 | end-to-end |
 
-### The routing bug that took out 31 of 32 cores
-
-Built the 32-core xclbin. Chess compiled. MLIR generated. aiecc packaged.
-Loaded it on the NPU. Ran the all-ones test.
-
-1 core produced -256.0000. The other 31 produced zeros.
-
-The AIE interconnect on XDNA2 does NOT support cross-column broadcast from
-a mem tile to cores in other columns. The official examples rely on this
-pattern. It silently fails on hardware. You get one column working and 31
-cores sitting idle.
-
-We discovered this the hard way — probing the raw output, finding exactly
-4 correct values out of 128. The fix: per-column DMA routing. Each of 8
-shim tiles feeds its column's 4 cores directly. Same-column routing works
-fine. Cross-column is a lie.
-
-First time this pattern has been proven on XDNA2.
+For comparison, `llama.cpp` on the same ROCm hardware hits 229 tok/s
+end-to-end — we're not claiming to beat it, we're claiming honesty about
+where we actually stand while we close that gap.
 
 ### What's next
 
-- Full Bonsai-1.7B on the NPU (tile the 2048-dim GEMV across kernel calls)
-- Per-layer xclbins at production dimensions
-- HIP kernel integration for the Radeon 8060S (13 GEMV kernels, 5 packing formats)
-- End-to-end spec-decode: NPU draft + GPU verify
+- Fix the in-process NPU GEMM kernel correctness bug so we can retire the
+  FastFlowLM dependency
+- Vision and RAG support (not started)
+- Close the gap with llama.cpp's GPU decode throughput
 
 ### Links
 
-GitHub: https://github.com/bong-water-water-bong/1bit-systems  
-Kernel: `1bit-systems/engine/npu/kernel/mm_ternary_32x64x128.cpp`  
-Docs: `docs/ternary-npu.md`
+GitHub: https://github.com/bong-water-water-bong/1bit-systems
 
-MIT. Open source. No NDAs. No inside access. Just a C++ compiler and spite.
+MIT licensed. Open issues, including the ones we filed on ourselves when we
+found our own numbers were wrong.
 
 ---
 
-*"The silicon was never the bottleneck. The business model was."*
+*"The silicon was never the bottleneck. Getting the numbers right was."*

--- a/docs/hn-post.md
+++ b/docs/hn-post.md
@@ -1,0 +1,77 @@
+# Hacker News Post Draft
+
+## Title:
+**Native ternary on AMD's NPU: 32 cores, 128/128 bit-exact, 118.9 µs — on a laptop**
+
+## Body:
+
+AMD shipped the Strix Halo with a 50 TOPS NPU and 32 AIE cores. Then they
+locked sub-8-bit compute behind a proprietary runtime.
+
+The silicon can do 2-bit packed ternary natively. The vector units are right
+there. AMD just decided you shouldn't be allowed to use them without paying.
+
+I bought one. I got angry. I fixed it.
+
+**32-core native ternary kernel. 128/128 bit-exact. 118.9 microseconds.
+314 KB xclbin. No FastFlowLM. No proprietary anything. MIT licensed.**
+
+### What this is
+
+- **Native ternary on the NPU**: 2-bit packed weights → BF16 MAC, decoded on-the-fly
+- **128/128 bit-exact**: all-ones test = -256.0000 exactly. Not "within tolerance." EXACTLY.
+- **118.9 µs per call**: 32,768 MACs (128 rows × 256 ternary) in one dispatch
+- **314 KB xclbin**: built with open-source Chess C++ + MLIR. Zero proprietary bits.
+- **Q2_0 decoder**: cos=1.000000 vs F16. We reverse-engineered the format bit-for-bit.
+
+### The "wait, AMD locked that?" part
+
+Ternary models store weights as {-1, 0, +1}. Bonsai-1.7B = 250 MB. Same model
+at FP16 = 3.4 GB. That's 13.6× smaller. The entire thing fits in L3 cache.
+
+AMD's NPU can process 4 ternary weights per byte — the AIE vector units have
+native 2-bit decode paths. But the official toolchain only exposes INT8. So
+everyone running 1-bit models on AMD NPUs has been upcasting to INT8 first,
+throwing away the whole point of ternary.
+
+We wrote the kernel they should have shipped: `mm_ternary_32x64x128`. Decodes
+2-bit packed ternary on-the-fly. Multiplies against BF16 activations. Reduces
+via dot product. Applies per-row scale. 4× less memory traffic than INT8.
+
+### The routing bug that took out 31 of 32 cores
+
+Built the 32-core xclbin. Chess compiled. MLIR generated. aiecc packaged.
+Loaded it on the NPU. Ran the all-ones test.
+
+1 core produced -256.0000. The other 31 produced zeros.
+
+The AIE interconnect on XDNA2 does NOT support cross-column broadcast from
+a mem tile to cores in other columns. The official examples rely on this
+pattern. It silently fails on hardware. You get one column working and 31
+cores sitting idle.
+
+We discovered this the hard way — probing the raw output, finding exactly
+4 correct values out of 128. The fix: per-column DMA routing. Each of 8
+shim tiles feeds its column's 4 cores directly. Same-column routing works
+fine. Cross-column is a lie.
+
+First time this pattern has been proven on XDNA2.
+
+### What's next
+
+- Full Bonsai-1.7B on the NPU (tile the 2048-dim GEMV across kernel calls)
+- Per-layer xclbins at production dimensions
+- HIP kernel integration for the Radeon 8060S (13 GEMV kernels, 5 packing formats)
+- End-to-end spec-decode: NPU draft + GPU verify
+
+### Links
+
+GitHub: https://github.com/bong-water-water-bong/1bit-systems  
+Kernel: `1bit-systems/engine/npu/kernel/mm_ternary_32x64x128.cpp`  
+Docs: `docs/ternary-npu.md`
+
+MIT. Open source. No NDAs. No inside access. Just a C++ compiler and spite.
+
+---
+
+*"The silicon was never the bottleneck. The business model was."*

--- a/docs/reddit-post.md
+++ b/docs/reddit-post.md
@@ -1,72 +1,67 @@
 # Reddit r/LocalLLaMA Post Draft
 
 ## Title:
-**74KB C++23 binary. 22 models. No Python. I unlocked AMD's NPU in 4 days.**
+**Model-agnostic C++ inference engine for AMD Strix Halo — drop in any GGUF, it routes to NPU/GPU/CPU automatically**
 
 ## Body:
 
-**tl;dr**: 74KB binary runs 22+ model architectures (LLMs, video gen, image gen,
-audio gen) on an AMD Strix Halo NPU + GPU + CPU. Zero Python. MIT.
+**tl;dr**: single C++ binary, no Python at runtime, auto-detects any GGUF
+model's architecture/quantization and routes it to whichever of NPU
+(via FastFlowLM), GPU (ROCm HIP / Vulkan), or CPU can actually run it. MIT.
 
-```
-curl -sL https://1bit.systems/npu-install.sh | bash
-1bit pull qwen3-0.6b
-1bit chat
+```bash
+git clone https://github.com/bong-water-water-bong/1bit-systems
+cd 1bit-systems
+cmake -B build -G Ninja -DCMAKE_HIP_ARCHITECTURES=gfx1151
+cmake --build build --target zaya_server -j8
+./build/zaya_server --model /path/to/model.h1b
 ```
 
 ### Why this exists
 
-I bought a Strix Halo laptop because the NPU promised 50 TOPS. What I got was
-a vendor-locked runtime that only works with their proprietary model format,
-behind a closed-source binary, and INT8 physically works on the silicon but
-the software stack won't let you use it without paying for FastFlowLM.
+Bought a Strix Halo laptop for the NPU. Found the official stack ties you to
+one proprietary model format and doesn't let you mix NPU/GPU/CPU in the same
+request. So I built a router that reads a model's own on-disk metadata and
+picks a backend — no manifest files, no per-model config.
 
-So I reverse-engineered it. Took 4 days.
+### What's actually in it (verified, not vibes)
 
-### What's in the 74KB
+| Piece | Detail |
+|-------|--------|
+| **Quant format support** | Q4_0/Q5_0/Q5_1/Q8_0/Q4_K/Q5_K/Q6_K/Q2_K/Q3_K/Q8_K/BF16 — each dequantizer checked bit-exact against the independent `gguf` Python package |
+| **CPU reference backend** | Llama/Mistral/Qwen2/Qwen3/Gemma/Phi, incl. MoE routing + Qwen3 Q/K-norm, verified against an independent numpy forward pass |
+| **GPU backend** | ROCm HIP kernels + a Vulkan (ZINC) path |
+| **NPU backend** | Delegates to FastFlowLM — see "the catch" below for why |
+| **Video generation** | `tools/video-lora/` — Wan2.2, LTX-Video, AnimateDiff, CogVideoX, Stable Video Diffusion, with LoRA support |
+| **Dependencies at runtime** | 0. No Python, no pip, no Docker |
 
-| Feature | Detail |
-|---------|--------|
-| **NPU inference** | 94 tok/s via FLM proxy (production), 97 tok/s C++ engine |
-| **GPU inference** | 22 tok/s on Radeon 8060S via Vulkan compute (Zig) |
-| **CPU scheduler** | Unified KV cache, RadixAttention, H2O eviction |
-| **Video generation** | Wan2.2, CogVideoX, HunyuanVideo, LTX-Video, Sana, Mochi, ... (14 models) |
-| **Image generation** | Flux, Flux Schnell, SDXL, SD3.5, Flux.2 |
-| **Audio generation** | Stable Audio Open (44.1kHz stereo), AudioLDM2 |
-| **LoRA support** | All models, unified loader |
-| **Dependencies** | 0. No Python. No pip. No Docker. No MLIR. |
+### The catch — said plainly
 
-### The model-agnostic bit
+The project's own in-process NPU engine (`engine/npu/`) has a **confirmed
+GEMM kernel correctness bug** on real hardware — not "needs tuning," actually
+produces wrong output. That's why the default NPU path is FastFlowLM (external
+subprocess, already correct) instead of our own kernel. It's disclosed in the
+README, not something you find out after building it.
 
-I built a single `AgnosticPipeline` that accepts any HuggingFace model ID and
-auto-detects the correct pipeline, defaults, and modality. `--model flux` works
-the same as `--model stabilityai/stable-audio-open-1.0` or
-`--model Wan-AI/Wan2.1-T2V-1.3B-Diffusers`.
+Real numbers, current as of this post (`site/benchmarks.json`):
 
-```bash
-# LLM
-1bit chat
+| Backend | tok/s | Status |
+|---------|:-----:|--------|
+| ROCm HIP (kernel-level) | 64 | validated |
+| NPU via FastFlowLM | 57 | validated |
+| GPU Vulkan (ZINC) | 22 | validated |
+| zaya_server end-to-end, Qwen 27B Q4_K | 30 | real prompt |
+| zaya_server end-to-end, Qwen 35B MoE Q4_K | 20 | real prompt |
 
-# Video
-video-lora generate --model wan --prompt "cat walking, cinematic"
-
-# Photography
-video-lora generate --model flux --prompt "portrait, soft lighting"
-
-# Audio
-video-lora generate --model stable-audio --prompt "rain on window" --audio-end-s 30
-```
-
-### The catch
-
-The C++ NPU engine (97 tok/s) has a coherence bug — output is garbled.
-Tracking in docs/journey.md. The FLM proxy (94 tok/s) is production-ready.
-If you're an XRT/XDNA low-level person, I could use the help.
+`llama.cpp` on the same hardware hits 229 tok/s end-to-end. We're behind it
+and saying so, rather than publishing a kernel-level microbenchmark next to
+it without the disclaimer (we used to do that — a self-filed issue caught it
+and the README's been fixed since).
 
 ### Links
 
-GitHub: https://github.com/1bit-systems/1bit  
-Benchmarks: docs/wiki/performance.md  
-Audit trail: docs/journey.md (1,200+ lines, every crash and fix)
+GitHub: https://github.com/bong-water-water-bong/1bit-systems
+Audit trail: `docs/journey.md` — every real bug and fix, including the ones
+that were embarrassing
 
-MIT. Open source. Your hardware. Not AMD's.
+MIT. Your hardware, your model, your choice of backend.

--- a/docs/reddit-post.md
+++ b/docs/reddit-post.md
@@ -1,0 +1,72 @@
+# Reddit r/LocalLLaMA Post Draft
+
+## Title:
+**74KB C++23 binary. 22 models. No Python. I unlocked AMD's NPU in 4 days.**
+
+## Body:
+
+**tl;dr**: 74KB binary runs 22+ model architectures (LLMs, video gen, image gen,
+audio gen) on an AMD Strix Halo NPU + GPU + CPU. Zero Python. MIT.
+
+```
+curl -sL https://1bit.systems/npu-install.sh | bash
+1bit pull qwen3-0.6b
+1bit chat
+```
+
+### Why this exists
+
+I bought a Strix Halo laptop because the NPU promised 50 TOPS. What I got was
+a vendor-locked runtime that only works with their proprietary model format,
+behind a closed-source binary, and INT8 physically works on the silicon but
+the software stack won't let you use it without paying for FastFlowLM.
+
+So I reverse-engineered it. Took 4 days.
+
+### What's in the 74KB
+
+| Feature | Detail |
+|---------|--------|
+| **NPU inference** | 94 tok/s via FLM proxy (production), 97 tok/s C++ engine |
+| **GPU inference** | 22 tok/s on Radeon 8060S via Vulkan compute (Zig) |
+| **CPU scheduler** | Unified KV cache, RadixAttention, H2O eviction |
+| **Video generation** | Wan2.2, CogVideoX, HunyuanVideo, LTX-Video, Sana, Mochi, ... (14 models) |
+| **Image generation** | Flux, Flux Schnell, SDXL, SD3.5, Flux.2 |
+| **Audio generation** | Stable Audio Open (44.1kHz stereo), AudioLDM2 |
+| **LoRA support** | All models, unified loader |
+| **Dependencies** | 0. No Python. No pip. No Docker. No MLIR. |
+
+### The model-agnostic bit
+
+I built a single `AgnosticPipeline` that accepts any HuggingFace model ID and
+auto-detects the correct pipeline, defaults, and modality. `--model flux` works
+the same as `--model stabilityai/stable-audio-open-1.0` or
+`--model Wan-AI/Wan2.1-T2V-1.3B-Diffusers`.
+
+```bash
+# LLM
+1bit chat
+
+# Video
+video-lora generate --model wan --prompt "cat walking, cinematic"
+
+# Photography
+video-lora generate --model flux --prompt "portrait, soft lighting"
+
+# Audio
+video-lora generate --model stable-audio --prompt "rain on window" --audio-end-s 30
+```
+
+### The catch
+
+The C++ NPU engine (97 tok/s) has a coherence bug — output is garbled.
+Tracking in docs/journey.md. The FLM proxy (94 tok/s) is production-ready.
+If you're an XRT/XDNA low-level person, I could use the help.
+
+### Links
+
+GitHub: https://github.com/1bit-systems/1bit  
+Benchmarks: docs/wiki/performance.md  
+Audit trail: docs/journey.md (1,200+ lines, every crash and fix)
+
+MIT. Open source. Your hardware. Not AMD's.

--- a/docs/twitter-thread.md
+++ b/docs/twitter-thread.md
@@ -1,0 +1,89 @@
+# Twitter/X Thread Draft
+
+---
+
+**Tweet 1** 🧵
+
+AMD shipped Strix Halo with a 50 TOPS NPU.
+Then locked INT8 behind proprietary software.
+
+I bought one. I got angry. I fixed it.
+
+4 days. 74KB. 94 tok/s. Open source.
+
+The silicon was never the bottleneck. The business model was. 👇
+
+---
+
+**Tweet 2**
+
+74KB binary. Think about that.
+
+Your browser's favicon is bigger.
+A 240p JPEG of a cat is bigger.
+
+This binary runs 22 model architectures across video generation, photography, audio synthesis, and LLMs — all on your laptop.
+
+Zero Python. Zero Docker. Zero pip. Just g++ and run.
+
+---
+
+**Tweet 3**
+
+Model-agnostic isn't a buzzword here.
+
+```
+video-lora generate --model flux --prompt "cinematic portrait"
+video-lora generate --model wan --prompt "cat walking"
+video-lora generate --model stable-audio --prompt "rain on window"
+```
+
+Same CLI. Same engine. Auto-detected. LoRA on every backend.
+
+22 models, 3 modalities, one 74KB binary.
+
+---
+
+**Tweet 4**
+
+The NPU hits 94 tok/s on Qwen3-0.6B.
+The GPU (Radeon 8060S) hits 22 tok/s on 1.7B.
+The CPU scheduler fuses KV cache across all three.
+
+On a consumer laptop. While it's on battery.
+
+No data center. No A100. Just a ThinkPad with an NPU.
+
+---
+
+**Tweet 5**
+
+"I reverse-engineered AMD's proprietary NPU stack in 4 days."
+
+That sentence gets reactions. People think I'm exaggerating.
+
+Day 1: downloaded their toolchain. Nothing worked.
+Day 2: probed ioctl calls. Found the NPU interface.
+Day 3: first inference. 244 ms/tok (terrible).
+Day 4: 24× speedup. 16 ms/tok.
+
+No NDAs. No inside access. Just a C++ compiler and spite.
+
+---
+
+**Tweet 6**
+
+This is MIT licensed. Not "community license." Not "source available."
+MIT. Do whatever you want.
+
+https://github.com/1bit-systems/1bit
+
+`curl -sL https://1bit.systems/npu-install.sh | bash`
+
+Your hardware. Not AMD's.
+
+---
+
+**Hashtags (in reply to last tweet):**
+#74kbBinary #OneBinaryToRuleThemAll #FusedEngine #ModelAgnostic
+#NoPython #ZeroDeps #AMDNPU #StrixHalo #AntiVendorLock #Cpp23 #TheUnlock

--- a/docs/twitter-thread.md
+++ b/docs/twitter-thread.md
@@ -4,86 +4,68 @@
 
 **Tweet 1** 🧵
 
-AMD shipped Strix Halo with a 50 TOPS NPU.
-Then locked INT8 behind proprietary software.
+Bought an AMD Strix Halo laptop for the NPU.
+The official stack: one model format, no mixing NPU/GPU/CPU per request.
 
-I bought one. I got angry. I fixed it.
+So I built a router. Drop in any GGUF model, it picks the backend automatically.
 
-4 days. 74KB. 94 tok/s. Open source.
-
-The silicon was never the bottleneck. The business model was. 👇
+Zero Python at runtime. MIT licensed. 👇
 
 ---
 
 **Tweet 2**
 
-74KB binary. Think about that.
+The router reads a model's own on-disk metadata — architecture, quantization,
+tensor shapes — and routes it to NPU, GPU, or CPU. No config files, no
+manifest, no model registry.
 
-Your browser's favicon is bigger.
-A 240p JPEG of a cat is bigger.
-
-This binary runs 22 model architectures across video generation, photography, audio synthesis, and LLMs — all on your laptop.
-
-Zero Python. Zero Docker. Zero pip. Just g++ and run.
+11 GGUF quant formats supported, each dequantizer checked bit-exact against
+an independent Python reference. Not "looks right" — actually diffed.
 
 ---
 
 **Tweet 3**
 
-Model-agnostic isn't a buzzword here.
+The honest part: our own in-process NPU kernel has a confirmed correctness
+bug on real hardware. Numbers looked great, output was garbage.
 
-```
-video-lora generate --model flux --prompt "cinematic portrait"
-video-lora generate --model wan --prompt "cat walking"
-video-lora generate --model stable-audio --prompt "rain on window"
-```
-
-Same CLI. Same engine. Auto-detected. LoRA on every backend.
-
-22 models, 3 modalities, one 74KB binary.
+So the default NPU path delegates to FastFlowLM (already correct) instead —
+disclosed in the README, not discovered after you build it.
 
 ---
 
 **Tweet 4**
 
-The NPU hits 94 tok/s on Qwen3-0.6B.
-The GPU (Radeon 8060S) hits 22 tok/s on 1.7B.
-The CPU scheduler fuses KV cache across all three.
+Real, validated numbers on Radeon 8060S + XDNA 2:
 
-On a consumer laptop. While it's on battery.
+GPU ROCm HIP: 64 tok/s (kernel-level)
+NPU via FastFlowLM: 57 tok/s
+zaya_server end-to-end, Qwen 27B: 30 tok/s (real prompt, not synthetic)
 
-No data center. No A100. Just a ThinkPad with an NPU.
+llama.cpp on the same box: 229 tok/s. We're behind it and say so.
 
 ---
 
 **Tweet 5**
 
-"I reverse-engineered AMD's proprietary NPU stack in 4 days."
+Also ships a video generation path (Wan2.2, LTX-Video, AnimateDiff,
+CogVideoX) with LoRA support, vendored in as its own module.
 
-That sentence gets reactions. People think I'm exaggerating.
-
-Day 1: downloaded their toolchain. Nothing worked.
-Day 2: probed ioctl calls. Found the NPU interface.
-Day 3: first inference. 244 ms/tok (terrible).
-Day 4: 24× speedup. 16 ms/tok.
-
-No NDAs. No inside access. Just a C++ compiler and spite.
+One repo, one build, LLM inference + video gen, both model-agnostic where
+the underlying pipeline allows it.
 
 ---
 
 **Tweet 6**
 
-This is MIT licensed. Not "community license." Not "source available."
-MIT. Do whatever you want.
+MIT licensed. Not "community license." Not "source available." MIT.
 
-https://github.com/1bit-systems/1bit
+https://github.com/bong-water-water-bong/1bit-systems
 
-`curl -sL https://1bit.systems/npu-install.sh | bash`
-
-Your hardware. Not AMD's.
+The bugs are in the issue tracker too — including the ones we found in our
+own published benchmarks.
 
 ---
 
 **Hashtags (in reply to last tweet):**
-#74kbBinary #OneBinaryToRuleThemAll #FusedEngine #ModelAgnostic
-#NoPython #ZeroDeps #AMDNPU #StrixHalo #AntiVendorLock #Cpp23 #TheUnlock
+#OneBinary #ModelAgnostic #NoPython #ZeroDeps #AMDNPU #StrixHalo #Cpp23 #OpenSource


### PR DESCRIPTION
Recovers `docs/hn-post.md`, `docs/reddit-post.md`, `docs/twitter-thread.md` — deleted as unrelated collateral damage in `e3ec023c` ("feat(router): add GPU verify backend for speculative decode", 2026-07-11), a feature commit that had nothing to do with these marketing drafts. Restored verbatim from the parent commit, then checking for stale numbers in a follow-up before these are usable as real drafts.