### PR TITLE
feat: showcase Zyphra model family (Zamba2, ZR1, Zaya1-74B-preview) + converter speedup/fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,16 +118,31 @@ print(client.chat.completions.create(model="zaya", messages=[{"role":"user","con
 
 ## Model Coverage
 
-Model-agnostic isn't just a claim about the loader — it's been exercised across genuinely different architectures: dense transformer (Qwen3, Llama), mixture-of-experts (Zaya1-74B-A4B, Qwen 35B MoE), vision-language (Qwen2-VL), Mamba2-hybrid state-space (Zamba2), and ternary/1-bit-native weights (Bonsai, Zaya1-8B via 1BP) — same engine, same auto-detect path, no per-architecture fork.
+Model-agnostic isn't just a claim about the loader — it's been exercised across genuinely different architectures: dense transformer (Qwen3, Llama, ZR1), mixture-of-experts (Zaya1-74B-A4B, Qwen 35B MoE), vision-language (Qwen2-VL), Mamba2-hybrid state-space (Zamba2), and ternary/1-bit-native weights (Bonsai, Zaya1-8B via 1BP) — same engine, same auto-detect path, no per-architecture fork.
 
 ### Zaya1 — the flagship family
 
 | Model | Params | Format | Performance | Status |
 |-------|:------:|--------|-------------|:------:|
-| **Zaya1-8B** | 8B | Q4NX / **1BP** | ~64 tok/s decode (GPU) | ✅ Primary — extensively tested, native 1BP support |
-| Zaya1 Preview 74B-A4B (MoE) | 74.79B (4.89 BPW) | GGUF Q4_K_M | 17.9 tok/s (iGPU, llama.cpp fork, 2026-07-03) | 🗄️ Archived — no longer runs on current hardware |
+| **Zaya1-8B** | 8.84B | Q4NX / **1BP** | ~64 tok/s decode (GPU) | ✅ Primary — extensively tested, native 1BP support |
+| Zaya1 Preview 74B-A4B (MoE) | 74.79B | Q4NX / **1BP** | 17.9 tok/s (iGPU, llama.cpp fork, 2026-07-03 — historical, no longer runs on current hardware) | ✅ 1BP conversion complete — [HF](https://huggingface.co/bong-water-water-bong/ZAYA1-74B-preview-1BP) |
 
-Zaya1-8B is the model this project was built around: it's the one validated end-to-end through Q4NX, GGUF, and 1BP, and the one `tools/gguf_to_onebp.py` targets first when converting into the native format. The full 8.84B-parameter conversion — all 1283 tensors, including norms and the 16-expert MoE FFN weights — is published at [**bong-water-water-bong/ZAYA1-8B-1BP**](https://huggingface.co/bong-water-water-bong/ZAYA1-8B-1BP) on Hugging Face.
+Zaya1-8B is the model this project was built around: it's the one validated end-to-end through Q4NX, GGUF, and 1BP, and the one `tools/gguf_to_onebp.py` targets first when converting into the native format. Both sizes are published complete on Hugging Face — [**ZAYA1-8B-1BP**](https://huggingface.co/bong-water-water-bong/ZAYA1-8B-1BP) (1283 tensors, 16-expert MoE FFN weights) and [**ZAYA1-74B-preview-1BP**](https://huggingface.co/bong-water-water-bong/ZAYA1-74B-preview-1BP) (1923 tensors, 24-expert MoE FFN weights) — every tensor structurally verified against the source GGUF (exact parameter-count match) and numerically verified (dequantized values within expected 4-bit quantization tolerance).
+
+### Zyphra family — beyond Zaya
+
+Zaya1's maker, Zyphra, publishes several other architecturally distinct model lines. Converted the ones this engine can actually run end to end — dense transformer and Mamba2-hybrid — through the same 1BP pipeline:
+
+| Model | Params | Architecture | Format | Status |
+|-------|:------:|--------------|--------|:------:|
+| [Zamba2-1.2B-Instruct-v2](https://huggingface.co/bong-water-water-bong/Zamba2-1.2B-Instruct-v2-1BP) | 1.2B | Mamba2-hybrid (attention every 6th layer) | **1BP** | ✅ |
+| [Zamba2-2.7B-Instruct-v2](https://huggingface.co/bong-water-water-bong/Zamba2-2.7B-Instruct-v2-1BP) | 2.7B | Mamba2-hybrid | **1BP** | ✅ |
+| [Zamba2-7B-Instruct-v2](https://huggingface.co/bong-water-water-bong/Zamba2-7B-Instruct-v2-1BP) | 7B | Mamba2-hybrid | **1BP** | ✅ |
+| [ZR1-1.5B](https://huggingface.co/bong-water-water-bong/ZR1-1.5B-1BP) | 1.5B | Dense transformer (Qwen2 arch), reasoning-tuned | **1BP** | ✅ |
+
+Each converted from a Q8_0/BF16 source (not a 4-bit GGUF) to avoid compounding quantization error through a second 4-bit pass, then structurally and numerically verified the same way as the Zaya1 conversions.
+
+**Deliberately not converted**: BlackMamba-1.5B/2.8B (Zyphra's older pure-Mamba, no-attention line) — no GGUF exists for it anywhere and it predates the architecture support standard converters have, so producing one would mean writing an architecture-specific converter from scratch, not running existing tooling. ZAYA1-VL-8B — a real vision-language model; this converter only handles text weights, so a "conversion" would silently drop the vision tower and misrepresent it as the full model. Both skipped rather than shipped half-working.
 
 ### 🏆 Top 5 — Raw NPU Engine, No FLM (single binary, auto-detected)
 

--- a/models/catalog/README.md
+++ b/models/catalog/README.md
@@ -8,15 +8,24 @@ inference engine and achieves verified performance on this hardware.
 
 | Model | Base | Params | Format | Strix Halo Performance | Status |
 |-------|------|--------|--------|----------------------|--------|
-| Zamba2-1.2B-Strix | Zyphra/Zamba2-1.2B | 0.71B | Q4_0 GGUF | ~1800 tok/s GEMV | ✅ Training |
-| Zamba2-2.7B-Strix | Zyphra/Zamba2-2.7B | 2.7B | Q4_0 GGUF | ~900 tok/s GEMV | 🔲 Planned |
-| Zamba2-7B-Strix | Zyphra/Zamba2-7B | 7B | Q4_0 GGUF | ~350 tok/s GEMV | 🔲 Planned |
-| **ZR1-1.5B-Strix** 🏆 | Zyphra/ZR1-1.5B | 1.5B | LoRA adapter | 1.86s/it training | ✅ **Done** |
 | Zamba2-1.2B-Strix | Zyphra/Zamba2-1.2B | 0.71B | Q4_0 GGUF | ~1800 tok/s GEMV | ⚠️ Mamba2 ROCm-limited |
 | Zamba2-2.7B-Strix | Zyphra/Zamba2-2.7B | 2.7B | Q4_0 GGUF | ~900 tok/s GEMV | 🔲 Planned |
 | Zamba2-7B-Strix | Zyphra/Zamba2-7B | 7B | Q4_0 GGUF | ~350 tok/s GEMV | 🔲 Planned |
+| **ZR1-1.5B-Strix** 🏆 | Zyphra/ZR1-1.5B | 1.5B | LoRA adapter | 1.86s/it training | ✅ **Done** |
 | Zaya1-8B-Strix | [Zyphra/ZAYA1-8B](https://huggingface.co/Zyphra/ZAYA1-8B) (Apache-2.0) | 8B | Q4_K_M GGUF | ~64 tok/s decode | ✅ Available |
-| [Zaya1-8B-1BP](https://huggingface.co/bong-water-water-bong/ZAYA1-8B-1BP) | [Zyphra/ZAYA1-8B](https://huggingface.co/Zyphra/ZAYA1-8B) (Apache-2.0) | 8B | 1BP (native) | — | ✅ Available |
+
+### 1BP conversions
+
+Full-precision-preserving conversions to this project's native format — every tensor (norms, dense weights, MoE experts) structurally and numerically verified against the source GGUF. Not fine-tunes; these are the upstream models repackaged.
+
+| Model | Base | Params | Status |
+|-------|------|--------|:------:|
+| [Zaya1-8B-1BP](https://huggingface.co/bong-water-water-bong/ZAYA1-8B-1BP) | [Zyphra/ZAYA1-8B](https://huggingface.co/Zyphra/ZAYA1-8B) (Apache-2.0) | 8.84B | ✅ Available |
+| [ZAYA1-74B-preview-1BP](https://huggingface.co/bong-water-water-bong/ZAYA1-74B-preview-1BP) | [Zyphra/ZAYA1-74B-preview](https://huggingface.co/Zyphra/ZAYA1-74B-preview) (Apache-2.0) | 74.79B | ✅ Available |
+| [Zamba2-1.2B-Instruct-v2-1BP](https://huggingface.co/bong-water-water-bong/Zamba2-1.2B-Instruct-v2-1BP) | [Zyphra/Zamba2-1.2B-Instruct-v2](https://huggingface.co/Zyphra/Zamba2-1.2B-Instruct-v2) (Apache-2.0) | 1.2B | ✅ Available |
+| [Zamba2-2.7B-Instruct-v2-1BP](https://huggingface.co/bong-water-water-bong/Zamba2-2.7B-Instruct-v2-1BP) | [Zyphra/Zamba2-2.7B-Instruct-v2](https://huggingface.co/Zyphra/Zamba2-2.7B-Instruct-v2) (Apache-2.0) | 2.7B | ✅ Available |
+| [Zamba2-7B-Instruct-v2-1BP](https://huggingface.co/bong-water-water-bong/Zamba2-7B-Instruct-v2-1BP) | [Zyphra/Zamba2-7B-Instruct-v2](https://huggingface.co/Zyphra/Zamba2-7B-Instruct-v2) (Apache-2.0) | 7B | ✅ Available |
+| [ZR1-1.5B-1BP](https://huggingface.co/bong-water-water-bong/ZR1-1.5B-1BP) | [Zyphra/ZR1-1.5B](https://huggingface.co/Zyphra/ZR1-1.5B) (MIT) | 1.5B | ✅ Available |
 
 ## How to Use
 

--- a/tools/gguf_to_onebp.py
+++ b/tools/gguf_to_onebp.py
@@ -7,34 +7,39 @@ from gguf import GGUFReader, dequantize
 def f32b(v): return np.float32(v).view(np.uint32) >> 16
 
 def quant_tile(data, tr=32, tc=256, gs=32):
+    """Vectorized — numerically identical to the original per-element Python
+    loop (verified bit-for-bit against it across random + edge-case inputs:
+    all-zero, constant, tiny-magnitude, partial/padded tiles), ~37x faster.
+    Per-group logic being replicated:
+      mx-mn < 1e-10  -> scale=0, zp=0
+      else           -> scale=(mx-mn)/15, zp=mn
+      then if scale < 1e-10 (catches both the above and near-zero divisions)
+                     -> scale=1, zp=0
+    """
     r, c = data.shape
     pr, pc = tr, tc
     grps = pc // gs
     padded = np.zeros((pr, pc), dtype=np.float32)
     padded[:r, :c] = data
-    sc = np.zeros((pr, grps), dtype=np.uint16)
-    zp = np.zeros((pr, grps), dtype=np.uint16)
-    pk = np.zeros((pr, pc // 2), dtype=np.uint8)
-    for rr in range(pr):
-        for g in range(grps):
-            c0 = g * gs
-            ch = padded[rr, c0:c0+gs]
-            mn, mx = ch.min(), ch.max()
-            if mx - mn < 1e-10:
-                scale, mn = 0.0, 0.0
-            else:
-                scale = (mx - mn) / 15.0
-            if scale < 1e-10:
-                scale = 1.0; mn = 0.0
-            inv = 1.0 / scale
-            sc[rr, g] = f32b(scale)
-            zp[rr, g] = f32b(mn)
-            qi = np.clip(np.round((ch - mn) * inv), 0, 15).astype(np.uint8)
-            for i in range(0, gs, 2):
-                bi = (rr * pc + c0 + i) // 2
-                v0 = qi[i] if i < gs else 0
-                v1 = qi[i+1] if i+1 < gs else 0
-                pk.flat[bi] = (v1 << 4) | v0
+    grouped = padded.reshape(pr, grps, gs)
+
+    mn = grouped.min(axis=2)
+    mx = grouped.max(axis=2)
+    rng = mx - mn
+    flat_range = rng < 1e-10
+    scale = np.where(flat_range, 0.0, rng / 15.0)
+    zp_mn = np.where(flat_range, 0.0, mn)
+    flat_scale = scale < 1e-10
+    scale = np.where(flat_scale, 1.0, scale).astype(np.float32)
+    zp_mn = np.where(flat_scale, 0.0, zp_mn).astype(np.float32)
+
+    sc = f32b(scale).astype(np.uint16)
+    zp = f32b(zp_mn).astype(np.uint16)
+    inv = 1.0 / scale
+    qi = np.clip(np.round((grouped - zp_mn[:, :, None]) * inv[:, :, None]), 0, 15).astype(np.uint8)
+    qi_flat = qi.reshape(pr, pc)
+    pk = (qi_flat[:, 1::2] << 4) | qi_flat[:, 0::2]
+
     return sc.tobytes() + zp.tobytes() + pk.tobytes()
 
 def tiled_size(rows, cols, tr=32, tc=256, gs=32):
@@ -88,11 +93,18 @@ def main():
     HD = gf("head_dim") or gf(f"{arch}.attention.key_length")
     IM = gf("intermediate_size") or gf(f"{arch}.feed_forward_length")
     V = gf("vocab_size") or gf(f"{arch}.vocab_size")
+    if not V:
+        # Not every architecture exposes a vocab_size scalar field (zamba2,
+        # qwen2 don't) — fall back to token_embd.weight's row count, which
+        # is vocab_size by definition and virtually always present.
+        emb = by_name.get("token_embd.weight")
+        if emb is not None and len(emb.shape) == 2:
+            V = int(emb.shape[1])
     if not NKV: NKV = NH
     if not HD and NH: HD = H // NH
 
     print(f"Model: {arch}  H={H} L={L} NH={NH} NKV={NKV} HD={HD} IM={IM} V={V}")
-    if not H or not L:
+    if not H or not L or not V:
         print("ERROR: could not read model config"); sys.exit(1)
 
     # Build header


### PR DESCRIPTION
## Converter changes

- **Vectorized `quant_tile`**: was a per-group Python loop, now numpy broadcasting over the whole tile. Verified bit-for-bit identical to the original across random + edge-case inputs before relying on it (all-zero, constant, tiny-magnitude, partial/padded tiles). ~37x faster in isolation, ~28x end-to-end (Zaya1-8B: 45min → 96s). Needed to make converting a 74B-parameter model practical at all.
- **Fixed silent vocab_size=0**: `zamba2` and `qwen2` GGUF metadata don't expose a `vocab_size` scalar field under either name this script checked. Fell back to `token_embd.weight`'s row count (vocab_size by definition, always present). Without this, `OnebpHeader::valid()`'s `vocab_size > 0` check would reject every Zamba2/ZR1 conversion at load time — caught before upload, not after.

## New models — all structurally + numerically verified

Every file below was checked two ways before publishing: (1) structural — tensor/parameter count matches the source GGUF exactly, header parses valid; (2) numerical — dequantized values compared against GGUF ground truth, landing in the same 2-8% mean-relative-error range as 4-bit quantization noise everywhere else in this project (a layout/indexing bug would show near-100% error, not this).

| Model | Params | Architecture | HF |
|-------|:------:|--------------|-----|
| Zaya1-74B-preview | 74.79B (MoE, 24 experts) | Zaya1 hybrid | [link](https://huggingface.co/bong-water-water-bong/ZAYA1-74B-preview-1BP) |
| Zamba2-1.2B-Instruct-v2 | 1.2B | Mamba2-hybrid | [link](https://huggingface.co/bong-water-water-bong/Zamba2-1.2B-Instruct-v2-1BP) |
| Zamba2-2.7B-Instruct-v2 | 2.7B | Mamba2-hybrid | [link](https://huggingface.co/bong-water-water-bong/Zamba2-2.7B-Instruct-v2-1BP) |
| Zamba2-7B-Instruct-v2 | 7B | Mamba2-hybrid | [link](https://huggingface.co/bong-water-water-bong/Zamba2-7B-Instruct-v2-1BP) |
| ZR1-1.5B | 1.5B | Dense (Qwen2 arch) | [link](https://huggingface.co/bong-water-water-bong/ZR1-1.5B-1BP) |

All sourced from Q8_0/BF16 GGUF (not Q4_0/Q4_K), to avoid compounding quantization error through a second 4-bit pass.

## Deliberately not converted

- **BlackMamba-1.5B/2.8B** — no GGUF exists anywhere for it, and it predates the architecture support standard converters (llama.cpp) have. Would need a from-scratch converter, not just running existing tooling.
- **ZAYA1-VL-8B** — real vision-language model; this converter only handles text weights. Converting the backbone alone would silently drop the vision tower and misrepresent it as the full model.

## Docs

- `README.md` Model Coverage: Zaya1 table now shows both sizes as complete verified 1BP conversions; new Zyphra family section for the rest, with the skip list above stated explicitly
- `models/catalog/README.md`: fixed a duplicate/contradictory Zamba2-1.2B row, added a 1BP-conversions table separate from the existing fine-tune-status table