### PR TITLE
fix: route qwen3 models to native npu_xrt engine, FLM as fallback only

### DIFF
--- a/include/model_router.h
+++ b/include/model_router.h
@@ -8,9 +8,12 @@
 // try-until-one-succeeds init loop (see BackendManager::init's preferred_ids
 // overload) rather than introducing a new selection primitive.
 //
-// npu_xrt is deliberately never returned here — its GEMM kernels are confirmed
-// broken (docs/GEMM-KERNEL-CORRECTNESS-CONFIRMED.md) and it stays manual-opt-in
-// only (see BackendInfo::auto_selectable in backend_manager.h).
+// npu_xrt is the default NPU route for qwen3 models as of 2026-07-20 — its
+// single-core GEMM kernels are correctness-verified on real hardware
+// (docs/GEMM-KERNEL-CORRECTNESS-CONFIRMED.md); npu_flm (FastFlowLM subprocess)
+// is kept only as a fallback. The 8-core multi-tile path is still unverified
+// in combination, so throughput is currently lower (~12 tok/s single-core vs
+// FLM's ~95 tok/s) until that lands.
 
 #include "common.h"
 #include <string>

--- a/src/model_router.cpp
+++ b/src/model_router.cpp
@@ -7,7 +7,10 @@
 //
 // Routes:
 //   (a) Zaya-style MoE models → hip_gpu + cpu_scalar (fast CCA/MoE kernels)
-//   (b) qwen3 architecture → npu_flm + cpu_generic (FLM catalog)
+//   (b) qwen3 architecture → npu_xrt + npu_flm + cpu_generic (native NPU engine,
+//       FLM subprocess as fallback only — see backend_manager.cpp, npu_xrt is
+//       the default now that its single-core GEMM kernels are correctness-verified,
+//       docs/GEMM-KERNEL-CORRECTNESS-CONFIRMED.md)
 //   (c) GGUF/H1B format → zinc_gpu + cpu_generic (multi-arch, multi-quant)
 //   (d) Everything else → hip_gpu + cpu_generic (dynamic engine, generic fallback)
 
@@ -17,7 +20,7 @@ BackendRoute select_backend_route(const ModelConfig& cfg) {
         return {{"hip_gpu", "cpu_scalar"}, "MoE model — CCA/MoE kernel path"};
     }
     if (cfg.architecture == "qwen3") {
-        return {{"npu_flm", "cpu_generic"}, "qwen3 architecture — FastFlowLM NPU path"};
+        return {{"npu_xrt", "npu_flm", "cpu_generic"}, "qwen3 architecture — native NPU engine, FLM subprocess as fallback"};
     }
     if (cfg.format == ModelFormat::GGUF || cfg.format == ModelFormat::H1B) {
         return {{"zinc_gpu", "cpu_generic"}, "GGUF/H1B model — ZINC GPU, generic CPU fallback"};


### PR DESCRIPTION
## Summary
- `model_router.cpp` still hard-routed every qwen3-architecture model to the FastFlowLM subprocess backend (`npu_flm`) as primary. `backend_manager.cpp` already treats `npu_xrt` as auto-selectable with the comment "NPU_XRT is the default now" and its single-core GEMM kernels are correctness-verified (`docs/GEMM-KERNEL-CORRECTNESS-CONFIRMED.md`) — the router was the one place not updated to match.
- Route is now `npu_xrt` → `npu_flm` → `cpu_generic` (native engine first, FLM subprocess kept only as a fallback, not removed).
- Fixed `model_router.h`'s header comment, which claimed npu_xrt's kernels were "confirmed broken" — stale as of the same correctness fix.

## Tradeoff (flagged, user-approved)
npu_xrt single-core is currently ~12 tok/s vs FLM's ~95 tok/s until the 8-core multi-tile path (currently unverified in combination) lands. Accepted intentionally to make "FLM is diagnostic-only, not the serving path" actually true in the routing code, not just the docs.

## Test plan
- [x] `g++ -c src/model_router.cpp` compiles clean standalone
- [ ] Full `unified_server` build currently blocked by an unrelated pre-existing bug on `feat/vl-preprocessing`/PR #566 (VlProcessor deleted copy ctor) — not touched by this PR, fixing separately
- [ ] Real end-to-end qwen3 NPU inference smoke test once build is unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)