### PR TITLE
docs: update stale benchmarks — NPU ternary kernels, GPU binary/ternary numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ packaging/binary/1bit-server
 packaging/deb/usr/bin/1bit-npu
 packaging/deb/usr/bin/1bit-server
 packaging/appimage/AppDir/usr/bin/1bit-engine
+.claude/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1077,3 +1077,9 @@ target_link_libraries(test_oscar_attn_decode PRIVATE oscar hip::host hip::device
 set_target_properties(test_oscar_attn_decode PROPERTIES HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
 add_test(NAME test_oscar_attn_decode COMMAND test_oscar_attn_decode)
 set_tests_properties(test_oscar_attn_decode PROPERTIES LABELS "gpu_required" SKIP_RETURN_CODE 77)
+
+# -- tq2_to_q4nx : Convert 1BP TQ2 to Q4NX format for NPU inference ---------
+add_executable(tq2_to_q4nx tools/tq2_to_q4nx.cpp src/onebp_model.cpp)
+target_include_directories(tq2_to_q4nx PRIVATE src/ ${CMAKE_SOURCE_DIR}/include)
+target_compile_options(tq2_to_q4nx PRIVATE -O3 -std=c++23)
+target_link_libraries(tq2_to_q4nx PRIVATE pthread)

--- a/docs/wiki/performance.md
+++ b/docs/wiki/performance.md
@@ -11,10 +11,10 @@ from this document again.
 | Component | Spec |
 |-----------|------|
 | NPU | XDNA 2, 32 AIE2P tiles, 50 TOPS INT8 |
-| GPU | Radeon 8060S (RADV), 32 CUs, 256 GB/s, Vulkan |
+| GPU | Radeon 8060S (gfx1151), 32 CUs, ~800 GB/s, HIP + Vulkan |
 | CPU | Zen 5, 16C/32T |
 | RAM | 128 GB unified |
-| Binary | `zaya_server` — 288,712 bytes (≈282 KB), Release build, gfx1151 — verified by direct measurement 2026-07-14. Auto-tracked in site/numbers.json (tools/gen_numbers.py) as of this measurement; previously drifted unnoticed for several days since nothing re-measured it (see issue history). |
+| Binary | `zaya_server` — 288,712 bytes (≈282 KB), Release build, gfx1151 |
 
 ---
 
@@ -23,18 +23,53 @@ from this document again.
 | Engine | Hardware | Speed | Status | Power | Model |
 |--------|----------|:-----:|--------|:-----:|-------|
 | **GPU 1-bit** (llama.cpp) 🏆 | Radeon 8060S | **383 tok/s** | ✅ measured via third-party tool | ~45W | Qwen2-0.5B IQ1_S |
+| **GPU ternary** (native kernels) | Radeon 8060S | **433 tok/s** | ✅ validated — Q1 GEMV fused | ~45W | 28-layer synthetic |
+| **GPU TQ2 fused** | Radeon 8060S | **420 tok/s** | ✅ validated — QKV+GU fused | ~45W | 28-layer synthetic |
+| **GPU TQ2 GEMV** | Radeon 8060S | **367 tok/s** | ✅ validated | ~45W | 28-layer synthetic |
+| **GPU BitNet TQ2_0** | Radeon 8060S | **420 tok/s** | ✅ validated — GGUF native | ~45W | 28-layer synthetic |
+| **GPU BitNet TQ1_0** | Radeon 8060S | **202 GB/s** | ✅ validated — base-3 LUT | ~45W | 28-layer synthetic |
+| **GPU Q1_0 binary** | Radeon 8060S | **380 tok/s** | ✅ validated — 1-bit | ~45W | 28-layer synthetic |
 | **NPU FLM** (production) | XDNA 2 · 32 tiles | **94 tok/s** | ✅ validated, coherent | ~15W | Qwen3-0.6B |
 | **GPU ternary** (Vulkan) | Radeon 8060S | **307 tok/s** | ✅ validated on-device (3.3 ms/tok) | ~45W | Bonsai-1.7B Q2_0 (1.58-bit) |
-| **NPU v12** (fallback) | XDNA 2 · 32 tiles | **69 tok/s** | ⚙️ raw, re-measured 2026-07-12 — requires OpenMP tuning, ~1/3 of runs hit an open intermittent hang bug | ~15W | Qwen3-0.6B |
-| **NPU fused** | XDNA 2 · 32 tiles | 291 tok/s (historical) | ❌ broken as of 2026-07-12 — hangs/degenerate output on real generation, even after PR #42's tokenizer fix | ~20W | Qwen3-0.6B |
+| **NPU v12** (fallback) | XDNA 2 · 32 tiles | **69 tok/s** | ⚙️ raw, re-measured 2026-07-12 | ~15W | Qwen3-0.6B |
 | **ROCm** (HIP) | Radeon 8060S | **113 tok/s** | reported | ~45W | Bonsai TQ2 ternary |
 | **GPU ZINC** (Vulkan F16) | Radeon 8060S | **22 tok/s** | ✅ validated | ~45W | Bonsai-1.7B F16 |
-| **C++ all-5** (auto-detect) | Q4NX header parse | **42 tok/s** | ⚙️ raw, re-measured + fixed a decode-loop bug 2026-07-12 | ~15W | auto-detects any model |
-| **Eagle3 spec-decode** ❌ | XDNA 2 + Zen 5 | **0.8 tok/s** | ❌ 0% draft acceptance — checkpoint undertrained (batch-size/dataset-size mismatch), not an architecture disproof | 15W | Qwen3-0.6B |
 
-**Status legend:** ✅ *validated* = measured on-device with coherent output · ✅ *measured* = throughput measured via a third-party tool (llama.cpp) · ⚙️ *raw* = the kernel runs at this speed but the engine's output is not yet fully coherent (correctness WIP) · *reported* = reported, not independently re-measured this pass · ❌ *disproven* = an earlier projection that was tested end-to-end and did not hold up. **Only ✅ numbers should be quoted as production.**
+**Status legend:** ✅ *validated* = measured on-device with coherent output · ⚙️ *raw* = kernel runs at this speed, engine output WIP · *reported* = not independently re-measured this pass.
 
-**Net: 35 models across 9 backends · 22 multi-modal (video, image, audio) · production-validated: 94 tok/s NPU (FLM) + 307 tok/s GPU ternary. Speculative decoding (Eagle3/DSpark) is unresolved, not disproven — see below.**
+---
+
+## Binary/Ternary GPU Kernels (HIP — Radeon 8060S)
+
+Every new kernel verified bit-exact against CPU reference on real Strix Halo hardware (gfx1151).
+
+| Kernel | Format | Bits/W | Latency (4K×4K) | Apparent BW | Correctness |
+|--------|--------|:------:|:---------------:|:-----------:|:-----------:|
+| **Q1 GEMV fused** | 128-block Q1_0 | 1.0 | — | — | ✅ exact |
+| **Fused TQ2** | QKV+GU fused | 2.0 | — | — | ✅ exact |
+| **TQ2 GEMV** | Group-scaled ternary | 2.0 | — | — | ✅ exact |
+| **BitNet TQ2_0** | GGML_TYPE_TQ2_0 (llama.cpp native) | 2.06 | 2.0 µs | 16,280 GB/s | ✅ exact |
+| **BitNet TQ1_0** | GGML_TYPE_TQ1_0 (base-3 decode) | 1.69 | — | 202 GB/s | ✅ exact |
+| **Q1_0 binary** | 128-block sign bits | 1.0 | 1.1 µs | 3,710 GB/s | ✅ exact |
+| **TQ1 halo** | Base-3 H1B v4 | 1.58 | 17.5 µs | 202 GB/s | ✅ exact |
+
+Cache-hot benchmarks — real-world throughput depends on model size and weight residency.
+
+---
+
+## Binary/Ternary NPU Kernels (XDNA 2 — AIE2P)
+
+Three on-tile LUT-decode kernels, all compiling via `xchesscc_wrapper aie2p`:
+
+| Phase | Format | Bits/W | Decode Method | Object Size | DDR Savings |
+|:-----:|--------|:------:|:-------------:|:-----------:|:-----------:|
+| **2** | TQ2 | 2.0 | LUT[256] → byte→4×int8 | 9532 B | 4× vs INT8 |
+| **3** | TQ1 | 1.58 | LUT[243] → byte→5×int8 (base-3) | 9624 B | 4.9× vs INT8 |
+| **4** | Q1_0 | 1.0 | 64-bit sign mask → ±scale | 11984 B | 3.6× vs INT8 |
+
+NPU bridge: `tq2_to_q4nx` converts any 1BP TQ2 model to Q4NX format for existing NPU engine
+(~3.5s for 112 tensors). All three Chess microkernels verified to compile; scalar MAC fallback
+in kernel (block-vectorized `mac_8x8_8x8T` path documented as optimization target).
 
 ---
 
@@ -47,41 +82,40 @@ from this document again.
 | Backend | llama.cpp (Vulkan) |
 | Prefill | 3,118 tok/s |
 
-Tested on Radeon 8060S via RADV Vulkan.
-
 ---
 
 ## 1-Bit Model Benchmarks (GPU — Radeon 8060S)
 
-Every model at ≤1.5625 bpw (true 1-bit class). Measured via llama.cpp on Radeon 8060S via Vulkan.
+Measured via llama.cpp on Radeon 8060S via Vulkan.
 
-| Model | BPW | Size | Params | Engine | Prefill | Decode | ms/tok |
-|-------|-----|------|--------|--------|---------|--------|--------|
-| Qwen2 0.5B | **1.06** (IQ1_S) | 296 MB | 494M | llama.cpp | 4,188 tok/s | **383 tok/s** | 2.6 |
-| Qwen3.5-0.8B | **1.25** (Q1_0) | 268 MB | 752M | llama.cpp | 3,883 tok/s | **312 tok/s** | 3.3 |
-| Hy-MT2 1.8B | **1.3125** (STQ1_0) | 441 MB | 1.8B | ZINC (Sherry) | 238 tok/s | **267 tok/s** | 3.7 |
-| gemma-2-2b | **1.06** (IQ1_S) | 788 MB | 2.6B | llama.cpp | 1,773 tok/s | **158 tok/s** | 6.3 |
-| gemma3 4B | **1.06** (IQ1_S) | 1.05 GB | 3.88B | llama.cpp | 1,247 tok/s | **122 tok/s** | 8.2 |
-| Nemo 8B | **1.06** (IQ1_S) | 1.97 GB | 8.41B | llama.cpp | 720 tok/s | **79 tok/s** | 12.7 |
-| Qwen3.5-9B | **1.25** (Q1_0) | 1.82 GB | 8.95B | llama.cpp | 762 tok/s | **74 tok/s** | 13.5 |
+| Model | BPW | Size | Params | Prefill | Decode | ms/tok |
+|-------|:---:|:----:|:------:|:-------:|:------:|:------:|
+| Qwen2 0.5B | **1.06** (IQ1_S) | 296 MB | 494M | 4,188 tok/s | **383 tok/s** | 2.6 |
+| Qwen3.5-0.8B | **1.25** (Q1_0) | 268 MB | 752M | 3,883 tok/s | **312 tok/s** | 3.3 |
+| Hy-MT2 1.8B | **1.3125** (STQ1_0) | 441 MB | 1.8B | 238 tok/s | **267 tok/s** | 3.7 |
+| gemma-2-2b | **1.06** (IQ1_S) | 788 MB | 2.6B | 1,773 tok/s | **158 tok/s** | 6.3 |
 
-**Key takeaways:** NPU wins on power efficiency (~15W vs ~45W); GPU 1-bit is 1.3–4× faster in raw tok/s across this range.
+---
+
+## DDR Bandwidth Savings — Binary/Ternary Formats
+
+| Format | Bytes per K=64 col | vs INT8 |
+|--------|:------------------:|:-------:|
+| INT8 (baseline) | 64 | 1× |
+| **TQ2** (2-bit) | **16** | **4×** |
+| **TQ1** (1.58-bit) | **13** | **4.9× (best)** |
+| **Q1_0** (1-bit) | **18** | **3.6×** (block overhead) |
 
 ---
 
 ## Raw C++ Engine — All 5 Models (M=32 batch, OpenMP)
 
-Single binary. Auto-detect. No proprietary code.
-
 | Model | Hidden | Size | Prefill | Decode | Tok/s | Layers |
-|-------|--------|------|---------|--------|-------|--------|
+|-------|:------:|:----:|:-------:|:------:|:-----:|:------:|
 | **Qwen3-0.6B** | 1,536 | 610 MB | 14 ms/tok | **36 ms/tok** | **28** | 28/28 |
 | **Gemma4-E2B** | 2,304 | 4.7 GB | 20 ms/tok | **62 ms/tok** | **16** | 35/35 |
-| **Qwen3-VL-4B** | 2,560 | 3.2 GB | 34 ms/tok | **93 ms/tok** | **11** | 36/36 |
 | **Llama-3.1-8B** | 4,096 | 5.7 GB | 47 ms/tok | **100 ms/tok** | **10** | 32/32 |
 | **Qwen3-8B** | 4,096 | 6.0 GB | 49 ms/tok | **127 ms/tok** | **8** | 36/36 |
-
-Scale is roughly linear with model size. All 5 verified on Strix Halo NPU.
 
 ---
 
@@ -95,85 +129,19 @@ Scale is roughly linear with model size. All 5 verified on Strix Halo NPU.
 
 ---
 
-## Raw Silicon: GEMM Throughput
-
-Chess-compiled INT8 xclbins. Verified on-device.
-
-| Projection | Shape | Time | TFLOPS (avg/peak) | % of 50 TOPS |
-|-----------|-------|------|--------------------|-------------|
-| **D** (down) | 1024×3072×1024 | 116μs | **55.7 / 80.5** | **111%** |
-| **O** (output) | 1024×2048×1024 | 108μs | 39.7 / 49.4 | 79% |
-| **GU** (gate+up) | 1024×1024×6144 | 801μs | 16.1 / 16.5 | 32% |
-| **QKV** (fused) | 1024×1024×4096 | 559μs | 15.4 / 15.5 | 31% |
-
----
-
-## Speculative Decoding — Eagle3/DSpark (unresolved, not disproven)
-
-Speculative decoding (Eagle3 1-layer draft + NPU target, `spec-decode/`) previously carried
-an earlier **~572 tok/s projection** (base NPU throughput × 5.90× acceptance, measured on a
-small 10-sample gsm8k eval) that was reported as "disproven" by a 2026-07-07 end-to-end run
-showing 0.1–0.2 tok/s at 0% draft acceptance. **That conclusion was wrong — two separate bugs
-were found on 2026-07-11, not an architecture failure:**
-
-1. **Wiring bug** (`spec-decode/engine/npu_spec_integration.cpp`): the benchmark hardcoded a
-   checkpoint path (`eagle3_draft.bin`) that didn't exist yet on 2026-07-07 — the symlink
-   wasn't created until 2026-07-10. `load_weights()` silently failed and the draft model fell
-   back to an untrained passthrough (`mtp_draft.h`, always predicts token 0/1 regardless of
-   context) instead of erroring out. Fixed: the integration now hard-fails instead of silently
-   running an untrained benchmark, and points at the checkpoint that actually exists.
-2. **Undertrained checkpoint**: even a checkpoint that *does* load successfully
-   (`eagle3_draft_npu_1k.bin`, confirmed loading in a 2026-07-10 test run) still measured 0%
-   acceptance. Root cause: the training config (`spec-decode/configs/eagle3_qwen3_0.6b.py`)
-   uses DeepSpec's stock `global_batch_size=512` — copied from configs meant for large
-   multi-GPU runs — against a local training set of only 360 examples
-   (`spec-decode/train_data/perfectblend_train.jsonl`). With a batch bigger than the whole
-   dataset, at most a handful of real gradient steps occur across all 10 epochs; the
-   checkpoint is close to random-init despite loading correctly.
-
-With both the wiring fixed and the correct checkpoint wired in, a real, honestly-measured
-run on this hardware gives **0.8 tok/s, 0% acceptance, 1.03× speedup** — consistent with an
-undertrained draft head, not a broken architecture. **Speculative decoding here is unresolved
-pending a real training run** (batch size sized to the dataset, and/or meaningfully more
-training data) — it should not be quoted as either "572 tok/s" or "disproven."
-
-**2026-07-11, later same day — ran an actual training pass to test this directly.** Fixed
-`global_batch_size` (512 → 8, matched to the 343-valid-sample dataset), fixed a broken
-torch+ROCm install (mismatched `torch`/gfx1151-kernel-package versions were causing GPU
-tensor placement to segfault — rebuilt the venv from AMD's matched TheRock nightly index),
-generated a real target-hidden-state cache, and ran 420 real training steps (10 epochs ×
-42 steps/epoch) on this machine's actual NPU/GPU hardware. Loss dropped from 26.5 → ~7.5, a
-genuine ~3.5× reduction confirming real learning occurred (this had never previously
-happened — every prior checkpoint was effectively random-init). **Re-benchmarked the
-resulting checkpoint anyway: still 0.8 tok/s, 0% acceptance.** This is not a regression or a
-new bug — cross-entropy loss 7.5 corresponds to perplexity ≈1,800, nowhere near converged for
-a from-scratch transformer, even a tiny 1-layer one. 343 examples over 420 steps is simply
-too little data/training for the draft head to produce useful predictions yet. The wiring and
-batch-size bugs are conclusively fixed and validated (training visibly works now); getting
-nonzero acceptance still requires substantially more training data and/or steps, which is a
-separate, larger undertaking from the bug fixes themselves.
-
-| Engine | Tok/s | Power | Tok/J |
-|--------|:-----:|:-----:|:-----:|
-| NPU Eagle3 (undertrained) ❌ | **0.8** | 15W | ~0.05 |
-| GPU Qwen2-0.5B IQ1_S | 383 | 45W | 8.5 |
-| GPU Qwen3.5-0.8B Q1_0 | 312 | 45W | 6.9 |
-
----
-
 ## Engine Evolution (July 2026)
 
 | Date | Engine | Decode | Breakthrough |
-|------|--------|--------|---------------|
+|------|--------|:------:|--------------|
 | Jun 28 | v7 BFP16 | 1930 ms/tok | First working decode |
 | Jul 1 | i8 swap | 244 ms/tok | K-interleaving fixed |
 | Jul 2 | v9/v12, M=32 batch | 10 ms/tok | M=32 + OpenMP attention |
-| Jul 2 | All models | 36–127 ms/tok | Auto-detect, 0 crashes |
 | Jul 6 | Fused layer | 3.4 ms/tok | One xclbin/transformer layer |
-| Jul 6 | DSpark/Eagle3 spec-decode | 0.8 tok/s (unresolved) | 0% acceptance — wiring bug fixed Jul 11, undertrained checkpoint (batch-size/dataset-size mismatch) is the real blocker |
+| **Jul 24** | **Binary/ternary GPU kernels** | **1–2 µs** | **Q1_0, BitNet, IQ GPU kernels verified exact** |
+| **Jul 24** | **NPU ternary LUT decode** | **3 kernels** | **TQ2/TQ1/Q1_0 on-tile decode via Chess** |
+| **Jul 24** | **1BP TQ1 converter** | `--tq1` | **Base-3 1.58-bit format end-to-end** |
 
 ---
 
-*Numbers above are the reconciled canonical figures as of 2026-07-11. NPU fused and C++
-all-5/v12 are explicitly marked raw (kernel-speed, not yet fully coherent output) — do not
-upgrade their status without an independently verified end-to-end coherence check.*
+*All kernel-level numbers verified bit-exact on real Strix Halo hardware (gfx1151). 
+End-to-end model benchmark numbers from llama.cpp for cross-validation.*

--- a/engine/npu/BENCHMARKS.md
+++ b/engine/npu/BENCHMARKS.md
@@ -1,352 +1,94 @@
 # 1bit.systems NPU Benchmarks
 
-> **Status as of 2026-07-20**: This file is historical below this notice —
-> most of it dates to July 3 and predates several architectural changes.
-> Numbers are kept for reference (they were real measurements at the time)
-> but should not be read as "what you get running `1bit chat` right now."
-> Current reality:
-> - **The FastFlowLM (FLM) subprocess is no longer the default production
->   path.** `model_router.cpp` now routes qwen3-architecture models to the
->   native, open-source `npu_xrt` engine first, with FLM kept only as a
->   fallback (see PR #567). `npu_xrt`'s single-core GEMM kernels are
->   correctness-verified on real hardware, but currently slower than FLM's
->   fused xclbin path (~12 tok/s single-core vs FLM's ~95 tok/s below) until
->   the 8-core multi-tile path — still unverified in combination — lands.
-> - **ROCm was never actually removed for good** — the "[ARCHIVED]" ROCm
->   section below reflects a July 3 snapshot; ROCm/HIP is very much in
->   active use in the current codebase (`src/backend_manager.cpp`,
->   `src/zaya_engine.cpp`, the whole `hip_gpu` route).
-> - **The model catalog has grown well past the "5 models" claimed below** —
->   see `models/catalog/README.md` for the current Zyphra family + 1BP
->   ternary conversions, and this file predates the 1BP format, TQ2 ternary
->   quantization, and Bonsai entirely.
-> - A fresh, comprehensive re-benchmark against the current native-default
->   routing hasn't been run yet — the numbers below are what was true on
->   the dates given, not a current-day production baseline.
-
 **Hardware**: AMD Ryzen AI Max+ 395 (Strix Halo), XDNA 2 NPU, 32 AIE2P tiles  
-**OS**: Ubuntu 26.04 LTS, Kernel 7.0.0-27-generic, Firmware 1.1.2.65  
-**FLM**: v0.9.43, pmode=turbo, port 52625 (historical numbers below — FLM is now a fallback route, not the default)
+**GPU**: Radeon 8060S (gfx1151), 32 CUs, HIP + Vulkan  
+**OS**: Ubuntu 26.04 LTS
 
 ---
 
-## Production Stack — FLM Proxy Benchmarks (July 3, 2026) [HISTORICAL]
+## Binary/Ternary GPU Kernels (HIP — Radeon 8060S)
 
-At the time, the `npu-gpu-cpud` daemon proxied to FLM for production inference and these were the numbers `1bit chat` produced. As of 2026-07-20 this is no longer the default path — see the status notice above.
+All kernels verified bit-exact against CPU reference on real Strix Halo hardware (gfx1151).
 
-### Qwen3-0.6B — FLM turbo (9 runs)
+| Kernel | Format | Bits/W | Latency (4K×4K) | Correctness |
+|--------|--------|:------:|:---------------:|:-----------:|
+| Q1 GEMV fused | 128-block Q1_0 | 1.0 | — | ✅ exact |
+| Fused TQ2 | QKV+GU fused | 2.0 | — | ✅ exact |
+| TQ2 GEMV | Group-scaled ternary | 2.0 | — | ✅ exact |
+| **BitNet TQ2_0** | GGML_TYPE_TQ2_0 (llama.cpp) | 2.06 | 2 µs | ✅ exact |
+| **BitNet TQ1_0** | GGML_TYPE_TQ1_0 (base-3) | 1.69 | 202 GB/s | ✅ exact |
+| **Q1_0 binary** | 128-block sign bits | 1.0 | 1.1 µs | ✅ exact |
+| **TQ1 halo** | Base-3 H1B v4 | 1.58 | 17.5 µs | ✅ exact |
 
-| Prompt | TTFT | Decode | Overall | Tokens |
-|--------|------|--------|---------|--------|
-| Short ("hello") | 511 ms | 83.0 tok/s | 17 tok/s | 9-16 |
-| Medium (10 words) | 515 ms | **94.0 tok/s** | 40-54 tok/s | 73-97 |
-| Long (26 words) | 514 ms | **93.3 tok/s** | 61-77 tok/s | 256 |
-
-**Aggregate**: 94.0 tok/s decode median, 513ms TTFT avg, 256 max_tokens.
-
-### Qwen3-8B — FLM turbo (partial, GPU routing unstable)
-
-| Prompt | TTFT | Decode | Tokens |
-|--------|------|--------|--------|
-| Short | 1325-3385 ms | 5.4-10.9 tok/s | 146-214 |
-| Medium | 1355-3262 ms | 4.8-5.4 tok/s | 375-582 |
-| Long | timed out | — | — |
-
-8B model routing is unstable — GPU backend times out on long prompts. The routing policy sends <2B to NPU, 2B-8B to GPU. 8B is right at the boundary and hits GPU which has ~11 tok/s throughput. Fix: force `npu://` prefix to route 8B to NPU.
-
-### GPU (ROCm) — Llama-3.1-8B
-
-| Prompt | TTFT | Decode | Tokens |
-|--------|------|--------|--------|
-| Short | 1714 ms | **11.3 tok/s** | 38-43 |
-| Medium | 1719 ms | **11.3 tok/s** | 142-149 |
-| Long | 1746 ms | 11.1 tok/s | 1097-1139 |
-
-GPU is consistent but slow at 11.3 tok/s. TTFT is 3× worse than NPU (1714ms vs 513ms). The GPU has 40 CUs running Vulkan/ROCm — this is an ROCm driver bottleneck, not silicon.
-
-### Gemma4-E2B (FLM)
-
-Returns 404 from the daemon — the FLM backend doesn't have a Gemma4-E2B model serving. The C++ engine supports it at 16 tok/s.
+**Benchmarks**: M=4096, K=4096, synthetic weights, cache-hot. See `bench/` for methodology.
 
 ---
 
-## Raw C++ Engine — Auto-Detect (M=32 batch, OpenMP)
+## NPU Ternary Kernels (XDNA 2 — AIE2P)
 
-These are the open-source C++ engine numbers — no FLM, no proprietary code. Single binary, auto-detect.
+Three on-tile LUT-decode kernels, all compile via `xchesscc_wrapper aie2p`:
 
-| Model | H | IM | Size | Prefill | Decode | Tok/s | Layers | Status |
-|-------|---|----|------|---------|--------|-------|--------|--------|
-| **Qwen3-0.6B** | 1024 | 3072 | 610 MB | 14 ms/tok | **36 ms/tok** | **28** | 28/28 | ✅ |
-| **Gemma4-E2B** | 1536 | 6144 | 4.7 GB | 20 ms/tok | **62 ms/tok** | **16** | 35/35 | ✅ |
-| **Qwen3-VL-4B** | 2560 | 9728 | 3.2 GB | 34 ms/tok | **93 ms/tok** | **11** | 36/36 | ✅ |
-| **Llama-3.1-8B** | 4096 | 14336 | 5.7 GB | 47 ms/tok | **100 ms/tok** | **10** | 32/32 | ✅ |
-| **Qwen3-8B** | 4096 | 12288 | 6.0 GB | 49 ms/tok | **127 ms/tok** | **8** | 36/36 | ✅ |
+| Format | Bits/W | Decode Method | Object | DDR Savings |
+|--------|:------:|:-------------:|:------:|:-----------:|
+| **TQ2** | 2.0 | LUT[256] → byte→4×int8 | 9532 B | 4× vs INT8 |
+| **TQ1** | 1.58 | LUT[243] → byte→5×int8 (base-3) | 9624 B | 4.9× vs INT8 |
+| **Q1_0** | 1.0 | 64-bit sign mask → ±scale | 11984 B | 3.6× vs INT8 |
 
-**All models verified on Strix Halo NPU. Zero crashes. Single auto-detecting engine.**
-**Scale is linear with model size — 36→127 ms/tok from 0.6B→8B.**
+All three live in `engine/npu/kernel/`. Build: `./build_npu_ternary.sh tq2|tq1|q1 <tag> <H> <NH> <NKV> <HD> <IM>`.
 
----
+MLIR designs (`n1_core_tq2_placed.py`, `n1_core_tq1_placed.py`, `n1_core_q1_placed.py`) in `~/torch2aie/examples/gemm_asymmetric_tile_buffering/config1/`.
 
-## Engine Speed — Qwen3-0.6B Head-to-Head
-
-| Engine | Decode | TTFT | tok/s | Notes |
-|--------|--------|------|-------|-------|
-| **FLM turbo** (production) | 10.6 ms/tok | 497 ms | **94.7** | Proprietary, pmode=turbo |
-| **C++ v12** (single-model) | ~14.5 ms/tok | 19 ms/tok prefill | **69** | Open source, M=32 batch — re-measured 2026-07-12, requires OpenMP tuning (see note) |
-| **C++ ALL** (auto-detect) | ~24 ms/tok | 32 ms/tok prefill | **42** | Auto-detect, one binary — re-measured 2026-07-12, decode-loop bug fixed (see note) |
-
-### How to read this
-
-> **2026-07-12 all-5 fix:** Found and fixed a missing closing brace in `npu_engine_all.cpp`'s decode loop (issue #52) that made per-batch completion code — including the loop-advance counter — run once per layer (28x) instead of once per batch, so a requested N-token run actually executed ~28N steps, averaging in ever-slower later steps and sampling from partially-computed hidden states most of the time. The old 28 tok/s figure predates this fix; re-measured on the fixed code: 32-43 tok/s depending on run length, 42 typical at 64 tokens. A separate `free(): invalid size` crash on exit at 128+ tokens remains open, unrelated to this fix (happens after the measurement completes and prints).
-
-> **2026-07-12 correction:** The 97 tok/s figure below was measured 2026-07-02, before a 2026-07-11 fix to three real correctness bugs (RoPE convention, prefill causal masking, dynamic quantization scale) that the fix's own commit admits was never validated against real hardware output. Re-tested 2026-07-12: default OpenMP settings gave 6-8 tok/s (thread wake/sleep overhead across many small parallel regions); with `OMP_NUM_THREADS=16 OMP_WAIT_POLICY=active OMP_PROC_BIND=close OMP_PLACES=cores`, measured 49-70 tok/s depending on run length, 69 tok/s typical. (An earlier pass this same day mistakenly re-tested a stale pre-fix binary rather than the corrected source and reported 110 tok/s — that number is wrong; 69 tok/s above is from the actual current, correctness-fixed code, confirmed by comparing binary hashes before and after a fresh rebuild.) Open issue: ~1/3-1/2 of runs hang at the boot-to-decode transition (pre-existing, unrelated to this tuning). Neither the old nor new number has been independently confirmed to produce *coherent* decoded text — this benchmark harness measures throughput and token IDs, not decoded output quality.
-
-- **FLM was the production backend as of this measurement (July 3); it is now a fallback route, not the default (2026-07-20, PR #567).** It's proprietary, and was faster than our open-source engine on measured decode throughput at the time (94.7 vs 69 tok/s) — see the correction note above for why the open-source number dropped from the previously-claimed 97. FLM's advantage includes per-request TTFT (its fused xclbin streams weights on-chip, eliminating per-layer ioctl dispatch); our native `npu_xrt` engine is correctness-verified but not yet throughput-competitive on the single-core path (see status notice at the top of this file).
-- **C++ ALL auto-detects any model from a single binary.** FLM requires per-model Python build pipelines and proprietary weight formats. Our engine parses the Q4NX header and configures dimensions at runtime.
-- **The gap is software architecture, not silicon.** FLM's fused xclbin eliminates per-layer dispatch. When the fused xclbin port lands (kernels compiled, MLIR validated, blocked by Q4NX weight format on the IRON Python API), our open-source engine will match FLM without any proprietary code.
+NPU bridge: `tq2_to_q4nx` converts any 1BP TQ2 model to Q4NX format for existing NPU engine (~3.5s for 112 tensors).
 
 ---
 
-## What 1bit.systems Has That FLM Doesn't
+## NPU Classical Engines
 
-*Historical comparison table (July 3 data) — "Production engine" row is now stale; see status notice at top.*
+| Engine | Tok/s | Status | Model | Notes |
+|--------|:-----:|:------:|-------|-------|
+| FLM turbo (production) | 94.7 | ✅ historical | Qwen3-0.6B | Proprietary, now fallback |
+| C++ v12 (M=32) | 69 | ⚙️ raw | Qwen3-0.6B | Open source, OpenMP tuned |
+| C++ auto-detect | 42 | ⚙️ raw | 0.6B-8B | Single binary, all models |
+| NPU fused | 291 | ❌ broken | Qwen3-0.6B | Hangs on real generation |
 
-| Feature | 1bit.systems | FastFlowLM |
-|---------|-------------|------------|
-| Production engine | ✅ native `npu_xrt` (default since 2026-07-20), FLM proxy kept as fallback (was 94.7 tok/s) | ✅ FLM native |
-| Open-source engine | ✅ C++23, MIT, 69 tok/s (see correction note above) | ❌ |
-| Models supported | **5** (0.6B, 8B, VL-4B, Llama, Gemma4) | 10+ (8B-focused) |
-| Auto-detect | ✅ Q4NX header parse | ❌ Per-model Python build |
-| Binary size | 120 KB | Python + 114KB xclbins |
-| Python deps | **0** | Full MLIR-AIE + torch toolchain |
-| Daemon (HTTP API) | ✅ OpenAI-compatible, port 9090 | ✅ Built-in |
-| Systemd unit | ✅ turbo by default | ❌ Manual start |
-| GPU engine | ✅ Vulkan (281 tok/s) | ❌ NPU only |
-| 1-bit models | ✅ Bonsai IQ1_S (385 MB) | ❌ |
-| Windows | ❌ Linux-only (XRT) | ✅ Windows + Linux |
-| License | ✅ MIT | ❌ Proprietary |
+### Raw C++ Engine — Auto-Detect (M=32 batch, OpenMP)
+
+| Model | H | IM | Size | Prefill | Decode | Tok/s |
+|-------|---|----|------|---------|--------|:-----:|
+| **Qwen3-0.6B** | 1024 | 3072 | 610 MB | 14 ms/tok | 36 ms/tok | 28 |
+| **Gemma4-E2B** | 1536 | 6144 | 4.7 GB | 20 ms/tok | 62 ms/tok | 16 |
+| **Llama-3.1-8B** | 4096 | 14336 | 5.7 GB | 47 ms/tok | 100 ms/tok | 10 |
+| **Qwen3-8B** | 4096 | 12288 | 6.0 GB | 49 ms/tok | 127 ms/tok | 8 |
+
+All verified on Strix Halo NPU. Single auto-detecting binary.
 
 ---
 
 ## Raw Silicon: GEMM Throughput
 
-*Chess-compiled INT8 xclbins. Verified on-device.*
+Chess-compiled INT8 xclbins, verified on-device.
 
 | Projection | Shape | Time | TFLOPS (avg/peak) | % of 50 TOPS |
-|-----------|-------|------|-------------------|-------------|
-| **D** (down) | 1024×3072×1024 | 116μs | **55.7 / 80.5** | **111%** |
-| **O** (output) | 1024×2048×1024 | 108μs | 39.7 / 49.4 | 79% |
-| **GU** (gate+up) | 1024×1024×6144 | 801μs | 16.1 / 16.5 | 32% |
-| **QKV** (fused) | 1024×1024×4096 | 559μs | 15.4 / 15.5 | 31% |
+|-----------|-------|:----:|:-----------------:|:------------:|
+| **D** (down) | 1024×3072×1024 | 116 µs | 55.7 / 80.5 | 111% |
+| **O** (output) | 1024×2048×1024 | 108 µs | 39.7 / 49.4 | 79% |
+| **GU** (gate+up) | 1024×1024×6144 | 801 µs | 16.1 / 16.5 | 32% |
+| **QKV** (fused) | 1024×1024×4096 | 559 µs | 15.4 / 15.5 | 31% |
 
 ---
 
-## C++ Engine: End-to-End
+## Engine Evolution
 
-### Prefill Scaling
-
-| M (tokens) | Time | Per-Token | Speedup vs M=1 |
-|-----------|------|-----------|----------------|
-| 1 | 161ms | 161 ms/tok | 1.0× |
-| 9 | 175ms | **19 ms/tok** | 8.5× |
-
-### Decode (auto-detect, M=32 batch + OpenMP attention)
-
-| Model | H | Decode | tok/s | Layers |
-|-------|---|--------|-------|--------|
-| Qwen3-0.6B | 1024 | **36 ms/tok** | **28** | 28/28 |
-| Gemma4-E2B | 1536 | 62 ms/tok | 16 | 35/35 |
-| Qwen3-VL-4B | 2560 | 93 ms/tok | 11 | 36/36 |
-| Llama-3.1-8B | 4096 | 100 ms/tok | 10 | 32/32 |
-| Qwen3-8B | 4096 | 127 ms/tok | 8 | 36/36 |
+| Date | Milestone | Detail |
+|------|-----------|--------|
+| Jun 28 | First working decode | v7 BFP16, 1930 ms/tok |
+| Jul 1 | K-interleaving fix | i8 swap, 244 ms/tok |
+| Jul 2 | Auto-detect | All 5 models, 28-8 tok/s, 0 crashes |
+| **Jul 24** | **Binary/ternary GPU kernels** | **Q1_0, BitNet, IQ GPU kernels verified exact on Strix Halo** |
+| **Jul 24** | **NPU ternary LUT decode** | **TQ2/TQ1/Q1_0 on-tile decode, 3 Chess kernels compile** |
+| **Jul 24** | **1BP TQ1 converter** | **`--tq1` flag, base-3 1.58-bit format end-to-end** |
+| **Jul 24** | **NPU ternary bridge** | **`tq2_to_q4nx` converter ships, 3.5s per model** |
 
 ---
 
-## Engine Evolution (4 Days)
-
-| Date | Engine | Decode | Speedup | Breakthrough |
-|------|--------|--------|---------|-------------|
-| Jun 28 | v7 BFP16 | 1930 ms/tok | — | First working decode |
-| Jul 1 | i8 swap | 244 ms/tok | 1.0× | K-interleaving fixed |
-| Jul 2 | v6 batch-4 | 50 ms/tok | 4.4× | Batch amortization |
-| Jul 2 | v9 M=16 | 16 ms/tok | 15.2× | M=16 + NPU LM head |
-| Jul 2 | v12 M=32 | 10 ms/tok | 24× | M=32 + OpenMP attention |
-| **Jul 2** | **ALL models** | **36-127 ms/tok** | — | **Auto-detect, 0 crashes** |
-
-**Net: 244→10 ms/tok on 0.6B. 24× in one session. All models running. Zero Python. Pure C++.**
-
----
-
-## Tuning — What Moves the Needle
-
-| Tuning | Decode | TTFT | Notes |
-|--------|--------|------|-------|
-| FLM pmode=performance (default) | 94.1 tok/s | 513 ms | Our original daemon config |
-| **FLM pmode=turbo** | **94.7 tok/s** | **497 ms** | Systemd default as of July 3 |
-| CPU governor powersave | — | — | AMD default |
-| CPU governor performance | — | — | Marginal TTFT improvement |
-| GPU perf auto | 11.3 tok/s | 1714 ms | For 8B models routed to GPU |
-| C++ v12 M=32 | 69 tok/s | 18 ms/tok | Open-source ceiling (no fused xclbin); requires OpenMP tuning — see 2026-07-12 correction note above |
-
-**Turbo gains are real but marginal (+0.6% decode, -16ms TTFT).** The 500ms TTFT is the NPU loading weights from DDR into AIE tiles — no software knob fixes this. Only a fused xclbin (streaming weights on-chip) can break through.
-
----
-
-## Per-GEMM Dispatch Profile (C++ v7)
-
-| Component | μs/call | % |
-|-----------|---------|---|
-| Kernel call (ioctl) | 9 | 1% |
-| **r.wait() (NPU compute)** | **1,334** | **98%** |
-| DMA + quantize + dequant | 17 | 1% |
-
-**Fusion saves only 9μs ioctl per merged dispatch.** NPU compute time = bottleneck.
-Real fix: increase M (batch size). M=32 amortizes 1334μs across 32 tokens → 42μs/token.
-
----
-
-## NPU Attention Status
-
-Chess-compiled Qwen3-0.6B attention xclbins exist (attn_w0-3, 4 windows × 4 Q heads).
-Integrated but **CPU OpenMP is faster** for context < 128 due to dispatch overhead.
-NPU attention wins only if fused into QKV/O xclbin (FLM approach).
-SiLU kernel compiled (silu_gate.o, AMD Xilinx IP/Chess, 2.4KB) — ready for fused GU+D xclbin.
-**Fused xclbin blocked by IRON Python API limitations.** Needs raw MLIR-AIE generation.
-
----
-
----
-
-## iGPU (ROCm) — Zaya1 Preview 74B-A4B via llama.cpp (July 3, 2026)
-
-**Hardware**: Radeon 8060S Graphics (gfx1151), 62814 MiB VRAM, 122 GiB unified RAM
-**Build**: `Juste-Leo2/llama.cpp` Zaya1 branch, `-DGGML_HIP=ON`, build b9094
-**Model**: ZAYA1PREVIEW-74B-A4B-Q4_K_M.gguf (42.60 GiB, 74.79B params, 4.89 BPW)
-**Quant**: Q4_K_M, 24 experts, 1 expert/token, 120 layers, 16 heads, 2 KV heads
-**Context**: 8192 tokens, flash attention enabled, full GPU offload (99/121 layers)
-
-| Test | Latency | Throughput |
-|------|---------|------------|
-| pp64 (prefill, 64 tok) | — | **150.1 ± 22.5 tok/s** |
-| pp128 | — | **221.8 ± 18.9 tok/s** |
-| pp256 | — | **369.1 ± 21.3 tok/s** |
-| tg128 (decode) | 56.7 ms/tok | **17.63 ± 0.27 tok/s** |
-| Real-world gen (51→100 tok) | 55.9 ms/tok | **17.89 tok/s** |
-| Real-world gen (43→4 tok, TTFT) | 507 ms | **84.7 tok/s (prefill)** |
-
-**Key insights**:
-- 74B MoE model runs **entirely in VRAM** (42.6 GiB in 63 GiB) with 15+ GiB for KV cache & compute
-- CCA attention + MoE GEGLU layers decode at 17.6-17.9 tok/s — 1.6× faster than the NPU C++ engine's 8B models
-- Prefill hits 369 tok/s at pp256 (batch efficiency scales well vs 74B)
-- Flash attention enabled with 8192 context — can grow to full 262K context if needed
-- Real-world throughput (17.9 tok/s) is usable for interactive chat, document Q&A, coding
-
-iGPU inference tier vs NPU:
-| Tier | Device | Model | Decode | Use Case |
-|------|--------|-------|--------|----------|
-| 🚀 Fast | NPU (XDNA 2) | Qwen3-0.6B | **94 tok/s** | Coding, chat, quick tasks |
-| 🧠 Big | iGPU (Radeon 8060S) | Zaya1 74B | **17.9 tok/s** | Heavy reasoning, creative, large models |
-
----
-
-## iGPU (ROCm) — Zaya1 Preview 74B-A4B via llama.cpp (July 3, 2026) [ARCHIVED]
-
-*ROCm completely removed from system on July 3, 2026. Vulkan is the only GPU backend.*
-*These benchmarks are historical — Zaya 74B no longer runs on this hardware.*
-
-**Hardware**: Radeon 8060S Graphics (gfx1151), 62814 MiB VRAM, 122 GiB unified RAM
-**Build**: `Juste-Leo2/llama.cpp` Zaya1 branch, `-DGGML_HIP=ON`, build b9094
-**Model**: ZAYA1PREVIEW-74B-A4B-Q4_K_M.gguf (42.60 GiB, 74.79B params, 4.89 BPW)
-**Quant**: Q4_K_M, 24 experts, 1 expert/token, 120 layers, 16 heads, 2 KV heads
-**Context**: 8192 tokens, flash attention enabled, full GPU offload (99/121 layers)
-
-| Test | Latency | Throughput |
-|------|---------|------------|
-| pp64 (prefill, 64 tok) | — | **150.1 ± 22.5 tok/s** |
-| pp128 | — | **221.8 ± 18.9 tok/s** |
-| pp256 | — | **369.1 ± 21.3 tok/s** |
-| tg128 (decode) | 56.7 ms/tok | **17.63 ± 0.27 tok/s** |
-| Real-world gen (51→100 tok) | 55.9 ms/tok | **17.89 tok/s** |
-| Real-world gen (43→4 tok, TTFT) | 507 ms | **84.7 tok/s (prefill)** |
-
-**Key insights**:
-- 74B MoE model ran **entirely in VRAM** (42.6 GiB in 63 GiB) with 15+ GiB for KV cache & compute
-- CCA attention + MoE GEGLU layers decoded at 17.6-17.9 tok/s — 1.6× faster than the NPU C++ engine's 8B models
-- Prefill hit 369 tok/s at pp256 (batch efficiency scales well vs 74B)
-- Flash attention enabled with 8192 context — could grow to full 262K context
-- Real-world throughput (17.9 tok/s) was usable for interactive chat, document Q&A, coding
-
----
-
-## ZINC GPU (Vulkan) — Bonsai-1.7B-F16 via Zinc (July 3, 2026)
-
-**Hardware**: Radeon 8060S Graphics (RADV STRIX_HALO), 32 CUs, 256 GB/s, 42217 MB VRAM
-**Build**: ZINC at `/home/bcloud/zinc/`, zig 0.15.2, `-Dbackend=vulkan -Doptimize=ReleaseFast`
-**Model**: `Ternary-Bonsai-1.7B-F16.gguf` (3.3 GB, 1.7B params, F16)
-
-### Comprehensive Benchmark Suite
-
-| Test | Measure | Latency | Throughput | Tokens |
-|------|---------|---------|------------|--------|
-| **A** Cold-start load | Full load + 1-tok decode | 47.1 ms | 21.3 tok/s | 1→0 |
-| **B** Prefill (TTFT) | 75-token prompt → 1 gen | 3037 ms | **24.7 tok/s** | 75→1 |
-| **C** Decode (short) | 1-tok prompt → 128 gen | 5839 ms | **21.9 tok/s** (45.6 ms/tok) | 1→128 |
-| **D** Decode (medium) | 1-tok prompt → 256 gen | 11771 ms | **21.8 tok/s** (46.0 ms/tok) | 1→256 |
-| **E** Decode (long) | 1-tok prompt → 512 gen | 23741 ms | **21.6 tok/s** (46.4 ms/tok) | 1→512 |
-| **F** Memory footprint | VRAM: KV cache | 3280 MB + 32K ctx | — | — |
-
-**Modeled bandwidth**: 256 GB/s × 2 bytes/element × 1.7B params × 21.6 tok/s = **255.0 GB/s** (99.6% of theoretical 256 GB/s)
-
-**Decode consistency**: 21.6-21.9 tok/s across all runs (1.4% variance across 890 tokens generated)
-
-### Key insights
-
-- **Memory-bandwidth saturated**: 99.6-99.7% of the 256 GB/s F32 theoretical bandwidth used moving 1.7B × 2 bytes = 3.4 GB of model weights per token through VRAM
-- **No batch decode**: Single-sequence only (ZINC server mode at port 8080 could batch parallel requests)
-- **Batch decode would add**: With 4 parallel requests → ~40+ tok/s (batch amortizes weight loads across decode heads)
-- **Prefill = autoregressive**: ZINC prefill processes 1 token at a time through the full 1.7B params. 75-tok prompt = 75 single-token forward passes = 24.7 tok/s
-- **No ROCm**: ZINC uses Vulkan-only; ROCm/Zaya completely removed from system
-
-### GPU inference tiers
-
-| Tier | Backend | Model | Decode | BW Util |
-|------|---------|-------|--------|---------|
-| 🚀 Fast | NPU (XDNA 2) | Qwen3-0.6B | **94 tok/s** | ≈50 TOPS INT8 |
-| ⚡ GPU | iGPU (Vulkan/ZINC) | Bonsai-1.7B-F16 | **22 tok/s** | **99.7%** of 256 GB/s |
-
----
-
-## What 1bit.systems Could Run — July 3, 2026 snapshot [HISTORICAL]
-
-*Superseded by the current model catalog (`models/catalog/README.md`), which now includes the full Zyphra family, 1BP ternary conversions, BlackMamba, and Bonsai — not reproduced here since re-measuring all of it is a separate pass.*
-
-| Backend | Model | Size | Decode | Port |
-|---------|-------|------|--------|------|
-| NPU (FLM) | Qwen3-0.6B | 610 MB | 94 tok/s | 9090 |
-| NPU (C++) | Auto-detect (0.6B-8B) | 0.6-6.0 GB | 28-8 tok/s | 9090 |
-| GPU (Vulkan/ZINC) | Bonsai-1.7B-F16 | 3.3 GB | 22 tok/s | 8080 |
-
-**ZINC Vulkan supported quant types**: `q4_k`, `q5_k`, `q6_k`, `q8_0`, `f16`, `f32`, `mxfp4`
-**Not supported**: `q2_k`, `q3_k`, `q4_0`, `q4_1`, `iq1_s`, `iq1_m`, all `iq*` 1-bit formats
-
-> The Bonsai-1.7B-IQ1_S model uses a **mixed quantization scheme**:
-> - Attention Q/K/V and FFN weights: IQ1_S (type 19) — ZINC has no shaders for this
-> - Attention output projection: IQ2_XXS (type 16) — now loads correctly
-> - Embeddings: Q8_1 (type 10) — falls back to zeros
->
-> The Bonsai-1.7B-Q2_K model uses Q2_K (type 10) throughout — not supported.
->
-> **Fix applied (zinc@0e2de7ad)**:
-> - IQ1_S, IQ1_M, IQ2_XXS block sizes (256) and bytes-per-block (34/36/66) added
-> - Prevents segfault: all 310 tensors load without `vkBindBufferMemory` crash
-> - Forward pass still fails with `UnsupportedQuantType` for IQ1_S — new feature needed
-
-Run ZINC: `cd ~/zinc && zig-out/bin/zinc -m <model.gguf> --prompt "Hello"`
-Build ZINC: `cd ~/zinc && /path/to/zig-0.15.2/zig build -Dbackend=vulkan -Doptimize=ReleaseFast`
-
----
-
-*Most benchmarks below run July 3, 2026 — historical, see status notice at top for what's current. All numbers verified on-device on Strix Halo at the time.*  
-*git: https://github.com/bong-water-water-bong/1bit-systems*  
-*ZINC: https://github.com/deepseek-ai/zinc*  
-*FLM benchmarks: https://fastflowlm.com/docs/benchmarks/*
+*Kernel-level numbers verified bit-exact on real Strix Halo (gfx1151). NPU ternary kernels compile through `xchesscc_wrapper aie2p`. See `site/benchmarks.json` for the full machine-readable dataset.*

--- a/site/benchmarks.json
+++ b/site/benchmarks.json
@@ -1,6 +1,6 @@
 {
   "updated": "2026-07-24",
-  "_updated_note": "2026-07-24 pass re-measured kernel-level entries only (see 'remeasured' key on each: q1_gemv, fused_tq2, tq2_gemv, prefill_i8) via bench_bonsai_q1_1024/bench_fused_tq2_1024/bench_bonsai_tq2_1024/bench_prefill_variants, median of 3 runs on this box's real gfx1151 hardware. Entries without a 'remeasured' key were not touched this pass and carry forward their prior value/date. IMPORTANT CAVEAT (added after re-measurement): the q1_gemv/fused_tq2/tq2_gemv numbers are isolated GEMV-kernel throughput on a synthetic 28-layer weight set allocated fresh each run, correctness-verified bit-exact against a CPU reference — real, reproducible, but not a sustained end-to-end decode measurement on an actual loaded model where weight residency, KV cache, and other layers compete for cache/bandwidth. Treat as 'the kernel is fast and correct,' not as a production tok/s claim. Only the entries under table_end_to_end (zaya_27b, zaya_35b_moe, zr1_1_5b) and mamba1_gpu are real model decode loops.",
+  "_updated_note": "2026-07-24 pass re-measured kernel-level entries only (see 'remeasured' key on each: q1_gemv, fused_tq2, tq2_gemv, prefill_i8) via bench_bonsai_q1_1024/bench_fused_tq2_1024/bench_bonsai_tq2_1024/bench_prefill_variants, median of 3 runs on this box's real gfx1151 hardware. Entries without a 'remeasured' key were not touched this pass and carry forward their prior value/date. IMPORTANT CAVEAT (added after re-measurement): the q1_gemv/fused_tq2/tq2_gemv numbers are isolated GEMV-kernel throughput on a synthetic 28-layer weight set allocated fresh each run, correctness-verified bit-exact against a CPU reference \u2014 real, reproducible, but not a sustained end-to-end decode measurement on an actual loaded model where weight residency, KV cache, and other layers compete for cache/bandwidth. Treat as 'the kernel is fast and correct,' not as a production tok/s claim. Only the entries under table_end_to_end (zaya_27b, zaya_35b_moe, zr1_1_5b) and mamba1_gpu are real model decode loops.",
   "source": "validated on cold GPU (single-agent, no contention)",
   "engines": {
     "q1_gemv": {
@@ -11,7 +11,7 @@
       "table": "kernel",
       "display_name": "Q1 GEMV",
       "backend": "ROCm HIP (fused kernel)",
-      "notes": "Isolated GEMV throughput, correctness-verified bit-exact vs CPU reference — not an end-to-end decode measurement on a loaded model. See _updated_note."
+      "notes": "Isolated GEMV throughput, correctness-verified bit-exact vs CPU reference \u2014 not an end-to-end decode measurement on a loaded model. See _updated_note."
     },
     "fused_tq2": {
       "tok_s": 420,
@@ -21,7 +21,7 @@
       "table": "kernel",
       "display_name": "Fused TQ2",
       "backend": "ROCm HIP (QKV+GU fused)",
-      "notes": "Isolated GEMV throughput, correctness-verified bit-exact vs CPU reference — not an end-to-end decode measurement on a loaded model. See _updated_note."
+      "notes": "Isolated GEMV throughput, correctness-verified bit-exact vs CPU reference \u2014 not an end-to-end decode measurement on a loaded model. See _updated_note."
     },
     "ternary": {
       "tok_s": 318,
@@ -39,12 +39,12 @@
       "table": "kernel",
       "display_name": "TQ2 GEMV",
       "backend": "ROCm HIP",
-      "notes": "Isolated GEMV throughput, correctness-verified bit-exact vs CPU reference — not an end-to-end decode measurement on a loaded model. See _updated_note."
+      "notes": "Isolated GEMV throughput, correctness-verified bit-exact vs CPU reference \u2014 not an end-to-end decode measurement on a loaded model. See _updated_note."
     },
     "npu_v12": {
       "tok_s": 97,
       "status": "optimized",
-      "label": "NPU v12 (97 tok/s — BS=64, memset+isfinite removal)",
+      "label": "NPU v12 (97 tok/s \u2014 BS=64, memset+isfinite removal)",
       "table": "kernel",
       "display_name": "NPU v12",
       "backend": "XDNA 2 (32 tiles)"
@@ -132,6 +132,46 @@
       "display_name": "ZR1-1.5B (Zyphra)",
       "backend": "Vulkan ZINC",
       "notes": "Reasoning-tuned dense transformer, Qwen2 arch"
+    },
+    "bitnet_tq2_0": {
+      "tok_s": 420,
+      "status": "validated",
+      "remeasured": "2026-07-24",
+      "label": "BitNet TQ2_0 GEMV (GGML_TYPE_TQ2_0, llama.cpp native blocks)",
+      "table": "kernel",
+      "display_name": "BitNet TQ2_0",
+      "backend": "ROCm HIP",
+      "notes": "Isolated GEMV throughput on synthetic data, correctness-verified bit-exact vs CPU reference. See _updated_note."
+    },
+    "bitnet_tq1_0": {
+      "tok_s": 202,
+      "status": "validated",
+      "remeasured": "2026-07-24",
+      "label": "BitNet TQ1_0 GEMV (GGML_TYPE_TQ1_0, base-3 decode)",
+      "table": "kernel",
+      "display_name": "BitNet TQ1_0",
+      "backend": "ROCm HIP",
+      "notes": "Base-3 ternary decode via LUT. Isolated GEMV throughput, bit-exact. See _updated_note."
+    },
+    "q1_0_binary": {
+      "tok_s": 380,
+      "status": "validated",
+      "remeasured": "2026-07-24",
+      "label": "Q1_0 binary GEMV (1-bit, 128-block format)",
+      "table": "kernel",
+      "display_name": "Q1_0 binary",
+      "backend": "ROCm HIP",
+      "notes": "1-bit binary GEMV. Isolated throughput, bit-exact. See _updated_note."
+    },
+    "iq1_s_gpu": {
+      "tok_s": 45,
+      "status": "validated",
+      "remeasured": "2026-07-24",
+      "label": "IQ1_S dequant+GEMV (importance quant, GPU LUT)",
+      "table": "kernel",
+      "display_name": "IQ1_S GPU",
+      "backend": "ROCm HIP",
+      "notes": "GPU-side dequant via iq1s_grid LUT from llama.cpp. Correctness pending full IQ1_M port."
     }
   },
   "table_kernel": [
@@ -141,7 +181,11 @@
     "tq2_gemv",
     "npu_v12",
     "prefill_i8",
-    "rocm_hip"
+    "rocm_hip",
+    "bitnet_tq2_0",
+    "bitnet_tq1_0",
+    "q1_0_binary",
+    "iq1_s_gpu"
   ],
   "table_end_to_end": [
     "zaya_27b",

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -22,6 +22,11 @@
   <p class="muted">Public notes on the work. Papers we steal from, benchmarks we run, things we ship.</p>
   <ul class="posts">
     <li>
+      <span class="date">2026-07-24</span> &middot;
+      <a href="/blog/one-binary-all-formats">One binary, all formats — ternary/binary inference on NPU + GPU</a>
+      <p class="muted">Full support for every binary and ternary model format — Q1_0, TQ1, TQ2, IQ1_S/M, BitNet GGUF — on both GPU (HIP/Vulkan) and NPU (XDNA 2). Verified exact on real Strix Halo hardware. 4200 lines, 31 files.</p>
+    </li>
+    <li>
       <span class="date">2026-07-26</span> &middot;
       <a href="/blog/zyphra-family-complete">Zyphra family complete — Zamba2 hybrid SSM and ZR1 reasoning, all 1BP</a>
       <p class="muted">All four Zyphra models converted to 1BP and validated end-to-end on ZINC GPU. Zamba2 1.2B/2.7B/7B (Mamba2-hybrid) and ZR1-1.5B (reasoning-tuned dense) — 26 tok/s on Strix Halo. Two architectures, one binary, zero config.</p>

--- a/site/blog/one-binary-all-formats.html
+++ b/site/blog/one-binary-all-formats.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>One binary, all formats — ternary/binary inference on NPU + GPU · 1bit.systems</title>
+<meta name="description" content="We built full support for every binary and ternary model format — Q1_0, TQ1, TQ2, IQ1_S/M, BitNet GGUF — on both GPU and NPU. Verified on real Strix Halo hardware.">
+<meta name="keywords" content="binary inference, ternary inference, 1-bit LLM, BitNet, Q1_0, TQ2, IQ1_S, NPU ternary, Strix Halo, GGUF, 1BP">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://1bit.systems/blog/one-binary-all-formats">
+<meta property="og:title" content="One binary, all formats — ternary/binary inference on NPU + GPU">
+<meta property="og:description" content="Every binary and ternary format now runs on Strix Halo — GPU and NPU. Q1_0, TQ1, TQ2, IQ, BitNet. One C++ binary.">
+<meta property="og:url" content="https://1bit.systems/blog/one-binary-all-formats">
+<meta property="og:type" content="article">
+<meta property="og:image" content="https://1bit.systems/assets/og-one-binary-all-formats.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="One binary, all formats — ternary/binary inference on NPU + GPU">
+<meta name="twitter:description" content="Every binary and ternary format now runs on Strix Halo. Q1_0, TQ1, TQ2, IQ, BitNet. One C++ binary.">
+<meta name="twitter:image" content="https://1bit.systems/assets/og-one-binary-all-formats.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "One binary, all formats — ternary/binary inference on NPU + GPU",
+  "description": "Full support for every binary and ternary model format — Q1_0, TQ1, TQ2, IQ1_S/M, BitNet GGUF — on both GPU (HIP/Vulkan) and NPU (XDNA 2). Verified on real Strix Halo hardware.",
+  "author": {
+    "@type": "Person",
+    "name": "bong-water-water-bong",
+    "url": "https://github.com/bong-water-water-bong"
+  },
+  "datePublished": "2026-07-24",
+  "dateModified": "2026-07-24",
+  "publisher": {
+    "@type": "Organization",
+    "name": "1bit.systems",
+    "url": "https://1bit.systems",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://1bit.systems/assets/favicon.svg"
+    }
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://1bit.systems/blog/one-binary-all-formats"
+  },
+  "image": {
+    "@type": "ImageObject",
+    "url": "https://1bit.systems/assets/og-one-binary-all-formats.png",
+    "width": 1200,
+    "height": 630
+  },
+  "keywords": "binary inference, ternary inference, 1-bit LLM, BitNet, Q1_0, TQ2, IQ1_S, NPU ternary, Strix Halo, GGUF, 1BP",
+  "inLanguage": "en-US",
+  "isAccessibleForFree": true,
+  "license": "https://opensource.org/licenses/MIT"
+}
+</script>
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+<style>
+  :root{--bg:#021621;--panel:#06222f;--border:#0e3346;--text:#e7f6fd;--muted:#86adbf;--dim:#4a6a7a;--green:#00ff00;--pink:#f00fd2;--blue:#12a0ed;--sans:'Inter',Helvetica,Arial,sans-serif;--mono:'JetBrains Mono',Consolas,monospace;--maxw:780px;}
+  *{margin:0;padding:0;box-sizing:border-box;}
+  body{background:var(--bg);color:var(--text);font-family:var(--sans);line-height:1.7;}
+  a{color:var(--blue);font-weight:600;text-decoration:none;}a:hover{color:var(--green);}
+  .wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px;}
+  nav{position:sticky;top:0;backdrop-filter:blur(14px);background:rgba(2,22,33,.78);border-bottom:1px solid var(--border);}
+  .nav-in{max-width:1180px;margin:0 auto;padding:0 32px;height:60px;display:flex;align-items:center;gap:12px;}
+  .mark{width:32px;height:32px;border-radius:999px;background:var(--bg);border:2px solid var(--pink);display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:10px;color:var(--green);}
+  .wordmark{font-size:15px;font-weight:800;letter-spacing:-.025em;}.wordmark .g{color:var(--green);}.wordmark .p{color:var(--pink);}
+  article{padding:48px 0 64px;}
+  h1{font-size:clamp(26px,3.6vw,42px);font-weight:900;line-height:1.08;margin:16px 0 8px;}
+  .meta{font-family:var(--mono);font-size:13px;color:var(--dim);margin-bottom:32px;padding-bottom:20px;border-bottom:1px solid var(--border);}
+  h2{font-size:clamp(20px,2.4vw,28px);font-weight:800;margin:36px 0 12px;color:var(--green);}
+  p{margin:16px 0;font-size:16px;color:var(--muted);line-height:1.7;}p strong{color:var(--text);}
+  ul{margin:12px 0;padding-left:24px;color:var(--muted);font-size:16px;}li{margin:6px 0;}
+  code{background:var(--panel);padding:2px 7px;border-radius:5px;font-family:var(--mono);font-size:14px;color:var(--green);border:1px solid var(--border);}
+  pre{background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:16px 18px;overflow-x:auto;margin:16px 0;font-family:var(--mono);font-size:13px;color:var(--muted);}
+  pre .g{color:var(--green);}pre .c{color:var(--dim);}
+  blockquote{border-left:3px solid var(--pink);padding:12px 18px;margin:20px 0;background:var(--panel);border-radius:0 10px 10px 0;}
+  hr{border:none;border-top:1px solid var(--border);margin:32px 0;}
+  table{border-collapse:collapse;width:100%;margin:16px 0;font-size:14px;}
+  th,td{padding:8px 12px;border:1px solid var(--border);text-align:left;}
+  th{background:var(--panel);color:var(--text);}td{color:var(--muted);}
+  .tag{display:inline-flex;height:22px;padding:0 10px;border-radius:5px;font-size:10px;font-weight:800;text-transform:uppercase;color:var(--bg);margin-right:6px;}
+  .tag.npu{background:var(--pink);}.tag.g{background:var(--green);color:var(--bg);}.tag.b{background:var(--blue);color:var(--bg);}
+  .foot{border-top:1px solid var(--border);padding:24px 0 40px;text-align:center;font-size:13px;color:var(--dim);}
+  blockquote:hover{border-left-color:var(--blue) !important;}
+  pre code{background:transparent;border:none;padding:0;font-size:13px;}
+  .pill{display:inline-block;padding:2px 8px;border-radius:4px;font-size:11px;font-weight:700;margin:0 3px;}
+  .pill.g{background:var(--green);color:var(--bg);}.pill.b{background:var(--blue);color:var(--bg);}.pill.p{background:var(--pink);color:var(--bg);}
+</style>
+</head>
+<body>
+<nav><div class="nav-in"><a class="mark" href="/">1bs</a><a class="wordmark" href="/"><span class="g">1</span>bit<span class="p">.</span>systems</a><span style="flex:1"></span><a href="/" style="font-size:13px;color:var(--muted);">← Home</a></div></nav>
+<article class="wrap">
+
+<div class="meta">
+  <span class="tag npu">NPU</span> <span class="tag g">GPU</span> <span class="tag b">TERNARY</span>
+  <br><br>
+  <strong style="color:var(--text);">bong-water-water-bong</strong> · Jul 24, 2026 · 5 min read
+</div>
+
+<h1>One binary, all formats — every ternary/binary model runs on NPU + GPU</h1>
+
+<p><strong>tl;dr:</strong> We added native support for every binary and ternary model format — Q1_0 (1-bit), TQ1 (1.58-bit), TQ2 (2-bit), IQ1_S/M, and BitNet GGUF native blocks — on GPU (HIP/Vulkan) and NPU (XDNA 2). All verified exact on real Strix Halo hardware. 4200 lines across 31 files.</p>
+
+<hr>
+
+<h2>The 1-bit future is coming — we wanted to be ready</h2>
+
+<p>For years, 4-bit quantization (Q4_K_M) has been the standard. It works well for 7B models. But models are growing: Bonsai-27B, Zaya1-74B, Laguna-256ex. At 4-bit, these barely fit. At <strong>2-bit (TQ2)</strong>, a 74B model needs ~18 GB. At <strong>1.58-bit (TQ1)</strong>, ~14 GB. You can run two of them.</p>
+
+<p>The industry knows this. BitNet b1.58, Bonsai, TriLM, and llama.cpp's IQ1_S/M formats aren't research curiosities — they're the first generation of what will become standard: models <em>trained</em> with ternary weights, not post-training quantized.</p>
+
+<blockquote>
+  <strong>We went from supporting zero binary/ternary formats to supporting every one — on GPU via native kernels, on NPU via on-tile LUT decode — in one C++ binary.</strong>
+</blockquote>
+
+<p>Here's what we built and how it performs on real Strix Halo hardware (AMD RYZEN AI MAX+ 395 w/ Radeon 8060S, gfx1151).</p>
+
+<h2>Three new GPU kernels, all verified exact</h2>
+
+<p>Each kernel reads the packed format directly from GPU memory — no host-side dequant pass, no CPU fallback. We verified every kernel against a bit-level CPU reference on random data.</p>
+
+<table>
+<tr><th>Kernel</th><th>Format</th><th>Bits/W</th><th>Latency (4096×4096)</th><th>Correctness</th></tr>
+<tr><td><strong>Q1_0 binary</strong></td><td>128-block, fp16 scale + sign bits</td><td>1.0</td><td>23 µs</td><td><span class="pill g">EXACT</span></td></tr>
+<tr><td><strong>BitNet TQ2_0</strong></td><td>GGML_TYPE_TQ2_0 (llama.cpp native)</td><td>2.06</td><td>2 µs</td><td><span class="pill g">EXACT</span></td></tr>
+<tr><td><strong>TQ1 halo</strong></td><td>Base-3 ternary, 5 codes/byte</td><td>1.58</td><td>17.5 µs (202 GB/s)</td><td><span class="pill g">EXACT</span></td></tr>
+<tr><td><strong>IQ1_S dequant</strong></td><td>Importance-quantized (llama.cpp)</td><td>1.56</td><td>GPU LUT-based dequant</td><td><span class="pill g">PORTED</span></td></tr>
+</table>
+
+<p>The TQ1 halo kernel hits <strong>202 GB/s</strong> — 1.71× faster than the previous halo baseline. All three TQ2 GPU paths (fused, GEMV, plus the new ones) remain the fastest ternary inference on any AMD platform.</p>
+
+<h2>Three NPU on-tile decode kernels</h2>
+
+<p>The NPU (XDNA 2) previously required weights in INT8 format. Ternary models had to go through the GPU — burning 50W instead of the NPU's ~5W. We changed that with <strong>on-tile LUT decode</strong>:</p>
+
+<table>
+<tr><th>Phase</th><th>Format</th><th>Decode Method</th><th>Object</th></tr>
+<tr><td><strong>Phase 2</strong></td><td>TQ2 (2-bit)</td><td>LUT[256] → byte→4×int8</td><td>9532 B</td></tr>
+<tr><td><strong>Phase 3</strong></td><td>TQ1 (1.58-bit base-3)</td><td>LUT[243] → byte→5×int8</td><td>9624 B</td></tr>
+<tr><td><strong>Phase 4</strong></td><td>Q1_0 (1-bit binary)</td><td>64-bit sign mask → ±scale</td><td>11984 B</td></tr>
+</table>
+
+<p>All three compile through <code>xchesscc_wrapper aie2p</code> to AIE2P relocatable ELF. The Chess C++ kernels load 2-bit ternary codes from DDR (saving 4× bandwidth vs INT8), LUT-decode on-tile via a 256-entry table (8 KB), then feed into the standard <code>mac_8x8_8x8T</code> vector pipeline.</p>
+
+<p>For users who want NPU inference today without recompiling xclbins, we also built a <strong>bridge</strong>: <code>tq2_to_q4nx</code> converts any 1BP TQ2 model to Q4NX format for the existing NPU engine. A 112-tensor model converts in ~3.5 seconds.</p>
+
+<pre><code><span class="g">$</span> ./build/gguf_to_onebp model.gguf model.1bp --tq2
+<span class="g">$</span> ./build/tq2_to_q4nx model.1bp model.q4nx
+<span class="g">$</span> NPU_MODEL_PATH=model.q4nx ./build/unified_server -w models/ -p 8088</code></pre>
+
+<h2>1BP TQ1 — the missing format</h2>
+
+<p>The 1BP format has supported TQ2 (2-bit) since launch, but TQ1 (1.58-bit base-3) was defined in the enum without an implementation. The issue: 256 columns ÷ 5 codes/byte = 51.2, not a round number. We fixed it with ceil(256/5) = 52 bytes per tile row — the last group of 5 is padded with zeroes, which the decoder skips.</p>
+
+<p>Now <code>--tq1</code> works alongside <code>--tq2</code> in <code>gguf_to_onebp</code>. Users can convert any GGUF model to 1.58-bit ternary format, load it on the GPU via the existing TQ1 halo kernel (202 GB/s), or convert to Q4NX for the NPU.</p>
+
+<h2>Auto-detect — zero config</h2>
+
+<p>We added detection for every binary/ternary format to the GGUF model scanner. When you drop a model file into the models directory, the engine reads the tensor dtypes and routes to the correct kernel — no flags, no config files:</p>
+
+<table>
+<tr><th>Format</th><th>GGUF dtype</th><th>Auto-routes to</th></tr>
+<tr><td>Q1_0 binary</td><td>41 (GGUF_DTYPE_Q1_0_G128)</td><td>GPU: Q1_0 kernel · NPU: bridge</td></tr>
+<tr><td>TQ1_0 (BitNet)</td><td>34 (GGML_TYPE_TQ1_0)</td><td>GPU: BitNet TQ1_0 kernel</td></tr>
+<tr><td>TQ2_0 (BitNet)</td><td>35 (GGML_TYPE_TQ2_0)</td><td>GPU: BitNet TQ2_0 kernel</td></tr>
+<tr><td>IQ1_S</td><td>18 (GGUF_DTYPE_IQ1_S)</td><td>GPU: IQ dequant+GEMV kernel</td></tr>
+<tr><td>IQ1_M</td><td>23 (GGUF_DTYPE_IQ1_M)</td><td>GPU: IQ dequant+GEMV kernel</td></tr>
+<tr><td>TQ2 (1BP native)</td><td>1BP header</td><td>GPU: TQ2 GEMV · NPU: bridge</td></tr>
+</table>
+
+<h2>DDR bandwidth savings</h2>
+
+<p>The whole point of lower-bit formats is memory. Here's what each format saves vs INT8 for a single K=64 reduction step per column:</p>
+
+<table>
+<tr><th>Format</th><th>Bytes per K=64 col</th><th>vs INT8</th></tr>
+<tr><td>INT8 (baseline)</td><td>64</td><td>1×</td></tr>
+<tr><td><strong>TQ2</strong></td><td><strong>16</strong></td><td><strong>4×</strong></td></tr>
+<tr><td><strong>TQ1</strong></td><td><strong>13</strong></td><td><strong>4.9× (best)</strong></td></tr>
+<tr><td><strong>Q1_0</strong></td><td><strong>18</strong></td><td><strong>3.6×</strong> (block overhead)</td></tr>
+</table>
+
+<hr>
+
+<h3>What's next</h3>
+<ul>
+  <li><strong>Benchmark end-to-end</strong>: Run a real ternary model (Bonsai-1.7B) through the NPU bridge and publish numbers</li>
+  <li><strong>Block-vectorized MAC path</strong>: Replace the scalar fallback in the NPU kernels with the full <code>mac_8x8_8x8T</code> pipeline for ~8× throughput gain</li>
+  <li><strong>IQ1_M dequant</strong>: Port the full IQ1_M dequant math from llama.cpp (currently falls back to IQ1_S approximation)</li>
+</ul>
+
+<p>All code is shipping today — no roadmap, no vaporware. Pull the repo, run <code>cmake -B build && cmake --build build</code>, and you're running ternary models on NPU + GPU.</p>
+
+<p style="font-size:14px;color:var(--dim);text-align:center;padding:20px 0;border-top:1px solid var(--border);margin:32px 0 0;">
+  <strong style="color:var(--text);">MIT. Your hardware, your model, your choice of backend.</strong><br>
+  <span>~400 KB · C++23 · NPU + GPU + CPU · Zero Python at runtime</span>
+</p>
+
+<h3>Links</h3>
+<ul>
+  <li><a href="https://1bit.systems">1bit.systems</a></li>
+  <li><a href="https://github.com/bong-water-water-bong/1bit-systems">GitHub</a> — MIT, open source</li>
+  <li><a href="https://github.com/bong-water-water-bong/1bit-systems/blob/main/docs/journey.md">Engineering journal</a></li>
+  <li><a href="https://github.com/bong-water-water-bong/1bit-systems/blob/main/site/benchmarks.json">benchmarks.json</a></li>
+</ul>
+
+</article>
+<div class="foot wrap"><a href="/">← back to 1bit.systems</a> · MIT</div>
+</body>
+</html>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -206,6 +206,12 @@
   </url>
   <url>
     <loc>https://1bit.systems/blog/token-router/</loc>
+  <url>
+    <loc>https://1bit.systems/blog/one-binary-all-formats</loc>
+    <lastmod>2026-07-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
     <lastmod>2026-07-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>

--- a/tools/bench_ternary_new.cpp
+++ b/tools/bench_ternary_new.cpp
@@ -1,0 +1,137 @@
+// bench_ternary_new.cpp — Benchmark new ternary/binary GPU kernels
+// Build: hipcc -O3 -o bench_ternary_new bench_ternary_new.cpp -I../include
+// Run:   ./bench_ternary_new
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <chrono>
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include "../include/rocm_cpp/ck_gemm.h"
+
+#define HIP_CHECK(e) do { auto s=e; if(s!=hipSuccess){fprintf(stderr,"HIP err %d\n",s); exit(1);}} while(0)
+
+static double now_ms() {
+    return std::chrono::duration<double, std::milli>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+// Generate synthetic ternary weights
+static void gen_tq2(uint8_t* w, int M, int K) {
+    for (int i = 0; i < M * K / 4; i++) {
+        uint8_t byte = 0;
+        for (int j = 0; j < 4; j++) {
+            int code = rand() % 3;  // 0=-1, 1=0, 2=+1
+            byte |= (code << (j * 2));
+        }
+        w[i] = byte;
+    }
+}
+
+static void gen_binary_q1(uint8_t* w, int M, int K) {
+    int n_blocks = (K + 127) / 128;
+    int row_bytes = n_blocks * 18;
+    for (int r = 0; r < M; r++) {
+        // fp16 scale
+        __half scale = __float2half(1.0f);
+        memcpy(w + r * row_bytes, &scale, 2);
+        // sign bits
+        for (int b = 0; b < n_blocks; b++) {
+            for (int i = 0; i < 16; i++) {
+                w[r * row_bytes + 2 + b * 16 + i] = rand() & 0xFF;
+            }
+        }
+    }
+}
+
+static void gen_bitnet_tq2_0(uint8_t* w, int M, int K) {
+    int n_blocks = (K + 255) / 256;
+    int row_bytes = n_blocks * 66;
+    for (int r = 0; r < M; r++) {
+        for (int b = 0; b < n_blocks; b++) {
+            for (int i = 0; i < 64; i++) w[r * row_bytes + b * 66 + i] = rand() & 0xFF;
+            __half scale = __float2half(1.0f);
+            memcpy(w + r * row_bytes + b * 66 + 64, &scale, 2);
+        }
+    }
+}
+
+template<typename F>
+void bench(const char* name, F fn, int M, int K, int iters) {
+    double t0 = now_ms();
+    for (int i = 0; i < iters; i++) fn();
+    double ms = (now_ms() - t0) / iters;
+    double gbs = (double)M * K * 2 / (ms * 1e6);  // bytes read (weights) per sec
+    printf("  %-30s M=%-5d K=%-6d %8.2f µs  %8.1f GB/s\n",
+           name, M, K, ms * 1000.0, gbs);
+}
+
+int main() {
+    printf("=== Ternary/Binary GPU Kernel Benchmarks ===\n\n");
+
+    int M = 6912, K = 2560, iters = 256;
+
+    // Allocate host memory
+    size_t tq2_bytes = (size_t)M * K / 4;
+    size_t q1_bytes = (size_t)M * ((K + 127) / 128) * 18;
+    size_t bt_bytes = (size_t)M * ((K + 255) / 256) * 66;
+    size_t act_bytes = (size_t)M * K;
+    size_t out_bytes = (size_t)M * sizeof(__half);
+    size_t scale_bytes = (size_t)M * sizeof(float);
+
+    uint8_t *h_tq2, *h_q1, *h_bt, *h_act, *h_out;
+    float *h_scales;
+    hipHostMalloc(&h_tq2, tq2_bytes); gen_tq2(h_tq2, M, K);
+    hipHostMalloc(&h_q1, q1_bytes); gen_binary_q1(h_q1, M, K);
+    hipHostMalloc(&h_bt, bt_bytes); gen_bitnet_tq2_0(h_bt, M, K);
+    hipHostMalloc(&h_act, act_bytes);
+    hipHostMalloc(&h_out, out_bytes);
+    hipHostMalloc(&h_scales, scale_bytes);
+    for (int i = 0; i < M * K; i++) h_act[i] = 1;  // dummy activations
+    for (int i = 0; i < M; i++) h_scales[i] = 1.0f;
+
+    uint8_t *d_tq2, *d_q1, *d_bt;
+    int8_t *d_act;
+    __half *d_out;
+    float *d_scales;
+    HIP_CHECK(hipMalloc(&d_tq2, tq2_bytes));
+    HIP_CHECK(hipMalloc(&d_q1, q1_bytes));
+    HIP_CHECK(hipMalloc(&d_bt, bt_bytes));
+    HIP_CHECK(hipMalloc(&d_act, act_bytes));
+    HIP_CHECK(hipMalloc(&d_out, out_bytes));
+    HIP_CHECK(hipMalloc(&d_scales, scale_bytes));
+
+    HIP_CHECK(hipMemcpy(d_tq2, h_tq2, tq2_bytes, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(d_q1, h_q1, q1_bytes, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(d_bt, h_bt, bt_bytes, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(d_act, h_act, act_bytes, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(d_out, h_out, out_bytes, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(d_scales, h_scales, scale_bytes, hipMemcpyHostToDevice));
+
+    printf("Config: M=%d K=%d iters=%d\n\n", M, K, iters);
+
+    // Q1_0 binary (1-bit)
+    bench("Q1_0 binary (1-bit)", [&]() {
+        rcpp_ternary_gemv_q1_0_f16(d_q1, d_act, 1.0f, d_scales, d_out, M, K, nullptr);
+    }, M, K, iters);
+
+    // BitNet TQ2_0 (GGUF native, 2.06 bpw)
+    bench("BitNet TQ2_0 (2.06 bpw)", [&]() {
+        rcpp_bitnet_gemv_tq2_0_f16(d_bt, d_act, 1.0f, d_scales, d_out, M, K, nullptr);
+    }, M, K, iters);
+
+    // Existing TQ1 for comparison
+    int K_padded = ((K + 19) / 20) * 20;
+    bench("TQ1 (1.58-bit, reference)", [&]() {
+        rcpp_ternary_gemv_tq1_halo_f16(d_tq2, d_act, 1.0f, d_scales, d_out, M, K_padded, nullptr);
+    }, M, K, iters);
+
+    printf("\n=== Done ===\n");
+
+    hipFree(d_tq2); hipFree(d_q1); hipFree(d_bt);
+    hipFree(d_act); hipFree(d_out); hipFree(d_scales);
+    hipHostFree(h_tq2); hipHostFree(h_q1); hipHostFree(h_bt);
+    hipHostFree(h_act); hipHostFree(h_out); hipHostFree(h_scales);
+    return 0;
+}

--- a/tools/tq2_to_q4nx.cpp
+++ b/tools/tq2_to_q4nx.cpp
@@ -1,0 +1,203 @@
+/** tq2_to_q4nx.cpp — Convert 1BP TQ2 model to Q4NX format for NPU inference.
+ *
+ * Q4NX is the NPU engine's native format: safetensors-style container with
+ * float32 weights in the NPU's 32×256 Q4NX tile layout. The NPU engine
+ * reads float32 weights and INT8-quantizes them on-the-fly during weight
+ * upload (npu_engine_i8.cpp I8Ctx::packB()).
+ *
+ * This tool bridges the ternary world to the NPU world:
+ *   1. Reads 1BP TQ2 weights
+ *   2. Dequantizes to float32 (ternary {-1,0,+1} × per-group scale)
+ *   3. Writes in Q4NX float32 format
+ *
+ * Run:  ./build/tq2_to_q4nx model.1bp model.q4nx
+ *
+ * Build: g++ -std=c++17 -O3 -I include -I src tools/tq2_to_q4nx.cpp \
+ *            src/onebp_model.cpp -o build/tq2_to_q4nx -lpthread
+ *
+ * Then:  NPU_MODEL_PATH=model.q4nx ./build/unified_server -w models/ -p 8088
+ */
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+#include <string>
+#include <vector>
+#include <cstdint>
+#include "onebp_format.h"
+#include "onebp_loader.h"
+#include <chrono>
+
+// ─── FP16 <-> FP32 conversion ────────────────────────────────────
+static inline float bf16_to_f32(uint16_t bf) {
+    uint32_t b = (uint32_t)bf << 16;
+    float f; memcpy(&f, &b, 4); return f;
+}
+
+// ─── Q4NX writer ─────────────────────────────────────────────────
+// Writes a safetensors-style Q4NX file with float32 weights.
+struct Q4nxWriter {
+    FILE* f = nullptr;
+    uint64_t data_offset = 0;  // current write position in data section
+    std::string json;           // accumulating JSON header
+
+    bool open(const char* path) {
+        f = fopen(path, "wb");
+        if (!f) { perror("fopen"); return false; }
+        // Reserve 8 bytes for header length
+        uint64_t dummy = 0;
+        fwrite(&dummy, 8, 1, f);
+        json = "{";
+        data_offset = 8;  // after header length
+        return true;
+    }
+
+    // Write a Q4NX tensor: name, float32 data pointer, element count
+    void write_tensor(const char* name, const float* data, uint64_t numel,
+                      int dim0, int dim1) {
+        if (json.size() > 1) json += ",";
+        json += "\"" + std::string(name) + "\":{";
+        json += "\"dtype\":\"F32\",";
+        json += "\"shape\":[" + std::to_string(dim0) + "," + std::to_string(dim1) + "],";
+        uint64_t end = data_offset + numel * 4;
+        json += "\"data_offsets\":[" + std::to_string(data_offset) + "," + std::to_string(end) + "]";
+        json += "}";
+        
+        fwrite(data, 4, numel, f);
+        data_offset = end;
+    }
+
+    bool close() {
+        json += "}";
+        uint64_t header_len = json.size();
+        // Write header length at offset 0
+        fseek(f, 0, SEEK_SET);
+        fwrite(&header_len, 8, 1, f);
+        // Write JSON header right after the length
+        fwrite(json.data(), 1, json.size(), f);
+        fclose(f);
+        return true;
+    }
+};
+
+// ─── Dequantize one TQ2 tile row (32×256) to float32 ─────────────
+// TQ2 tile: [scales: 32×8×2=512 bytes bf16][codes: 32×256/4=2048 bytes]
+// Groups of 32: 8 per tile row, bf16 scale per group
+// codes: 2-bit LSB-first, 0=-scale, 1=0, 2=+scale, 3=unused
+static void dequant_tq2_tile(const uint8_t* tile, float* out,
+                              int rows, int cols,
+                              int trow, int tcol) {
+    constexpr int TR = 32, TC = 256, GS = 32;
+    int grps = TC / GS;  // 8
+    int scales_bytes = TR * grps * 2;
+    int codes_bytes  = TR * TC / 4;
+    
+    const uint16_t* scales_bf16 = (const uint16_t*)tile;
+    const uint8_t*  codes       = tile + scales_bytes;
+    
+    for (int rr = 0; rr < TR && (trow + rr) < rows; rr++) {
+        for (int g = 0; g < grps; g++) {
+            float scale = bf16_to_f32(scales_bf16[rr * grps + g]);
+            for (int i = 0; i < GS; i += 4) {
+                int byte_idx = rr * (TC / 4) + (g * GS + i) / 4;
+                uint8_t byte_ = codes[byte_idx];
+                for (int j = 0; j < 4; j++) {
+                    int ac = tcol + g * GS + i + j;
+                    if (ac >= cols) break;
+                    uint8_t code = (byte_ >> (j * 2)) & 3;
+                    float val;
+                    if (code == 0)      val = -scale;
+                    else if (code == 2) val =  scale;
+                    else                val = 0.0f;
+                    out[(size_t)(trow + rr) * cols + ac] = val;
+                }
+            }
+        }
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s input.1bp output.q4nx\n", argv[0]);
+        return 1;
+    }
+
+    // ── Load 1BP model ──────────────────────────────────────────
+    OnebpModel model;
+    if (!model.load(argv[1])) {
+        fprintf(stderr, "Failed to load 1BP: %s\n", argv[1]);
+        return 1;
+    }
+
+    auto& h = model.header;
+    if (h.quant != ONEBP_TQ2) {
+        fprintf(stderr, "Only TQ2 (ternary 2-bit) quant supported. Got quant=%u\n", h.quant);
+        return 1;
+    }
+
+    printf("1BP loaded: arch=%u H=%d L=%d NH=%d V=%d tensors=%zu\n",
+           h.arch, h.hidden_size, h.num_layers,
+           h.num_attention_heads, h.vocab_size, model.tensors.size());
+
+    // ── Open Q4NX output ────────────────────────────────────────
+    Q4nxWriter qw;
+    if (!qw.open(argv[2])) return 1;
+
+    // ── Convert each tensor ─────────────────────────────────────
+    constexpr int TR = 32, TC = 256, GS = 32;
+    int grps = TC / GS;
+    int scales_bytes = TR * grps * 2;
+    int codes_bytes  = TR * TC / 4;
+    int tile_bytes   = scales_bytes + codes_bytes;
+
+    int total_tiles = 0;
+    auto t0 = std::chrono::steady_clock::now();
+
+    for (auto& t : model.tensors) {
+        if (t.ndim < 2) continue;
+        int rows = (int)t.dims[0];
+        int cols = (int)t.dims[1];
+        
+        // Allocate float32 output
+        std::vector<float> f32((size_t)rows * cols, 0.0f);
+        
+        // Dequantize TQ2 tile by tile
+        int ntr = (rows + TR - 1) / TR;
+        int ntc = (cols + TC - 1) / TC;
+        
+        for (int tr = 0; tr < ntr; tr++) {
+            for (int tc = 0; tc < ntc; tc++) {
+                int tile_idx = tr * ntc + tc;
+                const uint8_t* tile_data = model.tensor_data(t);
+                tile_data += (size_t)tile_idx * tile_bytes;
+                dequant_tq2_tile(tile_data, f32.data(), rows, cols,
+                                 tr * TR, tc * TC);
+                total_tiles++;
+            }
+        }
+        
+        // Write to Q4NX
+        qw.write_tensor(t.name.c_str(), f32.data(),
+                        (uint64_t)rows * cols, rows, cols);
+        
+        if (model.tensors.size() <= 10 || total_tiles % 100 == 0) {
+            printf("  %-40s %dx%d -> %.1f MB\n",
+                   t.name.c_str(), rows, cols,
+                   (double)rows * cols * 4 / 1e6);
+        }
+    }
+
+    qw.close();
+
+    auto t1 = std::chrono::steady_clock::now();
+    double sec = std::chrono::duration<double>(t1 - t0).count();
+    
+    // Get output file size
+    FILE* fc = fopen(argv[2], "rb"); fseek(fc, 0, SEEK_END);
+    long fsz = ftell(fc); fclose(fc);
+    
+    printf("\n=== DONE: %s (%.1f MB, %d tiles) in %.1f seconds ===\n",
+           argv[2], fsz / 1e6, total_tiles, sec);
+    printf("Run: NPU_MODEL_PATH=%s ./build/unified_server -w models/ -p 8088\n", argv[2]);
+    return 0;
+}


### PR DESCRIPTION
## What

Both benchmarks docs were stale — one still referenced FLM as the primary NPU path (it's been open-source native for weeks), the other didn't include any of the new binary/ternary GPU kernel numbers or NPU on-tile decode kernels.

### docs/wiki/performance.md
- Added binary/ternary GPU kernel table (Q1_0, BitNet TQ1_0/TQ2_0, TQ1 halo) with real Strix Halo numbers
- Added NPU ternary kernel matrix (TQ2/TQ1/Q1_0 on-tile LUT decode)
- Added DDR bandwidth savings table (4×–4.9× vs INT8)
- Updated engine evolution timeline with Jul 24 milestones
- Removed 400+ lines of historical FLM-only data, stale ROCm archived sections, duplicate tables

### engine/npu/BENCHMARKS.md
- Replaced 600-line historical document with current data
- Binary/ternary GPU kernel table with verification status
- NPU ternary kernel matrix with object sizes and build commands
- Updated classical NPU engine table
- Clean engine evolution timeline