### PR TITLE
fix: 6 issues from CI-audit batch (#322, #324, #330, #334, #336, #337)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           if [ -d /opt/rocm ] && [ -f /opt/rocm/lib/cmake/hip/hip-config.cmake ]; then
             echo "ROCm detected — full cmake configure + build."
-            cmake -B build -G Ninja -DCMALE_HIP_ARCHITECTURES=gfx1151
+            cmake -B build -G Ninja -DCMAKE_HIP_ARCHITECTURES=gfx1151
             # Build the server AND every test_* target so a dropped source or a
             # compile break fails CI (issue #236). Previously only the wiring
             # skeleton (test_medusa_skeleton) was built, so a broken engine

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,7 +610,7 @@ target_include_directories(dspark_gpu_bench PRIVATE
     ${CMAKE_SOURCE_DIR}/spec-decode
     ${_RC_ROCM_DEFAULT}/lib/python3.14/site-packages/_rocm_sdk_devel/include)
 target_compile_options(dspark_gpu_bench PRIVATE
-    -O3 -march=native -ffast-math -std=c++23 -fopenmp)
+    -O3 -march=native -ffast-math -std=c++23 -fopenmp -D__HIP_PLATFORM_AMD__)
 target_link_libraries(dspark_gpu_bench PRIVATE
     rocm_cpp
     ${CMAKE_DL_LIBS} m pthread hipblas)

--- a/include/rocm_cpp/ck_gemm.h
+++ b/include/rocm_cpp/ck_gemm.h
@@ -135,6 +135,20 @@ rcpp_ternary_gemv_wmma(const void* packed_weights_dev,
                        int M, int K,
                        void*       stream);
 
+// Block-scaled ternary (BST) GEMV — standard-arity wrapper matching the
+// rcpp_ternary_gemv_* dispatch convention. row_scales_dev is unused (BST
+// carries per-block scales inline in the packed weight data, not as a
+// separate row-scale array); kept in the signature only for dispatch-table
+// compatibility with the other variants above.
+rcpp_status_t
+rcpp_ternary_gemv_bst(const void* packed_weights_dev,
+                      const void* activations_i8_dev,
+                      float       activation_scale,
+                      const void* row_scales_dev,
+                      void*       output_dev,
+                      int M, int K,
+                      void*       stream);
+
 // halo-ai Lane B': TQ1 base-3 packing (halo-1bit v4, "tq1-halo" variant).
 // 5 ternaries per byte via d0 + d1·3 + d2·9 + d3·27 + d4·81 (d_i = 0/1/2 → -1/0/+1).
 // **Lossless for ternary** — any ±1/0 pattern survives intact, unlike Sherry.

