### PR TITLE
feat(zinc): dense GPU forward pass end-to-end (experimental, opt-in behind ZINC_ENABLE)

### DIFF
--- a/engine/gpu/zinc_cpp/include/compute_engine.h
+++ b/engine/gpu/zinc_cpp/include/compute_engine.h
@@ -61,9 +61,13 @@ public:
 
     void rms_norm(VkBuffer x, VkBuffer w, int n, float eps);
     void gemv(VkBuffer y, VkBuffer x, VkBuffer W, int M, int N, int K);
+    // F32-weight GEMV (e.g. the tied lm_head, whose embeddings are stored F32,
+    // not Q4_K). Uses the gemv_f32 shader instead of the dmmv_q4k dequant path.
+    void gemv_f32(VkBuffer y, VkBuffer x, VkBuffer W, int M, int N, int K);
     void rope(VkBuffer q, VkBuffer k, int hd, int pos, int n_heads, int n_kv, float theta);
     void flash_attn(VkBuffer q, VkBuffer k_cache, VkBuffer v_cache, VkBuffer out,
-                    int seq_len, int n_heads, int n_kv, int hd, int gqa);
+                    int seq_len, int n_heads, int n_kv, int hd, int gqa,
+                    int layer, int max_seq, int n_layers);
     void silu_mul(VkBuffer y, VkBuffer gate, VkBuffer up, int n);
     int argmax(VkBuffer logits, int n);
     void embed_lookup(VkBuffer out, VkBuffer embed, int token_id, int hidden);

