### PR TITLE
feat: TQ2 NPU ternary — block-vectorized mac_8x8_8x8T path

### DIFF
--- a/engine/npu/kernel/mm_ternary_tq2.cc
+++ b/engine/npu/kernel/mm_ternary_tq2.cc
@@ -1,114 +1,103 @@
-//===- mm_ternary_tq2.cc ----------------------------------------*- C++ -*-===//
+// mm_ternary_tq2.cc — TQ2 ternary — LUT decode + block-vectorized mac_8x8_8x8T
 //
-// TQ2 ternary AIE microkernel — LUT decode + scalar MAC
+// Decodes ternary to bf16 in L1, feeds through block_vector streams for
+// bfp16ebs8 conversion, then mac_8x8_8x8T for full vector throughput.
 //
-// Phase 2 final: loads 2-bit ternary codes from DDR, LUT-decodes on-tile,
-// applies per-group scales, accumulates with bf16 activations.
-//
-// The scalar MAC fallback is correct but ~8× slower than the block-vectorized
-// mac_8x8_8x8T path. Replace the inner accumulation loop with the reference
-// kernel's ping-pong MAC pattern for full throughput (see mm_bfp_mixed.cc).
+// The 8×8 weight block is assembled into a contiguous temp buffer, loaded
+// as a single vector, converted to bfp16ebs8 via accfloat, then pushed
+// to the output stream. The input stream's pop() returns the native type
+// mac_8x8_8x8T needs.
 //
 // Licensed under Apache 2.0 with LLVM Exceptions.
-//
-//===----------------------------------------------------------------------===//
 
 #include "aie_kernel_utils.h"
 #include <aie_api/aie.hpp>
 
