### PR TITLE
docs: fix CONTRIBUTING.md NPU xclbin instructions after build_xclbins.sh rewrite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,9 +144,20 @@ ls -lh build/zaya_server
 > Requires Strix Halo with XDNA 2 NPU, XRT 2.21+, and the torch2aie toolchain.
 
 ```bash
-# Build xclbins (one-time per projection shape)
+# xclbins for the standard model shapes are pre-built and checked into
+# engine/npu/xclbins/ — list what's available:
 cd engine/npu
 ./build_xclbins.sh
+
+# New projection shape not covered by the checked-in xclbins? Compile the
+# microkernel, then build via the torch2aie make flow directly (the aiecc
+# toolchain has a pre-existing version mismatch that blocks a wrapper script —
+# see docs/npu-ternary-roadmap.md):
+./build_npu_ternary.sh tq2 <tag> <H> <NH> <NKV> <HD> <IM> --compile-only
+make -C ~/torch2aie/examples/gemm_asymmetric_tile_buffering/config1 \
+  M=<M> K=<K> N=<N> m=128 k=64 n=128 use_placed=1 targetname=n1_core \
+  kernelsrc=mm_ternary_tq2.cc aie_py_src=n1_core_tq2_placed.py \
+  build/final_<M>x<K>x<N>_128x64x128.xclbin
 
 # Build the engine
 cd ../..

--- a/engine/npu/build_npu_ternary.sh
+++ b/engine/npu/build_npu_ternary.sh
@@ -64,7 +64,7 @@ compile_kernel() {
     echo "  ✓ ${src}: $(stat -c%s "$obj_path") bytes"
 }
 
-copy_xclbins() {
+check_xclbins() {
     local prefix="$1" tag="$2"
     local count=0
     for xclbin in "${XCLBIN_DIR}"/${prefix}_*_${tag}.xclbin; do
@@ -129,7 +129,7 @@ TAG="$1" H="$2" NH="$3" NKV="$4" HD="$5" IM="$6" M="${7:-128}"
 
 echo ""
 echo "=== ${FMT_NAME} xclbins: ${TAG} (H=$H) M=$M ==="
-copy_xclbins "$PREFIX" "$TAG"
+check_xclbins "$PREFIX" "$TAG"
 
 echo ""
 echo "To use: export NPU_XCLBIN_DIR=${XCLBIN_DIR}"


### PR DESCRIPTION
## Summary

Follow-up to PR #905, which rewrote `engine/npu/build_xclbins.sh` from a real build script into a listing-only tool over the pre-built xclbins checked into `engine/npu/xclbins/` — but merged before this doc fix landed (the commit was stranded on the closed `refactor/build-scripts-v2` branch), so `CONTRIBUTING.md` has been out of sync with actual script behavior on `main` since then.

- `CONTRIBUTING.md`: the "Build NPU Engine" section still said `./build_xclbins.sh` to build xclbins "one-time per projection shape." That's no longer true — the script only lists what's already checked in. A contributor with a new projection shape would run it and silently get a no-op listing instead of a build, no error. Replaced with the actual path: compile the microkernel via `build_npu_ternary.sh --compile-only`, then invoke the torch2aie `make` flow directly (per the toolchain caveat already documented in `docs/npu-ternary-roadmap.md`).
- `engine/npu/build_npu_ternary.sh`: renamed `copy_xclbins()` → `check_xclbins()` — it only counts/verifies pre-built xclbins, it never copies anything, and the old name was misleading.

## Test plan
- [x] Doc-only + one function rename; no behavior change to verify beyond CI (build/lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
