### PR TITLE
feat: complete Laguna family 1BP conversion — add DFlash draft model

### DIFF
--- a/models/catalog/README.md
+++ b/models/catalog/README.md
@@ -1,4 +1,4 @@
-# 1bit.systems Model Catalog — 21 Models (1BP)
+# 1bit.systems Model Catalog — 24 Models (1BP)
 
 All models available in **1BP format** — single-file, zero-config, memory-mappable.
 Converted via C++ toolchain (`tools/gguf_to_onebp.cpp`), zero Python at runtime.
@@ -14,6 +14,13 @@ Converted via C++ toolchain (`tools/gguf_to_onebp.cpp`), zero Python at runtime.
 | Qwen2.5-0.5B | 0.5B | 328 MB | ZINC / NPU | qwen2 |
 | TinyLlama-1.1B | 1.1B | 328 MB | ZINC / NPU | qwen2 (compat) |
 | ZR1-1.5B | 1.5B | 781 MB | ZINC / NPU | qwen2 |
+
+### Laguna (MoE, poolside) — 3
+| Model | Params | 1BP Size | 1BP TQ2 Size | Backend | Architecture |
+|-------|:------:|:--------:|:------------:|---------|:------------:|
+| Laguna-S-2.1 | 48×256ex | 73.5 GB | 36.7 GB | ZINC / NPU / HIP | laguna (MoE) |
+| Laguna-XS-2.1 | 40×256ex | 20.9 GB | 10.5 GB | ZINC / NPU / HIP | laguna (MoE) |
+| Laguna-S-2.1-DFlash (draft) | 6L dense | 665 MB | 665 MB | ZINC / NPU / HIP | dflash |
 
 ### MoE — 1
 | Model | Params | 1BP Size | Backend | Architecture |
@@ -54,7 +61,7 @@ Converted via C++ toolchain (`tools/gguf_to_onebp.cpp`), zero Python at runtime.
 |-------|:------:|:--------:|---------|:------------:|
 | Qwen2-VL-2B | 2B | 781 MB | ZINC (vision) | qwen2vl ✅ |
 
-## Total: 21 models
+## Total: 24 models
 All converted via C++ toolchain (`tools/gguf_to_onebp`).
 
 ## Conversion Pipeline (C++ only)

