### PR TITLE
fix: correct GGUF Q8_0/Q5_0/Q5_1 dtype enum values (8/6/7, not 7/8/9)

### DIFF
--- a/src/gguf_loader.cpp
+++ b/src/gguf_loader.cpp
@@ -19,20 +19,31 @@
 
 namespace {
 
+// Values verified directly against ggml.h's `enum ggml_type` (0=F32,
+// 1=F16, 2=Q4_0, 3=Q4_1, [4,5 removed], 6=Q5_0, 7=Q5_1, 8=Q8_0, 9=Q8_1,
+// 10..15=K-quants) and cross-checked with the `gguf` Python package's
+// GGMLQuantizationType. This enum previously had Q8_0/Q5_0/Q5_1 shifted
+// by one (7/8/9 instead of the real 8/6/7) — Q8_0 tensors were silently
+// falling through to the "unsupported" path (dtype 7 is really Q5_1,
+// which isn't handled either), and nothing was ever actually dispatched
+// as real Q5_0 (dtype 6, not in the switch at all before this fix).
 enum gguf_dtype : uint32_t {
     GGUF_TYPE_F32     = 0,
     GGUF_TYPE_F16     = 1,
     GGUF_TYPE_Q4_0    = 2,
     GGUF_TYPE_Q4_1    = 3,
-    GGUF_TYPE_Q8_0    = 7,
-    GGUF_TYPE_Q5_0    = 8,
-    GGUF_TYPE_Q5_1    = 9,
+    GGUF_TYPE_Q5_0    = 6,
+    GGUF_TYPE_Q5_1    = 7,
+    GGUF_TYPE_Q8_0    = 8,
     GGUF_TYPE_Q2_K    = 10,
     GGUF_TYPE_Q3_K    = 11,
     GGUF_TYPE_Q4_K    = 12,
     GGUF_TYPE_Q5_K    = 13,
     GGUF_TYPE_Q6_K    = 14,
     GGUF_TYPE_Q8_K    = 15,
+    // NOTE: this project-specific extension collides with the real
+    // GGML_TYPE_IQ2_XXS=16 — harmless today since IQ-quants aren't
+    // handled anywhere in this loader, but a landmine if that ever changes.
     GGUF_TYPE_BLOCK_SCALED_TERNARY = 16,
 };
 

--- a/tests/backends/backend_hip.cpp
+++ b/tests/backends/backend_hip.cpp
@@ -527,10 +527,14 @@ public:
             if (it->second.dtype == 1) {
                 std::vector<uint16_t> buf(n); fread(buf.data(), 2, n, gf);
                 HIP_OK(hipMemcpy(dptr, buf.data(), n * 2, hipMemcpyHostToDevice));
-            } else if (it->second.dtype == 7) {
-                // Q8_0 dequant to FP16. (dtype 7, not 8 — 8 is Q5_0, a
-                // different block layout this branch was silently
-                // misreading as Q8_0 whenever a model actually used it.)
+            } else if (it->second.dtype == 8) {
+                // Q8_0 dequant to FP16. GGML_TYPE_Q8_0 is genuinely 8 per
+                // ggml.h (0=F32,1=F16,2=Q4_0,3=Q4_1,6=Q5_0,7=Q5_1,8=Q8_0,
+                // 9=Q8_1,10..15=K-quants) — a previous pass here "corrected"
+                // this from 8 to 7 based on a wrong memory of the enum,
+                // which actually broke it (7 is Q5_1, not Q8_0). Verified
+                // against ggml.h directly and the real `gguf` Python
+                // package this time before touching it again.
                 std::vector<__half> buf(n);
                 int blks = (n + 31) / 32;
                 for (int b = 0; b < blks; b++) {
@@ -562,8 +566,8 @@ public:
                 HIP_OK(hipMemcpy(dptr, buf.data(), n * 2, hipMemcpyHostToDevice));
             } else {
                 // F32 → FP16. NOTE: also wrongly hit by any *other* unhandled
-                // quant type (Q2_K/Q3_K/Q5_K/Q8_K/Q4_0/Q5_0/legacy formats) —
-                // those aren't decoded correctly, they just don't crash.
+                // quant type (Q4_0=2, Q4_1=3, Q5_0=6, Q5_1=7, Q8_1=9, Q8_K=15,
+                // IQ*) — those aren't decoded correctly, they just don't crash.
                 std::vector<__half> buf(n);
                 std::vector<float> f32(n); fread(f32.data(), 4, n, gf);
                 for (size_t i = 0; i < n; i++) buf[i] = __float2half(f32[i]);


### PR DESCRIPTION
## Summary
- `src/gguf_loader.cpp` had a pre-existing enum bug: `GGUF_TYPE_Q8_0=7, Q5_0=8, Q5_1=9` — real ggml.h values are `Q5_0=6, Q5_1=7, Q8_0=8`. Q8_0 tensors were silently falling through to the F32 fallback path instead of being dequantized.
- A previous pass in this session "corrected" `tests/backends/backend_hip.cpp`'s originally-correct `dtype==8` Q8_0 check to `dtype==7`, based on the same wrong enum memory — re-introducing the identical bug there.
- Both fixed back to the real values and verified byte-exact against the Python `gguf` package's reference dequantizer (`GGMLQuantizationType.Q8_0`) across seeded random blocks, and cross-checked directly against `~/llama.cpp/ggml/include/ggml.h` source.

## Test plan
- [x] Standalone verification harness comparing dequant output to `gguf.quants.Q8_0.dequantize_blocks()` — byte-exact match
- [x] `cmake --build build -j$(nproc)` — clean build
- [x] `ctest` — full suite passes/skips as before (no regressions)
