### PR TITLE
fix: NPU Benchmark CI — stale .c→.cpp extension for dequantizer

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build dequantizer
         run: |
           mkdir -p engine/npu/build
-          gcc -c -O3 -o engine/npu/build/dequant_q4nx.o engine/npu/src/dequant_q4nx.c
+          g++ -c -O3 -std=c++23 -o engine/npu/build/dequant_q4nx.o engine/npu/src/dequant_q4nx.cpp
 
       - name: Build engine (continuous batch)
         run: |


### PR DESCRIPTION
Fixes NPU Benchmark CI: `dequant_q4nx` was renamed from `.c` to `.cpp` but the CI workflow still compiled `dequant_q4nx.c`. Changed to `g++` compiling `dequant_q4nx.cpp`.