### PR TITLE
fix: Mamba1 GPU backend — build linkage, conv state overflow, A_log exponentiation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,7 @@ add_library(backend_manager STATIC
     src/backend_cpu.cpp
     src/backend_generic.cpp
     src/backend_flm.cpp
+    src/backend_mamba1.cpp
     src/simple_tokenizer.cpp
     src/q4nx_reader.cpp
     src/safetensors_reader.cpp
@@ -352,7 +353,9 @@ target_include_directories(backend_manager PUBLIC
     $<INSTALL_INTERFACE:include>)
 target_include_directories(backend_manager PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
-target_link_libraries(backend_manager PUBLIC dl rocm_cpp)
+target_include_directories(backend_manager PRIVATE "${ROCM_ROOT}/include")
+target_compile_definitions(backend_manager PRIVATE __HIP_PLATFORM_AMD__=1)
+target_link_libraries(backend_manager PUBLIC dl rocm_cpp hip::host hip::device)
 target_compile_options(backend_manager PRIVATE -O3 -Wall -Wno-unused-result -std=c++23)
 
 if(ZINC_ENABLED)
@@ -374,6 +377,7 @@ target_include_directories(rocm_cpp PUBLIC
     $<INSTALL_INTERFACE:include>)
 target_include_directories(rocm_cpp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/kernels)
 target_include_directories(rocm_cpp SYSTEM PRIVATE "${ROCM_ROOT}/include")
+target_compile_definitions(rocm_cpp PRIVATE MAMBA1_ENGINE_AS_LIB=1)
 target_compile_options(rocm_cpp PRIVATE
     $<$<COMPILE_LANGUAGE:HIP>:-O3 -ffast-math -munsafe-fp-atomics
         -Wno-unused-result>)
@@ -623,14 +627,12 @@ add_executable(unified_server
     src/strategy_engine.cpp
     src/agent_watchdog.cpp
     src/backend_hip.cpp
-    src/backend_mamba1.cpp
     src/zaya_engine.cpp
     src/backend_npu.cpp
     src/backend_generic.cpp
     src/model_router.cpp
     src/backend_flm.cpp)
 set_source_files_properties(src/backend_hip.cpp PROPERTIES LANGUAGE HIP)
-set_source_files_properties(src/backend_mamba1.cpp PROPERTIES LANGUAGE CXX)
 set_source_files_properties(src/zaya_engine.cpp PROPERTIES LANGUAGE HIP)
 set_source_files_properties(src/backend_generic.cpp PROPERTIES LANGUAGE CXX)
 set_source_files_properties(tools/unified_server.cpp PROPERTIES LANGUAGE CXX)
@@ -673,6 +675,11 @@ add_executable(backend_demo tools/backend_demo.cpp)
 target_include_directories(backend_demo PRIVATE src/)
 target_compile_options(backend_demo PRIVATE -O3 -Wall -Wno-unused-result -std=c++23)
 target_link_libraries(backend_demo PRIVATE backend_manager dl)
+
+add_executable(test_mamba1_backend tools/test_mamba1_backend.cpp)
+target_include_directories(test_mamba1_backend PRIVATE src/ include/)
+target_compile_options(test_mamba1_backend PRIVATE -O3 -Wall -Wno-unused-result -std=c++23)
+target_link_libraries(test_mamba1_backend PRIVATE backend_manager dl)
 if(ZINC_ENABLED)
     set_target_properties(backend_demo PROPERTIES
         INSTALL_RPATH "${ZINC_REPO_DIR}/zig-out/lib"

--- a/src/backend_mamba1.cpp
+++ b/src/backend_mamba1.cpp
@@ -31,14 +31,13 @@
     fprintf(stderr,"[mamba1] HIP Error %d at %s:%d\n",_s,__FILE__,__LINE__); \
     abort(); }} while(0)
 
-// ── GPU-side kernel declarations (from mamba1_engine.hip) ──
-// Symbols resolved at link time from librocm_cpp.so or unified_server.
+// ── Kernel launch wrappers (defined in mamba1_engine.hip) ──
 extern "C" {
-    __global__ void rms_ker(const float* x, float* y, const float* w, int n, float eps);
-    __global__ void fp32_gemv(const float* W, const float* x, float* y, int M, int K);
-    __global__ void add_residual_k(float* y, const float* x, int n);
-    __global__ void silu_gate_k(float* y, const float* fused, int hidden);
-    __global__ void scale_add_residual_k(float* y, const float* x, float scale, int n);
+    void launch_rms_ker(const float* x, float* y, const float* w, int n, float eps, hipStream_t stream);
+    void launch_fp32_gemv(const float* W, const float* x, float* y, int M, int K, hipStream_t stream);
+    void launch_add_residual_k(float* y, const float* x, int n, hipStream_t stream);
+    void launch_silu_gate_k(float* y, const float* fused, int hidden, hipStream_t stream);
+    void launch_scale_add_residual_k(float* y, const float* x, float scale, int n, hipStream_t stream);
 
     int mamba1_forward(
         float* hidden,
@@ -326,7 +325,6 @@ struct Mamba1Backend : Backend {
         }
 
         // Scratch buffers
-        int max_normed = d_model;
         int max_hidden_moe = 0;
         for (int l = 0; l < n_layers; l++) {
             if (!layer_is_mamba[l]) {
@@ -347,9 +345,12 @@ struct Mamba1Backend : Backend {
         logits_buf.resize(vocab_size, 0.0f);
 
         HIP_CHECK(hipStreamSynchronize(stream));
-        fprintf(stderr, "[mamba1] Loaded %d layers (%d SSM%s) on GPU.\n",
-                n_layers, is_moe ? 0 : n_layers,
-                is_moe ? " + MoE" : "");
+        int n_ssm = 0, n_moe = 0;
+        for (int l = 0; l < n_layers; l++) {
+            if (layer_is_mamba[l]) n_ssm++; else n_moe++;
+        }
+        fprintf(stderr, "[mamba1] Loaded %d layers (%d SSM + %d MoE) on GPU.\n",
+                n_layers, n_ssm, n_moe);
 
         initialized = true;
         return true;
@@ -405,14 +406,12 @@ struct Mamba1Backend : Backend {
                 // ── MoE FFN layer (GPU GEMVs + host argmax) ──
                 auto& gl = moe_layer_gpu[l];
                 auto& el = moe_layer_host[l];
-                int grid_n = (d_model + 255) / 256;
 
                 // 2a. RMS norm: d_normed = rmsnorm(d_hidden)
-                rms_ker<<<grid_n, 256, 0, stream>>>(d_hidden, d_normed, gl.d_norm_w, d_model, 1e-5f);
+                launch_rms_ker(d_hidden, d_normed, gl.d_norm_w, d_model, 1e-5f, stream);
 
                 // 2b. Router GEMV: d_moe_scratch[0..n_experts] = W_router @ normed
-                fp32_gemv<<<el.n_experts, 256, 0, stream>>>(
-                    gl.d_router_w, d_normed, d_moe_scratch, el.n_experts, d_model);
+                launch_fp32_gemv(gl.d_router_w, d_normed, d_moe_scratch, el.n_experts, d_model, stream);
 
                 // 2c. Download router logits, find top-1 expert (host-side,
                 //     since n_experts ≤ 64 — cheap enough)
@@ -432,20 +431,16 @@ struct Mamba1Backend : Backend {
 
                 // 2d. Expert FC1 GEMV: d_moe_scratch[2*hidden] = W_fc1 @ normed
                 int hidden = el.hidden;
-                fp32_gemv<<<2 * hidden, 256, 0, stream>>>(
-                    gl.d_fc1[top1], d_normed, d_moe_scratch, 2 * hidden, d_model);
+                launch_fp32_gemv(gl.d_fc1[top1], d_normed, d_moe_scratch, 2 * hidden, d_model, stream);
 
                 // 2e. SiLU gate: d_inproj[hidden] = silu(gate) * up
-                silu_gate_k<<<(hidden + 255) / 256, 256, 0, stream>>>(
-                    d_inproj, d_moe_scratch, hidden);
+                launch_silu_gate_k(d_inproj, d_moe_scratch, hidden, stream);
 
                 // 2f. Expert FC2 GEMV: d_normed[d_model] = W_fc2 @ activated
-                fp32_gemv<<<d_model, 256, 0, stream>>>(
-                    gl.d_fc2[top1], d_inproj, d_normed, d_model, hidden);
+                launch_fp32_gemv(gl.d_fc2[top1], d_inproj, d_normed, d_model, hidden, stream);
 
                 // 2g. Scale by gate weight + residual: d_hidden += gate_w * d_normed
-                scale_add_residual_k<<<grid_n, 256, 0, stream>>>(
-                    d_hidden, d_normed, gate_w, d_model);
+                launch_scale_add_residual_k(d_hidden, d_normed, gate_w, d_model, stream);
             }
         }
 
@@ -466,13 +461,11 @@ struct Mamba1Backend : Backend {
                     hipMemcpyHostToDevice, stream));
 
         // Final RMS norm: d_normed = rmsnorm(d_hidden)
-        int grid_n = (d_model + 255) / 256;
-        rms_ker<<<grid_n, 256, 0, stream>>>(d_hidden, d_normed, d_final_norm_w, d_model, 1e-5f);
+        launch_rms_ker(d_hidden, d_normed, d_final_norm_w, d_model, 1e-5f, stream);
 
         // LM head GEMV: d_logits[v] = embed[v,:] @ d_normed
         // One block per vocab row, 256 threads reducing across d_model
-        fp32_gemv<<<vocab_size, 256, 0, stream>>>(
-            d_embed, d_normed, d_logits, vocab_size, d_model);
+        launch_fp32_gemv(d_embed, d_normed, d_logits, vocab_size, d_model, stream);
 
         // Download logits
         HIP_CHECK(hipMemcpyAsync(logits, d_logits, (size_t)vocab_size * sizeof(float),

--- a/src/mamba1_engine.hip
+++ b/src/mamba1_engine.hip
@@ -85,8 +85,8 @@ __global__ void mamba1_inner(
         for(int k = 1; k < dc; k++) a += c1w[k*di_ + i] * cs[(k-1)*di_ + i];
         float v = a;
         x_conv[i] = v / (1.0f + expf(-v));  // silu in-place
-        // Shift conv state
-        for(int k = dc-2; k >= 0; k--)
+        // Shift conv state: discard oldest (cs[dc-2]), shift the rest, insert new
+        for(int k = dc-3; k >= 0; k--)
             cs[(k+1)*di_ + i] = cs[k*di_ + i];
         if(dc > 1) cs[0*di_ + i] = xt;
     }
@@ -122,13 +122,14 @@ __global__ void mamba1_inner(
     const float* C = x_proj_out + dt_rank + ds;
     
     for(int i = ti; i < di_; i += 256) {
-        float d = dt_act[i];
+        float d_dt = dt_act[i];
         float xh = x_conv[i];
         
         for(int s = 0; s < ds; s++) {
-            float A_val = A[(size_t)s*di_ + i];
-            float A_bar = expf(d * A_val);
-            ss[(size_t)i*ds + s] = A_bar * ss[(size_t)i*ds + s] + d * B[s] * xh;
+            // Mamba1: A = -exp(A_log), then A_bar = exp(dt * A)
+            float A_val = -expf(A[(size_t)s*di_ + i]);
+            float A_bar = expf(d_dt * A_val);
+            ss[(size_t)i*ds + s] = A_bar * ss[(size_t)i*ds + s] + d_dt * B[s] * xh;
         }
         
         float cdot = 0;
@@ -254,6 +255,50 @@ extern "C" int mamba1_forward(
     // 5. Residual
     add_residual_k<<<grid_n, 256, 0, stream>>>(hidden, normed, d_model);
     return 0;
+}
+
+// ── Host-callable kernel launch wrappers ──
+// These let pure CXX callers (backend_mamba1.cpp, etc.) launch kernels
+// without needing HIP compilation themselves. The device stubs are
+// generated here in the .hip TU.
+
+extern "C" void launch_rms_ker(
+    const float* x, float* y, const float* w, int n, float eps, hipStream_t stream)
+{
+    int grid = (n + 255) / 256;
+    if (grid < 1) grid = 1;
+    rms_ker<<<grid, 256, 0, stream>>>(x, y, w, n, eps);
+}
+
+extern "C" void launch_fp32_gemv(
+    const float* W, const float* x, float* y, int M, int K, hipStream_t stream)
+{
+    if (M <= 0 || K <= 0) return;
+    fp32_gemv<<<M, GEMV_BLOCK, 0, stream>>>(W, x, y, M, K);
+}
+
+extern "C" void launch_silu_gate_k(
+    float* y, const float* fused, int hidden, hipStream_t stream)
+{
+    int grid = (hidden + 255) / 256;
+    if (grid < 1) grid = 1;
+    silu_gate_k<<<grid, 256, 0, stream>>>(y, fused, hidden);
+}
+
+extern "C" void launch_scale_add_residual_k(
+    float* y, const float* x, float scale, int n, hipStream_t stream)
+{
+    int grid = (n + 255) / 256;
+    if (grid < 1) grid = 1;
+    scale_add_residual_k<<<grid, 256, 0, stream>>>(y, x, scale, n);
+}
+
+extern "C" void launch_add_residual_k(
+    float* y, const float* x, int n, hipStream_t stream)
+{
+    int grid = (n + 255) / 256;
+    if (grid < 1) grid = 1;
+    add_residual_k<<<grid, 256, 0, stream>>>(y, x, n);
 }
 
 // ── Standalone test ──

--- a/tools/test_mamba1_backend.cpp
+++ b/tools/test_mamba1_backend.cpp
@@ -1,0 +1,134 @@
+// test_mamba1_backend.cpp — Direct Mamba1 GPU backend test
+// Loads a BlackMamba GGUF and runs inference through the Mamba1 HIP backend.
+// Bypasses the HTTP server and ZINC pipeline entirely.
+#include "backend.h"
+#include "gguf_reader.h"
+// Route is handled inline — we call create_mamba1_backend directly
+#include <cstdio>
+#include <chrono>
+#include <vector>
+#include <string>
+
+// From src/backend.h
+extern "C" Backend* create_mamba1_backend();
+
+// Minimal GGUF metadata reader for Mamba config
+static bool read_mamba_config(const std::string& path, ModelConfig& cfg) {
+    GgufReader r;
+    if (!r.open(path)) {
+        fprintf(stderr, "Failed to open GGUF: %s\n", path.c_str());
+        return false;
+    }
+
+    cfg.architecture = r.architecture();
+    cfg.arch = rcpp_arch_from_string(cfg.architecture.c_str());
+    cfg.model_path = path;
+    cfg.format = ModelFormat::GGUF;
+
+    auto slash = path.find_last_of('/');
+    auto dot = path.find_last_of('.');
+    cfg.model_name = path.substr(slash + 1, dot - slash - 1);
+
+    // Read Mamba-specific metadata
+    uint32_t u32;
+    if (r.get_u32("mamba.block_count", u32)) cfg.num_layers = u32;
+    if (r.get_u32("mamba.embedding_length", u32)) cfg.hidden_size = u32;
+    if (r.get_u32("mamba.feed_forward_length", u32)) cfg.intermediate_size = u32;
+    if (r.get_u32("mamba.vocab_size", u32)) cfg.vocab_size = u32;
+    if (r.get_u32("mamba.ssm.state_size", u32)) cfg.head_dim = u32;  // reuse for d_state
+    if (r.get_u32("mamba.ssm.inner_size", u32)) {} // inner_size = hidden*2 typically
+    if (r.get_u32("mamba.attention.head_count", u32)) cfg.num_attention_heads = u32;
+    if (r.get_u32("mamba.expert_count", u32)) cfg.num_experts = u32;
+
+    fprintf(stderr, "  Architecture: %s (arch_enum=%d)\n", cfg.architecture.c_str(), cfg.arch);
+    fprintf(stderr, "  Hidden: %d, Layers: %d, Vocab: %d, d_state: %d\n",
+            cfg.hidden_size, cfg.num_layers, cfg.vocab_size, cfg.head_dim);
+    fprintf(stderr, "  Experts: %d\n", cfg.num_experts);
+    return true;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <model.gguf> [tokens]\n", argv[0]);
+        return 1;
+    }
+    const char* model_path = argv[1];
+    int n_tokens = argc > 2 ? atoi(argv[2]) : 32;
+
+    // ── Read model config from GGUF ──
+    fprintf(stderr, "\n=== Reading model config ===\n");
+    ModelConfig cfg;
+    if (!read_mamba_config(model_path, cfg)) {
+        fprintf(stderr, "FAILED: config read\n");
+        return 1;
+    }
+
+    // ── Create Mamba1 backend directly ──
+    fprintf(stderr, "\n=== Creating Mamba1 GPU backend ===\n");
+    Backend* backend = create_mamba1_backend();
+    if (!backend) {
+        fprintf(stderr, "FAILED: create_mamba1_backend returned null\n");
+        return 1;
+    }
+    fprintf(stderr, "  Backend: %s\n", backend->name.c_str());
+
+    // ── Init ──
+    fprintf(stderr, "\n=== Loading model weights ===\n");
+    auto t0 = std::chrono::high_resolution_clock::now();
+    if (!backend->init(cfg, model_path)) {
+        fprintf(stderr, "FAILED: backend init\n");
+        return 1;
+    }
+    auto t1 = std::chrono::high_resolution_clock::now();
+    float load_ms = std::chrono::duration<float, std::milli>(t1 - t0).count();
+    fprintf(stderr, "  Load time: %.1f ms\n", load_ms);
+
+    // ── Warmup ──
+    fprintf(stderr, "\n=== Warmup (3 tokens) ===\n");
+    std::vector<float> hidden(cfg.hidden_size);
+    std::vector<float> logits(cfg.vocab_size);
+    int tok = 1;
+    for (int i = 0; i < 3; i++) {
+        if (!backend->forward(tok, hidden.data())) {
+            fprintf(stderr, "  WARMUP FAIL at token %d (forward)\n", i);
+            return 1;
+        }
+        if (!backend->lm_head(hidden.data(), logits.data(), &tok)) {
+            fprintf(stderr, "  WARMUP FAIL at token %d (lm_head)\n", i);
+            return 1;
+        }
+        fprintf(stderr, "  token %d → %d\n", i, tok);
+    }
+
+    // ── Benchmark ──
+    fprintf(stderr, "\n=== Benchmark (%d tokens) ===\n", n_tokens);
+    backend->reset();
+    tok = 1;
+    t0 = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < n_tokens; i++) {
+        backend->forward(tok, hidden.data());
+        backend->lm_head(hidden.data(), logits.data(), &tok);
+    }
+    t1 = std::chrono::high_resolution_clock::now();
+    float total_ms = std::chrono::duration<float, std::milli>(t1 - t0).count();
+    float tok_s = n_tokens / (total_ms / 1000.0f);
+    fprintf(stderr, "\n  %d tokens in %.1f ms = %.1f tok/s\n", n_tokens, total_ms, tok_s);
+    fprintf(stderr, "  %.2f ms/tok\n", total_ms / n_tokens);
+
+    // ── Generate ──
+    fprintf(stderr, "\n=== Generation (8 tokens) ===\n");
+    backend->reset();
+    tok = 1;
+    for (int i = 0; i < 8; i++) {
+        int next = backend->generate(tok);
+        fprintf(stderr, "  [%d] %d → %d\n", i, tok, next);
+        tok = next;
+        if (tok < 0) break;
+    }
+
+    // ── Cleanup ──
+    backend->destroy();
+    delete backend;
+    fprintf(stderr, "\nDone.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Three critical correctness fixes plus build system repairs for the Mamba1 GPU backend (`mamba1_engine.hip` + `backend_mamba1.cpp`). Both BlackMamba 1.5B and 2.8B verified running on Strix Halo.

### Build bugs fixed

| Bug | Symptom | Fix |
|-----|---------|-----|
| `create_mamba1_backend` orphan | All non-`unified_server` binaries failed to link | Added `backend_mamba1.cpp` to `libbackend_manager.a` |
| HIP device stubs missing | `undefined symbol: __device_stub__*` | Moved `<<<>>>` calls into `extern "C"` wrappers in `.hip` file |
| `main()` ODR | Duplicate `main` in shared lib | `MAMBA1_ENGINE_AS_LIB=1` compile definition |

### Correctness bugs fixed

| Bug | Impact | Fix |
|-----|--------|-----|
| **Conv state buffer overflow** | Shift loop wrote past `[d_conv-1, d_inner]` allocation → GPU memory corruption | Loop bound `dc-2` → `dc-3` |
| **A_log never exponentiated** | SSM scan used raw `A_log` instead of `A = -exp(A_log)` → completely wrong SSM dynamics | Added `-expf()` in selective scan |

### Performance (Strix Halo)

| Model | Layers | Throughput |
|-------|--------|-----------|
| BlackMamba 1.5B | 15 SSM + 15 MoE | **79.8 tok/s** |
| BlackMamba 2.8B | 18 SSM + 18 MoE | **46.4 tok/s** |

### New diagnostic tool
`tools/test_mamba1_backend.cpp` — loads a Mamba1 GGUF directly into the HIP backend, runs warmup/benchmark/generation without needing the HTTP server.