### PR TITLE
fix #473: gguf_loader.cpp read_f16() misread real float16 as bfloat16

### DIFF
--- a/src/gguf_loader.cpp
+++ b/src/gguf_loader.cpp
@@ -80,10 +80,20 @@ int gguf_block_bytes(uint32_t dtype) {
 // Reference: llama.cpp ggml-quants.c block_q4_K / block_q6_K / block_q8_K
 
 // Reads a float16 value from a byte pointer
+// Was `(uint32_t)bits << 16` reinterpreted as f32 — correct for widening a
+// bfloat16 (whose bits ARE float32's truncated upper half), but every caller
+// here reads real IEEE754 half-precision float16 (the K-quant super-block
+// d/dmin scale fields per the GGUF/GGML spec), which has a different
+// exponent width/bias (5 bits, bias 15) than float32 (8 bits, bias 127) —
+// the bit-shift silently produced the wrong value for every K-quant block
+// in every model loaded through this file. See issue #473.
 static inline float read_f16(const uint8_t* p) {
-    uint16_t bits; memcpy(&bits, p, 2);
-    uint32_t u = (uint32_t)bits << 16;
-    float v; memcpy(&v, &u, 4); return v;
+    uint16_t h; memcpy(&h, p, 2);
+    uint32_t s = (h >> 15) & 1, e = (h >> 10) & 0x1f, m = h & 0x3ff;
+    float sign = s ? -1.0f : 1.0f;
+    if (e == 0) return sign * (float)m * 5.9604644775390625e-08f;  // subnormal: m * 2^-24
+    if (e == 31) return m ? NAN : sign * INFINITY;
+    return sign * (1.0f + (float)m / 1024.0f) * powf(2.0f, (float)((int)e - 15));
 }
 
 static bool dequant_q4_k(const uint8_t* bd, float* out, int count) {


### PR DESCRIPTION
Closes #473.

`read_f16()` did `(uint32_t)bits << 16` reinterpreted as float32 — correct for widening a bfloat16 (whose bits literally are float32's truncated upper half), but wrong for what it's actually used on: the K-quant super-block `d`/`dmin` scale fields, which are genuine IEEE754 half-precision float16 (different exponent width/bias: 5 bits/15 vs float32's 8 bits/127). This silently corrupted the scale for every K-quant block (Q4_K, Q6_K, etc.) loaded through this file — the CPU/generic backend's real production GGUF loading path.

Replaced with a straightforward sign/exponent/mantissa decode (`powf` for normals, direct `m * 2^-24` for subnormals).

## Verification

Standalone numeric test against known float16 bit patterns:

| bits | expected | old (buggy) | new |
|---|---|---|---|
| 0x3C00 (1.0) | 1.0 | 0.0078125 | 1.0 |
| 0x4000 (2.0) | 2.0 | 2.0 (coincidence) | 2.0 |
| 0x3E00 (1.5) | 1.5 | 0.125 | 1.5 |
| 0xBC00 (-1.0) | -1.0 | -0.0078125 | -1.0 |
| 0x0001 (min subnormal) | 5.96e-8 | 9.18e-41 | 5.96e-8 |
| 0x7BFF (max normal) | 65504 | — | 65504 |

The old function was wrong for every case except 0.0 and 2.0 (which happened to survive the bit-shift by coincidence).

`cmake --build build` clean, `ctest` 13/13 non-skipped pass.
