### PR TITLE
fix #20: NPU worker pipe I/O has no timeout on the GEMM hot path

### DIFF
--- a/src/backend_npu.cpp
+++ b/src/backend_npu.cpp
@@ -115,6 +115,30 @@ static void attn_cpu(float* qo, float* at, int seq_len,
 }
 
 // ── Process helpers ──
+// Read exactly `len` bytes from `fd`, bounded by `timeout_ms` total across
+// the whole read (not per-call) — a single blocking read() has no timeout
+// at all, so a hung NPU worker subprocess would block the calling httplib
+// thread forever, eventually exhausting the whole server's thread pool.
+// Also handles short reads (pipes don't guarantee delivering the full
+// requested length in one read()), which a bare read() call did not.
+static bool read_with_timeout(int fd, void* buf, size_t len, int timeout_ms) {
+    size_t got = 0;
+    auto t0 = std::chrono::steady_clock::now();
+    while (got < len) {
+        int remaining_ms = timeout_ms - (int)std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - t0).count();
+        if (remaining_ms <= 0) return false;
+        fd_set fds; FD_ZERO(&fds); FD_SET(fd, &fds);
+        struct timeval tv = {remaining_ms / 1000, (remaining_ms % 1000) * 1000};
+        int r = select(fd + 1, &fds, nullptr, nullptr, &tv);
+        if (r <= 0) return false; // timeout or select error
+        ssize_t n = read(fd, (char*)buf + got, len - got);
+        if (n <= 0) return false; // EOF or read error
+        got += (size_t)n;
+    }
+    return true;
+}
+
 // Wait up to timeout_ms for child to exit. Returns true if exited.
 static bool wait_for_child(pid_t pid, int timeout_ms) {
     auto t0 = std::chrono::steady_clock::now();
@@ -202,6 +226,9 @@ struct NpuWorker {
     }
 
     // Send a GEMM operation, read back result. out_data auto-resized.
+    // Bounded by GEMM_TIMEOUT_MS per read — a hung worker subprocess used to
+    // block this call (and the calling httplib thread) forever (issue #20).
+    static constexpr int GEMM_TIMEOUT_MS = 30000;
     bool gemm(int op, int layer, int batch, int in_dim,
               const float* in_data, std::vector<float>& out_data) {
         if (!ready || stdin_fd < 0 || stdout_fd < 0) return false;
@@ -210,12 +237,11 @@ struct NpuWorker {
         if (write(stdin_fd, in_data, (size_t)batch * in_dim * sizeof(float)) !=
             (ssize_t)((size_t)batch * in_dim * sizeof(float))) return false;
         uint32_t resp[2];
-        if (read(stdout_fd, resp, sizeof(resp)) != (ssize_t)sizeof(resp)) return false;
+        if (!read_with_timeout(stdout_fd, resp, sizeof(resp), GEMM_TIMEOUT_MS)) return false;
         if (resp[0] != 0) return false;
         uint32_t out_dim = resp[1];
         out_data.resize((size_t)batch * out_dim);
-        return read(stdout_fd, out_data.data(), (size_t)batch * out_dim * sizeof(float)) ==
-               (ssize_t)((size_t)batch * out_dim * sizeof(float));
+        return read_with_timeout(stdout_fd, out_data.data(), (size_t)batch * out_dim * sizeof(float), GEMM_TIMEOUT_MS);
     }
 
     void shutdown() {

--- a/tests/backends/backend_npu.cpp
+++ b/tests/backends/backend_npu.cpp
@@ -27,6 +27,20 @@
 #include <fcntl.h>
 #include <signal.h>
 
+// Wait up to timeout_ms for child to exit. Returns true if exited.
+static bool wait_for_child(pid_t pid, int timeout_ms) {
+    auto t0 = std::chrono::steady_clock::now();
+    while (std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now() - t0).count() < timeout_ms) {
+        int status;
+        pid_t r = waitpid(pid, &status, WNOHANG);
+        if (r == pid) return true;
+        if (r < 0) return true;
+        usleep(10000); // 10ms poll interval
+    }
+    return false;
+}
+
 class NpuFlmBackend : public InferenceBackend {
     ModelConfig cfg_;
     bool loaded_ = false;
@@ -183,15 +197,27 @@ public:
 
     void unload_model() override {
         if (pid_ > 0) {
+            // Send /exit and give FLM a real chance to shut down gracefully
+            // before escalating — the old code slept a fixed 500ms then
+            // closed the pipes and sent SIGTERM after another fixed 200ms
+            // sleep regardless of whether the process had already exited,
+            // then sent SIGKILL unconditionally right after, even if
+            // SIGTERM had already worked. Same bug class as #3
+            // (backend_npu.cpp/backend_flm.cpp's already-fixed shutdown
+            // paths), just a separate, not-yet-fixed occurrence here.
             const char* exit_cmd = "/exit\n";
-            write(stdin_fd_, exit_cmd, strlen(exit_cmd));
-            usleep(500000);
-            close(stdin_fd_); close(stdout_fd_); close(stderr_fd_);
-            kill(pid_, SIGTERM); usleep(200000);
-            kill(pid_, SIGKILL);
-            // Reap child to prevent zombie. WNOHANG first, then wait if still alive.
-            if (waitpid(pid_, nullptr, WNOHANG) == 0)
-                waitpid(pid_, nullptr, 0);
+            if (stdin_fd_ >= 0) write(stdin_fd_, exit_cmd, strlen(exit_cmd));
+            if (!wait_for_child(pid_, 500)) {
+                kill(pid_, SIGTERM);
+                if (!wait_for_child(pid_, 2000)) {
+                    kill(pid_, SIGKILL);
+                    wait_for_child(pid_, 1000);
+                }
+            }
+            if (stdin_fd_ >= 0) close(stdin_fd_);
+            if (stdout_fd_ >= 0) close(stdout_fd_);
+            if (stderr_fd_ >= 0) close(stderr_fd_);
+            waitpid(pid_, nullptr, WNOHANG);
             pid_ = 0;
         }
         stdin_fd_ = stdout_fd_ = stderr_fd_ = -1;


### PR DESCRIPTION
## Summary

Continuing the `AUDIT_ISSUES.md` concurrency fixes (after #495).

`AUDIT_ISSUES.md` #20 named `src/backend_npu.cpp`'s blocking `read()` with no timeout. The startup handshake there was already fixed with a `select()`-based timeout in a prior pass, but the actual per-request GEMM communication (`gemm()`'s two `read()` calls for the response header and payload) was still a bare blocking `read()` with no bound — if the NPU worker subprocess hangs mid-request, the calling httplib thread blocks forever, eventually exhausting the whole server's thread pool.

- Added `read_with_timeout()` (`select()`-bounded, loops to handle short reads — a single `read()` call has no guarantee of returning the full requested length on a pipe) and used it for both reads in `gemm()`, bounded at 30s.
- Found and fixed a **second, separate occurrence** of #3's shutdown-race bug class while reviewing the sibling NPU backend implementation (`tests/backends/backend_npu.cpp` — a different file than `src/backend_npu.cpp`, used by the `zaya_server` binary): `unload_model()` slept a fixed 500ms, closed the pipes, sent SIGTERM after another fixed 200ms sleep regardless of whether the process had already exited, then sent SIGKILL unconditionally right after — even if SIGTERM had already worked. Replaced with the same graceful-wait-then-escalate pattern already used in `src/backend_npu.cpp`/`src/backend_flm.cpp` (issue #365).

## Test plan
- [x] `cmake --build build -j$(nproc)` — clean build (both `rocm_cpp` and `zaya_server` targets)
- [x] Full `ctest` suite passes (17/17)
- [x] `mcp__gitnexus__detect_changes` — medium risk, confined to the exact init/shutdown call graph touched
