### PR TITLE
docs: showcase model coverage — Zaya1 family + top-5 NPU benchmark table

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,20 +60,6 @@ Reverse-engineered AMD's XDNA 2 NPU in 4 days with no documentation. 1800+ hours
 | zaya_server (Qwen 35B MoE Q4_K) | **20 tok/s** | ROCm HIP | Full decode, speculative MTP, Strix Halo |
 | llama.cpp ROCm (PrismML) | **229 tok/s** | PrismML on same hardware | See [issue #235](https://github.com/bong-water-water-bong/1bit-systems/issues/235) |
 
-### 🏆 Top 5 — Raw NPU Engine, No FLM (single binary, auto-detected)
-
-*From [`engine/npu/BENCHMARKS.md`](engine/npu/BENCHMARKS.md), measured 2026-07-03/07-12 — predates the 2026-07-19 GGUF dequant correctness fixes (Q2_K/Q3_K/Q5_K, RoPE, dtype enums), so treat as directionally right pending re-measurement, not re-verified today.*
-
-| Model | Family | Decode | Tok/s | Correctness |
-|-------|--------|:------:|:-----:|:-----------:|
-| Qwen3-0.6B | Qwen3 | 36 ms/tok | **28** | 28/28 ✅ |
-| Gemma4-E2B | Gemma | 62 ms/tok | **16** | 35/35 ✅ |
-| Qwen3-VL-4B | Qwen3 (vision) | 93 ms/tok | **11** | 36/36 ✅ |
-| Llama-3.1-8B | Llama | 100 ms/tok | **10** | 32/32 ✅ |
-| Qwen3-8B | Qwen3 | 127 ms/tok | **8** | 36/36 ✅ |
-
-Same binary, same auto-detect path, no per-model glue — the loader reads architecture off the model header for all five.
-
 ---
 
 ## Quick Start
@@ -142,6 +128,20 @@ Model-agnostic isn't just a claim about the loader — it's been exercised acros
 | Zaya1 Preview 74B-A4B (MoE) | 74.79B (4.89 BPW) | GGUF Q4_K_M | 17.9 tok/s (iGPU, llama.cpp fork, 2026-07-03) | 🗄️ Archived — no longer runs on current hardware |
 
 Zaya1-8B is the model this project was built around: it's the one validated end-to-end through Q4NX, GGUF, and 1BP, and the one `tools/gguf_to_onebp.py` targets first when converting into the native format.
+
+### 🏆 Top 5 — Raw NPU Engine, No FLM (single binary, auto-detected)
+
+*From [`engine/npu/BENCHMARKS.md`](engine/npu/BENCHMARKS.md), measured 2026-07-03/07-12 — predates the 2026-07-19 GGUF dequant correctness fixes (Q2_K/Q3_K/Q5_K, RoPE, dtype enums), so treat as directionally right pending re-measurement, not re-verified today.*
+
+| Model | Family | Decode | Tok/s | Correctness |
+|-------|--------|:------:|:-----:|:-----------:|
+| Qwen3-0.6B | Qwen3 | 36 ms/tok | **28** | 28/28 ✅ |
+| Gemma4-E2B | Gemma | 62 ms/tok | **16** | 35/35 ✅ |
+| Qwen3-VL-4B | Qwen3 (vision) | 93 ms/tok | **11** | 36/36 ✅ |
+| Llama-3.1-8B | Llama | 100 ms/tok | **10** | 32/32 ✅ |
+| Qwen3-8B | Qwen3 | 127 ms/tok | **8** | 36/36 ✅ |
+
+Same binary, same auto-detect path, no per-model glue — the loader reads architecture off the model header for all five.
 
 ### Also validated
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ Reverse-engineered AMD's XDNA 2 NPU in 4 days with no documentation. 1800+ hours
 | zaya_server (Qwen 35B MoE Q4_K) | **20 tok/s** | ROCm HIP | Full decode, speculative MTP, Strix Halo |
 | llama.cpp ROCm (PrismML) | **229 tok/s** | PrismML on same hardware | See [issue #235](https://github.com/bong-water-water-bong/1bit-systems/issues/235) |
 
+### 🏆 Top 5 — Raw NPU Engine, No FLM (single binary, auto-detected)
+
+*From [`engine/npu/BENCHMARKS.md`](engine/npu/BENCHMARKS.md), measured 2026-07-03/07-12 — predates the 2026-07-19 GGUF dequant correctness fixes (Q2_K/Q3_K/Q5_K, RoPE, dtype enums), so treat as directionally right pending re-measurement, not re-verified today.*
+
+| Model | Family | Decode | Tok/s | Correctness |
+|-------|--------|:------:|:-----:|:-----------:|
+| Qwen3-0.6B | Qwen3 | 36 ms/tok | **28** | 28/28 ✅ |
+| Gemma4-E2B | Gemma | 62 ms/tok | **16** | 35/35 ✅ |
+| Qwen3-VL-4B | Qwen3 (vision) | 93 ms/tok | **11** | 36/36 ✅ |
+| Llama-3.1-8B | Llama | 100 ms/tok | **10** | 32/32 ✅ |
+| Qwen3-8B | Qwen3 | 127 ms/tok | **8** | 36/36 ✅ |
+
+Same binary, same auto-detect path, no per-model glue — the loader reads architecture off the model header for all five.
+
 ---
 
 ## Quick Start
@@ -113,6 +127,29 @@ print(client.chat.completions.create(model="zaya", messages=[{"role":"user","con
 - **NPU** — XDNA 2 (32 tiles), fully in-process via `npu_engine_universal` (XRT-based, C++23). Runs GGUF/Q4NX/1BP models directly — no FastFlowLM subprocess, no closed-source dependency. Instruction sequences and GEMM/MHA dispatch were reverse-engineered from FLM's 22 `.so` libraries; xclbin bitstreams are rebuilt from AIE generators via `aiecc`/Peano. See [`docs/fastflowlm-decode/SUMMARY.md`](docs/fastflowlm-decode/SUMMARY.md).
 - **GPU** — Radeon 8060S via Vulkan SPIR-V + ROCm HIP
 - **CPU** — Fallback (scalar / AVX-512)
+
+---
+
+## Model Coverage
+
+Model-agnostic isn't just a claim about the loader — it's been exercised across genuinely different architectures: dense transformer (Qwen3, Llama), mixture-of-experts (Zaya1-74B-A4B, Qwen 35B MoE), vision-language (Qwen2-VL), Mamba2-hybrid state-space (Zamba2), and ternary/1-bit-native weights (Bonsai, Zaya1-8B via 1BP) — same engine, same auto-detect path, no per-architecture fork.
+
+### Zaya1 — the flagship family
+
+| Model | Params | Format | Performance | Status |
+|-------|:------:|--------|-------------|:------:|
+| **Zaya1-8B** | 8B | Q4NX / **1BP** | ~64 tok/s decode (GPU) | ✅ Primary — extensively tested, native 1BP support |
+| Zaya1 Preview 74B-A4B (MoE) | 74.79B (4.89 BPW) | GGUF Q4_K_M | 17.9 tok/s (iGPU, llama.cpp fork, 2026-07-03) | 🗄️ Archived — no longer runs on current hardware |
+
+Zaya1-8B is the model this project was built around: it's the one validated end-to-end through Q4NX, GGUF, and 1BP, and the one `tools/gguf_to_onebp.py` targets first when converting into the native format.
+
+### Also validated
+
+| Model | Architecture | Backend | Note |
+|-------|--------------|---------|------|
+| Bonsai-1.7B | Ternary (IQ1_S mixed quant) | Vulkan/ZINC | 21.6-21.9 tok/s, 99.6% of theoretical memory bandwidth |
+| Zamba2 (1.2B / 2.7B / 7B) | Mamba2 SSD hybrid | ROCm (fallback) | Mamba2 lacks tuned ROCm kernels — PyTorch fallback, ~73× slower than attention models; see [`models/catalog/README.md`](models/catalog/README.md) |
+| Qwen2-VL | Vision-language | GPU | Minimal POC — real image-to-text, stops at EOS |
 
 ---
 


### PR DESCRIPTION
Adds a "Model Coverage" section to README.md showcasing the architecture diversity this engine actually handles: dense transformer, MoE, vision-language, Mamba2-hybrid, and ternary/1-bit-native — with the Zaya1 family (the model this project was built around) getting its own table, flagship 8B + the archived 74B-A4B MoE preview shown honestly as archived.

Also surfaces the real 5-model NPU benchmark table that already existed in `engine/npu/BENCHMARKS.md` (Qwen3-0.6B/8B/VL-4B, Gemma4-E2B, Llama-3.1-8B) up into the README's Benchmarks section — labeled with its actual measurement date (2026-07-03/07-12) since it predates the 07-19 GGUF dequant correctness fixes. No new numbers were invented for this PR.