### PR TITLE
fix: stale .c→.cpp refs in build scripts and docs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build dequantizer
         run: |
           mkdir -p engine/npu/build
-          gcc -c -O3 -o engine/npu/build/dequant_q4nx.o engine/npu/src/dequant_q4nx.c
+          g++ -c -O3 -std=c++23 -o engine/npu/build/dequant_q4nx.o engine/npu/src/dequant_q4nx.cpp
 
       - name: Build engine (continuous batch)
         run: |

--- a/engine/npu/README.md
+++ b/engine/npu/README.md
@@ -7,7 +7,7 @@ Pure C++ inference engine for Qwen3-0.6B on AMD Strix Halo NPU.
 | File | Purpose |
 |------|---------|
 | `src/npu_engine_i8.cpp` | Main engine — 4-live INT8 contexts, NPU attention |
-| `src/dequant_q4nx.c` | Q4NX weight dequantizer (C99) |
+| `src/dequant_q4nx.cpp` | Q4NX weight dequantizer (C99) |
 | `xclbins/n1_core_i8_v2.py` | INT8 MLIR generator with K-interleaving fix |
 | `kernel/edge_attention.cc` | NPU attention kernel (Chess C++) |
 | `build/dequant_q4nx.o` | Compiled dequantizer (committed, zero-dependency) |
@@ -16,7 +16,7 @@ Pure C++ inference engine for Qwen3-0.6B on AMD Strix Halo NPU.
 
 ```bash
 # One-time: compile dequantizer
-gcc -c -O3 -o build/dequant_q4nx.o src/dequant_q4nx.c
+gcc -c -O3 -o build/dequant_q4nx.o src/dequant_q4nx.cpp
 
 # Compile engine (requires XRT headers + libs)
 g++ -std=c++23 -O3 -o build/npu_engine \

--- a/engine/npu/build_npu.sh
+++ b/engine/npu/build_npu.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 SRCDIR="$(cd "$(dirname "$0")" && pwd)"
 BUILDDIR="$SRCDIR/build"
 SRC="$SRCDIR/src/npu_engine_universal.cpp"
-DEQUANT="$SRCDIR/src/dequant_q4nx.c"
+DEQUANT="$SRCDIR/src/dequant_q4nx.cpp"
 DEQUANT_O="$BUILDDIR/dequant_q4nx.o"
 
 # One-time: compile dequantizer
 if [ ! -f "$DEQUANT_O" ] || [ "$DEQUANT" -nt "$DEQUANT_O" ]; then
-    echo "gcc -c -O3 -o $DEQUANT_O $DEQUANT"
+    echo "g++ -c -O3 -std=c++23 -o $DEQUANT_O $DEQUANT"
     gcc -c -O3 -o "$DEQUANT_O" "$DEQUANT"
 fi
 


### PR DESCRIPTION
Fixes stale .c→.cpp references in engine/npu/build_npu.sh and engine/npu/README.md. Both still referenced dequant_q4nx.c which was renamed to .cpp.