### PR TITLE
fix: npu_engine_universal.cpp build break (return-statement with no value)

### DIFF
--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -1020,7 +1020,7 @@ int main(int argc,char**argv){
         }
         } catch (const std::exception& e) {
             fprintf(stderr, "[npu_engine] layer loop failed: %s — aborting batch\n", e.what());
-            return;
+            return 1;
         }
 
         // LM head on the (single, BS=1) decoded position -> greedy next token.


### PR DESCRIPTION
## Description

The exception-handling fix merged in #632 for issue #711 added a bare `return;` inside a catch block directly in `main(int, char**)` (returns `int`) — a hard compile error under standard C++, not just a warning. Confirmed by rebuilding from a clean checkout of `1dfdd429a`: `npu_engine_universal` currently does not build at all.

Fixes with `return 1;`, matching the established error-exit convention already used everywhere else in this same `main()`.

## Type of Change

- [x] NPU Engine (`[npu]`)

## Verification

- [x] Confirmed the build fails without this fix (`bash engine/npu/build_npu.sh`, compiler error at the exact line)
- [x] This one-line change resolves the compile error (verified the specific diagnostic goes away; a separate, pre-existing environment gap in this checkout — missing `-fopenmp` and `aiebu` library linking, unrelated to this change — currently prevents a full local link/build, filed separately)

## Related Issues

Related to #711 — see comment on that issue: the merged fix's only hunk in this file wraps a different code path (the non-`--worker` single-shot decode loop) than where #711 was originally reproduced (`--worker` mode's per-op GEMM dispatch). This PR only fixes the resulting build break; it does not re-address #711 itself.

---
*By submitting this PR, I confirm that any benchmark numbers or status changes accurately reflect real on-device measurements, or are explicitly marked `unvalidated` per the repo's process policy (see #54).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)