### PR TITLE
fix: build — always define ZINC_DISABLED for tokenizer stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,17 +334,17 @@ target_compile_definitions(backend_manager PRIVATE __HIP_PLATFORM_AMD__=1)
 target_link_libraries(backend_manager PUBLIC dl rocm_cpp hip::host hip::device)
 target_compile_options(backend_manager PRIVATE -O3 -Wall -Wno-unused-result -std=c++23)
 
+# ZINC_DISABLED is always set for the tokenizer: zinc_tokenizer_* symbols come
+# from the external libzinc.so (Zig), not from zinc_cpp (Vulkan compute).
+# The stubs in simple_tokenizer.cpp provide no-op implementations that let
+# the C++ ASCII fallback work without the Zig dependency (issue #798).
+# zinc_cpp itself (Vulkan GPU backend) is still linked when available.
+target_compile_definitions(backend_manager PRIVATE ZINC_DISABLED=1)
+
 if(ZINC_CPP_AVAILABLE)
     target_sources(backend_manager PRIVATE src/backend_zinc.cpp)
-    # add_dependencies removed - zinc_cpp is cmake target
     target_link_libraries(backend_manager PUBLIC zinc_cpp)
-    # backend_zinc.cpp includes vulkan_wrapper.h / compute_engine.h / model_loader.h
-    # from engine/gpu/zinc_cpp/include; zinc_cpp declares that dir PRIVATE so it
-    # does not propagate to consumers. unified_server adds it explicitly (line
-    # ~631) — backend_manager must too, or backend_zinc.cpp fails to compile.
     target_include_directories(backend_manager PRIVATE engine/gpu/zinc_cpp/include)
-else()
-    target_compile_definitions(backend_manager PRIVATE ZINC_DISABLED=1)
 endif()
 
 set(RCPP_HIP_SOURCES ${RCPP_SOURCES} src/prefill_dispatcher.cpp)

--- a/engine/gpu/zinc_cpp/CMakeLists.txt
+++ b/engine/gpu/zinc_cpp/CMakeLists.txt
@@ -49,7 +49,7 @@ if(NOT ZINC_CPP_AVAILABLE)
 endif()
 
 # ── Main executable ──
-add_executable(zinc_cpp ${ZINC_SOURCES})
+add_library(zinc_cpp STATIC ${ZINC_SOURCES})
 
 target_include_directories(zinc_cpp PRIVATE
     ${ZINC_INCLUDE_DIR}


### PR DESCRIPTION
## Fixes the build

After the 198-file restructuring, the build was broken:

1. `zinc_cpp` was `add_executable` but linked as a library → `add_library(STATIC)`
2. `ZINC_DISABLED` was only set when `ZINC_CPP_AVAILABLE` is false, but `zinc_tokenizer_*` symbols come from external `libzinc.so` (Zig), not from `zinc_cpp` (Vulkan compute). Now `ZINC_DISABLED=1` is always set so the C++ stubs in `simple_tokenizer.cpp` are used.

**Result: 0 build errors, 16/17 tests pass** (1 NPU-required test skips on this hardware).