### PR TITLE
docs: add BlackMamba to catalog with real measured numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,14 @@ Zaya1's maker, Zyphra, publishes several other architecturally distinct model li
 | [Zamba2-2.7B-Instruct-v2](https://huggingface.co/bong-water-water-bong/Zamba2-2.7B-Instruct-v2-1BP) | 2.7B | Mamba2-hybrid | **1BP** | ✅ |
 | [Zamba2-7B-Instruct-v2](https://huggingface.co/bong-water-water-bong/Zamba2-7B-Instruct-v2-1BP) | 7B | Mamba2-hybrid | **1BP** | ✅ |
 | [ZR1-1.5B](https://huggingface.co/bong-water-water-bong/ZR1-1.5B-1BP) | 1.5B | Dense transformer (Qwen2 arch), reasoning-tuned | **1BP** | ✅ |
+| [BlackMamba-1.5B](https://huggingface.co/bong-water-water-bong/BlackMamba-1.5B-1BP) | 1.5B | Mamba1 + top-1 MoE (no attention at all) | **1BP** | ✅ ⚠️ |
+| [BlackMamba-2.8B](https://huggingface.co/bong-water-water-bong/BlackMamba-2.8B-1BP) | 2.8B | Mamba1 + top-1 MoE | **1BP** | ✅ ⚠️ |
 
 Each converted from a Q8_0/BF16 source (not a 4-bit GGUF) to avoid compounding quantization error through a second 4-bit pass, then structurally and numerically verified the same way as the Zaya1 conversions.
 
-**Deliberately not converted**: BlackMamba-1.5B/2.8B (Zyphra's older pure-Mamba, no-attention line) — no GGUF exists for it anywhere and it predates the architecture support standard converters have, so producing one would mean writing an architecture-specific converter from scratch, not running existing tooling. ZAYA1-VL-8B — a real vision-language model; this converter only handles text weights, so a "conversion" would silently drop the vision tower and misrepresent it as the full model. Both skipped rather than shipped half-working.
+**BlackMamba required a from-scratch converter** (`scripts/blackmamba_to_gguf.py`) — no upstream GGUF export exists for this architecture, and it predates the architecture support standard converters have. Shipped with three real correctness bugs on the first pass (wrong Q4_0 nibble encoding, a conv1d weight `.reshape()` that silently scrambled channel/kernel-tap pairing, and a dropped MoE router bias), all found and fixed by cross-checking a new reference tool against the official Zyphra implementation — see the model cards on Hugging Face for the full writeup. The ⚠️: **no fast inference path exists in this engine for Mamba1+MoE yet** — `src/mamba1_engine.hip` has real kernels but they're not wired into any build target or MoE-aware loader, so the only way to actually run these weights today is the CPU reference tool used to verify them.
+
+**Deliberately not converted**: ZAYA1-VL-8B — a real vision-language model; this converter only handles text weights, so a "conversion" would silently drop the vision tower and misrepresent it as the full model. Skipped rather than shipped half-working.
 
 ### 🏆 Top 5 — Raw NPU Engine, No FLM (single binary, auto-detected)
 

--- a/models/catalog/README.md
+++ b/models/catalog/README.md
@@ -13,8 +13,10 @@ inference engine and achieves verified performance on this hardware.
 | Zamba2-7B-Strix | Zyphra/Zamba2-7B | 7B | Q4_0 GGUF | ~350 tok/s GEMV | 🔲 Planned |
 | **ZR1-1.5B-Strix** 🏆 | Zyphra/ZR1-1.5B | 1.5B | LoRA adapter | 1.86s/it training | ✅ **Done** |
 | Zaya1-8B-Strix | [Zyphra/ZAYA1-8B](https://huggingface.co/Zyphra/ZAYA1-8B) (Apache-2.0) | 8B | Q4_K_M GGUF | ~64 tok/s decode | ✅ Available |
-| BlackMamba-1.5B-Strix | [Zyphra/BlackMamba-1.5B](https://huggingface.co/Zyphra/BlackMamba-1.5B) (Apache-2.0) | 1.5B | Q4_0 GGUF | Not yet benchmarked | 🔲 Planned |
-| BlackMamba-2.8B-Strix | [Zyphra/BlackMamba-2.8B](https://huggingface.co/Zyphra/BlackMamba-2.8B) (Apache-2.0) | 2.8B | Q4_0 GGUF | Not yet benchmarked | 🔲 Planned |
+| BlackMamba-1.5B-Strix | [Zyphra/BlackMamba-1.5B](https://huggingface.co/Zyphra/BlackMamba-1.5B) (Apache-2.0) | 1.5B | Q4_0 GGUF | 46.3 tok/s (PyTorch/ROCm, Radeon 8060S)¹ | ⚠️ No engine path yet |
+| BlackMamba-2.8B-Strix | [Zyphra/BlackMamba-2.8B](https://huggingface.co/Zyphra/BlackMamba-2.8B) (Apache-2.0) | 2.8B | Q4_0 GGUF | 29.6 tok/s (PyTorch/ROCm, Radeon 8060S)¹ | ⚠️ No engine path yet |
+
+¹ BlackMamba is Mamba1+MoE, an architecture this project's engine has no fast inference path for yet (no build target wires up `src/mamba1_engine.hip`'s kernels to a loader that understands its MoE-expert tensor layout). This number is the official Zyphra reference implementation running via real PyTorch/ROCm on this same hardware — a genuine measurement, but not this project's own engine. See `models/*/README.md` on Hugging Face for the full verification writeup, including a CPU-scalar-reference cross-check and three real bugs found and fixed in the GGUF converter along the way.
 
 ### 1BP conversions
 
@@ -28,6 +30,8 @@ Full-precision-preserving conversions to this project's native format — every 
 | [Zamba2-2.7B-Instruct-v2-1BP](https://huggingface.co/bong-water-water-bong/Zamba2-2.7B-Instruct-v2-1BP) | [Zyphra/Zamba2-2.7B-Instruct-v2](https://huggingface.co/Zyphra/Zamba2-2.7B-Instruct-v2) (Apache-2.0) | 2.7B | ✅ Available |
 | [Zamba2-7B-Instruct-v2-1BP](https://huggingface.co/bong-water-water-bong/Zamba2-7B-Instruct-v2-1BP) | [Zyphra/Zamba2-7B-Instruct-v2](https://huggingface.co/Zyphra/Zamba2-7B-Instruct-v2) (Apache-2.0) | 7B | ✅ Available |
 | [ZR1-1.5B-1BP](https://huggingface.co/bong-water-water-bong/ZR1-1.5B-1BP) | [Zyphra/ZR1-1.5B](https://huggingface.co/Zyphra/ZR1-1.5B) (MIT) | 1.5B | ✅ Available |
+| [BlackMamba-1.5B-1BP](https://huggingface.co/bong-water-water-bong/BlackMamba-1.5B-1BP) | [Zyphra/BlackMamba-1.5B](https://huggingface.co/Zyphra/BlackMamba-1.5B) (Apache-2.0) | 1.5B | ✅ Available |
+| [BlackMamba-2.8B-1BP](https://huggingface.co/bong-water-water-bong/BlackMamba-2.8B-1BP) | [Zyphra/BlackMamba-2.8B](https://huggingface.co/Zyphra/BlackMamba-2.8B) (Apache-2.0) | 2.8B | ✅ Available |
 | [BlackMamba-1.5B-1BP](https://huggingface.co/bong-water-water-bong/BlackMamba-1.5B-1BP) | [Zyphra/BlackMamba-1.5B](https://huggingface.co/Zyphra/BlackMamba-1.5B) (Apache-2.0) | 1.5B | ✅ Available |
 
 ## How to Use


### PR DESCRIPTION
## Summary

`scripts/blackmamba_to_gguf.py` and `tools/blackmamba_cpu_reference.cpp` already landed on `main` (commit `85e076d93`) with the fix for three real bugs found while getting real inference numbers for the new BlackMamba 1BP models:

1. **Q4_0 nibble encoding was wrong** — two's-complement instead of excess-8/offset-binary, the exact pattern `gguf_reader.cpp` already has a comment warning about from a prior incident.
2. **conv1d weight `.reshape()` misuse** — scrambled channel/kernel-tap pairing.
3. **MoE router bias silently dropped**, router weight now kept F32 (argmax-sensitive, not a dense weight).

All caught by cross-checking a new CPU reference tool against a real PyTorch forward pass using the official Zyphra reference implementation, layer by layer, until they matched to within 0.04% (quantization noise, not a bug).

This PR adds the actual real numbers to the docs:

| Path | Hardware | 1.5B | 2.8B |
|------|----------|------|------|
| Official Zyphra reference (PyTorch/ROCm) | Radeon 8060S | 46.3 tok/s | 29.6 tok/s |
| `tools/blackmamba_cpu_reference.cpp` | scalar CPU | 7.0 tok/s | 3.9 tok/s |

Also updates `models/catalog/README.md` and the main `README.md`, which previously said BlackMamba was "deliberately not converted" — stale now that both models are live on Hugging Face ([BlackMamba-1.5B-1BP](https://huggingface.co/bong-water-water-bong/BlackMamba-1.5B-1BP), [BlackMamba-2.8B-1BP](https://huggingface.co/bong-water-water-bong/BlackMamba-2.8B-1BP)). Clearly flagged: no fast inference path exists yet for this architecture in the engine itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)