--- a/models/laguna-s-2.1-dflash/convert.log
+++ b/models/laguna-s-2.1-dflash/convert.log
@@ -1,0 +1,209 @@
+GGUF opened: arch=dflash tensors=76
+Model: H=3072 L=6 NH=72 NKV=8 HD=128 IM=12288 V=100352
+  tensor enc.aux_norm.weight: 6x3072 tiled=61440
+  tensor fc.weight: 3072x18432 tiled=35389440
+  tensor blk.0.attn_gate.weight: 72x3072 tiled=184320
+  Total tensors: 50, data size: 664.9 MB
+Quantizing 50 tensors...
+  [1/50] enc.aux_norm.weight... 18432 elements at offset 3682464
+got 18432 floats, tiling...
+  tiles: 1x12 fout=0x55a40e6c0730
+  enc.aux_norm.weight                                   6x3072 -> 60 KB
+  [2/50] fc.weight... 56623104 elements at offset 3768480
+got 56623104 floats, tiling...
+  tiles: 96x72 fout=0x55a40e6c0730
+  fc.weight                                          3072x18432 -> 34560 KB
+  [3/50] blk.0.attn_gate.weight... 221184 elements at offset 35631264
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x55a40e6c0730
+  blk.0.attn_gate.weight                               72x3072 -> 180 KB
+  [4/50] blk.0.attn_k.weight... 3145728 elements at offset 35755680
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.0.attn_k.weight                                1024x3072 -> 1920 KB
+  [5/50] blk.0.attn_output.weight... 28311552 elements at offset 37537952
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x55a40e6c0730
+  blk.0.attn_output.weight                           3072x9216 -> 17280 KB
+  [6/50] blk.0.attn_q.weight... 28311552 elements at offset 53463200
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x55a40e6c0730
+  blk.0.attn_q.weight                                9216x3072 -> 17280 KB
+  [7/50] blk.0.attn_v.weight... 3145728 elements at offset 69388960
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.0.attn_v.weight                                1024x3072 -> 1920 KB
+  [8/50] blk.0.ffn_down.weight... 37748736 elements at offset 71158432
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x55a40e6c0730
+  blk.0.ffn_down.weight                              3072x12288 -> 23040 KB
+  [9/50] blk.0.ffn_gate.weight... 37748736 elements at offset 92392096
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.0.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [10/50] blk.0.ffn_up.weight... 37748736 elements at offset 113638048
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.0.ffn_up.weight                                12288x3072 -> 23040 KB
+  [11/50] blk.1.attn_gate.weight... 221184 elements at offset 134871712
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x55a40e6c0730
+  blk.1.attn_gate.weight                               72x3072 -> 180 KB
+  [12/50] blk.1.attn_k.weight... 3145728 elements at offset 134996128
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.1.attn_k.weight                                1024x3072 -> 1920 KB
+  [13/50] blk.1.attn_output.weight... 28311552 elements at offset 136778400
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x55a40e6c0730
+  blk.1.attn_output.weight                           3072x9216 -> 17280 KB
+  [14/50] blk.1.attn_q.weight... 28311552 elements at offset 152703648
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x55a40e6c0730
+  blk.1.attn_q.weight                                9216x3072 -> 17280 KB
+  [15/50] blk.1.attn_v.weight... 3145728 elements at offset 168629408
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.1.attn_v.weight                                1024x3072 -> 1920 KB
+  [16/50] blk.1.ffn_down.weight... 37748736 elements at offset 170398880
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x55a40e6c0730
+  blk.1.ffn_down.weight                              3072x12288 -> 23040 KB
+  [17/50] blk.1.ffn_gate.weight... 37748736 elements at offset 191632544
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.1.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [18/50] blk.1.ffn_up.weight... 37748736 elements at offset 212878496
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.1.ffn_up.weight                                12288x3072 -> 23040 KB
+  [19/50] blk.2.attn_gate.weight... 221184 elements at offset 234112160
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x55a40e6c0730
+  blk.2.attn_gate.weight                               72x3072 -> 180 KB
+  [20/50] blk.2.attn_k.weight... 3145728 elements at offset 234236576
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.2.attn_k.weight                                1024x3072 -> 1920 KB
+  [21/50] blk.2.attn_output.weight... 28311552 elements at offset 236018848
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x55a40e6c0730
+  blk.2.attn_output.weight                           3072x9216 -> 17280 KB
+  [22/50] blk.2.attn_q.weight... 28311552 elements at offset 251944096
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x55a40e6c0730
+  blk.2.attn_q.weight                                9216x3072 -> 17280 KB
+  [23/50] blk.2.attn_v.weight... 3145728 elements at offset 267869856
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.2.attn_v.weight                                1024x3072 -> 1920 KB
+  [24/50] blk.2.ffn_down.weight... 37748736 elements at offset 270450336
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x55a40e6c0730
+  blk.2.ffn_down.weight                              3072x12288 -> 23040 KB
+  [25/50] blk.2.ffn_gate.weight... 37748736 elements at offset 301416096
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.2.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [26/50] blk.2.ffn_up.weight... 37748736 elements at offset 322662048
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.2.ffn_up.weight                                12288x3072 -> 23040 KB
+  [27/50] blk.3.attn_gate.weight... 221184 elements at offset 343895712
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x55a40e6c0730
+  blk.3.attn_gate.weight                               72x3072 -> 180 KB
+  [28/50] blk.3.attn_k.weight... 3145728 elements at offset 344020128
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.3.attn_k.weight                                1024x3072 -> 1920 KB
+  [29/50] blk.3.attn_output.weight... 28311552 elements at offset 345802400
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x55a40e6c0730
+  blk.3.attn_output.weight                           3072x9216 -> 17280 KB
+  [30/50] blk.3.attn_q.weight... 28311552 elements at offset 361727648
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x55a40e6c0730
+  blk.3.attn_q.weight                                9216x3072 -> 17280 KB
+  [31/50] blk.3.attn_v.weight... 3145728 elements at offset 377653408
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.3.attn_v.weight                                1024x3072 -> 1920 KB
+  [32/50] blk.3.ffn_down.weight... 37748736 elements at offset 379422880
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x55a40e6c0730
+  blk.3.ffn_down.weight                              3072x12288 -> 23040 KB
+  [33/50] blk.3.ffn_gate.weight... 37748736 elements at offset 400656544
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.3.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [34/50] blk.3.ffn_up.weight... 37748736 elements at offset 421902496
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.3.ffn_up.weight                                12288x3072 -> 23040 KB
+  [35/50] blk.4.attn_gate.weight... 221184 elements at offset 443136160
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x55a40e6c0730
+  blk.4.attn_gate.weight                               72x3072 -> 180 KB
+  [36/50] blk.4.attn_k.weight... 3145728 elements at offset 443260576
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.4.attn_k.weight                                1024x3072 -> 1920 KB
+  [37/50] blk.4.attn_output.weight... 28311552 elements at offset 445042848
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x55a40e6c0730
+  blk.4.attn_output.weight                           3072x9216 -> 17280 KB
+  [38/50] blk.4.attn_q.weight... 28311552 elements at offset 460968096
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x55a40e6c0730
+  blk.4.attn_q.weight                                9216x3072 -> 17280 KB
+  [39/50] blk.4.attn_v.weight... 3145728 elements at offset 476893856
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.4.attn_v.weight                                1024x3072 -> 1920 KB
+  [40/50] blk.4.ffn_down.weight... 37748736 elements at offset 478663328
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x55a40e6c0730
+  blk.4.ffn_down.weight                              3072x12288 -> 23040 KB
+  [41/50] blk.4.ffn_gate.weight... 37748736 elements at offset 499896992
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.4.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [42/50] blk.4.ffn_up.weight... 37748736 elements at offset 521142944
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.4.ffn_up.weight                                12288x3072 -> 23040 KB
+  [43/50] blk.5.attn_gate.weight... 221184 elements at offset 542376608
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x55a40e6c0730
+  blk.5.attn_gate.weight                               72x3072 -> 180 KB
+  [44/50] blk.5.attn_k.weight... 3145728 elements at offset 542501024
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.5.attn_k.weight                                1024x3072 -> 1920 KB
+  [45/50] blk.5.attn_output.weight... 28311552 elements at offset 544283296
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x55a40e6c0730
+  blk.5.attn_output.weight                           3072x9216 -> 17280 KB
+  [46/50] blk.5.attn_q.weight... 28311552 elements at offset 560208544
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x55a40e6c0730
+  blk.5.attn_q.weight                                9216x3072 -> 17280 KB
+  [47/50] blk.5.attn_v.weight... 3145728 elements at offset 576134304
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.5.attn_v.weight                                1024x3072 -> 1920 KB
+  [48/50] blk.5.ffn_down.weight... 37748736 elements at offset 578714784
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x55a40e6c0730
+  blk.5.ffn_down.weight                              3072x12288 -> 23040 KB
+  [49/50] blk.5.ffn_gate.weight... 37748736 elements at offset 609680544
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.5.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [50/50] blk.5.ffn_up.weight... 37748736 elements at offset 630926496
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.5.ffn_up.weight                                12288x3072 -> 23040 KB
+
+=== DONE: models/laguna-s-2.1-dflash/laguna-s-2.1-DFlash.1bp (664.9 MB) in 6 seconds ===