-constexpr int M_TILE = 32;
-constexpr int K_TILE = 64;
-constexpr int N_TILE = 128;
-
-// LUT: byte → 4× ternary values as uint32_t (one int8 per byte)
-alignas(32) static const uint32_t tq2_lut[256] = {
-    0x00000000,0x00000001,0x000000FF,0x00000000,0x00000100,0x00000101,0x000001FF,0x00000100,
-    0x0000FF00,0x0000FF01,0x0000FFFF,0x0000FF00,0x00000000,0x00000001,0x000000FF,0x00000000,
-    0x00010000,0x00010001,0x000100FF,0x00010000,0x00010100,0x00010101,0x000101FF,0x00010100,
-    0x0001FF00,0x0001FF01,0x0001FFFF,0x0001FF00,0x00010000,0x00010001,0x000100FF,0x00010000,
-    0x00FF0000,0x00FF0001,0x00FF00FF,0x00FF0000,0x00FF0100,0x00FF0101,0x00FF01FF,0x00FF0100,
-    0x00FFFF00,0x00FFFF01,0x00FFFFFF,0x00FFFF00,0x00FF0000,0x00FF0001,0x00FF00FF,0x00FF0000,
-    0x00000000,0x00000001,0x000000FF,0x00000000,0x00000100,0x00000101,0x000001FF,0x00000100,
-    0x0000FF00,0x0000FF01,0x0000FFFF,0x0000FF00,0x00000000,0x00000001,0x000000FF,0x00000000,
-    0x01000000,0x01000001,0x010000FF,0x01000000,0x01000100,0x01000101,0x010001FF,0x01000100,
-    0x0100FF00,0x0100FF01,0x0100FFFF,0x0100FF00,0x01000000,0x01000001,0x010000FF,0x01000000,
-    0x01010000,0x01010001,0x010100FF,0x01010000,0x01010100,0x01010101,0x010101FF,0x01010100,
-    0x0101FF00,0x0101FF01,0x0101FFFF,0x0101FF00,0x01010000,0x01010001,0x010100FF,0x01010000,
-    0x01FF0000,0x01FF0001,0x01FF00FF,0x01FF0000,0x01FF0100,0x01FF0101,0x01FF01FF,0x01FF0100,
-    0x01FFFF00,0x01FFFF01,0x01FFFFFF,0x01FFFF00,0x01FF0000,0x01FF0001,0x01FF00FF,0x01FF0000,
-    0x01000000,0x01000001,0x010000FF,0x01000000,0x01000100,0x01000101,0x010001FF,0x01000100,
-    0x0100FF00,0x0100FF01,0x0100FFFF,0x0100FF00,0x01000000,0x01000001,0x010000FF,0x01000000,
-    0x00000000,0x00000001,0x000000FF,0x00000000,0x00000100,0x00000101,0x000001FF,0x00000100,
-    0x0000FF00,0x0000FF01,0x0000FFFF,0x0000FF00,0x00000000,0x00000001,0x000000FF,0x00000000,
-    0x00010000,0x00010001,0x000100FF,0x00010000,0x00010100,0x00010101,0x000101FF,0x00010100,
-    0x0001FF00,0x0001FF01,0x0001FFFF,0x0001FF00,0x00010000,0x00010001,0x000100FF,0x00010000,
-    0x00FF0000,0x00FF0001,0x00FF00FF,0x00FF0000,0x00FF0100,0x00FF0101,0x00FF01FF,0x00FF0100,
-    0x00FFFF00,0x00FFFF01,0x00FFFFFF,0x00FFFF00,0x00FF0000,0x00FF0001,0x00FF00FF,0x00FF0000,
-    0x00000000,0x00000001,0x000000FF,0x00000000,0x00000100,0x00000101,0x000001FF,0x00000100,
-    0x0000FF00,0x0000FF01,0x0000FFFF,0x0000FF00,0x00000000,0x00000001,0x000000FF,0x00000000,
-    0x01000000,0x01000001,0x010000FF,0x01000000,0x01000100,0x01000101,0x010001FF,0x01000100,
-    0x0100FF00,0x0100FF01,0x0100FFFF,0x0100FF00,0x01000000,0x01000001,0x010000FF,0x01000000,
-    0x01010000,0x01010001,0x010100FF,0x01010000,0x01010100,0x01010101,0x010101FF,0x01010100,
-    0x0101FF00,0x0101FF01,0x0101FFFF,0x0101FF00,0x01010000,0x01010001,0x010100FF,0x01010000,
-    0x01FF0000,0x01FF0001,0x01FF00FF,0x01FF0000,0x01FF0100,0x01FF0101,0x01FF01FF,0x01FF0100,
-    0x01FFFF00,0x01FFFF01,0x01FFFFFF,0x01FFFF00,0x01FF0000,0x01FF0001,0x01FF00FF,0x01FF0000,
-    0x01000000,0x01000001,0x010000FF,0x01000000,0x01000100,0x01000101,0x010001FF,0x01000100,
-    0x0100FF00,0x0100FF01,0x0100FFFF,0x0100FF00,0x01000000,0x01000001,0x010000FF,0x01000000,
-};
+constexpr int M = 32, K = 64, N = 128;
 
 extern "C" {
+static int g = 0;
 
-static int g_counter = 0;
-
-// ─── TQ2 ternary GEMV ────────────────────────────────────────────
-void ternary_tq2_gemv(bfloat16 *pA, uint8_t *pB,
-                       bfloat16 *pS, bfloat16 *pC) {
+void ternary_tq2_gemv(bfloat16 *pA, uint8_t *pB, bfloat16 *pS, bfloat16 *pC) {
     event0();
-    pC += g_counter * M_TILE * N_TILE;
-    if (g_counter == 3) g_counter = 0; else g_counter++;
+    pC += g * M * N; if (g == 3) g = 0; else g++;
 
-    // Step 1: LUT-decode ternary codes to int8
-    // Packed as int8 in decoded buffer (use int8 via float cast for AIE2 compat)
-    alignas(32) float w_dec_f32[N_TILE * K_TILE];  // float for AIE2 compat
-
-    for (int n = 0; n < N_TILE; n++) {
-        auto *src = pB + n * K_TILE / 4;
-        auto *dst = w_dec_f32 + n * K_TILE;
+    // LUT-decode ternary → bf16
+    alignas(32) bfloat16 w[M * N]; // transposed: w[row*n + col] for contiguous 8×8 blocks
+    // Actually store in [n*K + k] layout, use temp buffer for 8×8 assembly
+    
+    // Decode ternary codes to bf16 in [n*K + k] layout
+    alignas(32) bfloat16 wb[N * K];
+    static const bfloat16 cv[4] = {(bfloat16)-1,(bfloat16)0,(bfloat16)1,(bfloat16)0};
+    for (int n = 0; n < N; n++) {
+        auto *s = pB + n * K / 4;
+        auto *d = wb + n * K;
         for (int i = 0; i < 16; i++) {
-            uint32_t lut = tq2_lut[src[i]];
-            dst[i*4+0] = (float)(int8_t)(lut & 0xFF);
-            dst[i*4+1] = (float)(int8_t)((lut >> 8) & 0xFF);
-            dst[i*4+2] = (float)(int8_t)((lut >> 16) & 0xFF);
-            dst[i*4+3] = (float)(int8_t)((lut >> 24) & 0xFF);
+            uint8_t b = s[i];
+            d[i*4+0] = cv[b & 3]; d[i*4+1] = cv[(b>>2)&3];
+            d[i*4+2] = cv[(b>>4)&3]; d[i*4+3] = cv[(b>>6)&3];
         }
     }
+    // Apply scales
+    for (int n = 0; n < N; n++)
+        for (int grp = 0; grp < 2; grp++)
+            for (int i = 0; i < 32; i++)
+                wb[n * K + grp * 32 + i] = wb[n * K + grp * 32 + i] * pS[n * 2 + grp];
 
-    // Step 2: Scalar MAC (correct, ~8× slower than block-vectorized)
-    // Optimization path: replace with mac_8x8_8x8T via bfp16ebs8 blocks
-    // See mm_bfp_mixed.cc for the full-throughput MAC reference.
-    for (int m = 0; m < M_TILE; m++) {
-        for (int n = 0; n < N_TILE; n++) {
-            float sum = 0.0f;
-            auto *w = w_dec_f32 + n * K_TILE;
-            auto *a = pA + m * K_TILE;
-            for (int g = 0; g < K_TILE / 32; g++) {
-                float s = (float)pS[n * (K_TILE / 32) + g];
-                for (int i = 0; i < 32; i++) {
-                    sum += w[g * 32 + i] * s * (float)a[g * 32 + i];
-                }
+    // Convert to bfp16ebs8 blocks: assemble 8×8 tiles into contiguous buffer
+    alignas(32) bfp16ebs8 w_bfp[N / 8 * K / 8];
+    alignas(32) bfp16ebs8 a_bfp[M * K / 64];
+
+    // Weight blocks: copy 8 strided rows into a flat temp buffer, then convert
+    {
+        aie::block_vector_output_buffer_stream<bfp16ebs8, 64> ws(w_bfp);
+        alignas(32) bfloat16 tmp[64]; // 8×8 contiguous buffer
+        for (int nb = 0; nb < N / 8; nb++) {
+            for (int kb = 0; kb < K / 8; kb++) {
+                // Copy 8 rows × 8 cols from strided layout to contiguous
+                for (int r = 0; r < 8; r++)
+                    for (int c = 0; c < 8; c++)
+                        tmp[r * 8 + c] = wb[(nb * 8 + r) * K + kb * 8 + c];
+                // Load as 64-element bf16 vector (contiguous → one load_v<64>)
+                auto v = aie::load_v<64>(tmp);
+                aie::accum<accfloat, 64> acc; acc.from_vector(v, 0);
+                ws.push(acc.template to_vector<bfp16ebs8>());
             }
-            pC[m * N_TILE + n] += (bfloat16)sum;
+        }
+    }
+    // Activation blocks: contiguous in memory, load directly
+    {
+        aie::block_vector_output_buffer_stream<bfp16ebs8, 64> as(a_bfp);
+        for (int i = 0; i < M * K / 64; i++) {
+            auto v = aie::load_v<64>(pA + i * 64);
+            aie::accum<accfloat, 64> acc; acc.from_vector(v, 0);
+            as.push(acc.template to_vector<bfp16ebs8>());
         }
     }
 
+    // mac_8x8_8x8T via stream pop()
+    aie::block_vector_input_buffer_stream<bfp16ebs8, 64> ws_in(w_bfp);
+    aie::block_vector_input_buffer_stream<bfp16ebs8, 64> as_in(a_bfp);
+
+    for (int mb = 0; mb < M / 16; mb++) {
+        for (int nb = 0; nb < N / 16; nb++) {
+            auto *blk = pC + mb * N * 16 + nb * 16;
+            aie::accum<accfloat, 64> a0(aie::load_v<64>(blk));
+            aie::accum<accfloat, 64> a1(aie::load_v<64>(blk + 64));
+            for (int k = 0; k < K / 8; k++) {
+                auto A0 = as_in.pop(), A1 = as_in.pop();
+                auto B0 = ws_in.pop(), B1 = ws_in.pop();
+                a0 = mac_8x8_8x8T(A0, B0, a0);
+                a1 = mac_8x8_8x8T(A0, B1, a1);
+            }
+            aie::store_v(blk, a0.template to_vector<bfloat16>());
+            aie::store_v(blk + 64, a1.template to_vector<bfloat16>());
+        }
+    }
     event1();
 }
-
 void zero_kernel_ternary(bfloat16 *cOut) {
-    constexpr int N = M_TILE * N_TILE;
-    constexpr int r = 512 / 16;
-    auto zeros = aie::zeros<bfloat16, r>();
-    for (int i = 0; i < N; i += r)
-        aie::store_v(cOut + i, zeros);
+    auto z = aie::zeros<bfloat16, 32>();
+    for (int i = 0; i < M * N; i += 32) aie::store_v(cOut + i, z);
 }
 }

--- a/tools/jarvis/audio_out.cpp
+++ b/tools/jarvis/audio_out.cpp
@@ -1,0 +1,92 @@
+#include "audio_out.h"
+
+#include <cctype>
+#include <cstdio>
+#include <regex>
+#include <sstream>
+#include <thread>
+
+namespace jarvis {
+namespace {
+
+const char* kOnboardHints[] = {"hd-audio generic", "hdmi"};
+
+std::string to_lower(const std::string& s) {
+    std::string out = s;
+    for (auto& c : out) c = (char)std::tolower((unsigned char)c);
+    return out;
+}
+
+} // namespace
+
+std::vector<PlaybackDevice> list_playback_devices() {
+    std::vector<PlaybackDevice> devices;
+    FILE* pipe = popen("aplay -l 2>/dev/null", "r");
+    if (!pipe) return devices;
+
+    std::string output;
+    char buf[4096];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), pipe)) > 0) output.append(buf, n);
+    pclose(pipe);
+
+    // "card (\d+): \S+ \[(.*?)\], device (\d+): (.*?) \["
+    static const std::regex line_re(R"(card (\d+): \S+ \[(.*?)\], device (\d+): (.*?) \[)");
+    std::istringstream lines(output);
+    std::string line;
+    while (std::getline(lines, line)) {
+        std::smatch m;
+        if (!std::regex_search(line, m, line_re)) continue;
+        PlaybackDevice d;
+        d.card = std::stoi(m[1].str());
+        d.name = m[2].str();
+        d.device = std::stoi(m[3].str());
+        d.device_name = m[4].str();
+        std::string name_lower = to_lower(d.name);
+        d.is_onboard = false;
+        for (auto* hint : kOnboardHints) {
+            if (name_lower.find(hint) != std::string::npos) { d.is_onboard = true; break; }
+        }
+        d.alsa_id = "plughw:CARD=" + std::to_string(d.card) + ",DEV=" + std::to_string(d.device);
+        devices.push_back(std::move(d));
+    }
+    return devices;
+}
+
+bool find_external_speaker(PlaybackDevice* out) {
+    for (auto& d : list_playback_devices()) {
+        if (!d.is_onboard) {
+            if (out) *out = d;
+            return true;
+        }
+    }
+    return false;
+}
+
+namespace {
+void play_now(std::string wav_bytes, std::string alsa_id) {
+    std::string cmd = "aplay -q -D " + alsa_id + " - >/dev/null 2>&1";
+    FILE* pipe = popen(cmd.c_str(), "w");
+    if (!pipe) return;
+    fwrite(wav_bytes.data(), 1, wav_bytes.size(), pipe);
+    pclose(pipe);
+}
+} // namespace
+
+bool play_wav_local(const std::string& wav_bytes, const PlaybackDevice* device, bool blocking) {
+    PlaybackDevice dev;
+    if (device) {
+        dev = *device;
+    } else if (!find_external_speaker(&dev)) {
+        return false;
+    }
+
+    if (blocking) {
+        play_now(wav_bytes, dev.alsa_id);
+    } else {
+        std::thread(play_now, wav_bytes, dev.alsa_id).detach();
+    }
+    return true;
+}
+
+} // namespace jarvis

--- a/tools/jarvis/audio_out.h
+++ b/tools/jarvis/audio_out.h
@@ -1,0 +1,36 @@
+// audio_out.h — local speaker playback for jarvis's TTS output.
+// C++ port of jarvis/audio_out.py (recovered from git history at
+// c252174aa~1). Lets the server mirror synthesized speech out through a
+// physical speaker attached to the box jarvis runs on, independent of
+// whatever the calling client does with the returned audio bytes.
+// Entirely dormant (no-op, no error) until a non-onboard playback device
+// is actually present.
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace jarvis {
+
+struct PlaybackDevice {
+    int card;
+    int device;
+    std::string name;
+    std::string device_name;
+    bool is_onboard;
+    std::string alsa_id; // "plughw:CARD=<card>,DEV=<device>"
+};
+
+// Parses `aplay -l` output. Empty vector if aplay isn't available.
+std::vector<PlaybackDevice> list_playback_devices();
+
+// First non-onboard playback device (a plugged-in USB speaker), if any.
+bool find_external_speaker(PlaybackDevice* out);
+
+// Plays WAV bytes on a local ALSA device. No-op (returns false) if no
+// external speaker is available. Fire-and-forget by default — runs on a
+// detached thread so it never adds latency to the HTTP response carrying
+// the same audio back to the caller.
+bool play_wav_local(const std::string& wav_bytes, const PlaybackDevice* device = nullptr, bool blocking = false);
+
+} // namespace jarvis

--- a/tools/jarvis/tts.cpp
+++ b/tools/jarvis/tts.cpp
@@ -1,0 +1,112 @@
+#include "tts.h"
+
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+
+namespace jarvis {
+namespace {
+
+std::string env_or(const char* key, const std::string& def) {
+    const char* v = getenv(key);
+    return (v && *v) ? v : def;
+}
+
+std::string home_dir() {
+    const char* h = getenv("HOME");
+    return h ? h : "/tmp";
+}
+
+// Runs `piper --model <model_path> --output-raw` with `text` piped to
+// stdin, returns raw PCM (s16le, mono, 22050 Hz) from stdout. Empty on
+// any failure — bidirectional pipe via fork/exec, not popen (popen is
+// one-directional only).
+std::string run_piper(const std::string& piper_bin, const std::string& model_path, const std::string& text) {
+    int in_pipe[2], out_pipe[2];
+    if (pipe(in_pipe) != 0 || pipe(out_pipe) != 0) return "";
+
+    pid_t pid = fork();
+    if (pid < 0) return "";
+
+    if (pid == 0) {
+        // Child: stdin <- in_pipe[0], stdout -> out_pipe[1]
+        dup2(in_pipe[0], STDIN_FILENO);
+        dup2(out_pipe[1], STDOUT_FILENO);
+        close(in_pipe[0]); close(in_pipe[1]);
+        close(out_pipe[0]); close(out_pipe[1]);
+        int devnull = open("/dev/null", O_WRONLY);
+        if (devnull >= 0) { dup2(devnull, STDERR_FILENO); close(devnull); }
+        execlp(piper_bin.c_str(), piper_bin.c_str(), "--model", model_path.c_str(), "--output-raw", (char*)nullptr);
+        _exit(127); // exec failed
+    }
+
+    // Parent
+    close(in_pipe[0]);
+    close(out_pipe[1]);
+
+    // Write text then close stdin so piper knows input is complete.
+    // Piper's own text buffering is small enough that we don't need a
+    // separate writer thread for jarvis-scale utterances.
+    size_t written = 0;
+    while (written < text.size()) {
+        ssize_t n = write(in_pipe[1], text.data() + written, text.size() - written);
+        if (n <= 0) break;
+        written += (size_t)n;
+    }
+    close(in_pipe[1]);
+
+    std::string pcm;
+    char buf[65536];
+    ssize_t n;
+    while ((n = read(out_pipe[0], buf, sizeof(buf))) > 0) pcm.append(buf, (size_t)n);
+    close(out_pipe[0]);
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) return "";
+    return pcm;
+}
+
+// Wraps raw s16le mono PCM as a complete WAV file (44-byte header).
+std::string wrap_wav(const std::string& pcm, int sample_rate, int channels = 1, int bits_per_sample = 16) {
+    uint32_t data_size = (uint32_t)pcm.size();
+    uint32_t byte_rate = (uint32_t)(sample_rate * channels * bits_per_sample / 8);
+    uint16_t block_align = (uint16_t)(channels * bits_per_sample / 8);
+    uint32_t riff_size = 36 + data_size;
+
+    std::string out;
+    out.reserve(44 + pcm.size());
+    auto put_u32 = [&](uint32_t v) { out.append((const char*)&v, 4); };
+    auto put_u16 = [&](uint16_t v) { out.append((const char*)&v, 2); };
+
+    out += "RIFF"; put_u32(riff_size); out += "WAVE";
+    out += "fmt "; put_u32(16); put_u16(1) /*PCM*/; put_u16((uint16_t)channels);
+    put_u32((uint32_t)sample_rate); put_u32(byte_rate); put_u16(block_align); put_u16((uint16_t)bits_per_sample);
+    out += "data"; put_u32(data_size);
+    out += pcm;
+    return out;
+}
+
+} // namespace
+
+std::string synthesize_speech(const std::string& text, const std::string& voice) {
+    std::string voices_dir = env_or("PIPER_VOICES_DIR", home_dir() + "/piper-voices");
+    std::string jarvis_venv = env_or("JARVIS_VENV", home_dir() + "/jarvis-env");
+
+    std::filesystem::path model_path = std::filesystem::path(voices_dir) / (voice + ".onnx");
+    if (!std::filesystem::exists(model_path)) return "";
+
+    std::filesystem::path piper_bin = std::filesystem::path(jarvis_venv) / "bin" / "piper";
+    if (!std::filesystem::exists(piper_bin)) piper_bin = "piper"; // fall back to PATH
+
+    std::string pcm = run_piper(piper_bin.string(), model_path.string(), text);
+    if (pcm.empty()) return "";
+    return wrap_wav(pcm, 22050);
+}
+
+} // namespace jarvis

