### PR TITLE
fix: add null checks to test/shim cleanup paths

### DIFF
--- a/engine/fusion/zero_copy/test_parallel_real.hip
+++ b/engine/fusion/zero_copy/test_parallel_real.hip
@@ -26,13 +26,27 @@ int run_gpu_on_shared(fusion::SharedBO* shbo, int N, int iter) {
     float* host   = (float*)shbo->host_ptr();
     float *d = nullptr;
 
-    (void)hipHostRegister(host, N * sizeof(float), hipHostRegisterMapped);
-    (void)hipHostGetDevicePointer((void**)&d, host, 0);
+    hipError_t reg_err = hipHostRegister(host, N * sizeof(float), hipHostRegisterMapped);
+    if (reg_err != hipSuccess) {
+        fprintf(stderr, "hipHostRegister failed: %s\n", hipGetErrorString(reg_err));
+        return reg_err == hipErrorOutOfMemory ? -1 : 999;
+    }
+    hipError_t dev_err = hipHostGetDevicePointer((void**)&d, host, 0);
+    if (dev_err != hipSuccess || d == nullptr) {
+        fprintf(stderr, "hipHostGetDevicePointer failed: %s\n", hipGetErrorString(dev_err));
+        hipHostUnregister(host);
+        return 998;
+    }
 
     // CPU writes → GPU reads via dev ptr (aliased pages, zero copy)
     for (int i = 0; i < N; i++) host[i] = (float)(iter * 1000000 + i);
-    float check[16];
-    (void)hipMemcpy(check, d, sizeof(check), hipMemcpyDeviceToHost);
+    float check[16] = {0};
+    hipError_t mc = hipMemcpy(check, d, sizeof(check), hipMemcpyDeviceToHost);
+    if (mc != hipSuccess) {
+        fprintf(stderr, "hipMemcpy D2H failed: %s\n", hipGetErrorString(mc));
+        hipHostUnregister(host);
+        return 997;
+    }
     int errs = 0;
     for (int i = 0; i < 16; i++) {
         if (fabsf(check[i] - (float)(iter * 1000000 + i)) > 1e-3f && ++errs <= 3)
@@ -42,8 +56,17 @@ int run_gpu_on_shared(fusion::SharedBO* shbo, int N, int iter) {
 
     // GPU writes via H2D → CPU reads back (zero copy, no D2H needed)
     for (int i = 0; i < N; i++) host[i] = (float)(iter * N + i) * 2.0f;
-    (void)hipMemcpy(d, host, N * sizeof(float), hipMemcpyHostToDevice);
-    (void)hipDeviceSynchronize();
+    mc = hipMemcpy(d, host, N * sizeof(float), hipMemcpyHostToDevice);
+    if (mc != hipSuccess) {
+        fprintf(stderr, "hipMemcpy H2D failed: %s\n", hipGetErrorString(mc));
+        hipHostUnregister(host);
+        return 996;
+    }
+    if (hipDeviceSynchronize() != hipSuccess) {
+        fprintf(stderr, "hipDeviceSynchronize failed\n");
+        hipHostUnregister(host);
+        return 995;
+    }
 
     // CPU reads same pages — should see GPU's writes
     for (int i = 0; i < N; i += 32) {
@@ -53,7 +76,7 @@ int run_gpu_on_shared(fusion::SharedBO* shbo, int N, int iter) {
                     i, host[i], expected);
     }
 
-    (void)hipHostUnregister(host);
+    hipHostUnregister(host);
     return errs;
 }
 
@@ -74,7 +97,7 @@ int main() {
         fprintf(stderr, "No HIP GPU found (err=%d, count=%d) — skipping GPU portion\n", err, ndev);
         // Continue without GPU — NPU-only test fallback
     } else {
-        (void)hipSetDevice(0);
+        hipSetDevice(0);
     }
 
     fusion::SharedBO* shbo = fusion::SharedBO::create(npu_dev, BUF);

--- a/tests/test_bonsai_e2e.cpp
+++ b/tests/test_bonsai_e2e.cpp
@@ -70,7 +70,7 @@ static void bonsai_gemv(rcpp_weight_format_t fmt,
     else if (fmt == RCPP_WEIGHT_FORMAT_BONSAI_Q1)  fn = &bonsai_q1_gemv_launch;
     if (!fn) {
         // Kernel not linked yet — null-fill so the forward pass doesn't SEGV.
-        (void)hipMemsetAsync(out_fp16, 0, (size_t)N * sizeof(uint16_t), nullptr);
+        if (out_fp16) (void)hipMemsetAsync(out_fp16, 0, (size_t)N * sizeof(uint16_t), nullptr);
         return;
     }
     fn(static_cast<const uint8_t*>(packed),
@@ -264,7 +264,7 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    auto hfree = [](void* p) { (void)hipFree(p); };
+    auto hfree = [](void* p) { if (p) { hipError_t _e = hipFree(p); if (_e != hipSuccess) fprintf(stderr, "hipFree: %s\n", hipGetErrorString(_e)); } };
     for (int l = 0; l < L; ++l) { hfree(Ks[l]); hfree(Vs[l]); }
     hfree(x_fp32); hfree(x); hfree(normed);
     hfree(q_fp16); hfree(k_fp16); hfree(v_fp16); hfree(o_fp16);

--- a/tests/test_sherry_e2e.cpp
+++ b/tests/test_sherry_e2e.cpp
@@ -273,7 +273,7 @@ int main(int argc, char** argv) {
     // Housekeeping. HIP frees on process exit are fine, but explicit is nicer.
     // Ignore hipFree returns — if a free fails on shutdown there's nothing
     // productive to do. Cast to void to silence [[nodiscard]].
-    auto hfree = [](void* p) { (void)hipFree(p); };
+    auto hfree = [](void* p) { if (p) { hipError_t _e = hipFree(p); if (_e != hipSuccess) fprintf(stderr, "hipFree: %s\n", hipGetErrorString(_e)); } };
     for (int l = 0; l < L; ++l) { hfree(Ks[l]); hfree(Vs[l]); }
     hfree(x_fp32); hfree(x); hfree(normed); hfree(x_i8); hfree(x_scale_dev);
     hfree(q_fp16); hfree(k_fp16); hfree(v_fp16); hfree(o_fp16);

--- a/tools/bitnet_decode.cpp
+++ b/tools/bitnet_decode.cpp
@@ -157,7 +157,7 @@ rcpp_status_t bonsai_gemv_dispatch(
                 "  Zeroing output; logits will be meaningless until librocm_cpp.so re-exports the symbol.\n");
             once = true;
         }
-        (void)hipMemsetAsync(out_fp16_dev, 0, (size_t)N * sizeof(uint16_t), stream);
+        if (out_fp16_dev) (void)hipMemsetAsync(out_fp16_dev, 0, (size_t)N * sizeof(uint16_t), stream);
         return RCPP_OK;
     }
     fn(static_cast<const uint8_t*>(packed_weights_dev),


### PR DESCRIPTION
Add null pointer guards before HIP API calls in test files:

- `test_parallel_real.hip`: Check `hipHostRegister`/`hipHostGetDevicePointer` return values before using device pointer (would crash GPU with null ptr deref on failure)
- `test_bonsai_e2e.cpp`: Add null check to `hfree()` lambda and `hipMemsetAsync`
- `test_sherry_e2e.cpp`: Add null check to `hfree()` lambda
- `bitnet_decode.cpp`: Add null check to `hipMemsetAsync`