### PR TITLE
fix #2: serialize concurrent HTTP handler access to shared inference state

### DIFF
--- a/tests/zaya_server.cpp
+++ b/tests/zaya_server.cpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <chrono>
 #include <algorithm>
+#include <mutex>
 
 #include <httplib.h>
 #include <nlohmann/json.hpp>
@@ -419,6 +420,16 @@ int main(int argc, char** argv) {
     router.strategy = strategy;
     if (!router.init()) { fprintf(stderr, "FATAL: TokenRouter init failed\n"); return 1; }
 
+    // httplib serves each connection from a thread pool — every access to
+    // `router` (a single stack object captured by reference in every
+    // handler below) must be serialized, or concurrent requests race on its
+    // KV cache position, active backend pointer, and loaded_models list
+    // (AUDIT_ISSUES.md #2). router.infer() is the real hot path but the
+    // metadata reads in "/" and "/v1/models" get the same guard for
+    // correctness — they're cheap, and a torn/half-updated read of
+    // router.primary while another thread is mid-infer() is still UB.
+    std::mutex g_router_mutex;
+
     ModelConfig cfg;
     fprintf(stderr, "DEBUG: about to detect model...\n"); fflush(stderr);
     bool detected = false;
@@ -513,6 +524,7 @@ int main(int argc, char** argv) {
     SimpleTokenizer tok;
 
     svr.Get("/", [&](const httplib::Request&, httplib::Response& res) {
+        std::lock_guard<std::mutex> lock(g_router_mutex);
         std::string resp = "{\"status\":\"" + std::string(model_loaded ? "ok" : "no_model") + "\",\"model_loaded\":" + (model_loaded ? "true" : "false") + ",\"model\":\"" + json_escape(cfg.model_name) + "\","
             "\"backend\":\"" + std::string(router.primary ? router.primary->name() : "none") + "\","
             "\"hidden_size\":" + std::to_string(cfg.hidden_size) + ","
@@ -532,6 +544,7 @@ int main(int argc, char** argv) {
     });
 
     svr.Get("/v1/models", [&](const httplib::Request&, httplib::Response& res) {
+        std::lock_guard<std::mutex> lock(g_router_mutex);
         std::string resp = "{\"object\":\"list\",\"data\":[";
         for (size_t i = 0; i < router.loaded_models.size(); i++) {
             if (i) resp += ",";
@@ -547,21 +560,30 @@ int main(int argc, char** argv) {
 
     svr.Post("/a2a/v1/message:send", [&](const httplib::Request& req, httplib::Response& res) {
         std::string task_id = a2a_new_task_id();
-        res.set_content(a2a_handle_message(req.body, task_id, router, tok, model_loaded), "application/json");
+        std::string result;
+        {
+            std::lock_guard<std::mutex> lock(g_router_mutex);
+            result = a2a_handle_message(req.body, task_id, router, tok, model_loaded);
+        }
+        res.set_content(result, "application/json");
     });
 
     svr.Post("/a2a/v1/message:sendStream", [&](const httplib::Request& req, httplib::Response& res) {
         std::string task_id = a2a_new_task_id();
         std::string body = req.body;
         res.set_chunked_content_provider("text/event-stream",
-            [task_id, body, &router, &tok, model_loaded](size_t, httplib::DataSink& sink) {
+            [task_id, body, &router, &tok, model_loaded, &g_router_mutex](size_t, httplib::DataSink& sink) {
                 std::string e1 = "event: taskStatus\ndata: " + a2a_task_status(task_id, "ctx-" + task_id, "TASK_STATE_SUBMITTED", "Task accepted") + "\n\n";
                 sink.write(e1.data(), e1.size());
 
                 std::string e2 = "event: taskStatus\ndata: " + a2a_task_status(task_id, "ctx-" + task_id, "TASK_STATE_WORKING", "Processing inference") + "\n\n";
                 sink.write(e2.data(), e2.size());
 
-                std::string result = a2a_handle_message(body, task_id, router, tok, model_loaded);
+                std::string result;
+                {
+                    std::lock_guard<std::mutex> lock(g_router_mutex);
+                    result = a2a_handle_message(body, task_id, router, tok, model_loaded);
+                }
                 std::string e3 = "event: taskArtifact\ndata: " + result + "\n\n";
                 sink.write(e3.data(), e3.size());
 
@@ -661,30 +683,34 @@ int main(int argc, char** argv) {
         std::vector<int> tokens = tok.encode(prompt);
         fprintf(stderr, "  → %d prompt tokens, max %d new\n", (int)tokens.size(), max_tokens);
 
-        InferenceResult result = router.infer(tokens, max_tokens, use_strat);
-        std::string text = tok.decode(result.tokens);
-        std::string finish_reason = "stop";
-        if (!result.tokens.empty() && result.tokens.back() != tok.eos_id && (int)result.tokens.size() >= max_tokens)
-            finish_reason = "length";
+        std::string resp_body;
+        {
+            std::lock_guard<std::mutex> lock(g_router_mutex);
+            InferenceResult result = router.infer(tokens, max_tokens, use_strat);
+            std::string text = tok.decode(result.tokens);
+            std::string finish_reason = "stop";
+            if (!result.tokens.empty() && result.tokens.back() != tok.eos_id && (int)result.tokens.size() >= max_tokens)
+                finish_reason = "length";
 
-        // Dynamic buffer -- no fixed-size limit (fixes #194: truncation of long output)
-        std::string resp_body =
-            std::string("{\"id\":\"chatcmpl-") + std::to_string((long long)time(nullptr)) +
-            "\",\"object\":\"chat.completion\",\"created\":" + std::to_string((long long)time(nullptr)) +
-            ",\"model\":\"" + json_escape(cfg.model_name) +
-            "\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"" +
-            json_escape(text) +
-            "\"},\"finish_reason\":\"" + finish_reason +
-            "\"}],\"usage\":{\"prompt_tokens\":" + std::to_string((int)tokens.size()) +
-            ",\"completion_tokens\":" + std::to_string((int)result.tokens.size()) +
-            ",\"total_tokens\":" + std::to_string((int)(tokens.size() + result.tokens.size())) +
-            "},\"x-backend\":\"" + (router.primary ? router.primary->name() : "none") +
-            "\",\"x-ms\":" + std::to_string((long long)result.gen_ms) +
-            ",\"x-tok-s\":" + std::to_string((double)result.tok_s) + "}";
+            // Dynamic buffer -- no fixed-size limit (fixes #194: truncation of long output)
+            resp_body =
+                std::string("{\"id\":\"chatcmpl-") + std::to_string((long long)time(nullptr)) +
+                "\",\"object\":\"chat.completion\",\"created\":" + std::to_string((long long)time(nullptr)) +
+                ",\"model\":\"" + json_escape(cfg.model_name) +
+                "\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"" +
+                json_escape(text) +
+                "\"},\"finish_reason\":\"" + finish_reason +
+                "\"}],\"usage\":{\"prompt_tokens\":" + std::to_string((int)tokens.size()) +
+                ",\"completion_tokens\":" + std::to_string((int)result.tokens.size()) +
+                ",\"total_tokens\":" + std::to_string((int)(tokens.size() + result.tokens.size())) +
+                "},\"x-backend\":\"" + (router.primary ? router.primary->name() : "none") +
+                "\",\"x-ms\":" + std::to_string((long long)result.gen_ms) +
+                ",\"x-tok-s\":" + std::to_string((double)result.tok_s) + "}";
+            fprintf(stderr, "  ← %d tokens in %.0fms (%.1f tok/s) [%s]\n",
+                    (int)result.tokens.size(), result.gen_ms, result.tok_s,
+                    router.primary ? router.primary->name() : "none");
+        }
         res.set_content(resp_body, "application/json");
-        fprintf(stderr, "  ← %d tokens in %.0fms (%.1f tok/s) [%s]\n",
-                (int)result.tokens.size(), result.gen_ms, result.tok_s,
-                router.primary ? router.primary->name() : "none");
     });
 
     svr.Post("/completion", [&](const httplib::Request& req, httplib::Response& res) {
@@ -715,16 +741,20 @@ int main(int argc, char** argv) {
             }
             input = tok.encode(prompt);
         }
-        InferenceResult result = router.infer(input, np, RouteStrategy::AUTO);
-        std::string text = tok.decode(result.tokens);
-        std::string rsp = "{\"tokens\":[";
-        for (size_t i = 0; i < result.tokens.size(); i++) {
-            if (i) rsp += ",";
-            rsp += std::to_string(result.tokens[i]);
+        std::string rsp;
+        {
+            std::lock_guard<std::mutex> lock(g_router_mutex);
+            InferenceResult result = router.infer(input, np, RouteStrategy::AUTO);
+            std::string text = tok.decode(result.tokens);
+            rsp = "{\"tokens\":[";
+            for (size_t i = 0; i < result.tokens.size(); i++) {
+                if (i) rsp += ",";
+                rsp += std::to_string(result.tokens[i]);
+            }
+            rsp += "],\"text\":\"" + json_escape(text) + "\",\"gen_ms\":" +
+                   std::to_string(result.gen_ms) + ",\"tok_s\":" +
+                   std::to_string(result.tok_s) + "}";
         }
-        rsp += "],\"text\":\"" + json_escape(text) + "\",\"gen_ms\":" +
-               std::to_string(result.gen_ms) + ",\"tok_s\":" +
-               std::to_string(result.tok_s) + "}";
         res.set_content(rsp, "application/json");
     });
 

--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -681,6 +681,7 @@ int main(int argc, char** argv) {
 
     // ── GET /v1/health — Backend status dashboard ──
     svr.Get("/v1/health", [&](const httplib::Request& req, httplib::Response& res) {
+        std::lock_guard<std::mutex> lock(g_config_mutex);
         json j = health_json(mgr);
         j["version"] = "unified-server-1.0";
         j["model"] = "zaya";
@@ -692,6 +693,7 @@ int main(int argc, char** argv) {
 
     // ── GET /v1/models — List models ──
     svr.Get("/v1/models", [&](const httplib::Request& req, httplib::Response& res) {
+        std::lock_guard<std::mutex> lock(g_config_mutex);
         auto* active = mgr.active_info();
         json j;
         j["object"] = "list";
@@ -740,26 +742,6 @@ int main(int argc, char** argv) {
 
         std::string backend_id = resolve_backend_id(req);
         SelectionStrategy strategy = resolve_strategy(req);
-        mgr.set_strategy(strategy);
-
-        // Look up the requested model from body["model"] and switch config if needed
-        std::string req_model = body.value("model", "");
-        if (!req_model.empty()) {
-            for (auto& dm : discovered) {
-                // Lock config mutex while switching model (fixes #364)
-                std::lock_guard<std::mutex> cfg_lock(g_config_mutex);
-                if (dm.model_name == req_model &&
-                    (dm.hidden != current_cfg.hidden || dm.n_layers != current_cfg.n_layers)) {
-                    printf("[model] switching to %s (%d layers, %d hidden)\n",
-                           dm.model_name.c_str(), dm.n_layers, dm.hidden);
-                    current_cfg = dm;
-                    g_tokenizer.load_from_gguf(current_cfg.model_path);
-                    BackendRoute swrt = select_backend_route(current_cfg);
-                    mgr.init(current_cfg, g_weights_dir, swrt.backend_ids_in_order);
-                    break;
-                }
-            }
-        }
 
         // Check for strategy engine routing
         std::string strategy_name = resolve_strategy_name(req);
@@ -790,6 +772,34 @@ int main(int argc, char** argv) {
         }
 
         int max_tokens = body.value("max_tokens", 256);
+        std::string req_model = body.value("model", "");
+
+        // g_config_mutex now spans the whole model-switch-decision +
+        // tokenize + generate critical section (fixes #2/#364 combined) —
+        // it used to be held only around the switch-model block itself,
+        // leaving mgr.set_strategy()/generate_completion() (the actual
+        // per-request inference call, touching mgr's active backend, KV
+        // cache position, etc.) completely unsynchronized against a
+        // concurrent request's model switch or its own inference call on
+        // httplib's thread pool.
+        std::lock_guard<std::mutex> lock(g_config_mutex);
+        mgr.set_strategy(strategy);
+
+        // Look up the requested model from body["model"] and switch config if needed
+        if (!req_model.empty()) {
+            for (auto& dm : discovered) {
+                if (dm.model_name == req_model &&
+                    (dm.hidden != current_cfg.hidden || dm.n_layers != current_cfg.n_layers)) {
+                    printf("[model] switching to %s (%d layers, %d hidden)\n",
+                           dm.model_name.c_str(), dm.n_layers, dm.hidden);
+                    current_cfg = dm;
+                    g_tokenizer.load_from_gguf(current_cfg.model_path);
+                    BackendRoute swrt = select_backend_route(current_cfg);
+                    mgr.init(current_cfg, g_weights_dir, swrt.backend_ids_in_order);
+                    break;
+                }
+            }
+        }
 
         // Tokenize with logprobs for cascade strategy
         std::vector<int> prompt_tokens;
@@ -870,6 +880,11 @@ int main(int argc, char** argv) {
         }
 
         std::string backend_id = resolve_backend_id(req);
+
+        // Same g_config_mutex-spans-the-whole-request treatment as
+        // /v1/chat/completions above (fixes #2) — mgr.set_strategy() and
+        // generate_completion() both touch mgr's shared, mutable state.
+        std::lock_guard<std::mutex> lock(g_config_mutex);
         mgr.set_strategy(resolve_strategy(req));
 
         // Accept prompt or tokens
@@ -980,19 +995,24 @@ int main(int argc, char** argv) {
 
         std::string backend_id = body.value("backend", "");
         bool ok = false;
-        if (!backend_id.empty()) {
-            ok = mgr.select_backend(backend_id);
-        }
-
         json j;
-        j["ok"] = ok;
-        j["selected"] = backend_id;
-        if (ok) {
-            auto* active = mgr.active_info();
-            j["active_backend"] = active ? active->id : "none";
-            j["active_type"] = active ? backend_name(active->type) : "none";
-        } else {
-            j["error"] = "Backend '" + backend_id + "' not found or not functional";
+        {
+            // mgr.select_backend() mutates the shared active-backend pointer
+            // that generate_completion() (under the same mutex, see
+            // /v1/chat/completions) reads mid-inference (fixes #2).
+            std::lock_guard<std::mutex> lock(g_config_mutex);
+            if (!backend_id.empty()) {
+                ok = mgr.select_backend(backend_id);
+            }
+            j["ok"] = ok;
+            j["selected"] = backend_id;
+            if (ok) {
+                auto* active = mgr.active_info();
+                j["active_backend"] = active ? active->id : "none";
+                j["active_type"] = active ? backend_name(active->type) : "none";
+            } else {
+                j["error"] = "Backend '" + backend_id + "' not found or not functional";
+            }
         }
         res.set_content(j.dump(2), "application/json");
         add_cors(res);
@@ -1001,8 +1021,18 @@ int main(int argc, char** argv) {
     // ── GET /v1/backend/status — Full backend report ──
     svr.Get("/v1/backend/status", [&](const httplib::Request& req, httplib::Response& res) {
         json j;
-        // Lock strategy mutex for consistent read of strategy name + watchdog (fixes #364)
-        std::lock_guard<std::mutex> lock(g_strategy_mutex);
+        // g_strategy_mutex alone (fixes #364) only protects g_strategy_engine
+        // + g_watchdog — mgr itself (report/backends/active_info/
+        // active_backend, all read below) is the inference handlers'
+        // g_config_mutex's responsibility. Reading mgr here under a
+        // different mutex than the one that guards it during an in-flight
+        // inference call doesn't actually serialize anything (fixes #2).
+        // std::lock (not two separate lock_guards) avoids a lock-order
+        // deadlock against any other path that might acquire the same two
+        // mutexes in the opposite order.
+        std::lock(g_config_mutex, g_strategy_mutex);
+        std::lock_guard<std::mutex> lock1(g_config_mutex, std::adopt_lock);
+        std::lock_guard<std::mutex> lock2(g_strategy_mutex, std::adopt_lock);
         j["strategy"] = g_strategy_engine.name();
         j["watchdog_running"] = g_watchdog ? g_watchdog->running() : false;
         j["report"] = mgr.report();
@@ -1040,8 +1070,11 @@ int main(int argc, char** argv) {
         json j;
         j["service"] = "1bit.systems --- One binary, all backends, intelligent routing";
         j["version"] = "1.0";
-        // Lock strategy mutex for consistent read (fixes #364)
-        std::lock_guard<std::mutex> lock(g_strategy_mutex);
+        // See /v1/backend/status above: mgr.active_backend() needs
+        // g_config_mutex, not just g_strategy_mutex (fixes #2/#364).
+        std::lock(g_config_mutex, g_strategy_mutex);
+        std::lock_guard<std::mutex> lock1(g_config_mutex, std::adopt_lock);
+        std::lock_guard<std::mutex> lock2(g_strategy_mutex, std::adopt_lock);
         j["status"] = mgr.active_backend() ? "ready" : "initializing";
         j["strategy"] = g_strategy_engine.name();
         j["endpoints"] = {


### PR DESCRIPTION
## Summary

Last of the `AUDIT_ISSUES.md` concurrency fixes (after #495/#496).

httplib serves requests from a thread pool. Both servers had a single shared, mutable inference-state object (`TokenRouter` in `zaya_server.cpp`; `BackendManager`'s `mgr` + `current_cfg` + `g_tokenizer` in `unified_server.cpp`) accessed from every request handler with no synchronization around the actual inference calls — only around a narrow model-switch block (`unified_server.cpp`'s existing `g_config_mutex`, "fixes #364") or nothing at all (`zaya_server.cpp`'s `TokenRouter` had none).

- **`zaya_server.cpp`**: added `g_router_mutex`, guarding every access to `router` across all handlers that touch it — `/`, `/v1/models` (metadata reads), `/a2a/v1/message:send` and `:sendStream` (including the nested streaming lambda, which needed the mutex added to its explicit capture list), `/v1/chat/completions`, `/completion` (the real per-request `router.infer()` hot path).
- **`unified_server.cpp`**: extended `g_config_mutex` to span the whole model-switch-decision + tokenize + generate critical section per request in `/v1/chat/completions` and `/v1/completions`, instead of just the switch block — `mgr.set_strategy()`/`generate_completion()` (the actual inference call) used to run completely unguarded. Also fixed `/v1/backend/select` (`mgr.select_backend()` mutates the shared active-backend pointer, was unguarded) and a subtler inconsistency in `/v1/backend/status` and `/`: both read `mgr` under `g_strategy_mutex` (which only protects `g_strategy_engine`/`g_watchdog` per its own comment), not `g_config_mutex` — two different mutexes guarding the same shared object don't actually serialize access to it. Fixed with `std::lock()` (not two separate `lock_guard`s) to acquire both mutexes without a lock-order deadlock risk against any other path.

## Validation

- `zaya_server.cpp`'s fix validated against real concurrent load (30 mixed GET/POST requests across 3 rounds, hammering `/`, `/v1/models`, `/v1/chat/completions` concurrently): no crash, no deadlock, correct 200/503 responses throughout.
- Couldn't get an equivalent live test running for `unified_server.cpp` — it hits an unrelated, confirmed-pre-existing startup segfault (#497, reproduces identically on the unmodified pre-fix binary via `git stash`) whenever a non-primary backend's `init()` fails during the startup benchmark sweep, before the HTTP server ever starts listening. Validated that fix via code review, clean compile, and the full ctest suite instead.

## Test plan
- [x] `cmake --build build -j$(nproc)` — clean build (both `zaya_server` and `unified_server` targets)
- [x] Full `ctest` suite passes (17/17)
- [x] Real concurrent-load smoke test against `zaya_server` (see above)
- [x] `mcp__gitnexus__detect_changes` — high risk flagged, but confined to `main()` containing all the edited lambdas (expected, not a sign of unintended scope)
