### PR TITLE
fix(blackmamba): Q4_0 nibble/offset-binary bugs + conv1d reshape; add CPU reference

### DIFF
--- a/models/catalog/README.md
+++ b/models/catalog/README.md
@@ -13,6 +13,8 @@ inference engine and achieves verified performance on this hardware.
 | Zamba2-7B-Strix | Zyphra/Zamba2-7B | 7B | Q4_0 GGUF | ~350 tok/s GEMV | 🔲 Planned |
 | **ZR1-1.5B-Strix** 🏆 | Zyphra/ZR1-1.5B | 1.5B | LoRA adapter | 1.86s/it training | ✅ **Done** |
 | Zaya1-8B-Strix | [Zyphra/ZAYA1-8B](https://huggingface.co/Zyphra/ZAYA1-8B) (Apache-2.0) | 8B | Q4_K_M GGUF | ~64 tok/s decode | ✅ Available |
+| BlackMamba-1.5B-Strix | [Zyphra/BlackMamba-1.5B](https://huggingface.co/Zyphra/BlackMamba-1.5B) (Apache-2.0) | 1.5B | Q4_0 GGUF | Not yet benchmarked | 🔲 Planned |
+| BlackMamba-2.8B-Strix | [Zyphra/BlackMamba-2.8B](https://huggingface.co/Zyphra/BlackMamba-2.8B) (Apache-2.0) | 2.8B | Q4_0 GGUF | Not yet benchmarked | 🔲 Planned |
 
 ### 1BP conversions
 
@@ -26,6 +28,7 @@ Full-precision-preserving conversions to this project's native format — every 
 | [Zamba2-2.7B-Instruct-v2-1BP](https://huggingface.co/bong-water-water-bong/Zamba2-2.7B-Instruct-v2-1BP) | [Zyphra/Zamba2-2.7B-Instruct-v2](https://huggingface.co/Zyphra/Zamba2-2.7B-Instruct-v2) (Apache-2.0) | 2.7B | ✅ Available |
 | [Zamba2-7B-Instruct-v2-1BP](https://huggingface.co/bong-water-water-bong/Zamba2-7B-Instruct-v2-1BP) | [Zyphra/Zamba2-7B-Instruct-v2](https://huggingface.co/Zyphra/Zamba2-7B-Instruct-v2) (Apache-2.0) | 7B | ✅ Available |
 | [ZR1-1.5B-1BP](https://huggingface.co/bong-water-water-bong/ZR1-1.5B-1BP) | [Zyphra/ZR1-1.5B](https://huggingface.co/Zyphra/ZR1-1.5B) (MIT) | 1.5B | ✅ Available |
+| [BlackMamba-1.5B-1BP](https://huggingface.co/bong-water-water-bong/BlackMamba-1.5B-1BP) | [Zyphra/BlackMamba-1.5B](https://huggingface.co/Zyphra/BlackMamba-1.5B) (Apache-2.0) | 1.5B | ✅ Available |
 
 ## How to Use
 

--- a/scripts/blackmamba_to_gguf.py
+++ b/scripts/blackmamba_to_gguf.py
@@ -8,6 +8,11 @@ GGML_F16 = 1
 GGML_F32 = 0
 
 def quant_q4_0(data):
+    # ggml Q4_0 packing: NOT interleaved consecutive pairs. The low nibble of
+    # byte j is element j, the high nibble of byte j is element j+16 (first
+    # half of the block in low nibbles, second half in high nibbles) -- see
+    # src/gguf_reader.cpp's dequant_q4_0, which documents this same mistake
+    # already having bitten this codebase once before in different code.
     n = len(data)
     out = bytearray()
     for i in range(0, n, 32):
@@ -15,12 +20,16 @@ def quant_q4_0(data):
         amax = np.max(np.abs(blk))
         scale = amax / 7.0 if amax > 0 else 1e-10
         out.extend(struct.pack('<e', np.float16(scale)))
-        for j in range(0, 32, 2):
+        for j in range(16):
             v0 = blk[j] / scale if j < len(blk) else 0
-            v1 = blk[j+1] / scale if j+1 < len(blk) else 0
-            q0 = max(-8, min(7, int(round(v0)))) & 0x0F
-            q1 = max(-8, min(7, int(round(v1)))) & 0x0F if j+1 < len(blk) else 0
-            out.append((q0 << 4) | q1)
+            v1 = blk[j + 16] / scale if j + 16 < len(blk) else 0
+            # Dequant is (nibble - 8) * scale (excess-8/offset-binary), not
+            # two's complement -- masking a signed int with & 0x0F produces
+            # two's complement, a completely different encoding. Must add 8
+            # after clamping to [-8,7], not just mask the signed value.
+            q0 = (max(-8, min(7, int(round(v0)))) + 8) & 0x0F
+            q1 = (max(-8, min(7, int(round(v1)))) + 8) & 0x0F
+            out.append((q1 << 4) | q0)
     return bytes(out)
 
 class Writer:
@@ -142,7 +151,12 @@ def convert(model_id, output):
         
         if f"{mb}.in_proj.weight" in sd:
             ip = sd[f"{mb}.in_proj.weight"].to(torch.float32).numpy()
-            c1w = sd[f"{mb}.conv1d.weight"].to(torch.float32).numpy().reshape(dc, di)
+            # Original shape is (d_inner, 1, d_conv) -- squeeze the singleton
+            # groups-dim, don't reshape(dc, di): reshape reinterprets the
+            # flat buffer with new dims, it does not transpose, so a wrong
+            # target shape silently scrambles which (channel, kernel-tap)
+            # pair each value belongs to instead of erroring.
+            c1w = sd[f"{mb}.conv1d.weight"].to(torch.float32).numpy().reshape(di, dc)
             c1b = sd[f"{mb}.conv1d.bias"].to(torch.float32).numpy()
             xp = sd[f"{mb}.x_proj.weight"].to(torch.float32).numpy()
             dpw = sd[f"{mb}.dt_proj.weight"].to(torch.float32).numpy()
@@ -164,7 +178,16 @@ def convert(model_id, output):
         # MoE
         router = sd.get(f"{mb}.router.weight")
         if router is not None:
-            w.add_tensor(f"blk.{l}.ffn_gate.weight", router.to(torch.float32).numpy().T, GGML_Q4_0)
+            # F32, not Q4_0: this is an 8x1152 argmax-routing matrix, not a
+            # dense weight -- a small quantization perturbation can flip
+            # which expert wins for a borderline token, changing the whole
+            # downstream computation, unlike the graceful magnitude error
+            # 4-bit quantization causes on a normal weight. Negligible size
+            # cost (36 KB) for correctness that actually matters here.
+            w.add_tensor(f"blk.{l}.ffn_gate.weight", router.to(torch.float32).numpy().T, GGML_F32)
+            router_bias = sd.get(f"{mb}.router.bias")
+            if router_bias is not None:
+                w.add_tensor(f"blk.{l}.ffn_gate.bias", router_bias.to(torch.float32).numpy(), GGML_F32)
             n_exp = router.shape[0]
             for e in range(n_exp):
                 fc1 = sd[f"{mb}.local_experts.{e}.linear_fc1.weight"].to(torch.float32).numpy()

--- a/tools/blackmamba_cpu_reference.cpp
+++ b/tools/blackmamba_cpu_reference.cpp
@@ -1,0 +1,318 @@
+// blackmamba_cpu_reference.cpp — scalar CPU reference forward pass for
+// BlackMamba (Zyphra) GGUF files produced by scripts/blackmamba_to_gguf.py.
+//
+// BlackMamba alternates two pure block types per layer (never both in one
+// layer — the HF checkpoint's "mamba_moe_layers" pattern is "r","8","r","8"...):
+//   "r" (regular): x = x + mamba1_ssm(rmsnorm(x))
+//   "8" (MoE):     x = x + top1_moe_swiglu(rmsnorm(x))
+// Followed by: logits = tied_embedding @ rmsnorm(x)
+//
+// This is a correctness-first, unoptimized scalar reference — not the
+// project's fast path (no Q4NX tiling, no GPU kernels, single-token
+// recurrent SSM update rather than a parallel scan). It exists to get a
+// real, honest baseline number and a coherence check (matches the same
+// "not exact-token-match, but not degenerately stuck" bar used by
+// tests/test_hip_generic_attention.cpp) before any faster path exists.
+//
+// Usage: blackmamba_cpu_reference <model.gguf> [n_tokens]
+
+#include "gguf_reader.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <chrono>
+#include <vector>
+#include <string>
+#include <algorithm>
+
+static float silu(float x) { return x / (1.0f + std::expf(-x)); }
+static float softplus(float x) { return x > 20.0f ? x : std::log1pf(std::expf(x)); }
+
+static void rmsnorm(const std::vector<float>& x, const std::vector<float>& w,
+                     std::vector<float>& out, float eps = 1e-5f) {
+    double ss = 0.0;
+    for (float v : x) ss += (double)v * v;
+    float inv = 1.0f / std::sqrt((float)(ss / x.size()) + eps);
+    out.resize(x.size());
+    for (size_t i = 0; i < x.size(); i++) out[i] = x[i] * inv * w[i];
+}
+
+// y = W @ x for a PyTorch nn.Linear-style weight (original shape (out,in))
+// that the Python converter wrote as `W.T` -- numpy .flatten() on a
+// transposed array respects the *logical* (in,out) shape, giving flat
+// layout W_flat[i*out_dim + o] = W_original[o,i]. Verified empirically
+// against a known small matrix (a plausible-but-wrong [out,in] reading of
+// this same data produces numerically different, wrong output -- this
+// isn't a hypothetical, it silently produced non-degenerate-looking but
+// numerically incorrect logits for the first several runs of this tool).
+static void matvec(const std::vector<float>& W, int out_dim, int in_dim,
+                    const std::vector<float>& x, std::vector<float>& y) {
+    y.assign(out_dim, 0.0);
+    std::vector<double> acc(out_dim, 0.0);
+    for (int i = 0; i < in_dim; i++) {
+        const float* row = &W[(size_t)i * out_dim];
+        float xi = x[i];
+        for (int o = 0; o < out_dim; o++) acc[o] += (double)row[o] * xi;
+    }
+    for (int o = 0; o < out_dim; o++) y[o] = (float)acc[o];
+}
+
+// y = W @ x for a weight written WITHOUT a .T in the converter (only
+// token_embd.weight / the tied LM head): original numpy shape (out_dim,
+// in_dim) flattened directly, so it's already row-major [out_dim, in_dim].
+static void matvec_untransposed(const std::vector<float>& W, int out_dim, int in_dim,
+                                 const std::vector<float>& x, std::vector<float>& y) {
+    y.assign(out_dim, 0.0f);
+    for (int o = 0; o < out_dim; o++) {
+        const float* row = &W[(size_t)o * in_dim];
+        double acc = 0.0;
+        for (int i = 0; i < in_dim; i++) acc += (double)row[i] * x[i];
+        y[o] = (float)acc;
+    }
+}
+
+struct MambaLayer {
+    std::vector<float> in_proj, conv_w, conv_b, x_proj, dt_w, dt_b, A_log, D, out_proj, norm_w;
+    int d_inner = 0, d_state = 0, dt_rank = 0, d_conv = 0;
+    // Persistent state
+    std::vector<float> ssm_state;      // [d_inner, d_state]
+    std::vector<float> conv_state;     // [d_inner, d_conv-1] ring buffer, oldest-first
+};
+
+struct MoeLayer {
+    std::vector<float> router_w, router_b, norm_w;
+    std::vector<std::vector<float>> fc1, fc2;  // per expert
+    int n_experts = 0, ffn_hidden = 0;
+};
+
+struct Layer {
+    bool is_mamba = false;
+    MambaLayer mamba;
+    MoeLayer moe;
+};
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <model.gguf> [n_tokens]\n", argv[0]);
+        return 1;
+    }
+    std::string path = argv[1];
+    int n_tokens = argc > 2 ? std::atoi(argv[2]) : 10;
+
+    GgufReader r;
+    if (!r.open(path)) { fprintf(stderr, "FAIL: could not open %s\n", path.c_str()); return 1; }
+
+    uint32_t H = 0, L = 0, V = 0, d_state = 0, d_conv = 0;
+    r.get_u32("mamba.embedding_length", H);
+    r.get_u32("mamba.block_count", L);
+    r.get_u32("mamba.vocab_size", V);
+    r.get_u32("mamba.ssm.state_size", d_state);
+    r.get_u32("mamba.ssm.conv_kernel", d_conv);
+    if (!H || !L || !V) { fprintf(stderr, "FAIL: could not read model config\n"); return 1; }
+    printf("Model: H=%u L=%u V=%u d_state=%u d_conv=%u\n", H, L, V, d_state, d_conv);
+
+    std::vector<float> embed, final_norm;
+    size_t n;
+    if (!r.get_tensor_f32("token_embd.weight", embed, &n)) { fprintf(stderr, "FAIL: no token_embd.weight\n"); return 1; }
+    r.get_tensor_f32("output_norm.weight", final_norm);
+
+    std::vector<Layer> layers(L);
+    for (uint32_t l = 0; l < L; l++) {
+        char pfx[64]; snprintf(pfx, sizeof(pfx), "blk.%u.", l);
+        std::string p(pfx);
+        auto& lay = layers[l];
+        std::vector<float> tmp;
+        if (r.has_tensor(p + "ssm_in.weight")) {
+            lay.is_mamba = true;
+            auto& m = lay.mamba;
+            m.d_state = d_state; m.d_conv = d_conv;
+            r.get_tensor_f32(p + "attn_norm.weight", m.norm_w);
+            r.get_tensor_f32(p + "ssm_in.weight", m.in_proj);
+            m.d_inner = (int)(m.in_proj.size() / H) / 2;
+            r.get_tensor_f32(p + "ssm_conv1d.weight", m.conv_w);
+            r.get_tensor_f32(p + "ssm_conv1d.bias", m.conv_b);
+            r.get_tensor_f32(p + "ssm_x.weight", m.x_proj);
+            m.dt_rank = (int)(m.x_proj.size() / m.d_inner) - 2 * d_state;
+            r.get_tensor_f32(p + "ssm_dt.weight", m.dt_w);
+            r.get_tensor_f32(p + "ssm_dt.bias", m.dt_b);
+            r.get_tensor_f32(p + "ssm_a", m.A_log);
+            r.get_tensor_f32(p + "ssm_d", m.D);
+            r.get_tensor_f32(p + "ssm_out.weight", m.out_proj);
+            m.ssm_state.assign((size_t)m.d_inner * d_state, 0.0f);
+            m.conv_state.assign((size_t)m.d_inner * (d_conv - 1), 0.0f);
+        } else if (r.has_tensor(p + "ffn_gate.weight")) {
+            lay.is_mamba = false;
+            auto& e = lay.moe;
+            r.get_tensor_f32(p + "attn_norm.weight", e.norm_w);
+            r.get_tensor_f32(p + "ffn_gate.weight", e.router_w);
+            r.get_tensor_f32(p + "ffn_gate.bias", e.router_b);  // may be absent on older exports
+            e.n_experts = (int)(e.router_w.size() / H);
+            e.fc1.resize(e.n_experts); e.fc2.resize(e.n_experts);
+            for (int x = 0; x < e.n_experts; x++) {
+                char ep[96]; snprintf(ep, sizeof(ep), "blk.%u.ffn_expert.%d.weight_1", l, x);
+                r.get_tensor_f32(ep, e.fc1[x]);
+                snprintf(ep, sizeof(ep), "blk.%u.ffn_expert.%d.weight_2", l, x);
+                r.get_tensor_f32(ep, e.fc2[x]);
+            }
+            e.ffn_hidden = (int)(e.fc1[0].size() / H) / 2;  // fused gate+up
+        } else {
+            fprintf(stderr, "FAIL: layer %u has neither ssm_in.weight nor ffn_gate.weight\n", l);
+            return 1;
+        }
+    }
+    printf("Loaded %u layers.\n", L);
+
+    bool dbg = std::getenv("BM_DEBUG_STEPS") != nullptr;
+    auto pv = [&](const char* label, const std::vector<float>& v) {
+        if (!dbg) return;
+        fprintf(stderr, "%s: ", label);
+        for (int k = 0; k < 5 && k < (int)v.size(); k++) fprintf(stderr, "%.6f ", v[k]);
+        fprintf(stderr, "\n");
+    };
+    auto mamba_step = [&](MambaLayer& m, const std::vector<float>& x_in, std::vector<float>& out) {
+        std::vector<float> xn;
+        rmsnorm(x_in, m.norm_w, xn);
+        pv("xn", xn);
+        std::vector<float> xz;
+        matvec(m.in_proj, 2 * m.d_inner, (int)H, xn, xz);
+        std::vector<float> x(xz.begin(), xz.begin() + m.d_inner);
+        std::vector<float> z(xz.begin() + m.d_inner, xz.end());
+        pv("x(pre-conv)", x);
+        pv("z", z);
+
+        // Depthwise causal conv1d (kernel=d_conv), per-channel, using ring state.
+        std::vector<float> xc(m.d_inner);
+        for (int c = 0; c < m.d_inner; c++) {
+            double acc = m.conv_b.empty() ? 0.0 : m.conv_b[c];
+            for (int k = 0; k < m.d_conv - 1; k++)
+                acc += (double)m.conv_state[(size_t)c * (m.d_conv - 1) + k] * m.conv_w[(size_t)c * m.d_conv + k];
+            acc += (double)x[c] * m.conv_w[(size_t)c * m.d_conv + (m.d_conv - 1)];
+            xc[c] = silu((float)acc);
+            // shift ring buffer
+            for (int k = 0; k < m.d_conv - 2; k++)
+                m.conv_state[(size_t)c * (m.d_conv - 1) + k] = m.conv_state[(size_t)c * (m.d_conv - 1) + k + 1];
+            if (m.d_conv > 1) m.conv_state[(size_t)c * (m.d_conv - 1) + (m.d_conv - 2)] = x[c];
+        }
+
+        pv("xc(post-conv)", xc);
+
+        std::vector<float> proj;
+        matvec(m.x_proj, m.dt_rank + 2 * (int)m.d_state, m.d_inner, xc, proj);
+        std::vector<float> dt_low(proj.begin(), proj.begin() + m.dt_rank);
+        std::vector<float> Bv(proj.begin() + m.dt_rank, proj.begin() + m.dt_rank + m.d_state);
+        std::vector<float> Cv(proj.begin() + m.dt_rank + m.d_state, proj.end());
+        pv("dt_low", dt_low);
+        pv("Bv", Bv);
+        pv("Cv", Cv);
+
+        std::vector<float> dt;
+        matvec(m.dt_w, m.d_inner, m.dt_rank, dt_low, dt);
+        for (int i = 0; i < m.d_inner; i++) dt[i] = softplus(dt[i] + m.dt_b[i]);
+        pv("dt", dt);
+
+        out.assign(m.d_inner, 0.0f);
+        for (int i = 0; i < m.d_inner; i++) {
+            double y = 0.0;
+            for (int s = 0; s < (int)m.d_state; s++) {
+                // ssm_a was written as A_log.T.flatten() by the converter
+                // (original shape (d_inner, d_state)) -- .T makes it
+                // logically (d_state, d_inner) before flatten, so the flat
+                // layout is state-major: flat[s*d_inner + i], not [i*d_state+s].
+                float A = -std::expf(m.A_log[(size_t)s * m.d_inner + i]);
+                float dA = std::expf(dt[i] * A);
+                float dB = dt[i] * Bv[s];
+                float& h = m.ssm_state[(size_t)i * m.d_state + s];
+                h = dA * h + dB * xc[i];
+                y += (double)Cv[s] * h;
+            }
+            y += (double)m.D[i] * xc[i];
+            out[i] = (float)y * silu(z[i]);
+        }
+        std::vector<float> final_out;
+        matvec(m.out_proj, (int)H, m.d_inner, out, final_out);
+        out = final_out;
+    };
+
+    auto moe_step = [&](MoeLayer& e, const std::vector<float>& x_in, std::vector<float>& out) {
+        std::vector<float> xn;
+        rmsnorm(x_in, e.norm_w, xn);
+        std::vector<float> logits;
+        matvec(e.router_w, e.n_experts, (int)H, xn, logits);
+        if (!e.router_b.empty()) for (int i = 0; i < e.n_experts; i++) logits[i] += e.router_b[i];
+        // BlackMamba's default routing_mode is "sinkhorn" (switch_mlp.py):
+        // argmax is over sigmoid(logits), and the winning expert's output is
+        // scaled by that sigmoid value directly -- NOT a softmax probability
+        // over all experts. sigmoid is monotonic so argmax is unaffected,
+        // but the gate weight formula is different (verified against
+        // github.com/Zyphra/BlackMamba's switch_mlp.py SwitchMLP.forward).
+        int top1 = (int)(std::max_element(logits.begin(), logits.end()) - logits.begin());
+        float gate_w = 1.0f / (1.0f + std::expf(-logits[top1]));
+
+        std::vector<float> fc1_out;
+        matvec(e.fc1[top1], 2 * e.ffn_hidden, (int)H, xn, fc1_out);
+        std::vector<float> act(e.ffn_hidden);
+        for (int i = 0; i < e.ffn_hidden; i++)
+            act[i] = silu(fc1_out[i]) * fc1_out[e.ffn_hidden + i];  // [gate; up]
+        matvec(e.fc2[top1], (int)H, e.ffn_hidden, act, out);
+        for (auto& v : out) v *= gate_w;
+    };
+
+    bool debug_layer0 = std::getenv("BM_DEBUG_LAYER0") != nullptr;
+    auto forward = [&](int token_id, std::vector<float>& logits) {
+        std::vector<float> x(H);
+        for (uint32_t i = 0; i < H; i++) x[i] = embed[(size_t)token_id * H + i];
+        int li = 0;
+        for (auto& lay : layers) {
+            std::vector<float> delta;
+            if (lay.is_mamba) mamba_step(lay.mamba, x, delta);
+            else moe_step(lay.moe, x, delta);
+            if (debug_layer0 && li == 0) {
+                fprintf(stderr, "layer0 output (first 8): ");
+                for (int k = 0; k < 8; k++) fprintf(stderr, "%.6f ", delta[k]);
+                double nrm = 0; for (float v : delta) nrm += (double)v * v;
+                fprintf(stderr, "\nlayer0 output norm: %.6f\n", std::sqrt(nrm));
+                std::exit(0);
+            }
+            for (uint32_t i = 0; i < H; i++) x[i] += delta[i];
+            li++;
+        }
+        std::vector<float> xn;
+        rmsnorm(x, final_norm, xn);
+        matvec_untransposed(embed, (int)V, (int)H, xn, logits);
+    };
+
+    // Fixed arbitrary prompt tokens (semantics don't matter -- only that the
+    // pipeline produces varied, non-degenerate output across positions, same
+    // bar as tests/test_hip_generic_attention.cpp).
+    std::vector<int> prompt = {1212, 318, 257, 1332, 13};
+    std::vector<int> predicted;
+    auto t0 = std::chrono::steady_clock::now();
+    int last = prompt[0];
+    for (size_t i = 0; i < prompt.size(); i++) {
+        std::vector<float> logits;
+        forward(prompt[i], logits);
+        last = (int)(std::max_element(logits.begin(), logits.end()) - logits.begin());
+    }
+    predicted.push_back(last);
+    for (int i = 1; i < n_tokens; i++) {
+        std::vector<float> logits;
+        forward(last, logits);
+        last = (int)(std::max_element(logits.begin(), logits.end()) - logits.begin());
+        predicted.push_back(last);
+    }
+    auto t1 = std::chrono::steady_clock::now();
+    double decode_s = std::chrono::duration<double>(t1 - t0).count();
+    double ms_per_tok = 1000.0 * decode_s / n_tokens;
+
+    printf("Predicted tokens: ");
+    for (int t : predicted) printf("%d ", t);
+    printf("\n");
+    std::vector<int> uniq(predicted.begin(), predicted.end());
+    std::sort(uniq.begin(), uniq.end());
+    uniq.erase(std::unique(uniq.begin(), uniq.end()), uniq.end());
+    bool degenerate = uniq.size() <= 1 && n_tokens > 2;
+    printf("Unique tokens: %zu / %d  %s\n", uniq.size(), n_tokens, degenerate ? "DEGENERATE (stuck)" : "varied (not stuck)");
+    printf("Decode: %.1f ms/tok, %.2f tok/s (scalar CPU reference, unoptimized, single-threaded)\n",
+           ms_per_tok, 1000.0 / ms_per_tok);
+    return degenerate ? 1 : 0;
+}


### PR DESCRIPTION
## Bug Fixes in `scripts/blackmamba_to_gguf.py`

### 1. Q4_0 nibble packing — wrong layout
ggml Q4_0 packs **low nibble** = element `j`, **high nibble** = element `j+16` (first half of block in low nibbles, second half in high). Was packing consecutive pairs `(j, j+1)`, which produces garbage when dequantized with the standard ggml dequant path.

*Reference: [`src/gguf_reader.cpp` dequant\_q4\_0](https://github.com/bong-water-water-bong/1bit-systems/blob/main/src/gguf_reader.cpp) — this same bug pattern already bit this codebase once before in different code.*

### 2. Q4_0 offset-binary encoding — wrong numeric representation
Q4_0 uses **excess-8** encoding: stored = clamped_value + 8, dequant = (nibble - 8) × scale. Was doing `signed_int & 0x0F`, which produces two's complement — a completely different encoding. A stored `0xF` (excess-8 → value +7) decodes as two's complement `-1` via the dequant path, giving a 8-LSB sign flip on every value.

### 3. Conv1d weight reshape — silent data corruption
Torch conv1d weight shape is `(d_inner, 1, d_conv)`. The original code used `.reshape(dc, di)` which reinterprets the flat buffer linearly — this does not transpose, so it silently scrambles which (channel, kernel-tap) pair each value belongs to. Fixed to `.reshape(di, dc)` after squeeze, matching the GGUF conv1d convention.

### 4. Router weight quantization sensitivity
The MoE router is an `8×1152` argmax-routing matrix — too small and too perturbation-sensitive for Q4_0. A single flipped expert selection changes the entire token's output path. Stored as F32.

## New file: `tools/blackmamba_cpu_reference.cpp`

Scalar CPU forward pass that serves as a correctness baseline before any GPU/NPU fast path exists. Matches the same "not exact-token-match, but not degenerately stuck" bar used by `test_hip_generic_attention.cpp`.

## Model catalog update

Added BlackMamba-1.5B and BlackMamba-2.8B entries to `models/catalog/README.md`.