--- a/models/laguna-s-2.1-dflash/convert_tq2.log
+++ b/models/laguna-s-2.1-dflash/convert_tq2.log
@@ -1,0 +1,209 @@
+GGUF opened: arch=dflash tensors=76
+Model: H=3072 L=6 NH=72 NKV=8 HD=128 IM=12288 V=100352
+  tensor enc.aux_norm.weight: 6x3072 tiled=61440
+  tensor fc.weight: 3072x18432 tiled=35389440
+  tensor blk.0.attn_gate.weight: 72x3072 tiled=184320
+  Total tensors: 50, data size: 664.9 MB
+Quantizing 50 tensors...
+  [1/50] enc.aux_norm.weight... 18432 elements at offset 3682464
+got 18432 floats, tiling...
+  tiles: 1x12 fout=0x5f709c63e730
+  enc.aux_norm.weight                                   6x3072 -> 60 KB
+  [2/50] fc.weight... 56623104 elements at offset 3768480
+got 56623104 floats, tiling...
+  tiles: 96x72 fout=0x5f709c63e730
+  fc.weight                                          3072x18432 -> 34560 KB
+  [3/50] blk.0.attn_gate.weight... 221184 elements at offset 35631264
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x5f709c63e730
+  blk.0.attn_gate.weight                               72x3072 -> 180 KB
+  [4/50] blk.0.attn_k.weight... 3145728 elements at offset 35755680
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.0.attn_k.weight                                1024x3072 -> 1920 KB
+  [5/50] blk.0.attn_output.weight... 28311552 elements at offset 37537952
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x5f709c63e730
+  blk.0.attn_output.weight                           3072x9216 -> 17280 KB
+  [6/50] blk.0.attn_q.weight... 28311552 elements at offset 53463200
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5f709c63e730
+  blk.0.attn_q.weight                                9216x3072 -> 17280 KB
+  [7/50] blk.0.attn_v.weight... 3145728 elements at offset 69388960
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.0.attn_v.weight                                1024x3072 -> 1920 KB
+  [8/50] blk.0.ffn_down.weight... 37748736 elements at offset 71158432
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x5f709c63e730
+  blk.0.ffn_down.weight                              3072x12288 -> 23040 KB
+  [9/50] blk.0.ffn_gate.weight... 37748736 elements at offset 92392096
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.0.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [10/50] blk.0.ffn_up.weight... 37748736 elements at offset 113638048
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.0.ffn_up.weight                                12288x3072 -> 23040 KB
+  [11/50] blk.1.attn_gate.weight... 221184 elements at offset 134871712
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x5f709c63e730
+  blk.1.attn_gate.weight                               72x3072 -> 180 KB
+  [12/50] blk.1.attn_k.weight... 3145728 elements at offset 134996128
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.1.attn_k.weight                                1024x3072 -> 1920 KB
+  [13/50] blk.1.attn_output.weight... 28311552 elements at offset 136778400
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x5f709c63e730
+  blk.1.attn_output.weight                           3072x9216 -> 17280 KB
+  [14/50] blk.1.attn_q.weight... 28311552 elements at offset 152703648
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5f709c63e730
+  blk.1.attn_q.weight                                9216x3072 -> 17280 KB
+  [15/50] blk.1.attn_v.weight... 3145728 elements at offset 168629408
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.1.attn_v.weight                                1024x3072 -> 1920 KB
+  [16/50] blk.1.ffn_down.weight... 37748736 elements at offset 170398880
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x5f709c63e730
+  blk.1.ffn_down.weight                              3072x12288 -> 23040 KB
+  [17/50] blk.1.ffn_gate.weight... 37748736 elements at offset 191632544
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.1.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [18/50] blk.1.ffn_up.weight... 37748736 elements at offset 212878496
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.1.ffn_up.weight                                12288x3072 -> 23040 KB
+  [19/50] blk.2.attn_gate.weight... 221184 elements at offset 234112160
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x5f709c63e730
+  blk.2.attn_gate.weight                               72x3072 -> 180 KB
+  [20/50] blk.2.attn_k.weight... 3145728 elements at offset 234236576
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.2.attn_k.weight                                1024x3072 -> 1920 KB
+  [21/50] blk.2.attn_output.weight... 28311552 elements at offset 236018848
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x5f709c63e730
+  blk.2.attn_output.weight                           3072x9216 -> 17280 KB
+  [22/50] blk.2.attn_q.weight... 28311552 elements at offset 251944096
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5f709c63e730
+  blk.2.attn_q.weight                                9216x3072 -> 17280 KB
+  [23/50] blk.2.attn_v.weight... 3145728 elements at offset 267869856
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.2.attn_v.weight                                1024x3072 -> 1920 KB
+  [24/50] blk.2.ffn_down.weight... 37748736 elements at offset 270450336
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x5f709c63e730
+  blk.2.ffn_down.weight                              3072x12288 -> 23040 KB
+  [25/50] blk.2.ffn_gate.weight... 37748736 elements at offset 301416096
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.2.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [26/50] blk.2.ffn_up.weight... 37748736 elements at offset 322662048
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.2.ffn_up.weight                                12288x3072 -> 23040 KB
+  [27/50] blk.3.attn_gate.weight... 221184 elements at offset 343895712
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x5f709c63e730
+  blk.3.attn_gate.weight                               72x3072 -> 180 KB
+  [28/50] blk.3.attn_k.weight... 3145728 elements at offset 344020128
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.3.attn_k.weight                                1024x3072 -> 1920 KB
+  [29/50] blk.3.attn_output.weight... 28311552 elements at offset 345802400
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x5f709c63e730
+  blk.3.attn_output.weight                           3072x9216 -> 17280 KB
+  [30/50] blk.3.attn_q.weight... 28311552 elements at offset 361727648
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5f709c63e730
+  blk.3.attn_q.weight                                9216x3072 -> 17280 KB
+  [31/50] blk.3.attn_v.weight... 3145728 elements at offset 377653408
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.3.attn_v.weight                                1024x3072 -> 1920 KB
+  [32/50] blk.3.ffn_down.weight... 37748736 elements at offset 379422880
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x5f709c63e730
+  blk.3.ffn_down.weight                              3072x12288 -> 23040 KB
+  [33/50] blk.3.ffn_gate.weight... 37748736 elements at offset 400656544
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.3.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [34/50] blk.3.ffn_up.weight... 37748736 elements at offset 421902496
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.3.ffn_up.weight                                12288x3072 -> 23040 KB
+  [35/50] blk.4.attn_gate.weight... 221184 elements at offset 443136160
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x5f709c63e730
+  blk.4.attn_gate.weight                               72x3072 -> 180 KB
+  [36/50] blk.4.attn_k.weight... 3145728 elements at offset 443260576
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.4.attn_k.weight                                1024x3072 -> 1920 KB
+  [37/50] blk.4.attn_output.weight... 28311552 elements at offset 445042848
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x5f709c63e730
+  blk.4.attn_output.weight                           3072x9216 -> 17280 KB
+  [38/50] blk.4.attn_q.weight... 28311552 elements at offset 460968096
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5f709c63e730
+  blk.4.attn_q.weight                                9216x3072 -> 17280 KB
+  [39/50] blk.4.attn_v.weight... 3145728 elements at offset 476893856
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.4.attn_v.weight                                1024x3072 -> 1920 KB
+  [40/50] blk.4.ffn_down.weight... 37748736 elements at offset 478663328
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x5f709c63e730
+  blk.4.ffn_down.weight                              3072x12288 -> 23040 KB
+  [41/50] blk.4.ffn_gate.weight... 37748736 elements at offset 499896992
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.4.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [42/50] blk.4.ffn_up.weight... 37748736 elements at offset 521142944
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.4.ffn_up.weight                                12288x3072 -> 23040 KB
+  [43/50] blk.5.attn_gate.weight... 221184 elements at offset 542376608
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x5f709c63e730
+  blk.5.attn_gate.weight                               72x3072 -> 180 KB
+  [44/50] blk.5.attn_k.weight... 3145728 elements at offset 542501024
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.5.attn_k.weight                                1024x3072 -> 1920 KB
+  [45/50] blk.5.attn_output.weight... 28311552 elements at offset 544283296
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x5f709c63e730
+  blk.5.attn_output.weight                           3072x9216 -> 17280 KB
+  [46/50] blk.5.attn_q.weight... 28311552 elements at offset 560208544
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5f709c63e730
+  blk.5.attn_q.weight                                9216x3072 -> 17280 KB
+  [47/50] blk.5.attn_v.weight... 3145728 elements at offset 576134304
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.5.attn_v.weight                                1024x3072 -> 1920 KB
+  [48/50] blk.5.ffn_down.weight... 37748736 elements at offset 578714784
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x5f709c63e730
+  blk.5.ffn_down.weight                              3072x12288 -> 23040 KB
+  [49/50] blk.5.ffn_gate.weight... 37748736 elements at offset 609680544
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.5.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [50/50] blk.5.ffn_up.weight... 37748736 elements at offset 630926496
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.5.ffn_up.weight                                12288x3072 -> 23040 KB
+
+=== DONE: models/laguna-s-2.1-dflash/laguna-s-2.1-DFlash-TQ2.1bp (664.9 MB) in 6 seconds ===


