### PR TITLE
site: re-measure kernel benchmarks on real hardware, fix remaining stale 41-TFLOPS/35-models spots (v2, clean)

### DIFF
--- a/site/badge_gpu.json
+++ b/site/badge_gpu.json
@@ -1,7 +1,7 @@
 {
  "schemaVersion": 1,
  "label": "GPU Kernels",
- "message": "417 tok/s",
+ "message": "433 tok/s",
  "color": "00ff00",
  "style": "flat-square"
 }

--- a/site/badge_prefill.json
+++ b/site/badge_prefill.json
@@ -1,7 +1,7 @@
 {
  "schemaVersion": 1,
  "label": "Prefill",
- "message": "42.21 TFLOPS",
+ "message": "43.44 TFLOPS",
  "color": "00ff00",
  "style": "flat-square"
 }

--- a/site/benchmarks.json
+++ b/site/benchmarks.json
@@ -1,18 +1,21 @@
 {
-  "updated": "2026-07-26",
+  "updated": "2026-07-24",
+  "_updated_note": "2026-07-24 pass re-measured kernel-level entries only (see 'remeasured' key on each: q1_gemv, fused_tq2, tq2_gemv, prefill_i8) via bench_bonsai_q1_1024/bench_fused_tq2_1024/bench_bonsai_tq2_1024/bench_prefill_variants, median of 3 runs on this box's real gfx1151 hardware. Entries without a 'remeasured' key were not touched this pass and carry forward their prior value/date.",
   "source": "validated on cold GPU (single-agent, no contention)",
   "engines": {
     "q1_gemv": {
-      "tok_s": 417,
+      "tok_s": 433,
       "status": "validated",
+      "remeasured": "2026-07-24",
       "label": "Q1_0 GEMV kernel (28-layer model, 128B blocks)",
       "table": "kernel",
       "display_name": "Q1 GEMV",
       "backend": "ROCm HIP (fused kernel)"
     },
     "fused_tq2": {
-      "tok_s": 415,
+      "tok_s": 420,
       "status": "validated",
+      "remeasured": "2026-07-24",
       "label": "Fused TQ2 kernel (QKV+GU, 1.15x speedup)",
       "table": "kernel",
       "display_name": "Fused TQ2",
@@ -27,8 +30,9 @@
       "backend": "Vulkan ZINC"
     },
     "tq2_gemv": {
-      "tok_s": 355,
+      "tok_s": 367,
       "status": "validated",
+      "remeasured": "2026-07-24",
       "label": "TQ2_0 GEMV kernel (28-layer model, g128)",
       "table": "kernel",
       "display_name": "TQ2 GEMV",
@@ -37,7 +41,7 @@
     "npu_v12": {
       "tok_s": 97,
       "status": "optimized",
-      "label": "NPU v12 (97 tok/s \u2014 BS=64, memset+isfinite removal)",
+      "label": "NPU v12 (97 tok/s — BS=64, memset+isfinite removal)",
       "table": "kernel",
       "display_name": "NPU v12",
       "backend": "XDNA 2 (32 tiles)"
@@ -71,10 +75,11 @@
       "label": "Zaya pure C++ server"
     },
     "prefill_i8": {
-      "tflops": 42.21,
+      "tflops": 43.44,
       "tok_s": 0,
       "status": "validated",
-      "label": "Prefill I8-APRE: 42.2 TFLOPS INT8 WMMA",
+      "remeasured": "2026-07-24",
+      "label": "Prefill I8-APRE: 43.4 TFLOPS INT8 WMMA",
       "table": "kernel",
       "display_name": "Prefill",
       "backend": "INT8 WMMA"
@@ -180,7 +185,7 @@
     "npu_fused"
   ],
   "system": {
-    "tflops_int8": 42.21
+    "tflops_int8": 43.44
   },
   "mamba1_gpu": {
     "blackmamba_1_5b_tok_s": 79.8,

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>1bit.systems — Open-Source NPU+GPU+CPU+Mamba1 Inference Engine for AMD Strix Halo</title>
-<meta name="description" content="Model-agnostic C++ inference engine for AMD Strix Halo: Mamba1 GPU backend (BlackMamba 79.8 tok/s), NPU (XDNA 2), Vulkan, ROCm HIP, CPU. FastFlowLM fully reverse-engineered and replaced. GGUF/ONNX/1BP ternary, TQ2 2-bit, ~41 TFLOPS prefill. Zero Python. MIT.">
+<meta name="description" content="Model-agnostic C++ inference engine for AMD Strix Halo: Mamba1 GPU backend (BlackMamba 79.8 tok/s), NPU (XDNA 2), Vulkan, ROCm HIP, CPU. FastFlowLM fully reverse-engineered and replaced. GGUF/ONNX/1BP ternary, TQ2 2-bit, ~43 TFLOPS prefill. Zero Python. MIT.">
 <!-- Google Search Console: verify at https://search.google.com/search-console -->
 <!-- Add site (URL prefix: https://1bit.systems), choose HTML tag method, -->
 <!-- then replace the content value below with your GSC-provided code: -->
@@ -136,13 +136,13 @@
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "1bit.systems",
-    "description": "Model-agnostic NPU+GPU+CPU inference engine for AMD Strix Halo. FastFlowLM fully reverse-engineered and replaced with a native open-source XDNA 2 NPU stack (zero proprietary code). GGUF/ONNX/1BP ternary formats, TQ2 2-bit quantization, ~41 TFLOPS INT8 prefill peak (sourced). 35 models across 7 families, 9 backends. No Python at runtime.",
+    "description": "Model-agnostic NPU+GPU+CPU inference engine for AMD Strix Halo. FastFlowLM fully reverse-engineered and replaced with a native open-source XDNA 2 NPU stack (zero proprietary code). GGUF/ONNX/1BP ternary formats, TQ2 2-bit quantization, ~43 TFLOPS INT8 prefill peak (sourced). 40 models across 16 families, 9 backends. No Python at runtime.",
     "url": "https://1bit.systems",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Linux",
     "author": { "@type": "Person", "name": "bong-water-water-bong" },
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-    "featureList": ["Open-source native NPU stack (no FastFlowLM dependency)", "Model-agnostic GGUF/ONNX/1BP loader", "TQ2 2-bit ternary quantization", "~41 TFLOPS INT8 prefill (sourced)", "35 supported models", "9 backends", "7 model families", "NPU+GPU+CPU"]
+    "featureList": ["Open-source native NPU stack (no FastFlowLM dependency)", "Model-agnostic GGUF/ONNX/1BP loader", "TQ2 2-bit ternary quantization", "~43 TFLOPS INT8 prefill (sourced)", "40 supported models", "9 backends", "16 model families", "NPU+GPU+CPU"]
   },
   {
     "@context": "https://schema.org",
@@ -163,7 +163,7 @@
         "name": "What is 1bit.systems?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "A model-agnostic NPU+GPU+CPU inference engine for AMD Strix Halo. FastFlowLM (AMD's closed-source NPU runtime) was fully reverse-engineered and replaced with a native open-source XDNA 2 stack — no proprietary code, no Python subprocess. Reads GGUF, ONNX, and its own 1BP ternary format (including TQ2 2-bit quantization). 35 models across 7 families, 9 backends. No Python at runtime. MIT licensed."
+          "text": "A model-agnostic NPU+GPU+CPU inference engine for AMD Strix Halo. FastFlowLM (AMD's closed-source NPU runtime) was fully reverse-engineered and replaced with a native open-source XDNA 2 stack — no proprietary code, no Python subprocess. Reads GGUF, ONNX, and its own 1BP ternary format (including TQ2 2-bit quantization). 40 models across 16 families, 9 backends. No Python at runtime. MIT licensed."
         }
       },
       {
@@ -187,7 +187,7 @@
         "name": "How fast is NPU inference on Strix Halo?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "NPU-native single-binary inference engine for AMD Strix Halo (XDNA 2 + gfx1151). Sourced prefill peak ~41 TFLOPS INT8. Per-backend tok/s figures are published, with sources and honesty flags, in docs/wiki/performance.md; headline engine tok/s claims without a reproducible source are deliberately not asserted here. Speculative decoding is unresolved (undertrained checkpoint; training fix in progress)."
+          "text": "NPU-native single-binary inference engine for AMD Strix Halo (XDNA 2 + gfx1151). Sourced prefill peak ~43 TFLOPS INT8. Per-backend tok/s figures are published, with sources and honesty flags, in docs/wiki/performance.md; headline engine tok/s claims without a reproducible source are deliberately not asserted here. Speculative decoding is unresolved (undertrained checkpoint; training fix in progress)."
         }
       }
     ]
@@ -212,7 +212,7 @@
     <div>
       <span class="eyebrow">AMD Strix Halo · Ryzen AI Max+ 395</span>
       <div style="margin-top:14px;"><span class="pill warn" style="font-size:12px;height:28px;padding:0 14px;"><span class="dot"></span>⚡ One binary to rule them all</span></div>
-      <h1><span class="g">35 models.</span> 9 backends. One binary.</h1>
+      <h1><span class="g">40 models.</span> 9 backends. One binary.</h1>
       <p style="margin-top:2px;font-size:clamp(22px,2.8vw,34px);font-weight:800;letter-spacing:-.025em;line-height:1.04;color:var(--blue);">Model-agnostic inference. Zero Python. MIT.</p>
       <p class="sub">Drop any GGUF model — auto-detects architecture, quantization, and routes to NPU (XDNA 2), GPU (ROCm/Vulkan), or CPU. No config files. No model registry.</p>
       <div class="cta-row">
@@ -482,7 +482,7 @@
     <div class="foot-fine">
       <div>Built with DeepSeek v4 (99.9%) · Shipped with Claude (0.1%) · One human.</div>
       <div>Coding agent based on <a href="https://github.com/earendil-works/pi-coding-agent" style="color:var(--muted);">pi</a> (MIT, © Earendil Works). Inference engines original to this repo.</div>
-      <div><span id="binary-size6">1.1 MB</span> single binary · open-source NPU stack · <span id="tflops3">41 TFLOPS</span> prefill · MIT</div>
+      <div><span id="binary-size6">1.1 MB</span> single binary · open-source NPU stack · <span id="tflops3">43 TFLOPS</span> prefill · MIT</div>
       <div style="margin-top:8px;">—bong-water-water-bong · <span class="p">"Sorry but not Sorry :)"</span></div>
       <div style="margin-top:8px;"><a href="mailto:admin@1bit.systems" style="color:var(--muted);">admin@1bit.systems</a> · <a href="/s/" style="color:#21262d;font-size:10px;" title="stats for nerds">.</a></div>
     </div>

--- a/site/numbers.json
+++ b/site/numbers.json
@@ -1,6 +1,7 @@
 {
   "_warning": "Manually maintained. Run tools/gen_numbers.py (if available) to regenerate.",
   "_missing": [],
+  "_benchmarks_remeasured": "2026-07-24, median of 3 runs on this box's real gfx1151 hardware (bench_sherry, bench_prefill_variants) — see _sources for the exact commands.",
   "binary": {
     "zaya_bytes": 1165080,
     "zaya_kb": 1138,
@@ -15,12 +16,12 @@
     "tui_stripped_kb": 829
   },
   "benchmarks": {
-    "halo_gemv_gbps": 148.2,
-    "prefill_tflops_4h": 29.7,
-    "prefill_tflops_i8apre": 40.99,
-    "sherry_gemv_gbps": 155.2,
-    "tq1_gemv_gbps": 201.1,
-    "tflops": 40.99
+    "halo_gemv_gbps": 171.9,
+    "prefill_tflops_4h": 31.22,
+    "prefill_tflops_i8apre": 43.44,
+    "sherry_gemv_gbps": 157.2,
+    "tq1_gemv_gbps": 201.4,
+    "tflops": 43.44
   },
   "_sources": {
     "halo_gemv_gbps": "bench_sherry -- halo baseline kernel",


### PR DESCRIPTION
## Summary

Replaces #889, which got tangled with unrelated feature commits due to a branch-history race with concurrent pushes to `main` (that branch ended up 34 files / 4228 additions instead of the intended 5-file diff). This branch is cut fresh from current `main` with just the two intended commits cherry-picked on top — diff is exactly `site/index.html`, `site/benchmarks.json`, `site/numbers.json`, `site/badge_gpu.json`, `site/badge_prefill.json`.

Ran the actual benchmark binaries on this box's real gfx1151 GPU (median of 3 runs each): `bench_bonsai_q1_1024`, `bench_fused_tq2_1024`, `bench_bonsai_tq2_1024`, `bench_prefill_variants`, `bench_sherry`.

All four flagship kernel numbers came in **higher** than published — not a regression, just stale:

| Metric | Published | Re-measured |
|---|---|---|
| Q1 GEMV | 417 tok/s | **433 tok/s** |
| Fused TQ2 | 415 tok/s | **420 tok/s** |
| TQ2 GEMV | 355 tok/s | **367 tok/s** |
| Prefill (I8-APRE) | 42.2 TFLOPS | **43.4 TFLOPS** |

`benchmarks.json`'s `"updated"` field was a future date (2026-07-26) relative to today; now dated 2026-07-24 with a `remeasured` key on each specific entry that was actually re-run this pass, so it doesn't overclaim freshness for entries that weren't touched (e2e model-level numbers — `zaya_27b`, `zr1_1_5b`, BlackMamba, `npu_v12`, etc. — were **not** re-verified: no BlackMamba/Zaya/ZR1 weight files are present on disk in this environment to re-run those without a fresh download).

`badge_gpu.json`/`badge_prefill.json` regenerated to match (CI's "Badge files match benchmarks.json" check caught the initial mismatch on #889).

Also found and fixed 6 more `~41 TFLOPS` / `35 models across 7 families` spots in `index.html`'s SEO meta description, JSON-LD structured data (description/featureList/FAQPage answers ×2), and the main hero `<h1>` — these were outside the sections touched in #887's Families/Models rewrite, so they got missed.

## Test plan
- [x] All 3 re-measured kernel benchmarks run 3× each on real hardware, values are stable (±3%), median used
- [x] `grep -c "41 TFLOPS\|35 models\|7 families"` on `index.html` → 0 remaining
- [x] `python3 -c "..."` confirms badge message strings match what the generator formula produces from the new `benchmarks.json` values exactly
- [x] `git diff origin/main --stat` confirms exactly the 5 intended files, nothing else bundled in

🤖 Generated with [Claude Code](https://claude.com/claude-code)
