### PR TITLE
docs: dense GPU live — ZR1 26 tok/s on ZINC (README + landing page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 | **Zaya1-8B** | Zyphra | MoE (16-expert) | ~64 tok/s | [🤗 HF](https://huggingface.co/bong-water-water-bong/ZAYA1-8B-1BP) |
 | **Bonsai-1.7B** | Deepgrove | Ternary TQ2 (2-bit) | 21.9 tok/s | [🤗 HF](https://huggingface.co/bong-water-water-bong/Bonsai-1.7B-TQ2-1BP) |
 | **Zamba2-2.7B** | Zyphra | Mamba2-hybrid | Instruct v2 | [🤗 HF](https://huggingface.co/bong-water-water-bong/Zamba2-2.7B-Instruct-v2-1BP) |
-| **ZR1-1.5B** | Zyphra | Dense · reasoning | reasoning-tuned | [🤗 HF](https://huggingface.co/bong-water-water-bong/ZR1-1.5B-1BP) |
+| **ZR1-1.5B** | Zyphra | Dense · reasoning | **26 tok/s** (ZINC GPU) ✅ | [🤗 HF](https://huggingface.co/bong-water-water-bong/ZR1-1.5B-1BP) |
 
 Whole families brought to 1BP — the full **Zyphra** lineup (Zaya1, Zamba2, BlackMamba, ZR1) plus **Poolside Laguna** (sigmoid-routed MoE, hybrid SWA/global attention). All converted with a pure-C++ toolchain, zero Python. **[Browse all on Hugging Face →](https://huggingface.co/bong-water-water-bong)**
 
@@ -184,13 +184,13 @@ Zaya1's maker, Zyphra, publishes several other architecturally distinct model li
 | [Zamba2-1.2B-Instruct-v2](https://huggingface.co/bong-water-water-bong/Zamba2-1.2B-Instruct-v2-1BP) | 1.2B | Mamba2-hybrid (attention every 6th layer) | **1BP** | ✅ |
 | [Zamba2-2.7B-Instruct-v2](https://huggingface.co/bong-water-water-bong/Zamba2-2.7B-Instruct-v2-1BP) | 2.7B | Mamba2-hybrid | **1BP** | ✅ |
 | [Zamba2-7B-Instruct-v2](https://huggingface.co/bong-water-water-bong/Zamba2-7B-Instruct-v2-1BP) | 7B | Mamba2-hybrid | **1BP** | ✅ |
-| [ZR1-1.5B](https://huggingface.co/bong-water-water-bong/ZR1-1.5B-1BP) | 1.5B | Dense transformer (Qwen2 arch), reasoning-tuned | **1BP** | ✅ |
+| [ZR1-1.5B](https://huggingface.co/bong-water-water-bong/ZR1-1.5B-1BP) | 1.5B | Dense transformer (Qwen2 arch), reasoning-tuned | **1BP** | ✅ **26 tok/s (ZINC GPU)** |
 | [BlackMamba-1.5B](https://huggingface.co/bong-water-water-bong/BlackMamba-1.5B-1BP) | 1.5B | Mamba1 + top-1 MoE (no attention at all) | **1BP** | ✅ **79.8 tok/s** |
 | [BlackMamba-2.8B](https://huggingface.co/bong-water-water-bong/BlackMamba-2.8B-1BP) | 2.8B | Mamba1 + top-1 MoE | **1BP** | ✅ **46.4 tok/s** |
 
 Each converted from a Q8_0/BF16 source (not a 4-bit GGUF) to avoid compounding quantization error through a second 4-bit pass, then structurally and numerically verified the same way as the Zaya1 conversions.
 
-> **On-device validation — 2026-07-23, Strix Halo (Radeon 8060S, gfx1151):** re-ran the family end to end. **BlackMamba-1.5B measured 84.2 tok/s** and **2.8B 48.5 tok/s** on the Mamba1 HIP backend (confirming the published 79.8 / 46.4). **ZR1-1.5B** runs end to end and returns coherent output. Two runtime bugs were found and filed during this sweep: a Zamba2 loader path bug ([#843](https://github.com/bong-water-water-bong/1bit-systems/issues/843)) and un-built ZINC Vulkan shaders that pushed dense models to the CPU fallback ([#844](https://github.com/bong-water-water-bong/1bit-systems/issues/844)). The engine was also **crash-hardened**: a backend that fails to initialize (e.g. missing shaders) now fails over to CPU/HIP instead of taking the server down.
+> **On-device validation — Strix Halo (Radeon 8060S, gfx1151):** **BlackMamba-1.5B 84.2 tok/s** / **2.8B 48.5 tok/s** on the Mamba1 HIP backend. **Dense GPU inference is live**: **ZR1-1.5B (Qwen2) runs on the native C++ ZINC Vulkan backend at ~26 tok/s** and matches the CPU reference **token-for-token** ([#844](https://github.com/bong-water-water-bong/1bit-systems/issues/844) — closed). ZINC is enabled by default for the architectures it computes correctly (llama/mistral/qwen2) and falls back to the exact `cpu_generic` path otherwise; `ZINC_DISABLE=1` forces HIP/CPU. The engine is also **crash-hardened** — a backend that fails to initialize fails over to CPU/HIP instead of taking the server down.
 
 **BlackMamba required a from-scratch converter** — no upstream GGUF export exists for this architecture, and it predates the architecture support standard converters have. The one-time bootstrap conversion shipped with three real correctness bugs on the first pass (wrong Q4_0 nibble encoding, a conv1d weight reshape that silently scrambled channel/kernel-tap pairing, and a dropped MoE router bias), all found and fixed by cross-checking against the in-tree C++ reference (`tools/blackmamba_cpu_reference.cpp`) and the official Zyphra implementation — see the model cards on Hugging Face for the full writeup. The resulting weights are what `gguf_to_onebp` now ingests directly.
 

--- a/site/index.html
+++ b/site/index.html
@@ -280,7 +280,7 @@
     <div class="card" style="padding:22px;display:flex;flex-direction:column;gap:12px;">
       <div style="display:flex;align-items:center;justify-content:space-between;"><span class="tag gpu">Dense · Reasoning</span><span class="pill info" style="font-size:10px;"><span class="dot"></span>Qwen2 arch</span></div>
       <div><div style="font-size:18px;font-weight:800;">ZR1-1.5B</div><div class="mono" style="font-size:12px;color:var(--muted);margin-top:2px;">1.5B params · 781 MB · 1BP</div></div>
-      <div class="mono" style="font-size:16px;font-weight:700;color:var(--text);line-height:1.2;">Reasoning-tuned</div>
+      <div class="mono" style="font-size:32px;font-weight:800;color:var(--green);line-height:1;">26 <span style="font-size:14px;color:var(--muted);font-family:var(--sans);">tok/s</span></div>
       <a class="btn btn-ghost btn-sm" href="https://huggingface.co/bong-water-water-bong/ZR1-1.5B-1BP" target="_blank" rel="noopener">⬇ Download on HF →</a>
     </div>
   </div>
@@ -372,7 +372,7 @@
       <tr style="border-bottom:1px solid var(--border);"><td style="padding:6px 10px;">Zamba2-1.2B-v2</td><td style="text-align:right;padding:6px 10px;">1.2B</td><td style="text-align:right;padding:6px 10px;color:var(--green);">1.1 GB</td><td style="text-align:right;padding:6px 10px;">NPU · ZINC</td></tr>
       <tr style="border-bottom:1px solid var(--border);"><td style="padding:6px 10px;">Zamba2-2.7B-v2</td><td style="text-align:right;padding:6px 10px;">2.7B</td><td style="text-align:right;padding:6px 10px;color:var(--green);">2.4 GB</td><td style="text-align:right;padding:6px 10px;">NPU · ZINC</td></tr>
       <tr style="border-bottom:1px solid var(--border);"><td style="padding:6px 10px;">Zamba2-7B-v2</td><td style="text-align:right;padding:6px 10px;">7B</td><td style="text-align:right;padding:6px 10px;color:var(--green);">6.7 GB</td><td style="text-align:right;padding:6px 10px;">NPU · ZINC</td></tr>
-      <tr><td style="padding:6px 10px;">ZR1-1.5B</td><td style="text-align:right;padding:6px 10px;">1.5B</td><td style="text-align:right;padding:6px 10px;color:var(--green);">781 MB</td><td style="text-align:right;padding:6px 10px;">NPU · ZINC</td></tr>
+      <tr><td style="padding:6px 10px;">ZR1-1.5B</td><td style="text-align:right;padding:6px 10px;">1.5B</td><td style="text-align:right;padding:6px 10px;color:var(--green);">781 MB</td><td style="text-align:right;padding:6px 10px;color:var(--green);font-weight:700;">26 tok/s ✅ ZINC GPU</td></tr>
     </table>
     </div>
   </div>


### PR DESCRIPTION
Reflect the #844 dense-GPU unlock: ZR1-1.5B runs on the C++ ZINC Vulkan backend at ~26 tok/s, token-for-token vs cpu_generic. Updates the on-device validation footnote and ZR1 rows in README + the landing page.