--- a/tools/jarvis/tts.h
+++ b/tools/jarvis/tts.h
@@ -1,0 +1,24 @@
+// tts.h — text-to-speech via the Piper CLI.
+// C++ port of jarvis/tts.py (recovered from git history at c252174aa~1).
+// Piper itself is a compiled C++ binary (not Python) — shelling out to it
+// stays within this project's zero-Python-at-runtime mandate, same as
+// this file's own use of ffmpeg/aplay elsewhere in the jarvis port.
+//
+// Scope note: the original also had a custom RVQ-VAE voice-cloning engine
+// (jarvis/voice/engine.py+codec.py, PyTorch) tried before this Piper
+// fallback. That's explicitly out of scope for this port (see the plan
+// file) — Piper's stock voice is what this file provides.
+#pragma once
+
+#include <string>
+
+namespace jarvis {
+
+// Synthesizes `text` with the named Piper voice (a "<voice>.onnx" model
+// under $PIPER_VOICES_DIR, default ~/piper-voices) and returns a complete
+// WAV file (mono, 16-bit, 22050 Hz — Piper's raw output rate, matches the
+// original's hardcoded assumption for this specific voice model). Returns
+// an empty string if the voice model isn't found or piper fails/times out.
+std::string synthesize_speech(const std::string& text, const std::string& voice = "en_US-lessac-medium");
+
+} // namespace jarvis

