### PR TITLE
fix: 1BP converter/loader dropped norms and MoE expert weights (91% of Zaya1-8B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Model-agnostic isn't just a claim about the loader — it's been exercised acros
 | **Zaya1-8B** | 8B | Q4NX / **1BP** | ~64 tok/s decode (GPU) | ✅ Primary — extensively tested, native 1BP support |
 | Zaya1 Preview 74B-A4B (MoE) | 74.79B (4.89 BPW) | GGUF Q4_K_M | 17.9 tok/s (iGPU, llama.cpp fork, 2026-07-03) | 🗄️ Archived — no longer runs on current hardware |
 
-Zaya1-8B is the model this project was built around: it's the one validated end-to-end through Q4NX, GGUF, and 1BP, and the one `tools/gguf_to_onebp.py` targets first when converting into the native format.
+Zaya1-8B is the model this project was built around: it's the one validated end-to-end through Q4NX, GGUF, and 1BP, and the one `tools/gguf_to_onebp.py` targets first when converting into the native format. The full 8.84B-parameter conversion — all 1283 tensors, including norms and the 16-expert MoE FFN weights — is published at [**bong-water-water-bong/ZAYA1-8B-1BP**](https://huggingface.co/bong-water-water-bong/ZAYA1-8B-1BP) on Hugging Face.
 
 ### 🏆 Top 5 — Raw NPU Engine, No FLM (single binary, auto-detected)
 

--- a/engine/npu/CMakeLists.txt
+++ b/engine/npu/CMakeLists.txt
@@ -32,6 +32,11 @@ if(XRT_FOUND)
     target_compile_definitions(npu_engine_universal PRIVATE -DXRT_ENABLE)
 endif()
 
+option(ONEBP_SUPPORT "Enable native 1BP model format loading" ON)
+if(ONEBP_SUPPORT)
+    target_compile_definitions(npu_engine_universal PRIVATE ONEBP_SUPPORT)
+endif()
+
 target_link_libraries(npu_engine_universal
     m dl pthread uuid
     OpenMP::OpenMP_CXX

--- a/engine/npu/src/onebp_loader.cpp
+++ b/engine/npu/src/onebp_loader.cpp
@@ -46,91 +46,106 @@ class OnebpModel {
     uint8_t*    map_ = nullptr;
     size_t      map_size_ = 0;
     OnebpHeader hdr_;
-    
+
     // Tensor index: parsed from file after header
     struct TensorEntry {
         std::string name;
-        int         rows, cols;
-        uint64_t    file_offset;
-        uint64_t    tiled_bytes;
+        int         ndim;         // 1 = raw vector, 2 = tiled matrix, 3 = MoE expert stack
+        int         rows, cols;   // per-expert dims for ndim==3; length is in `cols` for ndim==1
+        int         num_experts;  // 1 unless ndim==3
+        uint64_t    file_offset;  // start of this tensor's data (raw floats, or first expert's tiles)
+        uint64_t    total_bytes;  // whole tensor, all experts included
     };
     std::vector<TensorEntry> tensors_;
-    
+
 public:
     OnebpModel() = default;
     ~OnebpModel() { close(); }
-    
+
     bool open(const char* path) {
         // Memory-map the file
         fd_ = ::open(path, O_RDONLY);
         if (fd_ < 0) { perror("open"); return false; }
-        
+
         struct stat st;
         if (fstat(fd_, &st) < 0) { close(); return false; }
         map_size_ = (size_t)st.st_size;
-        
+
         map_ = (uint8_t*)mmap(nullptr, map_size_, PROT_READ, MAP_PRIVATE, fd_, 0);
         if (map_ == MAP_FAILED) { close(); return false; }
-        
+
         // Read header
         if (map_size_ < sizeof(OnebpHeader)) { fprintf(stderr, "File too small\n"); close(); return false; }
         memcpy(&hdr_, map_, sizeof(OnebpHeader));
-        
+
         if (!hdr_.valid()) {
             fprintf(stderr, "Invalid 1BP header (magic=0x%x ver=%u)\n", hdr_.magic, hdr_.version);
             close(); return false;
         }
-        
+
         // Parse tensor index
         const uint8_t* p = map_ + sizeof(OnebpHeader);
         for (uint32_t i = 0; i < hdr_.tensor_count; i++) {
             if ((size_t)(p - map_) + 4 > map_size_) break;
-            
+
             uint32_t name_len;
             memcpy(&name_len, p, 4); p += 4;
             if (name_len > 128) break;  // sanity
-            
+
             std::string name((const char*)p, name_len);
             p += name_len;
             if (*p == 0) p++;  // skip null terminator if present
-            
-            uint32_t ndim, dim0, dim1;
+
+            uint32_t ndim;
             memcpy(&ndim, p, 4); p += 4;
-            if (ndim >= 2) {
-                memcpy(&dim0, p, 4); p += 4;
-                memcpy(&dim1, p, 4); p += 4;
-            } else {
-                memcpy(&dim0, p, 4); dim1 = 1; p += 4;
+
+            // dims on disk: ndim==1 -> [length], ndim==2 -> [rows,cols],
+            // ndim==3 -> [num_experts,rows,cols] (see onebp_format.h)
+            uint32_t dims[3] = {1, 1, 1};
+            for (uint32_t d = 0; d < ndim && d < 3; d++) {
+                memcpy(&dims[d], p, 4); p += 4;
             }
-            
+
             uint64_t offset, bytes;
             memcpy(&offset, p, 8); p += 8;
             memcpy(&bytes, p, 8); p += 8;
-            
-            tensors_.push_back({name, (int)dim1, (int)dim0, offset, bytes});
+
+            TensorEntry te;
+            te.name = name;
+            te.ndim = (int)ndim;
+            if (ndim == 1) {
+                te.rows = 1; te.cols = (int)dims[0]; te.num_experts = 1;
+            } else if (ndim == 2) {
+                te.rows = (int)dims[0]; te.cols = (int)dims[1]; te.num_experts = 1;
+            } else {
+                te.num_experts = (int)dims[0]; te.rows = (int)dims[1]; te.cols = (int)dims[2];
+            }
+            te.file_offset = offset;
+            te.total_bytes = bytes;
+            tensors_.push_back(te);
         }
-        
+
         // Compute data section start = position after all index entries
         uint64_t data_start = (uint64_t)(p - map_);
-        
+
         // Fix offsets: they are relative to data_start
         for (auto& t : tensors_) {
             t.file_offset += data_start;
         }
-        
+
         return true;
     }
-    
+
     void close() {
         if (map_ && map_ != MAP_FAILED) munmap(map_, map_size_);
         if (fd_ >= 0) ::close(fd_);
         map_ = nullptr; fd_ = -1; map_size_ = 0;
         tensors_.clear();
     }
-    
+
     bool is_open() const { return map_ != nullptr; }
     const OnebpHeader& header() const { return hdr_; }
-    
+
     int tensor_count() const { return (int)tensors_.size(); }
     const TensorEntry* tensor(int i) const {
         return (i >= 0 && i < (int)tensors_.size()) ? &tensors_[i] : nullptr;
@@ -140,7 +155,7 @@ public:
             if (t.name == name) return &t;
         return nullptr;
     }
-    
+
     // ── Dequantize a single tile (32×256) to float32 ──
     // `tile_data` points to the 5120-byte tile in the mmap'ed file
     static void dequant_tile(const uint8_t* tile_data, float* output,
@@ -150,21 +165,21 @@ public:
         const uint16_t* scales = (const uint16_t*)tile_data;
         const uint16_t* zps    = (const uint16_t*)(tile_data + (size_t)tile_rows * groups * 2);
         const uint8_t*  qdata  = tile_data + (size_t)tile_rows * groups * 4;
-        
+
         for (int r = 0; r < tile_rows && r < out_rows; r++) {
             for (int g = 0; g < groups; g++) {
                 float scale = bf16_to_f32(scales[r * groups + g]);
                 float zp    = bf16_to_f32(zps[r * groups + g]);
                 float inv_scale = scale;  // for quant: (v - zp) / scale
                 if (scale < 1e-10f) { scale = 1.0f; inv_scale = 1.0f; }
-                
+
                 for (int i = 0; i < group_size && g * group_size + i < out_cols; i += 2) {
                     int col = g * group_size + i;
                     int byte_idx = (r * tile_cols + col) / 2;
                     uint8_t packed = qdata[byte_idx];
                     uint8_t v0 = packed & 0xF;
                     uint8_t v1 = packed >> 4;
-                    
+
                     output[r * out_cols + col] = (float)v0 * scale + zp;
                     if (col + 1 < out_cols)
                         output[r * out_cols + col + 1] = (float)v1 * scale + zp;
@@ -172,53 +187,98 @@ public:
             }
         }
     }
-    
-    // ── Dequantize a full tensor to float32 ──
-    bool get_tensor_f32(const char* name, std::vector<float>& out) const {
-        auto* te = find_tensor(name);
-        if (!te) return false;
-        
-        int R = te->rows, C = te->cols;
+
+    // ── Dequantize a tiled 2D matrix starting at `base` into `out` ──
+    void dequant_matrix(const uint8_t* base, int R, int C, std::vector<float>& out) const {
         int tr = hdr_.tile_rows, tc = hdr_.tile_cols, gs = hdr_.group_size;
         int ntr = (R + tr - 1) / tr;
         int ntc = (C + tc - 1) / tc;
         size_t tile_bytes = (size_t)tr * (tc / gs) * 4 + (size_t)tr * tc / 2;
-        
+
         out.resize((size_t)R * C);
         memset(out.data(), 0, out.size() * sizeof(float));
-        
-        const uint8_t* base = map_ + te->file_offset;
+
         for (int trr = 0; trr < ntr; trr++) {
             for (int tcc = 0; tcc < ntc; tcc++) {
                 int r0 = trr * tr, c0 = tcc * tc;
                 int rh = (R - r0) < tr ? (R - r0) : tr;
                 int cw = (C - c0) < tc ? (C - c0) : tc;
-                
-                // Temporary buffer for full tile dequant, then copy valid region
+
                 float tile_buf[32 * 256];  // max tile size
                 dequant_tile(base, tile_buf, rh, cw, tr, tc, gs);
-                
+
                 for (int r = 0; r < rh; r++)
                     for (int c = 0; c < cw; c++)
                         out[(size_t)(r0 + r) * C + (c0 + c)] = tile_buf[r * tc + c];
-                
+
                 base += tile_bytes;
             }
         }
+    }
+
+    // ── Get a tensor as float32: raw vector (ndim==1) or dequantized
+    // matrix (ndim==2). For ndim==3 (MoE expert stack) use
+    // get_tensor_f32_expert() instead — flattening experts together
+    // would silently mix independent weight matrices. ──
+    bool get_tensor_f32(const char* name, std::vector<float>& out) const {
+        auto* te = find_tensor(name);
+        if (!te) return false;
+
+        if (te->ndim == 1) {
+            out.resize((size_t)te->cols);
+            memcpy(out.data(), map_ + te->file_offset, out.size() * sizeof(float));
+            return true;
+        }
+        if (te->ndim == 3) {
+            fprintf(stderr, "'%s' is a %d-expert MoE tensor — use get_tensor_f32_expert()\n",
+                    name, te->num_experts);
+            return false;
+        }
+        dequant_matrix(map_ + te->file_offset, te->rows, te->cols, out);
         return true;
     }
-    
-    // ── Get raw tile pointer for direct NPU DMA ──
+
+    // ── Get one expert's slice of a 3D MoE tensor as float32 ──
+    bool get_tensor_f32_expert(const char* name, int expert_idx, std::vector<float>& out) const {
+        auto* te = find_tensor(name);
+        if (!te || te->ndim != 3) return false;
+        if (expert_idx < 0 || expert_idx >= te->num_experts) return false;
+
+        uint64_t per_expert_bytes = te->total_bytes / (uint64_t)te->num_experts;
+        dequant_matrix(map_ + te->file_offset + expert_idx * per_expert_bytes,
+                        te->rows, te->cols, out);
+        return true;
+    }
+
+    // ── Get raw tile pointer for direct NPU DMA (ndim==2 tensors only) ──
     // Returns pointer to the tile data in the mmap'ed file
     const uint8_t* get_tile_ptr(const char* name, int tile_row, int tile_col) const {
         auto* te = find_tensor(name);
-        if (!te) return nullptr;
-        
+        if (!te || te->ndim != 2) return nullptr;
+
         int tr = hdr_.tile_rows, tc = hdr_.tile_cols, gs = hdr_.group_size;
         int ntc = (te->cols + tc - 1) / tc;
         size_t tile_bytes = (size_t)tr * (tc / gs) * 4 + (size_t)tr * tc / 2;
-        
+
         uint64_t off = te->file_offset + (uint64_t)(tile_row * ntc + tile_col) * tile_bytes;
+        if (off + tile_bytes > map_size_) return nullptr;
+        return map_ + off;
+    }
+
+    // ── Get raw tile pointer within one expert's slice of a 3D tensor ──
+    const uint8_t* get_tile_ptr_expert(const char* name, int expert_idx,
+                                        int tile_row, int tile_col) const {
+        auto* te = find_tensor(name);
+        if (!te || te->ndim != 3) return nullptr;
+        if (expert_idx < 0 || expert_idx >= te->num_experts) return nullptr;
+
+        int tr = hdr_.tile_rows, tc = hdr_.tile_cols, gs = hdr_.group_size;
+        int ntc = (te->cols + tc - 1) / tc;
+        size_t tile_bytes = (size_t)tr * (tc / gs) * 4 + (size_t)tr * tc / 2;
+        uint64_t per_expert_bytes = te->total_bytes / (uint64_t)te->num_experts;
+
+        uint64_t off = te->file_offset + expert_idx * per_expert_bytes
+                     + (uint64_t)(tile_row * ntc + tile_col) * tile_bytes;
         if (off + tile_bytes > map_size_) return nullptr;
         return map_ + off;
     }
@@ -232,13 +292,13 @@ int main(int argc, char** argv) {
         fprintf(stderr, "Usage: %s model.1bp [tensor_name]\n", argv[0]);
         return 1;
     }
-    
+
     OnebpModel model;
     if (!model.open(argv[1])) {
         fprintf(stderr, "Failed to open %s\n", argv[1]);
         return 1;
     }
-    
+
     auto& h = model.header();
     printf("1BP Model: %s\n", argv[1]);
     printf("  Architecture: %s\n", h.model_tag);
@@ -249,7 +309,7 @@ int main(int argc, char** argv) {
            h.quant == 0 ? "Q4NX" : "other",
            h.tile_rows, h.tile_cols, h.group_size);
     printf("  Tensors: %d\n", h.tensor_count);
-    
+
     if (argc > 2) {
         std::vector<float> data;
         if (model.get_tensor_f32(argv[2], data)) {
@@ -262,18 +322,18 @@ int main(int argc, char** argv) {
             printf("  Tensor '%s' not found\n", argv[2]);
         }
     }
-    
+
     // List all tensors
     printf("\n  Tensor list:\n");
     for (int i = 0; i < model.tensor_count() && i < 10; i++) {
         auto* t = model.tensor(i);
-        printf("    %-50s %4dx%-4d  %llu bytes\n",
-               t->name.c_str(), t->rows, t->cols,
-               (unsigned long long)t->tiled_bytes);
+        printf("    %-50s ndim=%d %4dx%-4d x%d experts  %llu bytes\n",
+               t->name.c_str(), t->ndim, t->rows, t->cols, t->num_experts,
+               (unsigned long long)t->total_bytes);
     }
     if (model.tensor_count() > 10)
         printf("    ... and %d more\n", model.tensor_count() - 10);
-    
+
     return 0;
 #endif
 }

--- a/include/onebp_format.h
+++ b/include/onebp_format.h
@@ -18,6 +18,19 @@
  *      [512..1023]: 256 BF16 zero_points (same layout)
  *      [1024..5119]: 4096 bytes packed INT4 (2 per byte)
  *    Total per tile: 5120 bytes
+ *
+ *  Tensor index entry (variable-length):
+ *    [name_len:u32][name:str][ndim:u32][dims:u32 × ndim][offset:u64][bytes:u64]
+ *
+ *    ndim=2: dims=[rows, cols] — a plain weight matrix. `bytes` is the
+ *      tiled size of that one matrix.
+ *    ndim=3: dims=[num_experts, rows, cols] — a stack of `num_experts`
+ *      independently-tiled matrices (MoE expert weights: ffn_gate_up_exps,
+ *      ffn_down_exps, etc.), laid out back-to-back with no padding between
+ *      experts. `bytes` = num_experts × tiled_size(rows, cols). Each
+ *      expert's slice uses the exact same 32×256 tile scheme as a regular
+ *      2D tensor — there's no cross-expert structure to the quantization,
+ *      it's just N matrices concatenated.
  */
 
 #include <cstdint>

--- a/models/catalog/README.md
+++ b/models/catalog/README.md
@@ -15,7 +15,8 @@ inference engine and achieves verified performance on this hardware.
 | Zamba2-1.2B-Strix | Zyphra/Zamba2-1.2B | 0.71B | Q4_0 GGUF | ~1800 tok/s GEMV | ⚠️ Mamba2 ROCm-limited |
 | Zamba2-2.7B-Strix | Zyphra/Zamba2-2.7B | 2.7B | Q4_0 GGUF | ~900 tok/s GEMV | 🔲 Planned |
 | Zamba2-7B-Strix | Zyphra/Zamba2-7B | 7B | Q4_0 GGUF | ~350 tok/s GEMV | 🔲 Planned |
-| Zaya1-8B-Strix | Proprietary | 8B | Q4_K_M GGUF | ~64 tok/s decode | ✅ Available |
+| Zaya1-8B-Strix | [Zyphra/ZAYA1-8B](https://huggingface.co/Zyphra/ZAYA1-8B) (Apache-2.0) | 8B | Q4_K_M GGUF | ~64 tok/s decode | ✅ Available |
+| [Zaya1-8B-1BP](https://huggingface.co/bong-water-water-bong/ZAYA1-8B-1BP) | [Zyphra/ZAYA1-8B](https://huggingface.co/Zyphra/ZAYA1-8B) (Apache-2.0) | 8B | 1BP (native) | — | ✅ Available |
 
 ## How to Use
 

--- a/tools/gguf_to_onebp.py
+++ b/tools/gguf_to_onebp.py
@@ -37,14 +37,27 @@ def quant_tile(data, tr=32, tc=256, gs=32):
                 pk.flat[bi] = (v1 << 4) | v0
     return sc.tobytes() + zp.tobytes() + pk.tobytes()
 
+def tiled_size(rows, cols, tr=32, tc=256, gs=32):
+    ntr = (rows + tr - 1) // tr
+    ntc = (cols + tc - 1) // tc
+    return ntr * ntc * (tr * (tc // gs) * 4 + tr * tc // 2)
+
+def to_f32(ten):
+    """Dequantize a GGUF tensor to a flat float32 array (any dtype, any shape)."""
+    if ten.tensor_type <= 1:  # F32 or F16
+        dt = np.float32 if ten.tensor_type == 0 else np.float16
+        return np.frombuffer(ten.data, dtype=dt).astype(np.float32)
+    return dequantize(ten.data, ten.tensor_type).astype(np.float32).reshape(-1)
+
 def main():
     if len(sys.argv) < 3:
         print(f"Usage: {sys.argv[0]} input.gguf output.1bp [max_tensors]"); sys.exit(1)
-    
+
     print(f"Reading {sys.argv[1]}...")
     rd = GGUFReader(sys.argv[1])
     max_t = int(sys.argv[3]) if len(sys.argv) > 3 else 0
-    
+    by_name = {t.name: t for t in rd.tensors}
+
     def gf(field, alt=None):
         for fn in [field, alt] if alt else [field]:
             if not fn: continue
@@ -57,7 +70,7 @@ def main():
             try: return int(val)
             except: pass
         return 0
-    
+
     def gs_str(field):
         v = rd.fields.get(field)
         if v is None or len(v.parts) < 5: return ''
@@ -66,7 +79,7 @@ def main():
             try: return bytes(raw.tobytes()).decode('utf-8')
             except: return ''
         return ''
-    
+
     arch = gs_str("general.architecture") or "unknown"
     H = gf("hidden_size") or gf(f"{arch}.embedding_length")
     L = gf("num_hidden_layers") or gf(f"{arch}.block_count")
@@ -77,11 +90,11 @@ def main():
     V = gf("vocab_size") or gf(f"{arch}.vocab_size")
     if not NKV: NKV = NH
     if not HD and NH: HD = H // NH
-    
+
     print(f"Model: {arch}  H={H} L={L} NH={NH} NKV={NKV} HD={HD} IM={IM} V={V}")
     if not H or not L:
         print("ERROR: could not read model config"); sys.exit(1)
-    
+
     # Build header
     tr, tc, gs = 32, 256, 32
     hdr = struct.pack('<5I8i10I',
@@ -89,69 +102,87 @@ def main():
         H, L, NH, NKV, HD, IM, V, 4096,
         tr, tc, gs, 0, 0, 0, 1000000, 1, 2, 0)
     hdr = bytearray(hdr.ljust(256, b'\x00'))
-    
-    # Collect tensors
-    tlist = []
+
+    # Collect tensors — ndim 1 (norms/biases, stored raw), 2 (weight
+    # matrices, tile-quantized), and 3 (MoE expert stacks: [num_experts,
+    # rows, cols], each expert slice tile-quantized independently).
+    tlist = []  # (name, ndim, dims:list[int], file_off, byte_size)
     total = 0
+    n_skipped_other = 0
     for tn in rd.tensors:
-        if len(tn.shape) != 2: continue
-        rows = int(tn.shape[1]) if len(tn.shape) >= 2 else 1
-        cols = int(tn.shape[0]) if len(tn.shape) >= 2 else int(tn.shape[0])
-        if len(tn.shape) == 1:
-            rows, cols = 1, int(tn.shape[0])
-        elif rows * cols > 600_000_000:  # allow up to 600M (covers token_embd)
-            print(f"  SKIP oversized: {tn.name} {rows}x{cols}")
-            continue
-        ntr = (rows + tr - 1) // tr; ntc = (cols + tc - 1) // tc
-        tsz = ntr * ntc * (tr * (tc // gs) * 4 + tr * tc // 2)
-        tlist.append((tn.name, rows, cols, total, tsz))
-        total += tsz
-    
-    print(f"Tensors: {len(tlist)}, data: {total/1e6:.1f} MB")
+        shape = tn.shape
+        if len(shape) == 1:
+            length = int(shape[0])
+            sz = length * 4  # raw f32, no tiling — tiny, precision-sensitive
+            tlist.append((tn.name, 1, [length], total, sz))
+            total += sz
+        elif len(shape) == 2:
+            rows, cols = int(shape[1]), int(shape[0])
+            sz = tiled_size(rows, cols, tr, tc, gs)
+            tlist.append((tn.name, 2, [rows, cols], total, sz))
+            total += sz
+        elif len(shape) == 3:
+            cols, rows, n_experts = int(shape[0]), int(shape[1]), int(shape[2])
+            per_expert = tiled_size(rows, cols, tr, tc, gs)
+            sz = per_expert * n_experts
+            tlist.append((tn.name, 3, [n_experts, rows, cols], total, sz))
+            total += sz
+        else:
+            print(f"  SKIP unsupported ndim={len(shape)}: {tn.name} {shape}")
+            n_skipped_other += 1
+
+    print(f"Tensors: {len(tlist)} ({n_skipped_other} skipped, unsupported rank), data: {total/1e6:.1f} MB")
     struct.pack_into('<I', hdr, 88, len(tlist))
-    
+
     # Write output
     fout = open(sys.argv[2], 'wb')
     fout.write(bytes(hdr))
-    for name, nr, nc, off, sz in tlist:
+    for name, ndim, dims, off, sz in tlist:
         nb = len(name)
         fout.write(struct.pack('<I', nb))
         fout.write(name.encode())
         fout.write(b'\0')
-        fout.write(struct.pack('<III', 2, nr, nc))  # ndim=2 + dims
+        fout.write(struct.pack('<I', ndim))
+        fout.write(struct.pack(f'<{ndim}I', *dims))
         fout.write(struct.pack('<QQ', off, sz))
-    
-    # Quantize tensors
-    print(f"Quantizing {len(tlist)} tensors to Q4NX...")
+
+    # Quantize/write tensor data
+    print(f"Writing {len(tlist)} tensors...")
     done = 0
-    for name, nr, nc, off, sz in tlist:
+    for name, ndim, dims, off, sz in tlist:
         done += 1
         if max_t and done > max_t: break
-        
-        # Find tensor
-        ten = None
-        for t in rd.tensors:
-            if t.name == name: ten = t; break
+
+        ten = by_name.get(name)
         if ten is None: continue
-        
-        # Dequantize to float32
-        if ten.tensor_type <= 1:  # F32 or F16
-            dt = np.float32 if ten.tensor_type == 0 else np.float16
-            w = np.frombuffer(ten.data, dtype=dt).reshape(nr, nc).astype(np.float32)
-        else:
-            # Use gguf dequantize
-            w = dequantize(ten.data, ten.tensor_type).reshape(nr, nc).astype(np.float32)
-        
-        # Tile and quantize
-        ntr = (nr + tr - 1) // tr; ntc = (nc + tc - 1) // tc
-        for rr in range(ntr):
-            for cc in range(ntc):
-                td = w[rr*tr:rr*tr+tr, cc*tc:cc*tc+tc]
-                fout.write(quant_tile(td, tr, tc, gs))
-        
+        flat = to_f32(ten)
+
+        if ndim == 1:
+            fout.write(flat.tobytes())
+        elif ndim == 2:
+            nr, nc = dims
+            w = flat.reshape(nr, nc)
+            ntr = (nr + tr - 1) // tr; ntc = (nc + tc - 1) // tc
+            for rr in range(ntr):
+                for cc in range(ntc):
+                    td = w[rr*tr:rr*tr+tr, cc*tc:cc*tc+tc]
+                    fout.write(quant_tile(td, tr, tc, gs))
+        elif ndim == 3:
+            ne, nr, nc = dims
+            # GGUF stores expert-stacked tensors as (cols, rows, n_experts)
+            # i.e. flat is ordered [cols fastest, then rows, then experts]
+            w = flat.reshape(ne, nr, nc)
+            ntr = (nr + tr - 1) // tr; ntc = (nc + tc - 1) // tc
+            for e in range(ne):
+                we = w[e]
+                for rr in range(ntr):
+                    for cc in range(ntc):
+                        td = we[rr*tr:rr*tr+tr, cc*tc:cc*tc+tc]
+                        fout.write(quant_tile(td, tr, tc, gs))
+
         if done <= 5 or done % 100 == 0:
-            print(f"  [{done}/{len(tlist)}] {name}: {nr}x{nc}")
-    
+            print(f"  [{done}/{len(tlist)}] {name}: ndim={ndim} dims={dims}")
+
     fout.close()
     mb = os.path.getsize(sys.argv[2]) / 1e6
     print(f"\nDone: {sys.argv[2]} ({mb:.1f} MB)")


### PR DESCRIPTION
## What was broken

`tools/gguf_to_onebp.py`'s tensor collection loop only kept `ndim==2` tensors. For Zaya1-8B that meant:

- All 762 1D tensors (attn_norm, ffn_norm, output_norm, q/k_norm — every normalization weight) silently excluded. `onebp_weight_loader.cpp` looks these up by name at load time; missing them means norms zero-init instead of warning.
- All 120 3D tensors (`ffn_gate_up_exps`, `ffn_down_exps` — the MoE expert weights) dropped outright. That's **8.07B of the model's 8.84B parameters (91%)**.

The resulting `.1bp` file parsed as internally consistent (header/index/data all agreed with each other) but represented under 9% of the actual model. `engine/npu/src/onebp_loader.cpp`'s tensor-index parser had a second, independent bug: it always read exactly 2 dims off disk regardless of the `ndim` value it had just read, so it couldn't have supported 3D tensors even if the converter had written them.

## Fix

- `include/onebp_format.h`: document the extended tensor index format (ndim 1/2/3)
- `tools/gguf_to_onebp.py`: ndim==1 stored raw (small, precision-sensitive, no benefit to tiling); ndim==3 stored as `num_experts` independently Q4NX-tiled 32×256 slices concatenated back-to-back — reuses the existing `quant_tile()` unchanged
- `engine/npu/src/onebp_loader.cpp`: parse variable `ndim` correctly; add `get_tensor_f32_expert()` / `get_tile_ptr_expert()` for per-expert access; `get_tensor_f32()` now handles raw 1D tensors and rejects 3D with a clear message pointing at the expert accessor
- `engine/npu/CMakeLists.txt`: `ONEBP_SUPPORT` was only reachable via a stray cached `CMAKE_CXX_FLAGS` in one dev's local build dir, not a real CMake option — added `option(ONEBP_SUPPORT ... ON)` so it's on by default through a normal build
- `models/catalog/README.md`: Zaya1-8B base was labeled "Proprietary" — it's actually [Zyphra/ZAYA1-8B](https://huggingface.co/Zyphra/ZAYA1-8B), Apache-2.0. Fixed, added the new 1BP catalog row.
- `README.md`: links the Zaya1 family to the republished, complete conversion

## Verification

- Reconverted Zaya1-8B: all 1283 tensors present (762×1D + 401×2D + 120×3D), **8,840,233,464 total elements — exact match with the source GGUF's tensor-by-tensor element count**
- Numerically verified against GGUF ground truth: 1D norms bit-exact (lossless raw copy), 2D matrices and 3D MoE expert slices both land at 2-8% mean relative error, consistent with expected 4-bit quantization noise (a layout/indexing bug would show near-100% error, not this)
- Full CMake configure+build with the new default-on `ONEBP_SUPPORT` — clean, only pre-existing warnings
- Complete conversion published: [bong-water-water-bong/ZAYA1-8B-1BP](https://huggingface.co/bong-water-water-bong/ZAYA1-8B-1BP) (6.58 GB, up from the broken 491 MB)