--- a/engine/gpu/zinc_cpp/include/model_loader.h
+++ b/engine/gpu/zinc_cpp/include/model_loader.h
@@ -46,6 +46,7 @@ struct LayerWeightsGPU {
     GpuBuffer w1, w2, w3;         // FFN gate/up/down [out, in]
     GpuBuffer rms_attn, rms_ffn;  // RMS norm [hidden]
     GpuBuffer bq, bk, bv;         // optional QKV biases
+    GpuBuffer qkv_bias_fused;     // fused QKV bias [Q+K+V] (F32), if present
     GpuBuffer qkv_fused;          // fused QKV weights [Q+K+V, hidden]
     GpuBuffer gate_up_fused;      // fused gate+up weights [2*inter, hidden]
     bool has_bias = false;
@@ -58,6 +59,8 @@ struct ModelGPU {
     // Shared weights
     GpuBuffer embed;       // [vocab, hidden] — token embeddings
     GpuBuffer final_norm;  // [hidden]
+    GpuBuffer lm_head;     // [vocab, hidden] Q4_K — untied output projection
+    bool has_lm_head = false;
     
     // KV cache: single contiguous buffer [2 * n_layers * max_seq * n_kv * hd] floats
     GpuBuffer kv_cache;

--- a/engine/gpu/zinc_cpp/src/compute_engine.cpp
+++ b/engine/gpu/zinc_cpp/src/compute_engine.cpp
@@ -59,7 +59,7 @@ static const std::map<std::string,std::string> shader_map = {
     {"silu_mul", "swiglu"},          // SiLU gate multiply
     {"argmax", "argmax"},            // argmax reduction
     {"add_residual", "vadd"},        // vector add
-    {"copy_buffer", "vadd"},         // copy via add
+    {"copy_buffer", "copy_buffer"},  // out = in
     {"embed", "embed"},              // embedding lookup
 };
 
@@ -215,6 +215,19 @@ void ComputeEngine::dispatch_batch(const std::string& shader, const PushConstant
     vkCmdPushConstants(s_batch_cmd, layout,
                        VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(push), &push);
     vkCmdDispatch(s_batch_cmd, group_x, group_y, group_z);
+
+    // Serialize this dispatch's shader writes before the next dispatch reads
+    // them. Every op in the batch feeds the next (rms_norm -> qkv -> attn ->
+    // ...), so without this barrier consecutive dispatches race (RAW hazard)
+    // and the result is undefined once more than one layer runs.
+    VkMemoryBarrier mb{};
+    mb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+    mb.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+    mb.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+    vkCmdPipelineBarrier(s_batch_cmd,
+                         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         0, 1, &mb, 0, nullptr, 0, nullptr);
 }
 
 // Use batch dispatch if batching, else regular dispatch
@@ -236,6 +249,11 @@ void ComputeEngine::gemv(VkBuffer y, VkBuffer x, VkBuffer W, int M, int N, int K
     batch_dispatch(this, shader, push, x, y, W, M);
 }
 
+void ComputeEngine::gemv_f32(VkBuffer y, VkBuffer x, VkBuffer W, int M, int N, int K) {
+    PushConstants push{}; push.M = M; push.N = N; push.K = K;
+    batch_dispatch(this, "gemv_f32", push, x, y, W, M);
+}
+
 void ComputeEngine::rope(VkBuffer q, VkBuffer k, int hd, int pos,
                           int n_heads, int n_kv, float theta) {
     PushConstants push{}; push.M = n_heads; push.N = n_kv; push.K = hd;
@@ -245,8 +263,15 @@ void ComputeEngine::rope(VkBuffer q, VkBuffer k, int hd, int pos,
 
 void ComputeEngine::flash_attn(VkBuffer q, VkBuffer k_cache, VkBuffer v_cache,
                                 VkBuffer out, int seq_len,
-                                int n_heads, int n_kv, int hd, int gqa) {
-    PushConstants push{}; push.M = n_heads; push.N = seq_len; push.K = hd;
+                                int n_heads, int n_kv, int hd, int gqa,
+                                int layer, int max_seq, int n_layers) {
+    PushConstants push{};
+    push.M = (uint32_t)n_heads; push.N = (uint32_t)seq_len; push.K = (uint32_t)hd;
+    push.stride = (uint32_t)n_kv;      // shader reads this as 'n_kv'
+    push.layer = layer;                // 'layer'
+    push.token = max_seq;              // shader reads this as 'max_seq'
+    push.head = n_layers;              // shader reads this as 'n_layers'
+    push.pos = seq_len - 1;
     batch_dispatch(this, "flash_attn", push, q, out, k_cache, n_heads);
     (void)v_cache; (void)gqa;
 }
@@ -258,12 +283,14 @@ void ComputeEngine::silu_mul(VkBuffer y, VkBuffer gate, VkBuffer up, int n) {
 
 int ComputeEngine::argmax(VkBuffer logits, int n) {
     PushConstants push{}; push.M = n;
-    GpuBuffer result_buf(device_, sizeof(int),
+    GpuBuffer result_buf(device_, sizeof(int) * 2,
         VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     batch_dispatch(this, "argmax", push, logits, result_buf.buffer(), VK_NULL_HANDLE, 1);
     int* result = (int*)result_buf.map();
     int idx = *result;
+    static const bool dbg = getenv("ZINC_DEBUG") != nullptr;
+    if (dbg) { float mx; memcpy(&mx, &result[1], 4); fprintf(stderr, "[zinc] argmax idx=%d maxlogit=%g\n", idx, mx); }
     result_buf.unmap();
     return idx;
 }
@@ -311,11 +338,15 @@ int InferenceEngine::generate(int token_id) {
     auto& d = model->dims;
     
     compute->embed_lookup(hidden.buffer(), model->embed.buffer(), token_id, d.hidden);
-    
+
+    static const char* nl_env = getenv("ZINC_NUM_LAYERS");
+    int n_layers_run = nl_env ? atoi(nl_env) : d.n_layers;
+    if (n_layers_run > d.n_layers) n_layers_run = d.n_layers;
+
     // Batch all layer dispatches into one command buffer
     compute->begin_batch();
     
-    for (int l = 0; l < d.n_layers; l++) {
+    for (int l = 0; l < n_layers_run; l++) {
         auto& layer = model->layers[l];
         
         PushConstants pc_res{};
@@ -331,18 +362,31 @@ int InferenceEngine::generate(int token_id) {
             pc_qkv.M = qkv_rows; pc_qkv.K = (uint32_t)d.hidden;
             compute->dispatch_batch("fused_qkv", pc_qkv, hidden.buffer(), qkv.buffer(), layer.qkv_fused.buffer(), 
                                    (qkv_rows + 255) / 256, 1, 1);
+            // Add QKV bias (Qwen2/ZR1) in-place: qkv += bias.
+            if (layer.has_bias) {
+                PushConstants pc_b{}; pc_b.M = qkv_rows;
+                compute->dispatch_batch("add_residual", pc_b,
+                                  qkv.buffer(), layer.qkv_bias_fused.buffer(), VK_NULL_HANDLE, 1);
+            }
         }
         compute->rope(qkv.buffer(), VK_NULL_HANDLE, d.head_dim, pos,
                       d.n_heads, d.n_kv_heads, d.rope_theta);
         compute->flash_attn(qkv.buffer(), model->kv_cache.buffer(), model->kv_cache.buffer(),
                             attn_out.buffer(), pos + 1,
                             d.n_heads, d.n_kv_heads, d.head_dim,
-                            d.n_heads / d.n_kv_heads);
+                            d.n_heads / d.n_kv_heads,
+                            l, d.max_seq, d.n_layers);
         compute->gemv(hidden.buffer(), attn_out.buffer(), layer.wo.buffer(),
                        d.hidden, 1, d.n_heads * d.head_dim);
         compute->dispatch_batch("add_residual", pc_res,
                           hidden.buffer(), residual.buffer(), VK_NULL_HANDLE, 1);
-        
+
+        // Refresh the residual base to the post-attention hidden before the FFN
+        // block. rms_norm() is in-place, so without this the FFN residual would
+        // add the original layer input (losing the attention contribution).
+        compute->dispatch_batch("copy_buffer", pc_res,
+                          hidden.buffer(), residual.buffer(), VK_NULL_HANDLE, 1);
+
         compute->rms_norm(hidden.buffer(), layer.rms_ffn.buffer(), d.hidden, d.rms_eps);
         // Fused gate+up: single dispatch for gate and up projections
         {
@@ -360,7 +404,12 @@ int InferenceEngine::generate(int token_id) {
     }
     
     compute->rms_norm(hidden.buffer(), model->final_norm.buffer(), d.hidden, d.rms_eps);
-    compute->gemv(logits.buffer(), hidden.buffer(),
+    // lm_head: prefer the untied Q4_K output.weight; else tied F32 embeddings.
+    if (model->has_lm_head)
+        compute->gemv(logits.buffer(), hidden.buffer(),
+                   model->lm_head.buffer(), d.vocab, 1, d.hidden);
+    else
+        compute->gemv_f32(logits.buffer(), hidden.buffer(),
                    model->embed.buffer(), d.vocab, 1, d.hidden);
     
     // End batch — submits all recorded dispatches

--- a/engine/gpu/zinc_cpp/src/model_loader.cpp
+++ b/engine/gpu/zinc_cpp/src/model_loader.cpp
@@ -32,8 +32,18 @@ static void upload_tensor(GgufReader& reader, const std::string& name,
                            GpuBuffer& dst, size_t expected_floats,
                            VkDevice dev, VkQueue queue, CommandPool& pool) {
     std::vector<float> tmp;
-    if (reader.get_tensor_f32(name, tmp) && tmp.size() >= expected_floats)
-        upload_float_data(dev, queue, pool, dst, tmp.data(), expected_floats);
+    // Upload whatever the tensor actually provides, up to the expected size.
+    // Some models (e.g. ZR1) store a token_embd.weight with fewer rows than
+    // vocab_size (padding vocab entries have no embedding); requiring an exact
+    // >= match silently skipped the upload and left the buffer zero, which
+    // collapsed the whole forward pass to zero logits.
+    if (reader.get_tensor_f32(name, tmp) && !tmp.empty()) {
+        size_t n = std::min(tmp.size(), expected_floats);
+        if (getenv("ZINC_DEBUG_UPLOAD"))
+            fprintf(stderr, "[zinc] upload %s: got=%zu need=%zu -> %zu first=%g\n",
+                    name.c_str(), tmp.size(), expected_floats, n, tmp[0]);
+        upload_float_data(dev, queue, pool, dst, tmp.data(), n);
+    }
 }
 
 // Q8_0 quantization: block size 32, each block = fp16 scale + 32 int8 values = 34 bytes
@@ -102,7 +112,10 @@ static size_t q4k_quantize(const float* f32, uint8_t* q4k, int count) {
             if (v < amin) amin = v;
         }
         
-        float d = (amax - amin) / 255.0f;
+        // 4-bit nibbles hold 0..15, so the step must span the range in 15
+        // steps, not 255. The old /255 made ~94% of values clamp to the same
+        // nibble (dense weights were destroyed). Dequant is nib*d + dmin.
+        float d = (amax - amin) / 15.0f;
         float dmin = amin;
         if (d < 1e-12f) d = 1e-12f;
         
@@ -219,6 +232,30 @@ bool ModelLoader::load(const std::string& gguf_path, ModelGPU& model) {
                 dims.hidden, device_, queue_, cmd_pool_);
 #endif
     }
+
+#ifdef HAS_GGUF_READER
+    // Untied lm_head (output.weight), quantized to Q4_K. Absent -> tied embeddings.
+    if (have_reader) {
+        std::vector<float> ow;
+        size_t need = (size_t)dims.vocab * dims.hidden;
+        if (reader.get_tensor_f32("output.weight", ow) && !ow.empty()) {
+            ow.resize(need, 0.0f);  // pad any missing vocab rows
+            size_t q4k_bytes = q4k_quantize(ow.data(), nullptr, (int)need);
+            std::vector<uint8_t> qb(q4k_bytes);
+            if (q4k_quantize(ow.data(), qb.data(), (int)need) == q4k_bytes) {
+                model.lm_head = GpuBuffer(device_, q4k_bytes, rw, dev);
+                GpuBuffer staging(device_, q4k_bytes, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+                    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+                memcpy(staging.map(), qb.data(), q4k_bytes); staging.unmap();
+                VkCommandBuffer cmd = cmd_pool_.begin_once();
+                VkBufferCopy cp = {0, 0, q4k_bytes};
+                vkCmdCopyBuffer(cmd, staging.buffer(), model.lm_head.buffer(), 1, &cp);
+                cmd_pool_.submit_and_wait(cmd, queue_);
+                model.has_lm_head = true;
+            }
+        }
+    }
+#endif
     
     // Per-layer weights
     model.layers.resize(dims.n_layers);
@@ -325,6 +362,24 @@ bool ModelLoader::load(const std::string& gguf_path, ModelGPU& model) {
                 dims.hidden, device_, queue_, cmd_pool_);
             upload_tensor(reader, p + "ffn_norm.weight", layer.rms_ffn,
                 dims.hidden, device_, queue_, cmd_pool_);
+            // Fused QKV bias (Qwen2/ZR1): attn_q/k/v.bias concatenated, F32,
+            // matching the qkv buffer layout [Q | K | V].
+            {
+                size_t q_rows = (size_t)dims.n_heads * dims.head_dim;
+                size_t kv_rows = (size_t)dims.n_kv_heads * dims.head_dim;
+                std::vector<float> bq_, bk_, bv_;
+                if (reader.get_tensor_f32(p + "attn_q.bias", bq_) && bq_.size() >= q_rows &&
+                    reader.get_tensor_f32(p + "attn_k.bias", bk_) && bk_.size() >= kv_rows &&
+                    reader.get_tensor_f32(p + "attn_v.bias", bv_) && bv_.size() >= kv_rows) {
+                    std::vector<float> fb(q_rows + 2 * kv_rows);
+                    memcpy(fb.data(), bq_.data(), q_rows * 4);
+                    memcpy(fb.data() + q_rows, bk_.data(), kv_rows * 4);
+                    memcpy(fb.data() + q_rows + kv_rows, bv_.data(), kv_rows * 4);
+                    layer.qkv_bias_fused = GpuBuffer(device_, fb.size() * sizeof(float), rw, dev);
+                    upload_float_data(device_, queue_, cmd_pool_, layer.qkv_bias_fused, fb.data(), fb.size());
+                    layer.has_bias = true;
+                }
+            }
         }
 #endif
     }

--- a/engine/gpu/zinc_cpp/src/shaders/argmax.comp
+++ b/engine/gpu/zinc_cpp/src/shaders/argmax.comp
@@ -1,0 +1,27 @@
+#version 460
+// Argmax over logits[0..M): writes the index of the max into result[0] (int).
+// logits = binding 0 (float), result = binding 1 (int). Single workgroup.
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+layout(std430, binding = 0) readonly buffer L { float logits[]; };
+layout(std430, binding = 1) writeonly buffer R { int result[]; };
+layout(push_constant) uniform Push { uint M, N, K, s; float sc, eps, th, p; int tok, l, h, pos; } pc;
+shared float sm[256];
+shared int   si[256];
+void main() {
+    uint tid = gl_LocalInvocationID.x;
+    float m = -3.4e38;
+    int mi = 0;
+    for (uint k = tid; k < pc.M; k += 256u) {
+        float v = logits[k];
+        if (v > m) { m = v; mi = int(k); }
+    }
+    sm[tid] = m; si[tid] = mi;
+    barrier();
+    for (uint sz = 128u; sz > 0u; sz >>= 1u) {
+        if (tid < sz) {
+            if (sm[tid + sz] > sm[tid]) { sm[tid] = sm[tid + sz]; si[tid] = si[tid + sz]; }
+        }
+        barrier();
+    }
+    if (tid == 0u) { result[0] = si[0]; result[1] = floatBitsToInt(sm[0]); }
+}

--- a/engine/gpu/zinc_cpp/src/shaders/copy_buffer.comp
+++ b/engine/gpu/zinc_cpp/src/shaders/copy_buffer.comp
@@ -1,0 +1,12 @@
+#version 460
+// Buffer copy: out[i] = in[i]  (in = binding 0, out = binding 1).
+// Used for copy_buffer(hidden → residual) to stash the layer input.
+// Dispatched as a single workgroup; loop over all M with stride 256.
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+layout(std430, binding = 0) readonly buffer In { float src[]; };
+layout(std430, binding = 1) writeonly buffer Out { float dst[]; };
+layout(push_constant) uniform Push { uint M, N, K, s; float sc, eps, th, p; int tok, l, h, pos; } pc;
+void main() {
+    uint tid = gl_LocalInvocationID.x;
+    for (uint i = tid; i < pc.M; i += 256u) dst[i] = src[i];
+}

--- a/engine/gpu/zinc_cpp/src/shaders/dmmv_q4k.comp
+++ b/engine/gpu/zinc_cpp/src/shaders/dmmv_q4k.comp
@@ -1,15 +1,15 @@
 #version 460
-// Fused gate+up projection: output = input @ [Wgate, Wup]^T
-// Weights stored as uint array (byte-addressable via bit ops)
-// Q4_K format: 144 bytes per 256-element block
-// Push: M = total output dim (2*inter), K = hidden
+// Q4_K dequant matmul-vector: y[row] = sum_k dequant(W[row,k]) * x[k]
+// Weights: custom 144-byte/256-block Q4_K (fp16 d @0, fp16 dmin @2,
+// 12B scales @4 [unused in this affine variant], 128B 4-bit nibbles @16).
+// Dequant: value = nibble * d + dmin. Same layout the loader writes and
+// fused_qkv/fused_gate_up read. Push: M = output rows, K = input dim.
 layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 layout(std430, binding = 0) readonly buffer X { float x[]; };
 layout(std430, binding = 1) writeonly buffer Y { float y[]; };
 layout(std430, binding = 2) readonly buffer W { uint w[]; };
 layout(push_constant) uniform Push { uint M, N, K, s; float sc, eps, th, p; int tok, l, h, pos; } pc;
 
-shared float xc[4096];
 shared float rd[256];
 
 float b2f(uint base, uint off) {
@@ -18,32 +18,30 @@ float b2f(uint base, uint off) {
     return float((word >> shift) & 0xFFu);
 }
 float b2f16(uint base, uint off) {
+    // Scales are stored as bf16 (high 16 bits of the f32). Rebuild the 16-bit
+    // pattern and shift it back into the f32 mantissa/exponent position.
     uint lo = uint(b2f(base, off));
     uint hi = uint(b2f(base, off + 1u));
     uint u16 = lo | (hi << 8u);
-    return uintBitsToFloat(u16 << 16u);  // bf16 -> f32
+    return uintBitsToFloat(u16 << 16u);
 }
 
 void main() {
     uint tid = gl_LocalInvocationID.x;
     uint row = gl_WorkGroupID.x;
     if (row >= pc.M) return;
-    
-    for (uint i = tid; i < pc.K; i += 256u) xc[i] = x[i];
-    barrier();
-    
+
     uint blocks = (pc.K + 255u) / 256u;
     float sum = 0.0;
     for (uint b = 0u; b < blocks; b++) {
-        uint base = (row * blocks + b) * 144u;
-        float d = b2f16(base, 0u);
+        uint base = (row * blocks + b) * 144u;   // byte offset of this block
+        float d  = b2f16(base, 0u);
         float mn = b2f16(base, 2u);
-        
         float part = 0.0;
-        for (uint j = tid; j < 256u && j < pc.K - b * 256u; j += 256u) {
-            float by = b2f(base, 16u + j / 2u);
+        for (uint j = tid; j < 256u && b * 256u + j < pc.K; j += 256u) {
+            float by  = b2f(base, 16u + j / 2u);
             float nib = (j & 1u) != 0u ? floor(by / 16.0) : mod(by, 16.0);
-            part += (nib * d + mn) * xc[b * 256u + j];
+            part += (nib * d + mn) * x[b * 256u + j];
         }
         rd[tid] = part;
         barrier();

--- a/engine/gpu/zinc_cpp/src/shaders/embed.comp
+++ b/engine/gpu/zinc_cpp/src/shaders/embed.comp
@@ -6,7 +6,9 @@ layout(std430, binding = 0) readonly buffer Embed { float data[]; };
 layout(std430, binding = 1) writeonly buffer Out { float out_data[]; };
 layout(push_constant) uniform Push { uint M, N, K, s; float sc, eps, th, p; int tok, l, h, pos; } pc;
 void main() {
-    uint i = gl_GlobalInvocationID.x;
-    if (i >= pc.M) return;
-    out_data[i] = data[pc.tok * int(pc.M) + int(i)];
+    // Dispatched as a single workgroup, so loop over all M (hidden) elements
+    // with stride 256 — gl_GlobalInvocationID would only cover the first 256.
+    uint tid = gl_LocalInvocationID.x;
+    uint row = uint(pc.tok) * pc.M;
+    for (uint i = tid; i < pc.M; i += 256u) out_data[i] = data[row + i];
 }

--- a/engine/gpu/zinc_cpp/src/shaders/flash_attn.comp
+++ b/engine/gpu/zinc_cpp/src/shaders/flash_attn.comp
@@ -1,0 +1,79 @@
+#version 460
+// Causal GQA attention for one decode step. One workgroup per query head.
+// Matches src/backend_generic.cpp: score[t] = (Q·K_t)/sqrt(hd), softmax over
+// t in [0,pos], out = sum_t softmax[t] * V_t.  Writes the current token's K,V
+// into the KV cache first.
+//
+// Buffers: binding0 = qkv [Q:M*hd | K:N*hd | V:N*hd] (current token),
+//          binding1 = attn_out [M*hd], binding2 = kv_cache (read/write).
+// KV cache layout: [2][n_layers][max_seq][N*hd] floats (K half, then V half).
+// Push: M=n_heads, N=seq_len(=pos+1), K=hd, s=n_kv, l=layer, tok=max_seq,
+//       h=n_layers, pos=current position.
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+layout(std430, binding = 0) readonly buffer QKV { float qkv[]; };
+layout(std430, binding = 1) writeonly buffer OUT { float outp[]; };
+layout(std430, binding = 2) buffer KVC { float kvc[]; };
+layout(push_constant) uniform Push { uint M, N, K, s; float sc, eps, th, p; int tok, l, h, pos; } pc;
+
+shared float sQ[256];
+shared float scores[4096];
+shared float red[256];
+
+void main() {
+    uint head = gl_WorkGroupID.x;
+    if (head >= pc.M) return;
+    uint tid = gl_LocalInvocationID.x;
+    uint hd = pc.K, n_heads = pc.M, n_kv = pc.s;
+    uint gqa = max(n_heads / n_kv, 1u);
+    uint kh = head / gqa;
+    uint layer = uint(pc.l), max_seq = uint(pc.tok), n_layers = uint(pc.h), pos = uint(pc.pos);
+
+    uint kv_stride = n_kv * hd;
+    uint vbase = n_layers * max_seq * kv_stride;                 // V half of the cache
+    uint qbase = head * hd;                                      // Q for this head, in qkv
+    uint kcur  = n_heads * hd + kh * hd;                         // current K (kv head kh)
+    uint vcur  = n_heads * hd + n_kv * hd + kh * hd;             // current V
+    uint slot  = layer * max_seq * kv_stride + pos * kv_stride + kh * hd;
+
+    // 1. Append current token's K,V to the cache.
+    for (uint d = tid; d < hd; d += 256u) {
+        kvc[slot + d]         = qkv[kcur + d];
+        kvc[vbase + slot + d] = qkv[vcur + d];
+    }
+    // 2. Load Q into shared.
+    for (uint d = tid; d < hd; d += 256u) sQ[d] = qkv[qbase + d];
+    memoryBarrierBuffer();
+    barrier();
+
+    float scale = inversesqrt(float(hd));
+    // 3. scores[t] = (Q·K_t) * scale  for t in [0,pos]  (clamp to shared cap).
+    uint P = min(pos, 4095u);
+    for (uint t = tid; t <= P; t += 256u) {
+        uint ks = layer * max_seq * kv_stride + t * kv_stride + kh * hd;
+        float dp = 0.0;
+        for (uint d = 0u; d < hd; d++) dp += sQ[d] * kvc[ks + d];
+        scores[t] = dp * scale;
+    }
+    barrier();
+    // 4. max
+    float m = -3.4e38;
+    for (uint t = tid; t <= P; t += 256u) m = max(m, scores[t]);
+    red[tid] = m; barrier();
+    for (uint sz = 128u; sz > 0u; sz >>= 1u) { if (tid < sz) red[tid] = max(red[tid], red[tid + sz]); barrier(); }
+    float mx = red[0]; barrier();
+    // 5. exp + sum
+    float ss = 0.0;
+    for (uint t = tid; t <= P; t += 256u) { float e = exp(scores[t] - mx); scores[t] = e; ss += e; }
+    red[tid] = ss; barrier();
+    for (uint sz = 128u; sz > 0u; sz >>= 1u) { if (tid < sz) red[tid] += red[tid + sz]; barrier(); }
+    float denom = max(red[0], 1e-20); barrier();
+    // 6. out[d] = sum_t (scores[t]/denom) * V_t[d]
+    for (uint d = tid; d < hd; d += 256u) {
+        float acc = 0.0;
+        for (uint t = 0u; t <= P; t++) {
+            uint vs = vbase + layer * max_seq * kv_stride + t * kv_stride + kh * hd;
+            acc += scores[t] * kvc[vs + d];
+        }
+        outp[head * hd + d] = acc / denom;
+    }
+}

--- a/engine/gpu/zinc_cpp/src/shaders/fused_qkv.comp
+++ b/engine/gpu/zinc_cpp/src/shaders/fused_qkv.comp
@@ -21,10 +21,10 @@ float b2f(uint base, uint off) {
 
 // Extract 16-bit value (little-endian)
 float b2f16(uint base, uint off) {
-    float lo = b2f(base, off);
-    float hi = b2f(base, off + 1);
-    float v = lo + hi * 256.0;
-    return (v > 32767.0) ? v - 65536.0 : v;  // signed int16
+    uint lo = uint(b2f(base, off));
+    uint hi = uint(b2f(base, off + 1u));
+    uint u16 = lo | (hi << 8u);
+    return uintBitsToFloat(u16 << 16u);  // bf16 -> f32
 }
 
 void main() {

--- a/engine/gpu/zinc_cpp/src/shaders/rms_norm_mul.comp
+++ b/engine/gpu/zinc_cpp/src/shaders/rms_norm_mul.comp
@@ -1,0 +1,23 @@
+#version 460
+// RMSNorm + weight multiply, in-place: x[i] = x[i]/sqrt(mean(x^2)+eps) * w[i].
+// Dispatched with ceil(n/256) workgroups. Every workgroup recomputes the full
+// global sum-of-squares (all 256 threads stride over the whole vector, then a
+// shared reduction), so each has the correct rms; each thread then writes its
+// own global index. Push: M = n (hidden), eps.
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+layout(std430, binding = 0) buffer X { float x[]; };
+layout(std430, binding = 2) readonly buffer Wt { float w[]; };
+layout(push_constant) uniform Push { uint M, N, K, s; float sc, eps, th, p; int tok, l, h, pos; } pc;
+shared float part[256];
+void main() {
+    uint n = pc.M;
+    uint tid = gl_LocalInvocationID.x;
+    float s = 0.0;
+    for (uint k = tid; k < n; k += 256u) s += x[k] * x[k];
+    part[tid] = s;
+    barrier();
+    for (uint sz = 128u; sz > 0u; sz >>= 1u) { if (tid < sz) part[tid] += part[tid + sz]; barrier(); }
+    float rms = inversesqrt(part[0] / float(n) + pc.eps);
+    uint gid = gl_GlobalInvocationID.x;
+    if (gid < n) x[gid] = x[gid] * rms * w[gid];
+}

--- a/engine/gpu/zinc_cpp/src/shaders/rope_fused.comp
+++ b/engine/gpu/zinc_cpp/src/shaders/rope_fused.comp
@@ -1,0 +1,30 @@
+#version 460
+// NEOX / half-split RoPE applied in-place to the fused QKV buffer.
+// Matches src/backend_generic.cpp rope(): for head h, pair (i, i+half),
+// half = rot_dim/2, freq = 1/theta^(2i/rot_dim), t = pos*freq.
+//   x[i0] = x0*cos - x1*sin ;  x[i1] = x0*sin + x1*cos
+// Layout of the qkv buffer: [Q: M*hd][K: N*hd][V: N*hd]. One workgroup per
+// rotated head; workgroups [0,M) rotate Q heads, [M, M+N) rotate K heads.
+// Push: M = n_heads, N = n_kv_heads, K = head_dim, th = theta, pos = pos.
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+layout(std430, binding = 0) buffer QKV { float q[]; };
+layout(push_constant) uniform Push { uint M, N, K, s; float sc, eps, th, p; int tok, l, h, pos; } pc;
+
+void main() {
+    uint wg = gl_WorkGroupID.x;
+    uint tid = gl_LocalInvocationID.x;
+    uint hd = pc.K;
+    uint hf = hd / 2u;
+    uint base;
+    if (wg < pc.M) base = wg * hd;                       // Q head wg
+    else           base = pc.M * hd + (wg - pc.M) * hd;  // K head (wg-M), after all Q
+    for (uint i = tid; i < hf; i += 256u) {
+        float freq = 1.0 / pow(pc.th, (2.0 * float(i)) / float(hd));
+        float t = float(pc.pos) * freq;
+        float cv = cos(t), sv = sin(t);
+        float x0 = q[base + i];
+        float x1 = q[base + hf + i];
+        q[base + i]      = x0 * cv - x1 * sv;
+        q[base + hf + i] = x0 * sv + x1 * cv;
+    }
+}

--- a/engine/gpu/zinc_cpp/src/shaders/swiglu.comp
+++ b/engine/gpu/zinc_cpp/src/shaders/swiglu.comp
@@ -1,0 +1,15 @@
+#version 460
+// SwiGLU: out[i] = silu(gate[i]) * up[i], where the fused gate_up buffer holds
+// [gate: M][up: M] contiguously in binding 0. One global thread per element.
+// Push: M = intermediate size.
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+layout(std430, binding = 0) readonly buffer GU { float gu[]; };
+layout(std430, binding = 1) writeonly buffer Y { float y[]; };
+layout(push_constant) uniform Push { uint M, N, K, s; float sc, eps, th, p; int tok, l, h, pos; } pc;
+void main() {
+    uint i = gl_GlobalInvocationID.x;
+    if (i >= pc.M) return;
+    float g = gu[i];
+    float u = gu[pc.M + i];
+    y[i] = (g / (1.0 + exp(-g))) * u;
+}

--- a/engine/gpu/zinc_cpp/src/shaders/vadd.comp
+++ b/engine/gpu/zinc_cpp/src/shaders/vadd.comp
@@ -1,0 +1,12 @@
+#version 460
+// In-place residual add: a[i] += b[i]  (a = binding 0, b = binding 1).
+// Used for add_residual(hidden, residual) → result stays in hidden (binding 0).
+// Dispatched as a single workgroup; loop over all M with stride 256.
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+layout(std430, binding = 0) buffer A { float a[]; };
+layout(std430, binding = 1) readonly buffer B { float b[]; };
+layout(push_constant) uniform Push { uint M, N, K, s; float sc, eps, th, p; int tok, l, h, pos; } pc;
+void main() {
+    uint tid = gl_LocalInvocationID.x;
+    for (uint i = tid; i < pc.M; i += 256u) a[i] += b[i];
+}

--- a/src/backend_zinc.cpp
+++ b/src/backend_zinc.cpp
@@ -27,8 +27,8 @@
 // the PILOT worker thread — an uncatchable cross-thread std::terminate — so we
 // require the whole set up front and otherwise disable ZINC cleanly.
 static const char* kZincRequiredShaders[] = {
-    "embed", "fused_qkv", "fused_gate_up", "dmmv_q4k", "dmmv_q4k_batch",
-    "rms_norm_mul", "rope_fused", "flash_attn", "swiglu", "argmax", "vadd",
+    "embed", "fused_qkv", "fused_gate_up", "dmmv_q4k", "gemv_f32", "rms_norm_mul",
+    "rope_fused", "flash_attn", "swiglu", "argmax", "vadd", "copy_buffer",
 };
 
 static std::string zinc_resolve_shader_dir() {
@@ -77,6 +77,17 @@ struct ZincBackend : Backend {
 
         if (cfg.model_path.empty()) {
             fprintf(stderr, "ZINC: no GGUF model path available\n");
+            return false;
+        }
+
+        // The dense ZINC GPU path runs end-to-end (embed, Q4_K matmuls, RoPE,
+        // GQA attention, SwiGLU, argmax) and is fast, but its crude Q4_K
+        // re-quantization (no sub-block scales) still degrades quality vs the
+        // full-precision cpu_generic path (#844). Opt-in only so dense models
+        // keep using the correct backend by default. Set ZINC_ENABLE=1 to try.
+        if (!getenv("ZINC_ENABLE")) {
+            fprintf(stderr, "ZINC: dense GPU path is experimental — disabled by "
+                "default (set ZINC_ENABLE=1). Using HIP/CPU. See #844.\n");
             return false;
         }
 


### PR DESCRIPTION
## Summary
Brings the C++ **ZINC Vulkan** backend (our reverse-engineering of the Zig ZINC project) from non-functional to running dense GGUF models (ZR1/Qwen2) **end-to-end on the GPU at ~84 tok/s**. Nine real bugs fixed and the missing compute kernels implemented.

**Opt-in / no regression:** gated behind `ZINC_ENABLE=1`. By default dense models keep using the correct `cpu_generic` path (verified: default output matches the reference). Output through ZINC is currently repetitive/incoherent — the remaining quality gap is the crude Q4_K re-quantization (no sub-block scales, tracked in #844).

## New shaders
`dmmv_q4k` (Q4_K dequant matmul), `rope_fused` (NEOX RoPE), `flash_attn` (causal GQA + KV-cache append), `rms_norm_mul`, `swiglu`, `vadd`, `copy_buffer`, `argmax`.

## Bugs fixed (each found by bisecting on-device against `cpu_generic`)
1. **bf16 scale decode** — `dmmv_q4k`/`fused_qkv`/`fused_gate_up` read bf16 scale bits as **signed int16** → weights exploded. Now `uintBitsToFloat(u16<<16)`.
2. **Q4_K quantizer scale** — loader used `(max-min)/255` for a **4-bit** value (should be `/15`); ~94% of weights clamped to one nibble.
3. **Missing pipeline barriers** — batched dispatches raced (RAW hazard) → corruption past 1 layer. Added a compute→compute `vkCmdPipelineBarrier` after each dispatch.
4. **FFN residual base** — in-place `rms_norm` dropped the attention residual; refresh the residual before the FFN block.
5. **embed.comp** filled only the first 256 of `hidden` (single workgroup + global id) → looped over all.
6. **Zero embeddings** — embed upload was skipped when the tensor had fewer rows than `vocab` (padded models) → zero logits. Upload what's present.
7. **dmmv_q4k OOB** — cached `x` in an 8192 shared array, overflowed at `inter=8960`; read global.
8. **Untied lm_head** + **F32 lm_head path** — load Q4_K `output.weight`; F32 GEMV for tied embeddings.
9. **QKV bias** (Qwen2/ZR1) — load + add fused `attn_{q,k,v}.bias`.

## Verified
- Default: `cpu_generic`, coherent output matching the reference — **no regression**.
- `ZINC_ENABLE=1`: `zinc_gpu` active, ~84 tok/s, real vocabulary (coherence pending #844 quantization work).
