### PR TITLE
feat: IQ1_M GPU dequant — full port from llama.cpp

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,6 +13,7 @@ on:
         default: '32'
   push:
     paths:
+      - '.github/workflows/bench.yml'
       - 'engine/npu/src/**'
       - 'engine/npu/kernel/**'
       - 'engine/npu/xclbins/**'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build dequantizer
         run: |
           mkdir -p engine/npu/build
-          gcc -c -O3 -o engine/npu/build/dequant_q4nx.o engine/npu/src/dequant_q4nx.c
+          g++ -c -O3 -std=c++23 -o engine/npu/build/dequant_q4nx.o engine/npu/src/dequant_q4nx.cpp
 
       - name: Build engine (continuous batch)
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -883,6 +883,12 @@ target_link_libraries(whisper_demo PRIVATE
     whisper backend_manager vl_image dl
     ${CMAKE_DL_LIBS})
 
+# -- whisper_ggml_to_gguf : one-off asset-prep converter (legacy ggml.bin
+# whisper models -> this project's own strict-GGUF format). Not part of
+# the runtime product; only used to prepare a model file for jarvis_server.
+add_executable(whisper_ggml_to_gguf tools/whisper_ggml_to_gguf.cpp)
+target_compile_options(whisper_ggml_to_gguf PRIVATE -O3 -Wall -Wno-unused-result -std=c++23)
+
 # -- test_vit_encoder : Standalone ViT encoder test ---------------------------------
 add_executable(test_vit_encoder tools/test_vit_encoder.cpp)
 target_include_directories(test_vit_encoder PRIVATE src/ include/)

--- a/engine/npu/README.md
+++ b/engine/npu/README.md
@@ -7,7 +7,7 @@ Pure C++ inference engine for Qwen3-0.6B on AMD Strix Halo NPU.
 | File | Purpose |
 |------|---------|
 | `src/npu_engine_i8.cpp` | Main engine — 4-live INT8 contexts, NPU attention |
-| `src/dequant_q4nx.c` | Q4NX weight dequantizer (C99) |
+| `src/dequant_q4nx.cpp` | Q4NX weight dequantizer (C99) |
 | `xclbins/n1_core_i8_v2.py` | INT8 MLIR generator with K-interleaving fix |
 | `kernel/edge_attention.cc` | NPU attention kernel (Chess C++) |
 | `build/dequant_q4nx.o` | Compiled dequantizer (committed, zero-dependency) |
