### PR TITLE
fix: NPU build script Python 3.12 MLIR bindings env vars

### DIFF
--- a/engine/npu/build_npu_ternary.sh
+++ b/engine/npu/build_npu_ternary.sh
@@ -24,6 +24,9 @@ XCLBIN_DIR="${SCRIPT_DIR}/xclbins"
 TORCH2AIE="${HOME}/torch2aie"
 
 export PATH="${TORCH2AIE}/toolchain/bin:$PATH"
+# MLIR-AIE Python bindings require Python 3.12 (.so files compiled for cpython-312)
+export AIE_PYTHON="${TORCH2AIE}/.venv/bin/python3.12"
+export PYTHONPATH="${TORCH2AIE}/toolchain/mlir_aie/python"
 export AIETOOLS_DIR="${TORCH2AIE}/toolchain"
 export MLIR_AIE_DIR="${TORCH2AIE}/toolchain/mlir_aie"
 


### PR DESCRIPTION
## Summary

Rescued the one real, unmerged fix out of two abandoned branches (`fix/npu-benchmark-trigger`, `fix/xclbin-python-version`) that were mostly already superseded elsewhere — see the branch audit in this session for the full breakdown.

- `engine/npu/build_npu_ternary.sh`: sets `AIE_PYTHON`/`PYTHONPATH` for the MLIR-AIE Python bindings, which require cpython-312 `.so` files (cherry-picked from `fix/xclbin-python-version`, commit `c30530ead`).

Left out: `fix/npu-benchmark-trigger`'s "add bench.yml to NPU Benchmark trigger paths" commit — cherry-picking it produced an empty diff, confirming that single-line change is already present on `main`.

**Caveat worth a second look**: `main` already has a separate, dynamic mechanism for the same underlying Python-3.12-for-MLIR-AIE problem (a `PY_VER` check further down in the same script that prepends the venv's `python3.12` to `PATH` if the active `python3` isn't 3.12 — added by a later commit than the one this PR cherry-picks). The `AIE_PYTHON`/`PYTHONPATH` vars this PR adds aren't referenced anywhere else in the script, so they may be redundant with that existing check rather than filling a gap. Landing it anyway since it's a harmless, additive 3-line env-var export with no behavior change to existing working paths — but flagging in case the existing `PY_VER` check should be preferred instead and this dropped.

## Test plan
- [x] `bash -n engine/npu/build_npu_ternary.sh` — syntax OK
- [x] `shellcheck` — no new warnings introduced (pre-existing info-level warnings only)
- [x] Confirmed the other candidate commit from the same branch pair produces an empty cherry-pick (already on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)