### PR TITLE
perf: fix redundant GQA dequant + occupancy loss in INT8 KV decode kernel

### DIFF
--- a/src/kv_cache_attn_i8.hip
+++ b/src/kv_cache_attn_i8.hip
@@ -17,16 +17,66 @@
 //   kf = (float)k_i8 * (float)K_scales[pos * num_kv_heads + kv_head]
 //   vf = (float)v_i8 * (float)V_scales[pos * num_kv_heads + kv_head]
 //
-// The per-(pos, kv_head) scale is uniform across the warp while all threads
-// iterate over head_dim for a given (pos, kv_head) pair, so the scale is loaded
-// once per position by the whole block (broadcast via shared memory). No
-// divergent scale reads.
+// DECODE kernel design (2026-07-18 rework, see #338 follow-up research):
+// split-KV Flash-Decoding (matches src/kv_cache_attn_fd.hip's fp16 approach)
+// COMBINED with GQA-group-per-block dequant sharing. Two separate fixes for
+// two separate problems, needed together:
+//
+// 1. GQA-group-per-block: the original layout put one Q-head per block
+//    (grid.x = num_q_heads). Under GQA, `gqa_ratio` Q-heads share one
+//    KV-head, so `gqa_ratio` blocks each independently re-read *and*
+//    re-dequantize the exact same K/V row from global memory every
+//    position, even though the raw int8 bytes and scale are identical
+//    across the group. This mirrors a bug independently found and fixed
+//    upstream for llama.cpp's CUDA/HIP flash-attention tile kernel
+//    (Nathanw1014/llama.cpp@strix-halo-fa-fixes, same gfx1151 target):
+//    dequant fused into a per-Q-head dot product can never be shared, so
+//    it gets paid gqa_ratio times over. Fix: one block per KV-head, one
+//    warp per Q-head in that KV-head's group; the whole block loads
+//    K_row/V_row into shared memory ONCE per position, each warp then does
+//    its own independent dot product / online-softmax update against that
+//    shared copy. Q·K itself is NOT shared (each Q-head's query differs
+//    and must be scored independently) — only the KV read + dequant is.
+//
+// 2. But (1) alone *regresses* throughput here: it shrinks the grid from
+//    num_q_heads blocks down to num_kv_heads blocks — e.g. 20 -> 5 blocks
+//    on BitNet-2B-4T shape, badly under-subscribing gfx1151's 32-40 CUs
+//    (measured: 0.80-0.99x vs fp16, worse than the original 1.08-1.33x).
+//    This is the exact occupancy problem src/kv_cache_attn_fd.hip's header
+//    comment already documents for the fp16 kernel ("catastrophically
+//    under-subscribed... ~4-5 GB/s off a ~256 GB/s peak"). Fix: split the
+//    seq_len axis into TILE-sized chunks the same way kv_cache_attn_fd.hip
+//    does, grid = (num_kv_heads, num_kv_tiles) instead of (num_kv_heads),
+//    each block computing an unnormalized partial (o, m, l) for its tile;
+//    a second small reduce pass (kv_cache_attn_reduce_i8_kernel, ported
+//    from kv_cache_attn_fd.hip's dtype-agnostic reduce — same partials
+//    layout [num_q_heads, num_kv_tiles, head_dim+2], reused via source
+//    duplication since it's defined in a different translation unit)
+//    combines tiles into the final per-Q-head output. At long seq_len this
+//    also multiplies occupancy well past the original single-pass kernel's
+//    (e.g. seq_len=2048, TILE=32: 5 kv_heads * 64 tiles = 320 blocks vs the
+//    original 20), on top of eliminating the redundant KV reads. TILE=32
+//    (smaller than kv_cache_attn_fd.hip's fp16 TILE=128) was chosen by
+//    sweeping {16, 32, 128} on real hardware via tools/bench_kv_i8.cpp: 32
+//    is the best balance — it keeps the short-context case (seq_len=64,
+//    otherwise still occupancy-starved at 1 tile) solidly ahead of fp16
+//    without giving up much of the much larger long-context win.
+//
+// Verified bit-for-bit-equivalent-within-tolerance against the pre-rework
+// kernel and against the fp16 reference kernel via tools/bench_kv_i8.cpp on
+// real gfx1151 hardware; see that tool's output for measured speedup.
+//
+// PREFILL kernel below is unchanged (still one block per (t, Q-head) pair)
+// — same redundancy exists there too, but decode is the hot path for
+// interactive/streaming generation and is what this rework targets; fixing
+// prefill the same way is a natural follow-up, not done here.
 
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
 #include <cfloat>
 #include <cstdint>
 #include <cmath>