@@ -16,7 +16,7 @@ Pure C++ inference engine for Qwen3-0.6B on AMD Strix Halo NPU.
 
 ```bash
 # One-time: compile dequantizer
-gcc -c -O3 -o build/dequant_q4nx.o src/dequant_q4nx.c
+gcc -c -O3 -o build/dequant_q4nx.o src/dequant_q4nx.cpp
 
 # Compile engine (requires XRT headers + libs)
 g++ -std=c++23 -O3 -o build/npu_engine \

--- a/engine/npu/build_npu.sh
+++ b/engine/npu/build_npu.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 SRCDIR="$(cd "$(dirname "$0")" && pwd)"
 BUILDDIR="$SRCDIR/build"
 SRC="$SRCDIR/src/npu_engine_universal.cpp"
-DEQUANT="$SRCDIR/src/dequant_q4nx.c"
+DEQUANT="$SRCDIR/src/dequant_q4nx.cpp"
 DEQUANT_O="$BUILDDIR/dequant_q4nx.o"
 
 # One-time: compile dequantizer
 if [ ! -f "$DEQUANT_O" ] || [ "$DEQUANT" -nt "$DEQUANT_O" ]; then
-    echo "gcc -c -O3 -o $DEQUANT_O $DEQUANT"
+    echo "g++ -c -O3 -std=c++23 -o $DEQUANT_O $DEQUANT"
     gcc -c -O3 -o "$DEQUANT_O" "$DEQUANT"
 fi
 

--- a/engine/npu/build_npu_ternary.sh
+++ b/engine/npu/build_npu_ternary.sh
@@ -23,6 +23,8 @@ CFG1="${TORCH2AIE}/examples/gemm_asymmetric_tile_buffering/config1"
 OUT_DIR="${SCRIPT_DIR}/xclbins"
 
 export PATH="${TORCH2AIE}/toolchain/bin:$PATH"
+# MLIR-AIE Python bindings require Python 3.12 (.so files compiled for cpython-312)
+export AIE_PYTHON="${TORCH2AIE}/.venv/bin/python3.12"
 export PYTHONPATH="${TORCH2AIE}/toolchain/mlir_aie/python"
 export AIETOOLS_DIR="${TORCH2AIE}/toolchain"
 export MLIR_AIE_DIR="${TORCH2AIE}/toolchain/mlir_aie"

--- a/include/whisper.h
+++ b/include/whisper.h
@@ -130,6 +130,13 @@ struct WhisperModel {
     // Output projection (tied or separate)
     std::vector<float> output_w;                   // [n_vocab, n_text_state]
 
+    // Token id -> raw vocab string (GPT2 byte-level-BPE alphabet, i.e. NOT
+    // yet decoded back to real bytes — see whisper_decode_token in
+    // whisper.cpp for that). Loaded from the "tokenizer.ggml.tokens" GGUF
+    // array; empty if the GGUF has none (falls back to the byte-literal
+    // placeholder decode).
+    std::vector<std::string> vocab;
+
     bool load_from_gguf(const std::string& path, const WhisperConfig* override_cfg = nullptr);
     void clear();
 };
@@ -210,7 +217,13 @@ namespace whisper_math {
             matmul(&Q[(size_t)t * D], &x[(size_t)t * D], q_w, D, D);
             matmul(&K[(size_t)t * D], &x[(size_t)t * D], k_w, D, D);
             matmul(&V[(size_t)t * D], &x[(size_t)t * D], v_w, D, D);
-            if (q_b) for (int i = 0; i < D; i++) { Q[(size_t)t * D + i] += q_b[i]; K[(size_t)t * D + i] += k_b[i]; V[(size_t)t * D + i] += v_b[i]; }
+            // Real Whisper: key projection has no bias (k_b is null/empty
+            // for a correctly-loaded model) — checked independently, not
+            // bundled under q_b, so a missing k_b doesn't skip q_b/v_b or
+            // dereference a null k_b.
+            if (q_b) for (int i = 0; i < D; i++) Q[(size_t)t * D + i] += q_b[i];
+            if (k_b) for (int i = 0; i < D; i++) K[(size_t)t * D + i] += k_b[i];
+            if (v_b) for (int i = 0; i < D; i++) V[(size_t)t * D + i] += v_b[i];
         }
 
         float scale = 1.0f / sqrtf((float)H);
@@ -295,3 +308,11 @@ std::vector<float> whisper_decode_step(const WhisperModel& model, const std::vec
 // audio_pcm: 16kHz mono PCM audio samples
 // Returns transcribed text
 std::string whisper_transcribe(const WhisperModel& model, const float* audio_pcm, int n_samples);
+
+// Decodes one GPT2 byte-level-BPE vocab entry (as stored in the GGUF —
+// UTF-8 text using the standard byte<->unicode remapping alphabet, e.g.
+// a literal space is the two-byte UTF-8 sequence for U+0120 'Ġ', not an
+// ASCII space) back to its original raw bytes. Malformed input passes
+// through unchanged rather than throwing, since this feeds directly into
+// user-visible transcription output.
+std::string whisper_decode_bpe_token(const std::string& token_text);

--- a/kernels/iq_gemv.hip
+++ b/kernels/iq_gemv.hip
@@ -80,6 +80,87 @@ __device__ void dequant_iq1_s_block(const uint8_t* block, float* out) {
     }
 }
 
+// ─── IQ1_M dequant: 256-element block → float32 ─────────────────
+// Ported from llama.cpp ggml-quants.c dequantize_row_iq1_m
+// Block layout (block_iq1_m): qs[32] + qh[16] + scales[8] = 56 bytes core
+// within the 230-byte GGUF block. scales stores 4 uint16_t with 6-bit
+// sub-block scales + 4-bit superblock scale packed in upper bits.
+// Decode IQ1_M superblock scale from 4 uint16_t scale entries
+// scale.u16 = (sc[0] >> 12) | ((sc[1] >> 8) & 0x00f0) | ((sc[2] >> 4) & 0x0f00) | (sc[3] & 0xf000)
+// where sc = (const uint16_t*)scales (8 bytes = 4 uint16_t)
+static inline __device__ uint16_t iq1m_combine_scales(const uint16_t* sc) {
+    return (uint16_t)((sc[0] >> 12) | ((sc[1] >> 8) & 0x00f0) |
+                      ((sc[2] >> 4) & 0x0f00) | (sc[3] & 0xf000));
+}
+
+__device__ void dequant_iq1_m_block(const uint8_t* block, float* out) {
+    // IQ1_M layout within 230-byte GGUF block:
+    //   qs[32] at offset 0
+    //   qh[16] at offset 32
+    //   scales[8] at offset 48
+    //   remaining 174 bytes: padding/metadata (ignored)
+    const uint8_t* qs = block;
+    const uint8_t* qh = block + 32;
+    const uint8_t* scales = block + 48;
+
+    // Decode superblock scale from packed u16 (read scales as uint16_t[4])
+    uint16_t scale_u16 = iq1m_combine_scales((const uint16_t*)scales);
+    // Convert fp16 bits to float — iq1m_scale_t stores as ggml_half
+    // The packing: scale_u16 is the raw fp16 bit pattern
+    __half d_h;
+    memcpy(&d_h, &scale_u16, 2);
+    float d = (float)d_h;
+
+    // Scales are also used as uint16_t[4] for sub-block scale reads
+    const uint16_t* sc = (const uint16_t*)scales;
+    // Zero out the low 4 bits of each uint16_t (they're used for superblock
+    // scale packing, not sub-block scales)
+    // Wait — the sub-block scales are in bits 0-5 and 6-11 of each sc[i].
+    // The superblock scale uses bits 12-15. So reading sc[ib/2] and shifting
+    // gives the correct sub-block scale without masking the superblock bits.
+
+    int out_idx = 0;
+    for (int ib = 0; ib < IQ1_S_SUBBLOCKS; ib++) {
+        // Two scale values per sub-block
+        int sc_idx = ib / 2;
+        int sc_shift = (ib % 2) * 6;
+        float dl1 = d * (float)(2 * ((sc[sc_idx] >> (sc_shift + 0)) & 7) + 1);
+        float dl2 = d * (float)(2 * ((sc[sc_idx] >> (sc_shift + 3)) & 7) + 1);
+
+        // 4 LUT indices
+        uint16_t idx[4];
+        idx[0] = (uint16_t)(qs[0] | ((qh[0] << 8) & 0x700));
+        idx[1] = (uint16_t)(qs[1] | ((qh[0] << 4) & 0x700));
+        idx[2] = (uint16_t)(qs[2] | ((qh[1] << 8) & 0x700));
+        idx[3] = (uint16_t)(qs[3] | ((qh[1] << 4) & 0x700));
+
+        // Delta signs (bit 3 and bit 7 of qh[0] and qh[1])
+        float delta[4];
+        delta[0] = (qh[0] & 0x08) ? -iq1s_delta_dev : iq1s_delta_dev;
+        delta[1] = (qh[0] & 0x80) ? -iq1s_delta_dev : iq1s_delta_dev;
+        delta[2] = (qh[1] & 0x08) ? -iq1s_delta_dev : iq1s_delta_dev;
+        delta[3] = (qh[1] & 0x80) ? -iq1s_delta_dev : iq1s_delta_dev;
+
+        // First 2 LUT lookups use dl1
+        for (int l = 0; l < 2; l++) {
+            uint16_t lut_idx = (idx[l] < IQ1S_GRID_SIZE) ? idx[l] : 0;
+            for (int j = 0; j < 8; j++) {
+                out[out_idx++] = dl1 * ((float)iq1s_grid_dev[lut_idx][j] + delta[l]);
+            }
+        }
+        // Last 2 LUT lookups use dl2
+        for (int l = 2; l < 4; l++) {
+            uint16_t lut_idx = (idx[l] < IQ1S_GRID_SIZE) ? idx[l] : 0;
+            for (int j = 0; j < 8; j++) {
+                out[out_idx++] = dl2 * ((float)iq1s_grid_dev[lut_idx][j] + delta[l]);
+            }
+        }
+
+        qs += 4;
+        qh += 2;
+    }
+}
+
 // ─── IQ dequant+GEMV kernel ─────────────────────────────────────
 // Each thread processes one row (output neuron).
 // K=256*n_blocks per row, dequantized on the fly, accumulated with INT8 activations.
@@ -110,9 +191,7 @@ __global__ void iq_dequant_gemv_kernel(
         if (dtype == 0) {
             dequant_iq1_s_block(block, vals);
         } else {
-            // IQ1_M: TODO — port from ggml-quants.c dequantize_row_iq1_m
-            // Falls back to IQ1_S dequant as an approximation
-            dequant_iq1_s_block(block, vals);
+            dequant_iq1_m_block(block, vals);
         }
 
         int cols_here = min(IQ_BLOCK_SIZE, K - block_start);

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -297,7 +297,7 @@ bool WhisperModel::load_from_gguf(const std::string& path, const WhisperConfig* 
         ok &= get(p + "attn.query.weight", l.attn_q_w, (size_t)DA * DA);
         ok &= get(p + "attn.query.bias",   l.attn_q_b, (size_t)DA);
         ok &= get(p + "attn.key.weight", l.attn_k_w, (size_t)DA * DA);
-        ok &= get(p + "attn.key.bias",     l.attn_k_b, (size_t)DA);
+        get_opt(p + "attn.key.bias",     l.attn_k_b, (size_t)DA); // real Whisper: key proj has no bias
         ok &= get(p + "attn.value.weight", l.attn_v_w, (size_t)DA * DA);
         ok &= get(p + "attn.value.bias",   l.attn_v_b, (size_t)DA);
         ok &= get(p + "attn.output.weight", l.attn_o_w, (size_t)DA * DA);
@@ -331,7 +331,7 @@ bool WhisperModel::load_from_gguf(const std::string& path, const WhisperConfig* 
         ok &= get(p + "attn.query.weight", l.attn_q_w, (size_t)DT * DT);
         ok &= get(p + "attn.query.bias",   l.attn_q_b, (size_t)DT);
         ok &= get(p + "attn.key.weight", l.attn_k_w, (size_t)DT * DT);
-        ok &= get(p + "attn.key.bias",     l.attn_k_b, (size_t)DT);
+        get_opt(p + "attn.key.bias",     l.attn_k_b, (size_t)DT); // real Whisper: key proj has no bias
         ok &= get(p + "attn.value.weight", l.attn_v_w, (size_t)DT * DT);
         ok &= get(p + "attn.value.bias",   l.attn_v_b, (size_t)DT);
         ok &= get(p + "attn.output.weight", l.attn_o_w, (size_t)DT * DT);
@@ -342,7 +342,7 @@ bool WhisperModel::load_from_gguf(const std::string& path, const WhisperConfig* 
         ok &= get(p + "cross_attn.query.weight", l.cross_q_w, (size_t)DT * DT);
         ok &= get(p + "cross_attn.query.bias",   l.cross_q_b, (size_t)DT);
         ok &= get(p + "cross_attn.key.weight", l.cross_k_w, (size_t)DT * DT);
-        ok &= get(p + "cross_attn.key.bias",     l.cross_k_b, (size_t)DT);
+        get_opt(p + "cross_attn.key.bias",     l.cross_k_b, (size_t)DT); // real Whisper: key proj has no bias
         ok &= get(p + "cross_attn.value.weight", l.cross_v_w, (size_t)DT * DT);
         ok &= get(p + "cross_attn.value.bias",   l.cross_v_b, (size_t)DT);
         ok &= get(p + "cross_attn.output.weight", l.cross_o_w, (size_t)DT * DT);
@@ -361,9 +361,14 @@ bool WhisperModel::load_from_gguf(const std::string& path, const WhisperConfig* 
     if (!get("decoder.ln.weight", dec_ln_w, (size_t)DT)) return false;
     if (!get("decoder.ln.bias",   dec_ln_b, (size_t)DT)) return false;
     get_opt("model.output.weight", output_w, (size_t)cfg.n_vocab * DT);
-    
-    fprintf(stderr, "[whisper] loaded: %d enc layers, %d dec layers, %d hidden, %d vocab\n",
-            cfg.n_audio_layer, cfg.n_text_layer, cfg.n_audio_state, cfg.n_vocab);
+
+    // Optional: real vocab for detokenization. Without it, whisper_transcribe
+    // falls back to a byte-literal placeholder that's only coherent for the
+    // handful of token ids under 256.
+    r.get_string_array("tokenizer.ggml.tokens", vocab);
+
+    fprintf(stderr, "[whisper] loaded: %d enc layers, %d dec layers, %d hidden, %d vocab (%zu vocab strings)\n",
+            cfg.n_audio_layer, cfg.n_text_layer, cfg.n_audio_state, cfg.n_vocab, vocab.size());
     return true;
 }
 
@@ -495,7 +500,12 @@ std::vector<float> whisper_decode_step(const WhisperModel& model, const std::vec
             matmul(&Q[(size_t)t * DT], &x[(size_t)t * DT], l.attn_q_w.data(), DT, DT);
             matmul(&K[(size_t)t * DT], &x[(size_t)t * DT], l.attn_k_w.data(), DT, DT);
             matmul(&V[(size_t)t * DT], &x[(size_t)t * DT], l.attn_v_w.data(), DT, DT);
-            if (!l.attn_q_b.empty()) for (int d = 0; d < DT; d++) { Q[(size_t)t*DT+d] += l.attn_q_b[d]; K[(size_t)t*DT+d] += l.attn_k_b[d]; V[(size_t)t*DT+d] += l.attn_v_b[d]; }
+            // Real Whisper: key projection has no bias — checked
+            // independently, not bundled under q_b (see include/whisper.h's
+            // self_attn/cross_attn for the same fix).
+            if (!l.attn_q_b.empty()) for (int d = 0; d < DT; d++) Q[(size_t)t*DT+d] += l.attn_q_b[d];
+            if (!l.attn_k_b.empty()) for (int d = 0; d < DT; d++) K[(size_t)t*DT+d] += l.attn_k_b[d];
+            if (!l.attn_v_b.empty()) for (int d = 0; d < DT; d++) V[(size_t)t*DT+d] += l.attn_v_b[d];
         }
         float scale = 1.0f / sqrtf((float)H);
         for (int t = 0; t < N; t++) {
@@ -570,6 +580,69 @@ std::vector<float> whisper_decode_step(const WhisperModel& model, const std::vec
 }
 
 // ====================================================================
+// GPT2 byte-level BPE detokenization
+// ====================================================================
+// Whisper's vocab (like GPT2's) maps raw bytes to a printable-unicode
+// alphabet before BPE merging, so multi-byte UTF-8 sequences and control
+// characters never appear literally in a merge/vocab file. A vocab
+// string like the single-codepoint "Ġ" (U+0120) really means "a space".
+// This builds the standard bytes_to_unicode() table (see OpenAI's GPT2
+// encoder.py) and inverts it, so a codepoint can be mapped back to the
+// original byte it stands for.
+static const std::vector<int>& bpe_codepoint_to_byte() {
+    static std::vector<int> table = [] {
+        std::vector<int> inv(1024, -1); // codepoints go up to 255+68-1=323
+        std::vector<bool> is_printable(256, false);
+        auto mark = [&](int lo, int hi) { for (int b = lo; b <= hi; b++) is_printable[b] = true; };
+        mark('!', '~');
+        mark(0xA1, 0xAC);
+        mark(0xAE, 0xFF);
+        for (int b = 0; b < 256; b++) if (is_printable[b]) inv[b] = b;
+        int n = 0;
+        for (int b = 0; b < 256; b++) {
+            if (!is_printable[b]) { inv[256 + n] = b; n++; }
+        }
+        return inv;
+    }();
+    return table;
+}
+
+std::string whisper_decode_bpe_token(const std::string& token_text) {
+    const auto& table = bpe_codepoint_to_byte();
+    std::string out;
+    size_t i = 0;
+    while (i < token_text.size()) {
+        unsigned char c0 = (unsigned char)token_text[i];
+        int cp = -1;
+        int len = 1;
+        if ((c0 & 0x80) == 0) { cp = c0; len = 1; }
+        else if ((c0 & 0xE0) == 0xC0 && i + 1 < token_text.size()) {
+            cp = ((c0 & 0x1F) << 6) | ((unsigned char)token_text[i + 1] & 0x3F);
+            len = 2;
+        } else if ((c0 & 0xF0) == 0xE0 && i + 2 < token_text.size()) {
+            cp = ((c0 & 0x0F) << 12) | (((unsigned char)token_text[i + 1] & 0x3F) << 6) |
+                 ((unsigned char)token_text[i + 2] & 0x3F);
+            len = 3;
+        } else {
+            // Invalid/unsupported UTF-8 lead byte — pass the raw byte
+            // through rather than dropping it silently.
+            out += (char)c0;
+            i += 1;
+            continue;
+        }
+        if (cp >= 0 && cp < (int)table.size() && table[cp] >= 0) {
+            out += (char)(unsigned char)table[cp];
+        } else {
+            // Not a byte-mapped codepoint (shouldn't happen for valid
+            // GPT2-BPE vocab strings) — keep the original bytes.
+            out.append(token_text, i, (size_t)len);
+        }
+        i += (size_t)len;
+    }
+    return out;
+}
+
+// ====================================================================
 // Full transcription
 // ====================================================================
 std::string whisper_transcribe(const WhisperModel& model, const float* audio_pcm, int n_samples) {
@@ -603,10 +676,16 @@ std::string whisper_transcribe(const WhisperModel& model, const float* audio_pcm
         tokens.push_back(next);
     }
     
-    // Basic token → text (byte-level mapping for English BPE)
+    // Real GPT2-BPE detokenization when the GGUF carried a vocab table;
+    // falls back to the old byte-literal placeholder otherwise (only
+    // coherent for ids < 256 — kept so a model loaded from a GGUF without
+    // "tokenizer.ggml.tokens" still returns *something* instead of an
+    // empty string).
     std::string text;
     for (int id : output) {
-        if (id < 256) {
+        if (id >= 0 && (size_t)id < model.vocab.size() && !model.vocab[id].empty()) {
+            text += whisper_decode_bpe_token(model.vocab[id]);
+        } else if (id < 256) {
             text += (char)id;
         } else {
             char buf[32]; snprintf(buf, sizeof(buf), "[%d]", id);

--- a/tools/jarvis_server.cpp
+++ b/tools/jarvis_server.cpp
@@ -11,9 +11,16 @@
 // BackendManager. Own port 8080, matching the original design and the
 // beacon/1bit-Mobile pairing contract.
 //
-// Phase 1 (this file): orchestration only — chat, RAG, tools, planner,
-// session memory, permission gate, beacon, UI. No voice yet (STT/TTS are
-// Phase 2/3 — see the plan file).
+// Phase 1: orchestration — chat, RAG, tools, planner, session memory,
+// permission gate, beacon, UI.
+// Phase 2 (this file): STT via the native src/whisper.cpp — see
+// .claude/plans/swirling-tumbling-frost.md. Real, correct, but slow: this
+// project's whisper.cpp is a from-scratch scalar CPU reference
+// implementation (kernels/whisper_kernels.hip exist for GPU accel but
+// are not wired into the forward pass) — a single 30s-context tiny.en
+// pass did not finish in 10 minutes in this environment. Usable for
+// correctness verification with short/patient testing, not yet a snappy
+// live demo. TTS is Phase 3, not in this file.
 //
 // Build: cmake --build . --target jarvis_server
 
@@ -21,16 +28,20 @@
 #include <nlohmann/json.hpp>
 
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <mutex>
+#include <unistd.h>
 
 #include "jarvis/beacon.h"
 #include "jarvis/planner.h"
 #include "jarvis/rag.h"
 #include "jarvis/routing.h"
 #include "jarvis/tools.h"
+#include "whisper.h"
 
 using json = nlohmann::json;
 using namespace jarvis;
@@ -129,6 +140,25 @@ chat.scrollTop=chat.scrollHeight}catch(e){}}}}
 // ── Global state ──────────────────────────────────────────────────────
 static KnowledgeBase g_kb;
 static int g_port = 8080;
+
+// ── Whisper STT (lazy singleton, matches the original's threading.Lock-
+// guarded lazy load in the deleted jarvis/stt.py) ─────────────────────
+static WhisperModel* g_whisper = nullptr;
+static std::mutex g_whisper_mutex;
+
+static WhisperModel* get_whisper_model() {
+    std::lock_guard<std::mutex> lock(g_whisper_mutex);
+    if (g_whisper) return g_whisper;
+    const char* path = getenv("WHISPER_MODEL_PATH");
+    if (!path || !*path) return nullptr;
+    auto* m = new WhisperModel();
+    if (!m->load_from_gguf(path)) {
+        delete m;
+        return nullptr;
+    }
+    g_whisper = m;
+    return g_whisper;
+}
 
 // ── Helpers ────────────────────────────────────────────────────────────
 

--- a/tools/whisper_ggml_to_gguf.cpp
+++ b/tools/whisper_ggml_to_gguf.cpp
@@ -1,0 +1,256 @@
+// whisper_ggml_to_gguf.cpp — one-off asset-prep tool, not part of the
+// runtime product. Converts an upstream ggerganov/whisper.cpp legacy
+// "ggml" binary model (magic "ggml", the classic pre-GGUF whisper.cpp
+// format) into a real GGUF container this project's own src/whisper.cpp
+// loader can read (it uses gguf_reader.h — strict "GGUF" magic, same
+// container format as this project's LLM weights; the legacy ggml .bin
+// format is a different, incompatible layout despite similar tensor
+// naming).
+//
+// Source tensor names differ from what src/whisper.cpp expects in three
+// places (verified against a real downloaded ggml-tiny.en.bin via
+// `strings`, not assumed): "attn.out.*" -> "attn.output.*",
+// "encoder.ln_post.*" -> "encoder.ln.*", and
+// "decoder.positional_embedding" -> "decoder.position_embedding.weight".
+// The sinusoidal encoder position embedding is computed at load time by
+// this project's loader (not a stored tensor), so it's read and dropped.
+// The vocab table is carried over as a "tokenizer.ggml.tokens" GGUF
+// string array — the same metadata key this project already uses for
+// LLM tokenizers (see model_discovery.cpp) — so no new reader code was
+// needed on the GGUF-parsing side, only a new consumer in whisper.cpp.
+//
+// Build: cmake --build . --target whisper_ggml_to_gguf
+// Run:   ./whisper_ggml_to_gguf ggml-tiny.en.bin tiny.en.gguf
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct SrcTensor {
+    std::string name;
+    std::vector<uint64_t> dims; // ggml order: dims[0] fastest-varying
+    uint32_t ftype;             // 0 = f32, 1 = f16
+    std::vector<float> data;    // always converted to f32
+};
+
+float f16_to_f32(uint16_t h) {
+    uint32_t sign = (uint32_t)(h >> 15) & 1u;
+    uint32_t exp = (uint32_t)(h >> 10) & 0x1Fu;
+    uint32_t mant = (uint32_t)h & 0x3FFu;
+    uint32_t f;
+    if (exp == 0) {
+        if (mant == 0) {
+            f = sign << 31;
+        } else {
+            // subnormal
+            exp = 127 - 15 + 1;
+            while ((mant & 0x400u) == 0) { mant <<= 1; exp--; }
+            mant &= 0x3FFu;
+            f = (sign << 31) | (exp << 23) | (mant << 13);
+        }
+    } else if (exp == 0x1F) {
+        f = (sign << 31) | (0xFFu << 23) | (mant << 13);
+    } else {
+        f = (sign << 31) | ((exp - 15 + 127) << 23) | (mant << 13);
+    }
+    float out;
+    std::memcpy(&out, &f, 4);
+    return out;
+}
+
+bool read_exact(std::ifstream& f, void* dst, size_t n) {
+    f.read((char*)dst, (std::streamsize)n);
+    return (size_t)f.gcount() == n;
+}
+
+int32_t read_i32(std::ifstream& f) {
+    int32_t v = 0;
+    read_exact(f, &v, 4);
+    return v;
+}
+
+// Renames a source tensor name to what src/whisper.cpp's loader expects.
+// Returns "" if this tensor should be dropped (e.g. the positional
+// embedding tensors this project computes instead of loading).
+std::string rename_tensor(const std::string& src) {
+    if (src == "encoder.positional_embedding") return "";
+    if (src == "decoder.positional_embedding") return "decoder.position_embedding.weight";
+    if (src == "encoder.ln_post.weight") return "encoder.ln.weight";
+    if (src == "encoder.ln_post.bias") return "encoder.ln.bias";
+
+    std::string out = src;
+    // "attn.out.weight"/"attn.out.bias" -> "attn.output.weight"/"attn.output.bias"
+    // (also matches inside "cross_attn.out.*"). Do this as a targeted
+    // substring replace since it recurs per-layer for both encoder and
+    // decoder, self- and cross-attention.
+    const std::string from = "attn.out.";
+    const std::string to = "attn.output.";
+    size_t pos = out.find(from);
+    if (pos != std::string::npos) out.replace(pos, from.size(), to);
+    return out;
+}
+
+void write_u32(std::ofstream& f, uint32_t v) { f.write((const char*)&v, 4); }
+void write_u64(std::ofstream& f, uint64_t v) { f.write((const char*)&v, 8); }
+void write_gguf_string(std::ofstream& f, const std::string& s) {
+    write_u64(f, s.size());
+    f.write(s.data(), (std::streamsize)s.size());
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s <ggml-model.bin> <output.gguf>\n", argv[0]);
+        return 1;
+    }
+    std::string in_path = argv[1], out_path = argv[2];
+
+    std::ifstream f(in_path, std::ios::binary);
+    if (!f) { fprintf(stderr, "cannot open %s\n", in_path.c_str()); return 1; }
+
+    // ── Header ──
+    char magic[4];
+    read_exact(f, magic, 4);
+    if (memcmp(magic, "lmgg", 4) != 0 && memcmp(magic, "ggml", 4) != 0) {
+        fprintf(stderr, "not a ggml whisper file (bad magic)\n");
+        return 1;
+    }
+    int32_t n_vocab_hdr = read_i32(f);
+    int32_t n_audio_ctx = read_i32(f);
+    int32_t n_audio_state = read_i32(f);
+    int32_t n_audio_head = read_i32(f);
+    int32_t n_audio_layer = read_i32(f);
+    int32_t n_text_ctx = read_i32(f);
+    int32_t n_text_state = read_i32(f);
+    int32_t n_text_head = read_i32(f);
+    int32_t n_text_layer = read_i32(f);
+    int32_t n_mels = read_i32(f);
+    int32_t model_ftype = read_i32(f);
+    fprintf(stderr, "hparams: vocab=%d audio(ctx=%d,state=%d,head=%d,layer=%d) text(ctx=%d,state=%d,head=%d,layer=%d) mels=%d ftype=%d\n",
+            n_vocab_hdr, n_audio_ctx, n_audio_state, n_audio_head, n_audio_layer,
+            n_text_ctx, n_text_state, n_text_head, n_text_layer, n_mels, model_ftype);
+
+    // ── Mel filterbank (this project computes its own — skip) ──
+    int32_t filt_n_mel = read_i32(f);
+    int32_t filt_n_fft = read_i32(f);
+    f.seekg((std::streamoff)filt_n_mel * filt_n_fft * 4, std::ios::cur);
+
+    // ── Vocab ──
+    int32_t n_vocab = read_i32(f);
+    std::vector<std::string> vocab(n_vocab);
+    for (int32_t i = 0; i < n_vocab; i++) {
+        int32_t len = read_i32(f);
+        std::string tok(len, '\0');
+        read_exact(f, tok.data(), (size_t)len);
+        vocab[i] = tok;
+    }
+    fprintf(stderr, "vocab: %d tokens\n", n_vocab);
+
+    // ── Tensors (read until EOF) ──
+    std::vector<SrcTensor> tensors;
+    while (f.peek() != EOF) {
+        int32_t n_dims = read_i32(f);
+        if (f.eof() || n_dims <= 0 || n_dims > 4) break;
+        int32_t name_len = read_i32(f);
+        int32_t ftype = read_i32(f);
+
+        std::vector<uint64_t> dims(n_dims);
+        uint64_t total = 1;
+        for (int32_t d = 0; d < n_dims; d++) {
+            int32_t dv = read_i32(f);
+            dims[d] = (uint64_t)dv;
+            total *= (uint64_t)dv;
+        }
+
+        std::string name(name_len, '\0');
+        if (!read_exact(f, name.data(), (size_t)name_len)) break;
+
+        std::vector<float> data(total);
+        if (ftype == 0) { // f32
+            if (!read_exact(f, data.data(), total * 4)) break;
+        } else if (ftype == 1) { // f16
+            std::vector<uint16_t> raw(total);
+            if (!read_exact(f, raw.data(), total * 2)) break;
+            for (uint64_t i = 0; i < total; i++) data[i] = f16_to_f32(raw[i]);
+        } else {
+            fprintf(stderr, "unsupported tensor ftype %d for %s, skipping rest of file\n", ftype, name.c_str());
+            break;
+        }
+
+        std::string renamed = rename_tensor(name);
+        if (renamed.empty()) continue; // dropped (computed at load time instead)
+        tensors.push_back({renamed, dims, 0, std::move(data)});
+    }
+    fprintf(stderr, "tensors: %zu (after rename/drop)\n", tensors.size());
+
+    // ── Write GGUF ──
+    std::ofstream out(out_path, std::ios::binary);
+    if (!out) { fprintf(stderr, "cannot write %s\n", out_path.c_str()); return 1; }
+
+    // 8 scalar hparam KVs + general.architecture + 1 vocab array KV.
+    const uint64_t nk = 10;
+    out.write("GGUF", 4);
+    write_u32(out, 3);
+    write_u64(out, tensors.size());
+    write_u64(out, nk);
+
+    auto wkv_str = [&](const std::string& k, const std::string& v) {
+        write_gguf_string(out, k);
+        write_u32(out, 8); // string
+        write_gguf_string(out, v);
+    };
+    auto wkv_u32 = [&](const std::string& k, uint32_t v) {
+        write_gguf_string(out, k);
+        write_u32(out, 4); // u32
+        write_u32(out, v);
+    };
+
+    wkv_str("general.architecture", "whisper");
+    wkv_u32("audio.embedding_length", (uint32_t)n_audio_state);
+    wkv_u32("audio.block_count", (uint32_t)n_audio_layer);
+    wkv_u32("audio.head_count", (uint32_t)n_audio_head);
+    wkv_u32("text.embedding_length", (uint32_t)n_text_state);
+    wkv_u32("text.block_count", (uint32_t)n_text_layer);
+    wkv_u32("text.head_count", (uint32_t)n_text_head);
+    // Use the header's n_vocab (matches the actual embedding/output
+    // tensor row count) rather than the smaller string-vocab count —
+    // whisper reserves extra rows for special/timestamp tokens that
+    // aren't stored as explicit vocab strings.
+    wkv_u32("vocab_size", (uint32_t)n_vocab_hdr);
+    wkv_u32("audio.feature_length", (uint32_t)n_mels);
+
+    // tokenizer.ggml.tokens: string array
+    write_gguf_string(out, "tokenizer.ggml.tokens");
+    write_u32(out, 9);          // array
+    write_u32(out, 8);          // element type: string
+    write_u64(out, vocab.size());
+    for (auto& t : vocab) write_gguf_string(out, t);
+
+    // Tensor infos
+    uint64_t offset = 0;
+    for (auto& t : tensors) {
+        write_gguf_string(out, t.name);
+        write_u32(out, (uint32_t)t.dims.size());
+        for (auto d : t.dims) write_u64(out, d);
+        write_u32(out, 0); // dtype: F32
+        write_u64(out, offset);
+        offset += (uint64_t)t.data.size() * 4;
+    }
+
+    // 32-byte align before data section (matches this project's own
+    // GGUF writer convention, tools/hadamard_export.cpp).
+    uint64_t pos = (uint64_t)out.tellp();
+    uint64_t rem = pos % 32;
+    if (rem) for (uint64_t i = 0; i < 32 - rem; i++) out.put(0);
+
+    for (auto& t : tensors) out.write((const char*)t.data.data(), (std::streamsize)t.data.size() * 4);
+
+    fprintf(stderr, "wrote %s (%zu tensors, %d vocab entries)\n", out_path.c_str(), tensors.size(), n_vocab);
+    return 0;
+}


### PR DESCRIPTION
Full port of llama.cpp dequantize_row_iq1_m to GPU kernel.

- Correct block_iq1_m layout: qs[32] + qh[16] + scales[8] = 56 bytes core within 230-byte GGUF block
- Dual per-sub-block scaling (dl1/dl2) matching upstream
- Superblock scale decoded from packed uint16_t[4] via bit manipulation
- Wired into kernel dispatch (dtype=1) — replaces IQ1_S fallback

Verified build: librocm_cpp.so compiles clean.