### PR TITLE
fix(zinc): build shaders + resolve at runtime + graceful degradation (#844)

### DIFF
--- a/engine/gpu/zinc_cpp/CMakeLists.txt
+++ b/engine/gpu/zinc_cpp/CMakeLists.txt
@@ -73,10 +73,17 @@ endif()
 # ── Shader compilation: GLSL .comp → SPIR-V .spv ──
 # If glslc is available, compile shaders on build
 if(GLSLC_EXECUTABLE)
-    set(SHADER_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../shaders)
+    # ZINC's GLSL compute shaders live in src/shaders/ (embed.comp, fused_qkv.comp,
+    # rms_norm.comp, ...). The old path pointed at ../shaders (engine/gpu/shaders),
+    # which is empty — so no .spv were ever produced and every dense/GGUF model
+    # that routed to zinc_gpu failed the shader load at runtime (#844).
+    set(SHADER_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/shaders)
     set(SHADER_OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/shaders)
-    
+
     file(GLOB SHADER_SOURCES ${SHADER_SRC_DIR}/*.comp)
+    if(NOT SHADER_SOURCES)
+        message(FATAL_ERROR "ZINC: no .comp shaders found in ${SHADER_SRC_DIR} — dense GPU inference would fail at runtime.")
+    endif()
     foreach(SHADER ${SHADER_SOURCES})
         get_filename_component(SHADER_NAME ${SHADER} NAME_WE)
         set(SPV_OUTPUT ${SHADER_OUT_DIR}/${SHADER_NAME}.spv)

--- a/engine/gpu/zinc_cpp/src/vulkan_wrapper.cpp
+++ b/engine/gpu/zinc_cpp/src/vulkan_wrapper.cpp
@@ -4,10 +4,39 @@
 #include <set>
 #include <algorithm>
 #include <cstdio>
+#include <cstdlib>
+#include <fstream>
 
 // ═══════════════════════════════════════════════════════════════════
 //  ShaderCache
 // ═══════════════════════════════════════════════════════════════════
+
+// Locate a compiled .spv file. The engine used to load shaders by bare name
+// relative to the CWD (ignoring the shader_dir passed to ZincEngine::init),
+// so any process whose CWD wasn't the shader output dir threw "Cannot open
+// shader" (#844). Search the same locations the backend resolver uses.
+static std::string zinc_locate_spv(const std::string& filename) {
+    auto ok = [](const std::string& p) { std::ifstream f(p, std::ios::binary); return f.good(); };
+    if (ok(filename)) return filename;  // already a valid relative/absolute path
+    std::vector<std::string> dirs;
+    if (const char* e = std::getenv("ZINC_SHADER_DIR")) dirs.emplace_back(e);
+#ifdef ZINC_SHADER_DIR
+    dirs.emplace_back(ZINC_SHADER_DIR);
+#endif
+    for (const char* c : {"shaders",
+                          "build_cmake/zinc_cpp_build/shaders",
+                          "build/zinc_cpp_build/shaders",
+                          "engine/gpu/zinc_cpp/build/shaders",
+                          "engine/gpu/shaders",
+                          "/usr/share/1bit-systems/shaders",
+                          "/usr/local/share/1bit-systems/shaders"})
+        dirs.emplace_back(c);
+    for (const auto& d : dirs) {
+        std::string p = d + "/" + filename;
+        if (ok(p)) return p;
+    }
+    return filename;  // fall through — load_path() will throw with the bare name
+}
 
 ShaderCache::~ShaderCache() {
     for (auto& [name, mod] : cache_) {
@@ -18,7 +47,7 @@ ShaderCache::~ShaderCache() {
 VkShaderModule ShaderCache::load(const std::string& name) {
     auto it = cache_.find(name);
     if (it != cache_.end()) return it->second;
-    return load_path(name + ".spv");
+    return load_path(zinc_locate_spv(name + ".spv"));
 }
 
 VkShaderModule ShaderCache::load_path(const std::string& path) {

--- a/src/backend_zinc.cpp
+++ b/src/backend_zinc.cpp
@@ -22,6 +22,15 @@
 // return "" so the caller can fail the backend GRACEFULLY instead of letting
 // a missing-shader std::runtime_error escape a worker thread and call
 // std::terminate on the whole server.
+// Every .spv the ZINC compute path dispatches (post shader_map translation in
+// compute_engine.cpp). If ANY is missing the backend will throw mid-decode on
+// the PILOT worker thread — an uncatchable cross-thread std::terminate — so we
+// require the whole set up front and otherwise disable ZINC cleanly.
+static const char* kZincRequiredShaders[] = {
+    "embed", "fused_qkv", "fused_gate_up", "dmmv_q4k", "dmmv_q4k_batch",
+    "rms_norm_mul", "rope_fused", "flash_attn", "swiglu", "argmax", "vadd",
+};
+
 static std::string zinc_resolve_shader_dir() {
     auto has_shaders = [](const std::string& d) -> bool {
         if (d.empty()) return false;
@@ -85,6 +94,26 @@ struct ZincBackend : Backend {
                 "ZINC: compiled Vulkan shaders (embed.spv) not found — disabling ZINC "
                 "backend (set ZINC_SHADER_DIR to enable). Falling back to HIP/CPU.\n");
             return false;
+        }
+        // Require the FULL dispatch set before we touch Vulkan / start the PILOT
+        // worker — a shader that's missing but only requested mid-decode throws
+        // on a worker thread and std::terminates the whole server (#844).
+        {
+            std::string missing;
+            for (const char* s : kZincRequiredShaders) {
+                struct stat st;
+                if (stat((shader_dir + "/" + s + ".spv").c_str(), &st) != 0) {
+                    if (!missing.empty()) missing += ", ";
+                    missing += s;
+                }
+            }
+            if (!missing.empty()) {
+                fprintf(stderr,
+                    "ZINC: incomplete Vulkan shader set in %s (missing: %s) — disabling "
+                    "ZINC backend, falling back to HIP/CPU. See issue #844.\n",
+                    shader_dir.c_str(), missing.c_str());
+                return false;
+            }
         }
 
         try {


### PR DESCRIPTION
## Summary
Fixes the ZINC Vulkan shader build + runtime resolution, and makes an incomplete ZINC backend degrade gracefully instead of crashing the server. Follow-up to #844.

## The three layers (each was blocking the next)
1. **Shaders never compiled** — `SHADER_SRC_DIR` pointed at the empty `engine/gpu/shaders/` instead of `engine/gpu/zinc_cpp/src/shaders/`, so `glslc` had nothing to compile. Fixed + `FATAL_ERROR` if the glob is empty. → all 8 `.comp` now build to `.spv`.
2. **Wrong runtime path** — `ShaderCache::load()` opened `name.spv` relative to CWD, ignoring the `shader_dir` from `ZincEngine::init()`. Added `zinc_locate_spv()` that searches `ZINC_SHADER_DIR` / compile-define / build + install dirs. → `embed.spv` now loads.
3. **Incomplete set crashed the server** — the dispatch path needs **11** shaders; 8 are still missing/misnamed (`dmmv_q4k`, `dmmv_q4k_batch`, `rms_norm_mul`, `rope_fused`, `flash_attn`, `swiglu`, `argmax`, `vadd`). A shader missing but requested mid-decode throws on the **PILOT worker thread** → uncatchable `std::terminate`. `backend_zinc.cpp` now validates the full set in `init()` and **disables ZINC gracefully** if incomplete.

## Verified on-device (Strix Halo gfx1151)
ZR1-1.5B now detects the incomplete ZINC set, disables it, and **serves via `cpu_generic` with coherent output** — server stays up. Before: `std::terminate` / core dump.

## Not in scope (tracked in #844)
Implementing the 8 missing shaders (Q4_K `dmmv_q4k` matmul, RoPE, flash-attention, argmax, etc.) to actually run dense models on ZINC GPU. Until then they use the CPU fallback; BlackMamba/Zaya on HIP are unaffected.