+#include <mutex>
 
 #include "rocm_cpp/ck_gemm.h"
 
@@ -35,79 +85,100 @@ namespace {
 constexpr int BLOCK = 128;
 constexpr int WARP  = 32;
 constexpr int MAX_HEAD_DIM = 256;
+constexpr int TILE  = 32;   // swept {16,32,128} on real hardware — see file header
+// Max GQA ratio the decode kernel's static shared-memory layout supports —
+// generous enough for every realistic config (BitNet-2B-4T=4, Qwen3-family
+// up to 8); rcpp_kv_cache_attn_decode_i8() rejects anything larger rather
+// than silently truncating the group.
+constexpr int MAX_GQA_RATIO = 16;
+constexpr int MAX_BLOCK_DECODE = MAX_GQA_RATIO * WARP;
 
 // Fast-math sentinel — see prim_kernels.hip. -FLT_MAX avoids the
 // -Wnan-infinity-disabled UB that -INFINITY triggers under -ffast-math.
 constexpr float NEG_SENTINEL = -FLT_MAX;
 
-__global__ __launch_bounds__(BLOCK)
-void kv_cache_attn_decode_i8_kernel(
+// Pass 1: one block per (kv_head, kv_tile); one warp per Q-head within that
+// kv_head's GQA group. Writes unnormalized partials
+// [num_q_heads, num_kv_tiles, head_dim+2] — same layout as
+// kv_cache_attn_fd.hip's fp16 split kernel, so the reduce pass below is
+// dtype-agnostic and structurally identical to that file's pass 2.
+// blockDim.x must be exactly gqa_ratio * WARP, set by the launcher below.
+__global__ __launch_bounds__(MAX_BLOCK_DECODE)
+void kv_cache_attn_decode_i8_split_kernel(
     const __half*  __restrict__ Q,
     const int8_t*  __restrict__ K,
     const int8_t*  __restrict__ V,
     const __half*  __restrict__ K_scales,   // [seq_len, num_kv_heads]
     const __half*  __restrict__ V_scales,   // [seq_len, num_kv_heads]
-    __half*        __restrict__ out,
+    float*         __restrict__ partials,
     int num_q_heads, int num_kv_heads, int head_dim,
-    int seq_len, float scale)
+    int seq_len, int num_kv_tiles, float scale, int gqa_ratio)
 {
-    const int h = blockIdx.x;
-    if (h >= num_q_heads) return;
+    const int kv_head = blockIdx.x;
+    const int tile     = blockIdx.y;
+    if (kv_head >= num_kv_heads || tile >= num_kv_tiles) return;
 
     const int tid  = threadIdx.x;
     const int lane = tid & (WARP - 1);
-    const int wid  = tid / WARP;
-    const int gqa_ratio = num_q_heads / num_kv_heads;
-    const int kv_head   = h / gqa_ratio;
+    const int wid  = tid / WARP;         // which Q-head within this group
+    if (wid >= gqa_ratio) return;
+    const int h = kv_head * gqa_ratio + wid;   // global Q-head index
 
-    __shared__ __half Q_shared[MAX_HEAD_DIM];
-    for (int d = tid; d < head_dim; d += BLOCK) {
-        Q_shared[d] = Q[(size_t)h * head_dim + d];
+    const int t_begin = tile * TILE;
+    const int t_end   = min(t_begin + TILE, seq_len);
+
+    // Each warp stages its own Q-head's query vector.
+    __shared__ __half Q_shared[MAX_GQA_RATIO][MAX_HEAD_DIM];
+    for (int d = lane; d < head_dim; d += WARP) {
+        Q_shared[wid][d] = Q[(size_t)h * head_dim + d];
     }
-    __syncthreads();
+
+    // K/V row + scales for the current position, shared by every warp in
+    // the block (loaded once per position, cooperatively, by all threads).
+    __shared__ int8_t K_shared[MAX_HEAD_DIM];
+    __shared__ int8_t V_shared[MAX_HEAD_DIM];
+    __shared__ float  ks_shared, vs_shared;
+    __syncthreads();  // Q_shared writes visible before first load below
 
     float m = NEG_SENTINEL;
     float l = 0.0f;
-    const int elems_per_thread = (head_dim + BLOCK - 1) / BLOCK;
+    const int elems_per_thread = (head_dim + WARP - 1) / WARP;
     float o_local[8] = {0};
 
-    // Single-barrier-per-step reduction with double-buffered warp-partial LDS:
-    //   iter t writes s_sum[buf], syncthreads, then everyone reads s_sum[buf].
-    //   iter t+1 writes s_sum[buf^1], so a fast warp cannot overwrite a slot a
-    //   slow warp is still reading in iter t. The __syncthreads() at the top of
-    //   iter t+1 ensures slow warps have finished their iter-t read before any
-    //   warp proceeds to iter t+1's post-reduce path. Net: 1 barrier/seq-step
-    //   instead of the original 3 (scale broadcast + two-stage warp reduce),
-    //   which at seq_len=1024 × 20 heads saves ~40k block-wide barriers/call.
-    //
-    // Scales are loaded directly from global: every lane in the block hits the
-    // same 2-byte address, so the hardware serves them as a single cache-line
-    // broadcast without an explicit LDS hop.
-    constexpr int NWARPS = BLOCK / WARP;
-    __shared__ float s_sum[2][NWARPS];
-    int buf = 0;
+    // Degenerate tile (past seq_len) — emit neutral partials for this
+    // warp's Q-head so the reduce pass skips it cleanly.
+    if (t_begin >= t_end) {
+        float* out_base = partials + ((size_t)h * num_kv_tiles + tile) * (head_dim + 2);
+        if (lane == 0) {
+            out_base[head_dim]     = NEG_SENTINEL;
+            out_base[head_dim + 1] = 0.0f;
+        }
+        for (int d = lane; d < head_dim; d += WARP) out_base[d] = 0.0f;
+        return;
+    }
 
-    for (int t = 0; t < seq_len; ++t) {
+    for (int t = t_begin; t < t_end; ++t) {
         const int8_t* K_row = K + ((size_t)t * num_kv_heads + kv_head) * head_dim;
         const int8_t* V_row = V + ((size_t)t * num_kv_heads + kv_head) * head_dim;
-
         const size_t sc_idx = (size_t)t * num_kv_heads + kv_head;
-        const float ks = (float)K_scales[sc_idx];
-        const float vs = (float)V_scales[sc_idx];
+
+        for (int d = tid; d < head_dim; d += blockDim.x) {
+            K_shared[d] = K_row[d];
+            V_shared[d] = V_row[d];
+        }
+        if (tid == 0) {
+            ks_shared = (float)K_scales[sc_idx];
+            vs_shared = (float)V_scales[sc_idx];
+        }
+        __syncthreads();
 
         float partial = 0.0f;
-        for (int d = tid; d < head_dim; d += BLOCK) {
-            partial += (float)Q_shared[d] * (float)K_row[d];
+        for (int d = lane; d < head_dim; d += WARP) {
+            partial += (float)Q_shared[wid][d] * (float)K_shared[d];
         }
         #pragma unroll
         for (int o = WARP / 2; o > 0; o >>= 1) partial += __shfl_xor(partial, o);
-        if (lane == 0) s_sum[buf][wid] = partial;
-        __syncthreads();
-        float s_acc = 0.0f;
-        #pragma unroll
-        for (int w = 0; w < NWARPS; ++w) s_acc += s_sum[buf][w];
-        const float s = s_acc * ks * scale;
-        buf ^= 1;
+        const float s = partial * ks_shared * scale;
 
         const float m_new = (s > m) ? s : m;
         const float alpha = std::expf(m - m_new);
@@ -115,12 +186,82 @@ void kv_cache_attn_decode_i8_kernel(
         l = l * alpha + beta;
         #pragma unroll
         for (int k = 0; k < 8; ++k) o_local[k] *= alpha;
-        const float beta_vs = beta * vs;
+        const float beta_vs = beta * vs_shared;
+        for (int ei = 0; ei < elems_per_thread; ++ei) {
+            int d = lane + ei * WARP;
+            if (d < head_dim) {
+                o_local[ei] += beta_vs * (float)V_shared[d];
+            }
+        }
+        m = m_new;
+
+        // Ensure every warp is done reading K_shared/V_shared for this
+        // position before the next iteration's cooperative load overwrites
+        // them.
+        __syncthreads();
+    }
+
+    // Emit *unnormalized* partials — pass 2 does the final normalize.
+    float* out_base = partials + ((size_t)h * num_kv_tiles + tile) * (head_dim + 2);
+    for (int ei = 0; ei < elems_per_thread; ++ei) {
+        int d = lane + ei * WARP;
+        if (d < head_dim) out_base[d] = o_local[ei];
+    }
+    if (lane == 0) {
+        out_base[head_dim]     = m;
+        out_base[head_dim + 1] = l;
+    }
+}
+
+// Pass 2: one block per Q-head. Structurally identical to
+// kv_cache_attn_fd.hip's kv_cache_attn_reduce_kernel (that one has internal
+// linkage in a different translation unit, so it's duplicated here rather
+// than shared — matches this codebase's existing per-file self-containment
+// convention, e.g. the HIP_CHECK macro).
+__global__ __launch_bounds__(BLOCK)
+void kv_cache_attn_reduce_i8_kernel(
+    const float*  __restrict__ partials,
+    __half*       __restrict__ out,
+    int num_q_heads, int head_dim, int num_kv_tiles)
+{
+    const int h = blockIdx.x;
+    if (h >= num_q_heads) return;
+
+    const int tid = threadIdx.x;
+
+    float m = NEG_SENTINEL;
+    float l = 0.0f;
+    const int elems_per_thread = (head_dim + BLOCK - 1) / BLOCK;
+    float o_local[8] = {0};
+
+    __shared__ float s_ml[2];
+
+    for (int tile = 0; tile < num_kv_tiles; ++tile) {
+        const float* in_base =
+            partials + ((size_t)h * num_kv_tiles + tile) * (head_dim + 2);
+
+        if (tid == 0) {
+            s_ml[0] = in_base[head_dim];
+            s_ml[1] = in_base[head_dim + 1];
+        }
+        __syncthreads();
+        const float tile_m = s_ml[0];
+        const float tile_l = s_ml[1];
+        __syncthreads();
+
+        if (tile_l == 0.0f) continue;
+
+        const float m_new = (tile_m > m) ? tile_m : m;
+        const float alpha = std::expf(m - m_new);
+        const float beta  = std::expf(tile_m - m_new);
+        l = l * alpha + beta * tile_l;
+
+        #pragma unroll
+        for (int k = 0; k < 8; ++k) o_local[k] *= alpha;
+
         for (int ei = 0; ei < elems_per_thread; ++ei) {
             int d = tid + ei * BLOCK;
-            if (d < head_dim) {
-                o_local[ei] += beta_vs * (float)V_row[d];
-            }
+            if (d < head_dim) o_local[ei] += beta * in_base[d];
         }
         m = m_new;
     }
@@ -132,6 +273,36 @@ void kv_cache_attn_decode_i8_kernel(
             out[(size_t)h * head_dim + d] = __float2half(o_local[ei] * inv_l);
         }
     }
+}
+
+// Growing-only scratch for pass-1 partials, same pattern as
+// kv_cache_attn_fd.hip's PartialsCache (separate instance — different TU).
+struct I8PartialsCache {
+    std::mutex mu;
+    float*     ptr   = nullptr;
+    size_t     cap_f = 0;
+
+    float* acquire(size_t need_f) {
+        std::lock_guard<std::mutex> g(mu);
+        if (need_f <= cap_f) return ptr;
+        if (ptr) {
+            hipError_t fst = hipFree(ptr);
+            (void)fst;  // [[nodiscard]]; best-effort free, see fd.hip
+        }
+        size_t new_cap = (cap_f == 0) ? need_f : cap_f;
+        while (new_cap < need_f) new_cap = new_cap + (new_cap >> 1) + 1;
+        void* p = nullptr;
+        hipError_t st = hipMalloc(&p, new_cap * sizeof(float));
+        if (st != hipSuccess) { ptr = nullptr; cap_f = 0; return nullptr; }
+        ptr   = static_cast<float*>(p);
+        cap_f = new_cap;
+        return ptr;
+    }
+};
+
+I8PartialsCache& i8_partials_cache() {
+    static I8PartialsCache c;
+    return c;
 }
 
 __global__ __launch_bounds__(BLOCK)
@@ -299,16 +470,36 @@ rcpp_kv_cache_attn_decode_i8(const void* Q_dev,
     if (num_q_heads % num_kv_heads != 0)             return RCPP_INVALID_ARG;
     if (head_dim <= 0 || head_dim > MAX_HEAD_DIM)    return RCPP_INVALID_ARG;
     if (seq_len <= 0)                                return RCPP_INVALID_ARG;
-    dim3 grid(num_q_heads, 1, 1), block(BLOCK, 1, 1);
-    hipLaunchKernelGGL(kv_cache_attn_decode_i8_kernel,
-                       grid, block, 0, (hipStream_t)stream,
+    const int gqa_ratio = num_q_heads / num_kv_heads;
+    if (gqa_ratio > MAX_GQA_RATIO)                   return RCPP_INVALID_ARG;
+
+    const int num_kv_tiles = (seq_len + TILE - 1) / TILE;
+    const size_t need_f =
+        (size_t)num_q_heads * (size_t)num_kv_tiles * (size_t)(head_dim + 2);
+    float* partials = i8_partials_cache().acquire(need_f);
+    if (!partials) return RCPP_HIP_ERROR;
+
+    // Pass 1 — fill partials. One block per (kv_head, tile), one warp per
+    // Q-head in that kv_head's GQA group.
+    dim3 grid1(num_kv_heads, num_kv_tiles, 1), block1(gqa_ratio * WARP, 1, 1);
+    hipLaunchKernelGGL(kv_cache_attn_decode_i8_split_kernel,
+                       grid1, block1, 0, (hipStream_t)stream,
                        static_cast<const __half*>(Q_dev),
                        static_cast<const int8_t*>(K_i8_dev),
                        static_cast<const int8_t*>(V_i8_dev),
                        static_cast<const __half*>(K_scales_fp16_dev),
                        static_cast<const __half*>(V_scales_fp16_dev),
+                       partials,
+                       num_q_heads, num_kv_heads, head_dim,
+                       seq_len, num_kv_tiles, scale, gqa_ratio);
+
+    // Pass 2 — reduce tiles into final fp16 out. One block per Q-head.
+    dim3 grid2(num_q_heads, 1, 1), block2(BLOCK, 1, 1);
+    hipLaunchKernelGGL(kv_cache_attn_reduce_i8_kernel,
+                       grid2, block2, 0, (hipStream_t)stream,
+                       partials,
                        static_cast<__half*>(out_dev),
-                       num_q_heads, num_kv_heads, head_dim, seq_len, scale);
+                       num_q_heads, head_dim, num_kv_tiles);
     return RCPP_OK;
 }
 


### PR DESCRIPTION
## Background

Researched `Nathanw1014/llama.cpp@strix-halo-fa-fixes` (targets the same gfx1151 chip) — it fixes a real bug in flash-attention decode with quantized KV cache under GQA: the kernel assigns one Q-head per thread block and dequantizes K/V inline, fused into the dot product, so `gqa_ratio` Q-heads sharing one KV-head each independently re-dequantize the same KV data every position. Their fix: batch the GQA group into one block, dequantize once.

Checked our own `src/kv_cache_attn_i8.hip` — it has the **identical architectural pattern**, independently arrived at: `blockIdx.x` = Q-head, `gqa_ratio = num_q_heads/num_kv_heads`, dequant fused into the per-Q-head dot product. Confirmed with a real baseline run on this machine's gfx1151 hardware: INT8 barely beat FP16 (1.08–1.33x) despite moving half the bytes — the classic signature of being compute/latency-bound on redundant work rather than bandwidth-bound.

## What this PR does

Two fixes, needed together (the first alone actively regresses things — see below):

1. **GQA-group-per-block**: one block per KV-head, one warp per Q-head in that KV-head's group. The whole block loads `K_row`/`V_row` into shared memory once per position; each warp does its own independent dot product / online-softmax update against that one shared copy. `Q·K` itself is *not* shared (each Q-head's query differs and must be scored independently) — only the KV read + dequant is.

2. **Split-KV tiling** (grid = `num_kv_heads × num_kv_tiles` instead of just `num_kv_heads`), reusing the two-pass partial/reduce structure already proven in `src/kv_cache_attn_fd.hip` for the fp16 kernel. This was necessary because (1) alone shrinks the grid from `num_q_heads` blocks to `num_kv_heads` blocks (20→5 on this repo's BitNet-2B-4T test shape) — badly under-subscribing gfx1151's 32–40 compute units. Measured this regression directly before adding tiling: 0.80–0.99x vs fp16, *worse* than the untouched baseline. `kv_cache_attn_fd.hip`'s own header comment already documents this exact occupancy problem for the fp16 case — same fix pattern applies here.

`TILE` was swept at {16, 32, 128} on real hardware; 32 is the best overall balance (128 leaves `seq_len=64` still occupancy-starved at 1 tile; 16 gives up some of the long-context ceiling).

## Verification (all on this machine's real gfx1151 hardware, via `tools/bench_kv_i8.cpp`)

BitNet-2B-4T shape (NH=20, NKV=5, HD=128, gqa_ratio=4):

| seq_len | fp16 baseline speedup (before) | this PR |
|---|---|---|
| 64 | 1.11x | 1.4–1.9x |
| 256 | 1.09x | ~5x |
| 512 | 1.08x | ~9x |
| 1024 | 1.33x | ~11–17x |
| 2048 | 1.08x | ~10–15x |

(Some run-to-run variance at larger sizes from shared-iGPU scheduling noise — consistently and substantially above baseline at every size across multiple runs, never below.)

- ✅ **Correctness**: `max|diff|` vs the fp16 reference kernel is *identical* to the pre-change kernel at every seq_len tested — the algorithm is unchanged, only the parallelization structure changed.
- ✅ Full `cmake --build build` succeeds, including `tools/bitnet_decode.cpp` (the one other real caller of `rcpp_kv_cache_attn_decode_i8` besides the benchmark).
- ✅ Checked blast radius before editing: exactly 2 real callers of the public C-ABI function (`tools/bitnet_decode.cpp`, `tools/bench_kv_i8.cpp`), signature unchanged.

## Not done here

`kv_cache_attn_prefill_i8_kernel` has the same per-Q-head redundancy but wasn't touched — decode is the interactive/streaming hot path this rework targeted; prefill is a natural, separate follow-up (documented in the file's header comment).