--- a/kernels/ternary_gemv_sherry.hip
+++ b/kernels/ternary_gemv_sherry.hip
@@ -64,8 +64,8 @@ static std::once_flag sherry_lut_flag;
 static void init_sherry_lut(hipStream_t stream) {
     uint32_t host_lut[32];
     for (uint32_t v = 0; v < 32; ++v) host_lut[v] = build_sherry_entry(v);
-    hipMemcpyToSymbolAsync(HIP_SYMBOL(sherry_unpack_lut), host_lut,
-                           sizeof(host_lut), 0, hipMemcpyHostToDevice, stream);
+    HIP_CHECK(hipMemcpyToSymbolAsync(HIP_SYMBOL(sherry_unpack_lut), host_lut,
+                           sizeof(host_lut), 0, hipMemcpyHostToDevice, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
 }
 

--- a/kernels/ternary_gemv_tq1_halo.hip
+++ b/kernels/ternary_gemv_tq1_halo.hip
@@ -58,8 +58,8 @@ static void init_tq1_lut(hipStream_t stream) {
         lo[byte] = pack4i8(v[0], v[1], v[2], v[3]);
         hi[byte] = pack4i8(v[4], 0, 0, 0);
     }
-    hipMemcpyToSymbolAsync(HIP_SYMBOL(tq1_lut_lo), lo, sizeof(lo), 0, hipMemcpyHostToDevice, stream);
-    hipMemcpyToSymbolAsync(HIP_SYMBOL(tq1_lut_hi), hi, sizeof(hi), 0, hipMemcpyHostToDevice, stream);
+    HIP_CHECK(hipMemcpyToSymbolAsync(HIP_SYMBOL(tq1_lut_lo), lo, sizeof(lo), 0, hipMemcpyHostToDevice, stream));
+    HIP_CHECK(hipMemcpyToSymbolAsync(HIP_SYMBOL(tq1_lut_hi), hi, sizeof(hi), 0, hipMemcpyHostToDevice, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
 }
 

--- a/kernels/zaya_moe_ternary_gemv.hip
+++ b/kernels/zaya_moe_ternary_gemv.hip
@@ -60,8 +60,8 @@ static void init_zaya_tq1_lut(hipStream_t stream) {
         lo[byte] = _zaya_pack4i8(v[0], v[1], v[2], v[3]);
         hi[byte] = _zaya_pack4i8(v[4], 0, 0, 0);
     }
-    hipMemcpyToSymbolAsync(HIP_SYMBOL(zaya_tq1_lut_lo), lo, sizeof(lo), 0, hipMemcpyHostToDevice, stream);
-    hipMemcpyToSymbolAsync(HIP_SYMBOL(zaya_tq1_lut_hi), hi, sizeof(hi), 0, hipMemcpyHostToDevice, stream);
+    HIP_CHECK(hipMemcpyToSymbolAsync(HIP_SYMBOL(zaya_tq1_lut_lo), lo, sizeof(lo), 0, hipMemcpyHostToDevice, stream));
+    HIP_CHECK(hipMemcpyToSymbolAsync(HIP_SYMBOL(zaya_tq1_lut_hi), hi, sizeof(hi), 0, hipMemcpyHostToDevice, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
 }
 

--- a/kernels/zaya_moe_wmma_batched.hip
+++ b/kernels/zaya_moe_wmma_batched.hip
@@ -91,9 +91,13 @@ __global__ void wmma_batched_gemv(
     // output. We use a local float buffer and convert to half.
     float tmp_f32[WMMA_M * WMMA_N];
     store_matrix_sync(tmp_f32, acc, WMMA_M, layout_t::mem_row_major);
-    #pragma unroll
+    // tokens_here/cols_here are runtime-bounded (min(WMMA_N/M, ...)), not
+    // compile-time constants, so a full #pragma unroll here can never
+    // actually be honored — that's the source of the "loop not unrolled"
+    // transform-warning (issue #337), not the WMMA fragment loads/mma_sync
+    // in the K-loop above as originally suspected. Removed; loop bound is
+    // <=16 either way so the compiler's own default unrolling is adequate.
     for (int i = 0; i < tokens_here; i++) {
-        #pragma unroll
         for (int j = 0; j < cols_here; j++) {
             out[(b_base + i) * (size_t)M + m_base + j] = __float2half(tmp_f32[i * WMMA_M + j]);
         }

--- a/src/backend_cpu.cpp
+++ b/src/backend_cpu.cpp
@@ -35,7 +35,7 @@ static constexpr float RMD_EPS = 1e-5f;
 static constexpr float ROPE_BASE = 5000000.0f;
 
 // ── SIMD / threading support ──
-#if defined(__AVX512F__)
+#if defined(__AVX512F__) || defined(__AVX2__)
 #include <immintrin.h>
 #endif
 
@@ -85,11 +85,8 @@ static void matmul_t(float* out, const float* in, const float* wt, int M, int K)
             __m256 w = _mm256_loadu_ps(wt + i * (size_t)K + k);
             vacc = _mm256_fmadd_ps(act, w, vacc);
         }
-        float s = _mm256_reduce_ps(vacc); // horizontal add
-        s += _mm256_cvtss_f32(_mm256_permute2f128_ps(vacc, vacc, 1));
-        // Actually just reduce manually
         alignas(32) float tmp[8]; _mm256_store_ps(tmp, vacc);
-        s += tmp[1]+tmp[2]+tmp[3]+tmp[4]+tmp[5]+tmp[6]+tmp[7];
+        float s = 0; for (int j = 0; j < 8; j++) s += tmp[j];
         for (; k < K; k++) s += in[k] * wt[i * (size_t)K + k];
         out[i] = s;
     }

--- a/src/backend_factory.cpp
+++ b/src/backend_factory.cpp
@@ -75,10 +75,28 @@ static Backend* try_create_npu() {
     return b;
 }
 
+// Check for a backend symbol statically linked into the main executable
+// itself (e.g. ROCM_CPP_STATIC_HIP builds link src/backend_hip.cpp directly
+// rather than loading librocm_cpp.so). dlopen(NULL) doesn't create a new
+// handle — it just bumps the refcount on the already-loaded executable, so
+// this is cheap and safe to call from a detection probe (issue #330: the
+// actual creation path in BackendManager::create_instance_rt() already does
+// this exact check, but the detection probes here didn't, so a statically
+// linked build reported the backend as unavailable even though it could be
+// created).
+static bool has_static_symbol(const char* symbol) {
+    void* self = dlopen(NULL, RTLD_NOW | RTLD_LOCAL);
+    if (!self) return false;
+    bool found = dlsym(self, symbol) != nullptr;
+    dlclose(self);
+    return found;
+}
+
 // ── Auto-detect available backends ──
 bool has_hip_gpu() {
     void* lib = dlopen("librocm_cpp.so", RTLD_NOW | RTLD_LOCAL);
     if (lib) { dlclose(lib); return true; }
+    if (has_static_symbol("create_hip_backend")) return true;
     // Check for render nodes via file I/O instead of popen (fixes #67)
     struct stat st;
     if (stat("/dev/dri/renderD128", &st) == 0) return true;
@@ -91,6 +109,7 @@ bool has_vulkan() {
     // Check if librocm_cpp is available (it contains the Vulkan backend)
     void* lib = dlopen("librocm_cpp.so", RTLD_NOW | RTLD_LOCAL);
     if (lib) { dlclose(lib); return true; }
+    if (has_static_symbol("create_vulkan_backend")) return true;
 
     // Probe via libvulkan — just check that the loader exists and we can
     // enumerate physical devices. Use a minimal vkCreateInstance call
@@ -112,6 +131,7 @@ bool has_vulkan() {
 bool has_npu() {
     void* lib = dlopen("librocm_cpp.so", RTLD_NOW | RTLD_LOCAL);
     if (lib) { dlclose(lib); return true; }
+    if (has_static_symbol("create_npu_backend")) return true;
     // Check via XRT
     lib = dlopen("libxrt_coreutil.so", RTLD_LAZY);
     if (!lib) lib = dlopen("libxrt_coreutil.so.2", RTLD_LAZY);

--- a/src/bonsai_q1_1024.hip
+++ b/src/bonsai_q1_1024.hip
@@ -193,8 +193,8 @@ extern "C" void bonsai_q1_convert_to_1024(
     const size_t old_row_stride = (size_t)old_blocks_per_row * 18;
 
     uint8_t* dst = nullptr;
-    hipMalloc(&dst, total_bytes);
-    hipMemset(dst, 0, total_bytes); // zero-fill in case N_out not multiple of 8
+    HIP_CHECK(hipMalloc(&dst, total_bytes));
+    HIP_CHECK(hipMemset(dst, 0, total_bytes)); // zero-fill in case N_out not multiple of 8
 
     for (int t = 0; t < num_tiles; ++t) {
         for (int nb = 0; nb < new_blocks_per_row; ++nb) {

--- a/src/bonsai_tq2_1024.hip
+++ b/src/bonsai_tq2_1024.hip
@@ -179,8 +179,8 @@ extern "C" void bonsai_tq2_convert_to_1024(
     const size_t old_row_stride = (size_t)old_blocks_per_row * 34; // old block = 34B
 
     uint8_t* dst = nullptr;
-    hipMalloc(&dst, total_bytes);
-    hipMemset(dst, 0, total_bytes);
+    HIP_CHECK(hipMalloc(&dst, total_bytes));
+    HIP_CHECK(hipMemset(dst, 0, total_bytes));
 
     for (int t = 0; t < num_tiles; ++t) {
         for (int nb = 0; nb < new_blocks_per_row; ++nb) {


### PR DESCRIPTION
## Summary
- #322: fix broken AVX2 `matmul_t` horizontal reduction (non-existent `_mm256_reduce_ps` 1-arg call + double-counted manual sum), plus a second bug found in the same path: `<immintrin.h>` was guarded behind `__AVX512F__` only, so AVX2 intrinsics were never declared on real AVX2-only hardware
- #324: fix CI typo `-DCMALE_HIP_ARCHITECTURES` → `-DCMAKE_HIP_ARCHITECTURES`
- #330: `has_hip_gpu()`/`has_vulkan()`/`has_npu()` now check for statically-linked backend symbols via `dlopen(NULL)+dlsym`, matching the pattern `BackendManager::create_instance_rt()` already used
- #334: add missing `rcpp_ternary_gemv_bst` declaration to `include/rocm_cpp/ck_gemm.h`
- #336: add `-D__HIP_PLATFORM_AMD__` to `dspark_gpu_bench`'s CXX compile options
- #337: root-caused (differently than suspected) and fixed the `zaya_moe_wmma_batched.hip` unroll warning — it's on the output-store epilogue loop (runtime-bounded trip count), not the WMMA K-loop
- Partial #338: fixed the highest-risk subset (LUT uploads + bonsai engine allocations) of a much larger, still-open issue covering ~315 remaining warnings in dev-only test/bench tooling

## Test plan
- [x] Full clean rebuild (`cmake -B build` + `cmake --build build`) succeeds for all 151 targets, zero errors
- [x] #322: isolated AVX2 reduction verified bit-exact vs scalar reference; actual file compiled clean under forced `-mavx2 -mno-avx512f`
- [x] #334: `bitnet_decode` builds and links (previously failed)
- [x] #336: `dspark_gpu_bench` builds and links (previously failed)
- [x] #337: warning confirmed gone after rebuild
- [x] gitnexus `detect_changes` — low risk, no unexpected affected processes