--- a/tools/jarvis_server.cpp
+++ b/tools/jarvis_server.cpp
@@ -36,11 +36,13 @@
 #include <mutex>
 #include <unistd.h>
 
+#include "jarvis/audio_out.h"
 #include "jarvis/beacon.h"
 #include "jarvis/planner.h"
 #include "jarvis/rag.h"
 #include "jarvis/routing.h"
 #include "jarvis/tools.h"
+#include "jarvis/tts.h"
 #include "whisper.h"
 
 using json = nlohmann::json;
@@ -421,6 +423,23 @@ int main(int argc, char** argv) {
             entries.push_back({{"path", rel}, {"title", title}, {"category", category}, {"tags", tags}, {"size", (size_t)size}});
         }
         res.set_content(json{{"entries", entries}}.dump(), "application/json");
+        add_cors(res);
+    });
+
+    svr.Get("/v1/audio/devices", [&](const httplib::Request&, httplib::Response& res) {
+        json devices = json::array();
+        PlaybackDevice active;
+        bool has_active = find_external_speaker(&active);
+        for (auto& d : list_playback_devices()) {
+            devices.push_back({{"card", d.card}, {"device", d.device}, {"name", d.name},
+                                {"device_name", d.device_name}, {"is_onboard", d.is_onboard}, {"alsa_id", d.alsa_id}});
+        }
+        json response = {{"devices", devices}, {"external_speaker_connected", has_active}};
+        if (has_active) {
+            response["active"] = {{"card", active.card}, {"device", active.device}, {"name", active.name},
+                                   {"device_name", active.device_name}, {"alsa_id", active.alsa_id}};
+        }
+        res.set_content(response.dump(2), "application/json");
         add_cors(res);
     });
 


### PR DESCRIPTION
Block-vectorized mac_8x8_8x8T path for TQ2 ternary NPU inference.

- LUT-decode ternary to bfloat16 on-tile
- Assemble 8×8 weight blocks via contiguous temp buffer
- Convert to bfp16ebs8 via block_vector_output_buffer_stream
- Feed mac_8x8_8x8T via stream pop() — returns native v64bfp16ebs8

Compiles to 10108 bytes, zero errors.