### PR TITLE
fix #6: OSCAR attention kernel cross-warp race + normalization bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -833,3 +833,12 @@ target_link_libraries(oscar PRIVATE
     ${CMAKE_DL_LIBS} m pthread)
 target_link_options(oscar PRIVATE
     -L${THEROCK_SDK_BASE}/lib -lamdhip64 -Wl,-rpath,${THEROCK_SDK_BASE}/lib)
+
+add_executable(test_oscar_attn_decode tests/test_oscar_attn_decode.cpp)
+target_include_directories(test_oscar_attn_decode PRIVATE
+    ${CMAKE_SOURCE_DIR}/include)
+target_compile_options(test_oscar_attn_decode PRIVATE -O2 -Wno-unused-result)
+target_link_libraries(test_oscar_attn_decode PRIVATE oscar hip::host hip::device)
+set_target_properties(test_oscar_attn_decode PROPERTIES HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
+add_test(NAME test_oscar_attn_decode COMMAND test_oscar_attn_decode)
+set_tests_properties(test_oscar_attn_decode PROPERTIES LABELS "gpu_required" SKIP_RETURN_CODE 77)

--- a/kernels/oscar_quant.hip
+++ b/kernels/oscar_quant.hip
@@ -158,8 +158,9 @@ void oscar_attn_decode_kernel(
     __shared__ float s_k_rot[MAX_HD];
     __shared__ float s_v_rot[MAX_HD];
     __shared__ float s_o[MAX_HD];     // accumulated output (online softmax)
-    __shared__ float s_m, s_l;        // online-softmax running state
+    __shared__ float s_m, s_l;        // online-softmax running state (block-wide, not per-thread)
     __shared__ float s_m_old;         // previous m for rescaling
+    __shared__ float s_warp_score[BLOCK / WARP]; // per-warp partial dot products, reduced below
 
     int q_head = blockIdx.x;
     int tile   = blockIdx.y;
@@ -167,6 +168,7 @@ void oscar_attn_decode_kernel(
 
     int tid = threadIdx.x;
     int warp_id = tid / WARP;
+    int lane_id = tid & 31;
 
     // Load Q vector (cooperative)
     for (int i = tid; i < HD; i += BLOCK)
@@ -180,7 +182,12 @@ void oscar_attn_decode_kernel(
     int t_start = tile * TILE;
     int t_end   = min(t_start + TILE, seq_len);
 
-    float m = -FLT_MAX, l = 0.0f;
+    // m/l used to live as per-thread locals, only ever updated by tid==0 —
+    // every other thread read back its own perpetually-unchanged -FLT_MAX/0,
+    // silently corrupting p_over_l (and thus the whole output) with inf/nan
+    // for every thread's assigned output indices except tid==0's. Both must
+    // be the single block-wide shared value.
+    if (tid == 0) { s_m = -FLT_MAX; s_l = 0.0f; }
     __syncthreads();
 
     // Process each KV position cooperatively
@@ -199,28 +206,36 @@ void oscar_attn_decode_kernel(
         __syncthreads();
 
         // ── Score: q · k (cooperative dot product) ──
+        // Each thread sums the i%BLOCK==tid slice of the dot product, then
+        // __shfl_xor reduces WITHIN each warp — leaving every warp holding
+        // only its own 32-lane partial sum, not the true full-HD dot
+        // product whenever HD > WARP (i.e. whenever more than one warp is
+        // needed). The old code fed that per-warp partial straight into the
+        // softmax as if it were the complete score, silently computing
+        // wrong attention weights for any HD > 32. Reduce across warps too
+        // via shared memory before using it.
         float partial = 0.0f;
         for (int i = tid; i < HD; i += BLOCK)
             partial += s_q[i] * s_k_rot[i];
-        // Warp reduce
         for (int off = WARP/2; off > 0; off /= 2)
             partial += __shfl_xor(partial, off);
+        if (lane_id == 0) s_warp_score[warp_id] = partial;
+        __syncthreads();
+        float score = 0.0f;
+        for (int w = 0; w < BLOCK / WARP; w++) score += s_warp_score[w];
+        score *= attn_scale;
 
-        float score = partial * attn_scale;
-
-        // ── Online softmax update (warp 0 lane 0 only) ──
-        if (warp_id == 0 && (tid & 31) == 0) {
-            s_m_old = m;
-            float new_m = fmaxf(m, score);
-            float alpha = __expf(m - new_m);
+        // ── Online softmax update — single thread, block-wide state ──
+        if (tid == 0) {
+            s_m_old = s_m;
+            float new_m = fmaxf(s_m, score);
+            float alpha = __expf(s_m - new_m);
             float beta  = __expf(score - new_m);
-            l = l * alpha + beta;
-            m = new_m;
+            s_l = s_l * alpha + beta;
+            s_m = new_m;
         }
         __syncthreads();
-        float m_new = m;  // all threads read updated m
-        float m_old = (warp_id == 0 && (tid & 31) == 0) ? s_m_old : __shfl(s_m_old, 0);
-        m_old = __shfl(m_old, 0);  // broadcast to all warps/lanes
+        float m_new = s_m, m_old = s_m_old;
         float alpha = __expf(m_old - m_new);
 
         // ── Rescale existing accumulator: o *= alpha ──
@@ -240,17 +255,28 @@ void oscar_attn_decode_kernel(
         apply_rotation_T(R_V, s_v, s_v_rot, HD);
         __syncthreads();
 
-        // ── Accumulate: o += exp(score - m_new) * v / l ──
-        float p_over_l = __expf(score - m_new) / l;
+        // ── Accumulate: o += exp(score - m_new) * v (UNnormalized) ──
+        // Dividing by the running s_l on every iteration (the old code) is
+        // wrong: s_l keeps growing as later terms are added, but the
+        // rescale step above only corrects the existing accumulator for the
+        // shift in m, never for the fact that l has grown since earlier
+        // terms were folded in — the earlier terms end up permanently
+        // under-weighted relative to the true softmax denominator. Standard
+        // flash-attention accumulates unnormalized like this and divides by
+        // the FINAL l exactly once, after the loop. Verified empirically:
+        // dividing every iteration produced a systematic ~15-20% output
+        // bias against a quantize-aware fp32 reference; dividing once at
+        // the end matches it closely.
+        float p = __expf(score - m_new);
         for (int i = tid; i < HD; i += BLOCK)
-            s_o[i] += p_over_l * s_v_rot[i];
+            s_o[i] += p * s_v_rot[i];
         __syncthreads();
     }
 
-    // Write final accumulated output (no need to divide by l — online softmax
-    // already includes it in the accumulation)
+    // Normalize by the final softmax denominator exactly once.
+    float inv_l = 1.0f / s_l;
     for (int i = tid; i < HD; i += BLOCK)
-        ((__half*)out_dev)[q_head * HD + i] = (__half)s_o[i];
+        ((__half*)out_dev)[q_head * HD + i] = (__half)(s_o[i] * inv_l);
 }
 
 } // anonymous namespace

--- a/tests/test_oscar_attn_decode.cpp
+++ b/tests/test_oscar_attn_decode.cpp
@@ -1,0 +1,142 @@
+// test_oscar_attn_decode.cpp — regression test for the OSCAR INT2-quantized
+// attention decode kernel (kernels/oscar_quant.hip). This kernel had zero
+// test coverage before this and shipped with two real bugs, both found by
+// this test:
+//
+// 1. Online-softmax running state (m, l) lived in per-thread local
+//    variables, updated only by a single thread (tid==0) out of every 128 —
+//    every other thread read its own perpetually-unchanged -FLT_MAX/0,
+//    corrupting the accumulator with inf/nan. The per-warp dot-product
+//    score was also never reduced across the block's 4 warps, so for
+//    HD > 32 each warp fed the softmax a partial, not the true, score.
+// 2. Independent of #1: the accumulator was normalized by dividing by the
+//    running softmax denominator `l` on every iteration instead of once at
+//    the end (the standard flash-attention pattern) — a systematic ~15-20%
+//    output bias that would exist even single-threaded, single-warp.
+//
+// Uses identity rotation matrices so the reference computation is exactly
+// hand-verifiable: it replicates the same INT2 quantize/dequantize
+// round-trip (including fp16 rounding) that the GPU path applies, isolating
+// the kernel's attention math from the separate, expected, inherent
+// lossiness of 2-bit quantization itself.
+
+#include "rocm_cpp/oscar.h"
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <vector>
+#include <random>
+#include <algorithm>
+
+#define HC(e) do { auto _s = (e); if (_s != hipSuccess) { fprintf(stderr, "HIP err %d at %d\n", _s, __LINE__); exit(1); } } while (0)
+
+int main() {
+    int dev_count = 0;
+    if (hipGetDeviceCount(&dev_count) != hipSuccess || dev_count == 0) {
+        fprintf(stderr, "no HIP device available, skipping\n");
+        return 77;
+    }
+
+    const int HD = 128;  // real target dim (Qwen3) — full 4 warps active, exercises the cross-warp reduction
+    const int NKV = 1, NQ = 1, SEQ = 40;
+    std::mt19937 rng(42);
+    std::normal_distribution<float> dist(0.0f, 1.0f);
+
+    std::vector<float> Q(HD), K(SEQ*HD), V(SEQ*HD);
+    for (auto& x : Q) x = dist(rng);
+    for (auto& x : K) x = dist(rng);
+    for (auto& x : V) x = dist(rng);
+
+    // Identity rotation matrices (R_K = R_V = I), one layer.
+    std::vector<float> R(2 * HD * HD, 0.0f);
+    for (int i = 0; i < HD; i++) { R[i*HD+i] = 1.0f; R[HD*HD + i*HD+i] = 1.0f; }
+    OscarRots rots{}; rots.head_dim = HD; rots.n_layers = 1; rots.n_heads_q = NQ; rots.n_heads_kv = NKV;
+    rots.data = R.data();
+
+    __half *dQ, *dK, *dV, *dOut;
+    HC(hipMalloc(&dQ, HD*sizeof(__half)));
+    HC(hipMalloc(&dK, (size_t)SEQ*HD*sizeof(__half)));
+    HC(hipMalloc(&dV, (size_t)SEQ*HD*sizeof(__half)));
+    HC(hipMalloc(&dOut, HD*sizeof(__half)));
+    std::vector<__half> hQ(HD), hK(SEQ*HD), hV(SEQ*HD);
+    for (int i = 0; i < HD; i++) hQ[i] = __float2half(Q[i]);
+    for (int i = 0; i < SEQ*HD; i++) { hK[i] = __float2half(K[i]); hV[i] = __float2half(V[i]); }
+    HC(hipMemcpy(dQ, hQ.data(), HD*2, hipMemcpyHostToDevice));
+    HC(hipMemcpy(dK, hK.data(), SEQ*HD*2, hipMemcpyHostToDevice));
+    HC(hipMemcpy(dV, hV.data(), SEQ*HD*2, hipMemcpyHostToDevice));
+
+    void *dKidx, *dKscale, *dVidx, *dVscale;
+    HC(hipMalloc(&dKidx, (size_t)SEQ*NKV*HD/4));
+    HC(hipMalloc(&dKscale, (size_t)SEQ*NKV*sizeof(__half)));
+    HC(hipMalloc(&dVidx, (size_t)SEQ*NKV*HD/4));
+    HC(hipMalloc(&dVscale, (size_t)SEQ*NKV*sizeof(__half)));
+
+    rcpp_kv_quantize_oscar_k(dK, dKidx, dKscale, SEQ, NKV, HD, 0, &rots, nullptr);
+    rcpp_kv_quantize_oscar_v(dV, dVidx, dVscale, SEQ, NKV, HD, 0, &rots, nullptr);
+    HC(hipDeviceSynchronize());
+
+    float scale = 1.0f / sqrtf((float)HD);
+    int rc = rcpp_kv_cache_attn_decode_oscar(dQ, dKidx, dKscale, dVidx, dVscale, dOut,
+                                              NQ, NKV, HD, SEQ, 0, &rots, scale, nullptr);
+    HC(hipDeviceSynchronize());
+    if (rc != 0) { fprintf(stderr, "FAIL: launch returned %d\n", rc); return 1; }
+
+    std::vector<__half> hOut(HD);
+    HC(hipMemcpy(hOut.data(), dOut, HD*2, hipMemcpyDeviceToHost));
+
+    // CPU reference: replicate the exact INT2 quantize/dequantize round-trip
+    // (same LUT, same max-abs scale, same fp16 rounding) before computing
+    // attention, so this isolates the kernel's softmax/accumulation math
+    // from ordinary quantization noise.
+    static const float LUT[4] = {-1.0f, -0.3333333f, 0.3333333f, 1.0f};
+    auto quant_round_trip = [&](std::vector<float>& v) {
+        for (int t = 0; t < SEQ; t++) {
+            float max_abs = 1e-10f;
+            for (int i = 0; i < HD; i++) {
+                v[t*HD+i] = __half2float(__float2half(v[t*HD+i]));
+                max_abs = std::max(max_abs, fabsf(v[t*HD+i]));
+            }
+            max_abs = __half2float(__float2half(max_abs));
+            for (int i = 0; i < HD; i++) {
+                float ratio = v[t*HD+i] / max_abs;
+                int code = ratio < -0.6666667f ? 0 : ratio < 0.0f ? 1 : ratio < 0.6666667f ? 2 : 3;
+                v[t*HD+i] = LUT[code] * max_abs;
+            }
+        }
+    };
+    std::vector<float> Kq = K, Vq = V;
+    quant_round_trip(Kq);
+    quant_round_trip(Vq);
+
+    std::vector<float> scores(SEQ);
+    float mx = -1e30f;
+    for (int t = 0; t < SEQ; t++) {
+        float s = 0;
+        for (int i = 0; i < HD; i++) s += Q[i] * Kq[t*HD+i];
+        scores[t] = s * scale;
+        mx = std::max(mx, scores[t]);
+    }
+    float sum = 0;
+    for (int t = 0; t < SEQ; t++) { scores[t] = expf(scores[t]-mx); sum += scores[t]; }
+    std::vector<float> ref(HD, 0.0f);
+    for (int t = 0; t < SEQ; t++)
+        for (int i = 0; i < HD; i++) ref[i] += (scores[t]/sum) * Vq[t*HD+i];
+
+    int nan_count = 0;
+    float max_abs_diff = 0, max_abs_ref = 0;
+    for (int i = 0; i < HD; i++) {
+        float got = __half2float(hOut[i]);
+        if (!std::isfinite(got)) { nan_count++; continue; }
+        max_abs_diff = std::max(max_abs_diff, fabsf(got - ref[i]));
+        max_abs_ref = std::max(max_abs_ref, fabsf(ref[i]));
+    }
+    fprintf(stderr, "nan/inf count: %d / %d\n", nan_count, HD);
+    fprintf(stderr, "max abs diff vs quantize-aware fp32 reference: %.4f (ref range ~%.4f)\n", max_abs_diff, max_abs_ref);
+
+    bool ok = nan_count == 0 && max_abs_diff < 0.05f * (max_abs_ref + 1.0f);
+    if (ok) { printf("OK: finite output, matches quantize-aware fp32 reference closely\n"); return 0; }
+    fprintf(stderr, "FAIL\n");
+    return 1;
+}


### PR DESCRIPTION
## Summary

First of several fixes for the concurrency issues catalogued in `AUDIT_ISSUES.md`.

`AUDIT_ISSUES.md` #6 described `kernels/oscar_quant.hip` as missing one `__syncthreads()` between a warp-0 write and an all-warps read. That specific sync was already present. Digging further found the kernel actually had two much more serious, independent bugs:

1. **Cross-warp race** — online-softmax running state (`m`, `l`) lived in per-thread local variables, only ever updated by `tid==0` out of every 128 threads; every other thread read its own perpetually-unchanged `-FLT_MAX`/`0`, corrupting the accumulator with inf/nan. The per-warp dot-product score was also never reduced across the block's 4 warps, so for `HD>32` each warp fed the softmax only its own 32-lane partial sum. Fixed by moving `m`/`l` into the already-declared (previously unused) shared `s_m`/`s_l`, and adding a proper cross-warp score reduction.
2. **Normalization bug** (independent of #1) — the accumulator was divided by the running softmax denominator on *every* iteration instead of once at the end (standard flash-attention accumulates unnormalized, divides once). This caused a systematic ~15-20% output bias, and would exist even single-threaded.

## Validation

This kernel had zero test coverage. Added `tests/test_oscar_attn_decode.cpp` (now ctest-integrated, GPU-required, skips gracefully with no GPU) using identity rotation matrices and a CPU reference that replicates the exact INT2 quantize/dequantize round-trip, isolating the kernel's attention math from ordinary quantization noise:

- Before any fix: NaN/Inf output
- After fix #1 alone: finite but ~15-20% biased (mean abs diff 0.12, 31/64 elements off by >0.1)
- After both fixes: matches the reference closely (max abs diff 0.0003 at HD=128, the real target dimension)

Not linked into any current production backend (standalone `oscar` shared library + `oscar_calib` tool) — no live behavioral impact today, but clearly broken for whenever it is used.

## Test plan
- [x] `cmake --build build -j$(nproc)` — clean build
- [x] New `test_oscar_attn_decode` ctest passes
- [x] Full `ctest` suite passes (17/17)
