### PR TITLE
fix(blackmamba): prefix GGUF metadata keys with architecture name

### DIFF
--- a/scripts/blackmamba_to_gguf.py
+++ b/scripts/blackmamba_to_gguf.py
@@ -105,17 +105,22 @@ def convert(model_id, output):
     
     w = Writer(output, "mamba")
     w.add_string("general.architecture", "mamba")
-    w.add_uint32("block_count", nl)
-    w.add_uint32("embedding_length", H)
-    w.add_uint32("feed_forward_length", di)
-    w.add_uint32("context_length", 2048)
-    w.add_float32("attention.layer_norm_rms_epsilon", 1e-5)
-    w.add_uint32("ssm.conv_kernel", dc)
-    w.add_uint32("ssm.inner_size", di)
-    w.add_uint32("ssm.state_size", ds)
-    w.add_uint32("ssm.dt_rank", dt_rank)
-    w.add_uint32("ssm.group_count", 1)
-    w.add_uint32("vocab_size", V)
+    # GGUF convention (and every reader in this repo, e.g. model_discovery.cpp's
+    # `ends_with(key, ".block_count")` suffix matching) expects these keys
+    # prefixed with the architecture name — bare "block_count" etc. matched
+    # neither the HF-style nor the architecture-prefixed lookup in any reader,
+    # so BlackMamba's H/L/IM always came back 0 (config silently unreadable).
+    w.add_uint32("mamba.block_count", nl)
+    w.add_uint32("mamba.embedding_length", H)
+    w.add_uint32("mamba.feed_forward_length", di)
+    w.add_uint32("mamba.context_length", 2048)
+    w.add_float32("mamba.attention.layer_norm_rms_epsilon", 1e-5)
+    w.add_uint32("mamba.ssm.conv_kernel", dc)
+    w.add_uint32("mamba.ssm.inner_size", di)
+    w.add_uint32("mamba.ssm.state_size", ds)
+    w.add_uint32("mamba.ssm.dt_rank", dt_rank)
+    w.add_uint32("mamba.ssm.group_count", 1)
+    w.add_uint32("mamba.vocab_size", V)
     
     emb = sd["embedding.word_embeddings.weight"].to(torch.float32).numpy()
     w.add_tensor("token_embd.weight", emb, GGML_F16)

--- a/scripts/blackmamba_to_gguf.py
+++ b/scripts/blackmamba_to_gguf.py
@@ -60,11 +60,14 @@ class Writer:
         self.f.seek(8)
         self.f.write(struct.pack('<QQ', self.nt, self.nk))
         self.f.write(bytes(self.kv))
-        pos = self.f.tell()
+        # No alignment padding here -- GGUF's tensor-info section immediately
+        # follows KV metadata with no gap. Padding belongs only right before
+        # the tensor *data* section below. A stray pad here was previously
+        # dormant only because the old (unprefixed) metadata keys happened to
+        # land the KV section on a 32-byte boundary by coincidence; prefixing
+        # keys with the architecture name changed that byte count and exposed
+        # a real corrupt-file bug (readers found garbage tensor names/n_dims).
         align = 32
-        if pos % align:
-            self.f.write(b'\x00' * (align - pos % align))
-        tdo = self.f.tell()
         offset = 0
         for name, shape, dtype in self.ti:
             nb = name.encode()


### PR DESCRIPTION
## Summary
`scripts/blackmamba_to_gguf.py` wrote metadata keys unprefixed (`"block_count"`, `"embedding_length"`) instead of GGUF-convention architecture-prefixed (`"mamba.block_count"`). Every reader in this repo expects the prefixed form — `model_discovery.cpp`'s `ends_with(key, ".block_count")` suffix match requires the leading dot, and `tools/gguf_to_onebp.py`'s config reader falls back to `f"{arch}.embedding_length"` specifically. Neither matched the bare keys, so `H`/`L`/`IM` silently came back 0 instead of erroring loudly.

Caught while converting BlackMamba-1.5B/2.8B to the 1BP ternary format today (`gguf_to_onebp.py` reported `H=0 L=0 ... ERROR: could not read model config` despite the GGUF parsing structurally fine).

## Test plan
- [x] Regenerated both BlackMamba GGUFs with the fix, config now reads correctly (`H=1152 L=30` for 1.5B)
- [ ] 1BP conversion + HF upload (follow-up, in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)