### PR DESCRIPTION
## Summary

Completes the Laguna family 1BP conversion by adding the last missing variant — **Laguna-S-2.1-DFlash**, the 6-layer dense draft head used for speculative decoding with the full Laguna-S-2.1 MoE.

## Changes

- **`models/laguna-s-2.1-dflash/convert.log`** — Q4NX (4-bit) conversion of `laguna-s-2.1-DFlash-Q4_K_M.gguf` → `laguna-s-2.1-DFlash.1bp` (665 MB)
- **`models/laguna-s-2.1-dflash/convert_tq2.log`** — TQ2 (2-bit ternary) conversion → `laguna-s-2.1-DFlash-TQ2.1bp` (665 MB)
- **`models/catalog/README.md`** — Added new "Laguna (MoE, poolside)" section with all 3 variants; updated total count from 21 → 24 models

## Laguna Family Status (all converted ✅)

| Model | Layers | Type | Q4 (1BP) | TQ2 (1BP) |
|-------|:------:|:----:|:--------:|:---------:|
| Laguna-S-2.1 | 48 | MoE (256 experts) | 73.5 GB | 36.7 GB |
| Laguna-XS-2.1 | 40 | MoE (256 experts) | 20.9 GB | 10.5 GB |
| Laguna-S-2.1-DFlash | 6 | Dense draft head | **665 MB** | **665 MB** |

## Notes

- The original BF16 GGUF from `poolside/Laguna-S-2.1-GGUF` used an unknown quantization dtype (30) not supported by our converter. Used Q4_K_M variant from `coolthor/Laguna-S-2.1-attnQ8-DFlash-Q4-GGUF` instead.
- All 50 tensors converted successfully in ~6s each.