### PR TITLE
feat: rescue Laguna-DFlash + new model families catalog additions

### DIFF
--- a/models/Gemma-2-2B/convert.log
+++ b/models/Gemma-2-2B/convert.log
@@ -1,0 +1,737 @@
+GGUF opened: arch=gemma2 tensors=288
+Model: H=2304 L=26 NH=8 NKV=4 HD=256 IM=9216 V=2304
+  tensor blk.0.ffn_down.weight: 2304x9216 tiled=13271040
+  tensor blk.0.ffn_gate.weight: 9216x2304 tiled=13271040
+  tensor blk.0.ffn_up.weight: 9216x2304 tiled=13271040
+  Total tensors: 182, data size: 1206.6 MB
+Quantizing 182 tensors...
+  [1/182] blk.0.ffn_down.weight... 21233664 elements at offset 489895776
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.0.ffn_down.weight                              2304x9216 -> 12960 KB
+  [2/182] blk.0.ffn_gate.weight... 21233664 elements at offset 507314016
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.0.ffn_gate.weight                              9216x2304 -> 12960 KB
+  [3/182] blk.0.ffn_up.weight... 21233664 elements at offset 519257952
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.0.ffn_up.weight                                9216x2304 -> 12960 KB
+  [4/182] blk.0.attn_k.weight... 2359296 elements at offset 531229536
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.0.attn_k.weight                                1024x2304 -> 1440 KB
+  [5/182] blk.0.attn_output.weight... 4718592 elements at offset 532556640
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.0.attn_output.weight                           2304x2048 -> 2880 KB
+  [6/182] blk.0.attn_q.weight... 4718592 elements at offset 535210848
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.0.attn_q.weight                                2048x2304 -> 2880 KB
+  [7/182] blk.0.attn_v.weight... 2359296 elements at offset 537865056
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.0.attn_v.weight                                1024x2304 -> 1440 KB
+  [8/182] blk.1.ffn_down.weight... 21233664 elements at offset 539809632
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.1.ffn_down.weight                              2304x9216 -> 12960 KB
+  [9/182] blk.1.ffn_gate.weight... 21233664 elements at offset 557227872
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.1.ffn_gate.weight                              9216x2304 -> 12960 KB
+  [10/182] blk.1.ffn_up.weight... 21233664 elements at offset 569171808
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.1.ffn_up.weight                                9216x2304 -> 12960 KB
+  [11/182] blk.1.attn_k.weight... 2359296 elements at offset 581143392
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.1.attn_k.weight                                1024x2304 -> 1440 KB
+  [12/182] blk.1.attn_output.weight... 4718592 elements at offset 582470496
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.1.attn_output.weight                           2304x2048 -> 2880 KB
+  [13/182] blk.1.attn_q.weight... 4718592 elements at offset 585124704
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.1.attn_q.weight                                2048x2304 -> 2880 KB
+  [14/182] blk.1.attn_v.weight... 2359296 elements at offset 587778912
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.1.attn_v.weight                                1024x2304 -> 1440 KB
+  [15/182] blk.10.ffn_down.weight... 21233664 elements at offset 589723488
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.10.ffn_down.weight                             2304x9216 -> 12960 KB
+  [16/182] blk.10.ffn_gate.weight... 21233664 elements at offset 607141728
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.10.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [17/182] blk.10.ffn_up.weight... 21233664 elements at offset 619085664
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.10.ffn_up.weight                               9216x2304 -> 12960 KB
+  [18/182] blk.10.attn_k.weight... 2359296 elements at offset 631057248
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.10.attn_k.weight                               1024x2304 -> 1440 KB
+  [19/182] blk.10.attn_output.weight... 4718592 elements at offset 632384352
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.10.attn_output.weight                          2304x2048 -> 2880 KB
+  [20/182] blk.10.attn_q.weight... 4718592 elements at offset 635038560
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.10.attn_q.weight                               2048x2304 -> 2880 KB
+  [21/182] blk.10.attn_v.weight... 2359296 elements at offset 637692768
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.10.attn_v.weight                               1024x2304 -> 1440 KB
+  [22/182] blk.11.ffn_down.weight... 21233664 elements at offset 639637344
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.11.ffn_down.weight                             2304x9216 -> 12960 KB
+  [23/182] blk.11.ffn_gate.weight... 21233664 elements at offset 651581280
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.11.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [24/182] blk.11.ffn_up.weight... 21233664 elements at offset 663525216
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.11.ffn_up.weight                               9216x2304 -> 12960 KB
+  [25/182] blk.11.attn_k.weight... 2359296 elements at offset 675496800
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.11.attn_k.weight                               1024x2304 -> 1440 KB
+  [26/182] blk.11.attn_output.weight... 4718592 elements at offset 676823904
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.11.attn_output.weight                          2304x2048 -> 2880 KB
+  [27/182] blk.11.attn_q.weight... 4718592 elements at offset 679478112
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.11.attn_q.weight                               2048x2304 -> 2880 KB
+  [28/182] blk.11.attn_v.weight... 2359296 elements at offset 682132320
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.11.attn_v.weight                               1024x2304 -> 1440 KB
+  [29/182] blk.12.ffn_down.weight... 21233664 elements at offset 683468640
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.12.ffn_down.weight                             2304x9216 -> 12960 KB
+  [30/182] blk.12.ffn_gate.weight... 21233664 elements at offset 695412576
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.12.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [31/182] blk.12.ffn_up.weight... 21233664 elements at offset 707356512
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.12.ffn_up.weight                               9216x2304 -> 12960 KB
+  [32/182] blk.12.attn_k.weight... 2359296 elements at offset 719328096
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.12.attn_k.weight                               1024x2304 -> 1440 KB
+  [33/182] blk.12.attn_output.weight... 4718592 elements at offset 720655200
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.12.attn_output.weight                          2304x2048 -> 2880 KB
+  [34/182] blk.12.attn_q.weight... 4718592 elements at offset 723309408
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.12.attn_q.weight                               2048x2304 -> 2880 KB
+  [35/182] blk.12.attn_v.weight... 2359296 elements at offset 725963616
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.12.attn_v.weight                               1024x2304 -> 1440 KB
+  [36/182] blk.13.ffn_down.weight... 21233664 elements at offset 727299936
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.13.ffn_down.weight                             2304x9216 -> 12960 KB
+  [37/182] blk.13.ffn_gate.weight... 21233664 elements at offset 744718176
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.13.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [38/182] blk.13.ffn_up.weight... 21233664 elements at offset 756662112
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.13.ffn_up.weight                               9216x2304 -> 12960 KB
+  [39/182] blk.13.attn_k.weight... 2359296 elements at offset 768633696
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.13.attn_k.weight                               1024x2304 -> 1440 KB
+  [40/182] blk.13.attn_output.weight... 4718592 elements at offset 769960800
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.13.attn_output.weight                          2304x2048 -> 2880 KB
+  [41/182] blk.13.attn_q.weight... 4718592 elements at offset 772615008
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.13.attn_q.weight                               2048x2304 -> 2880 KB
+  [42/182] blk.13.attn_v.weight... 2359296 elements at offset 775269216
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.13.attn_v.weight                               1024x2304 -> 1440 KB
+  [43/182] blk.14.ffn_down.weight... 21233664 elements at offset 777213792
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.14.ffn_down.weight                             2304x9216 -> 12960 KB
+  [44/182] blk.14.ffn_gate.weight... 21233664 elements at offset 789157728
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.14.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [45/182] blk.14.ffn_up.weight... 21233664 elements at offset 801101664
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.14.ffn_up.weight                               9216x2304 -> 12960 KB
+  [46/182] blk.14.attn_k.weight... 2359296 elements at offset 813073248
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.14.attn_k.weight                               1024x2304 -> 1440 KB
+  [47/182] blk.14.attn_output.weight... 4718592 elements at offset 814400352
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.14.attn_output.weight                          2304x2048 -> 2880 KB
+  [48/182] blk.14.attn_q.weight... 4718592 elements at offset 817054560
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.14.attn_q.weight                               2048x2304 -> 2880 KB
+  [49/182] blk.14.attn_v.weight... 2359296 elements at offset 819708768
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.14.attn_v.weight                               1024x2304 -> 1440 KB
+  [50/182] blk.15.ffn_down.weight... 21233664 elements at offset 821045088
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.15.ffn_down.weight                             2304x9216 -> 12960 KB
+  [51/182] blk.15.ffn_gate.weight... 21233664 elements at offset 832989024
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.15.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [52/182] blk.15.ffn_up.weight... 21233664 elements at offset 844932960
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.15.ffn_up.weight                               9216x2304 -> 12960 KB
+  [53/182] blk.15.attn_k.weight... 2359296 elements at offset 856904544
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.15.attn_k.weight                               1024x2304 -> 1440 KB
+  [54/182] blk.15.attn_output.weight... 4718592 elements at offset 858231648
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.15.attn_output.weight                          2304x2048 -> 2880 KB
+  [55/182] blk.15.attn_q.weight... 4718592 elements at offset 860885856
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.15.attn_q.weight                               2048x2304 -> 2880 KB
+  [56/182] blk.15.attn_v.weight... 2359296 elements at offset 863540064
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.15.attn_v.weight                               1024x2304 -> 1440 KB
+  [57/182] blk.16.ffn_down.weight... 21233664 elements at offset 864876384
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.16.ffn_down.weight                             2304x9216 -> 12960 KB
+  [58/182] blk.16.ffn_gate.weight... 21233664 elements at offset 882294624
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.16.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [59/182] blk.16.ffn_up.weight... 21233664 elements at offset 894238560
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.16.ffn_up.weight                               9216x2304 -> 12960 KB
+  [60/182] blk.16.attn_k.weight... 2359296 elements at offset 906210144
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.16.attn_k.weight                               1024x2304 -> 1440 KB
+  [61/182] blk.16.attn_output.weight... 4718592 elements at offset 907537248
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.16.attn_output.weight                          2304x2048 -> 2880 KB
+  [62/182] blk.16.attn_q.weight... 4718592 elements at offset 910191456
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.16.attn_q.weight                               2048x2304 -> 2880 KB
+  [63/182] blk.16.attn_v.weight... 2359296 elements at offset 912845664
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.16.attn_v.weight                               1024x2304 -> 1440 KB
+  [64/182] blk.17.ffn_down.weight... 21233664 elements at offset 914790240
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.17.ffn_down.weight                             2304x9216 -> 12960 KB
+  [65/182] blk.17.ffn_gate.weight... 21233664 elements at offset 926734176
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.17.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [66/182] blk.17.ffn_up.weight... 21233664 elements at offset 938678112
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.17.ffn_up.weight                               9216x2304 -> 12960 KB
+  [67/182] blk.17.attn_k.weight... 2359296 elements at offset 950649696
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.17.attn_k.weight                               1024x2304 -> 1440 KB
+  [68/182] blk.17.attn_output.weight... 4718592 elements at offset 951976800
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.17.attn_output.weight                          2304x2048 -> 2880 KB
+  [69/182] blk.17.attn_q.weight... 4718592 elements at offset 954631008
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.17.attn_q.weight                               2048x2304 -> 2880 KB
+  [70/182] blk.17.attn_v.weight... 2359296 elements at offset 957285216
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.17.attn_v.weight                               1024x2304 -> 1440 KB
+  [71/182] blk.18.ffn_down.weight... 21233664 elements at offset 958621536
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.18.ffn_down.weight                             2304x9216 -> 12960 KB
+  [72/182] blk.18.ffn_gate.weight... 21233664 elements at offset 970565472
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.18.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [73/182] blk.18.ffn_up.weight... 21233664 elements at offset 982509408
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.18.ffn_up.weight                               9216x2304 -> 12960 KB
+  [74/182] blk.18.attn_k.weight... 2359296 elements at offset 994480992
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.18.attn_k.weight                               1024x2304 -> 1440 KB
+  [75/182] blk.18.attn_output.weight... 4718592 elements at offset 995808096
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.18.attn_output.weight                          2304x2048 -> 2880 KB
+  [76/182] blk.18.attn_q.weight... 4718592 elements at offset 998462304
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.18.attn_q.weight                               2048x2304 -> 2880 KB
+  [77/182] blk.18.attn_v.weight... 2359296 elements at offset 1001116512
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.18.attn_v.weight                               1024x2304 -> 1440 KB
+  [78/182] blk.19.ffn_down.weight... 21233664 elements at offset 1002452832
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.19.ffn_down.weight                             2304x9216 -> 12960 KB
+  [79/182] blk.19.ffn_gate.weight... 21233664 elements at offset 1019871072
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.19.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [80/182] blk.19.ffn_up.weight... 21233664 elements at offset 1031815008
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.19.ffn_up.weight                               9216x2304 -> 12960 KB
+  [81/182] blk.19.attn_k.weight... 2359296 elements at offset 1043786592
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.19.attn_k.weight                               1024x2304 -> 1440 KB
+  [82/182] blk.19.attn_output.weight... 4718592 elements at offset 1045113696
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.19.attn_output.weight                          2304x2048 -> 2880 KB
+  [83/182] blk.19.attn_q.weight... 4718592 elements at offset 1047767904
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.19.attn_q.weight                               2048x2304 -> 2880 KB
+  [84/182] blk.19.attn_v.weight... 2359296 elements at offset 1050422112
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.19.attn_v.weight                               1024x2304 -> 1440 KB
+  [85/182] blk.2.ffn_down.weight... 21233664 elements at offset 1052366688
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.2.ffn_down.weight                              2304x9216 -> 12960 KB
+  [86/182] blk.2.ffn_gate.weight... 21233664 elements at offset 1064310624
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.2.ffn_gate.weight                              9216x2304 -> 12960 KB
+  [87/182] blk.2.ffn_up.weight... 21233664 elements at offset 1076254560
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.2.ffn_up.weight                                9216x2304 -> 12960 KB
+  [88/182] blk.2.attn_k.weight... 2359296 elements at offset 1088226144
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.2.attn_k.weight                                1024x2304 -> 1440 KB
+  [89/182] blk.2.attn_output.weight... 4718592 elements at offset 1089553248
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.2.attn_output.weight                           2304x2048 -> 2880 KB
+  [90/182] blk.2.attn_q.weight... 4718592 elements at offset 1092207456
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.2.attn_q.weight                                2048x2304 -> 2880 KB
+  [91/182] blk.2.attn_v.weight... 2359296 elements at offset 1094861664
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.2.attn_v.weight                                1024x2304 -> 1440 KB
+  [92/182] blk.20.ffn_down.weight... 21233664 elements at offset 1096197984
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.20.ffn_down.weight                             2304x9216 -> 12960 KB
+  [93/182] blk.20.ffn_gate.weight... 21233664 elements at offset 1108141920
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.20.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [94/182] blk.20.ffn_up.weight... 21233664 elements at offset 1120085856
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.20.ffn_up.weight                               9216x2304 -> 12960 KB
+  [95/182] blk.20.attn_k.weight... 2359296 elements at offset 1132057440
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.20.attn_k.weight                               1024x2304 -> 1440 KB
+  [96/182] blk.20.attn_output.weight... 4718592 elements at offset 1133384544
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.20.attn_output.weight                          2304x2048 -> 2880 KB
+  [97/182] blk.20.attn_q.weight... 4718592 elements at offset 1136038752
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.20.attn_q.weight                               2048x2304 -> 2880 KB
+  [98/182] blk.20.attn_v.weight... 2359296 elements at offset 1138692960
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.20.attn_v.weight                               1024x2304 -> 1440 KB
+  [99/182] blk.21.ffn_down.weight... 21233664 elements at offset 1140029280
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.21.ffn_down.weight                             2304x9216 -> 12960 KB
+  [100/182] blk.21.ffn_gate.weight... 21233664 elements at offset 1157447520
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.21.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [101/182] blk.21.ffn_up.weight... 21233664 elements at offset 1169391456
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.21.ffn_up.weight                               9216x2304 -> 12960 KB
+  [102/182] blk.21.attn_k.weight... 2359296 elements at offset 1181363040
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.21.attn_k.weight                               1024x2304 -> 1440 KB
+  [103/182] blk.21.attn_output.weight... 4718592 elements at offset 1182690144
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.21.attn_output.weight                          2304x2048 -> 2880 KB
+  [104/182] blk.21.attn_q.weight... 4718592 elements at offset 1185344352
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.21.attn_q.weight                               2048x2304 -> 2880 KB
+  [105/182] blk.21.attn_v.weight... 2359296 elements at offset 1187998560
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.21.attn_v.weight                               1024x2304 -> 1440 KB
+  [106/182] blk.22.ffn_down.weight... 21233664 elements at offset 1189943136
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.22.ffn_down.weight                             2304x9216 -> 12960 KB
+  [107/182] blk.22.ffn_gate.weight... 21233664 elements at offset 1201887072
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.22.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [108/182] blk.22.ffn_up.weight... 21233664 elements at offset 1213831008
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.22.ffn_up.weight                               9216x2304 -> 12960 KB
+  [109/182] blk.22.attn_k.weight... 2359296 elements at offset 1225802592
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.22.attn_k.weight                               1024x2304 -> 1440 KB
+  [110/182] blk.22.attn_output.weight... 4718592 elements at offset 1227129696
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.22.attn_output.weight                          2304x2048 -> 2880 KB
+  [111/182] blk.22.attn_q.weight... 4718592 elements at offset 1229783904
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.22.attn_q.weight                               2048x2304 -> 2880 KB
+  [112/182] blk.22.attn_v.weight... 2359296 elements at offset 1232438112
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.22.attn_v.weight                               1024x2304 -> 1440 KB
+  [113/182] blk.23.ffn_down.weight... 21233664 elements at offset 1233774432
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.23.ffn_down.weight                             2304x9216 -> 12960 KB
+  [114/182] blk.23.ffn_gate.weight... 21233664 elements at offset 1245718368
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.23.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [115/182] blk.23.ffn_up.weight... 21233664 elements at offset 1257662304
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.23.ffn_up.weight                               9216x2304 -> 12960 KB
+  [116/182] blk.23.attn_k.weight... 2359296 elements at offset 1269633888
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.23.attn_k.weight                               1024x2304 -> 1440 KB
+  [117/182] blk.23.attn_output.weight... 4718592 elements at offset 1270960992
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.23.attn_output.weight                          2304x2048 -> 2880 KB
+  [118/182] blk.23.attn_q.weight... 4718592 elements at offset 1273615200
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.23.attn_q.weight                               2048x2304 -> 2880 KB
+  [119/182] blk.23.attn_v.weight... 2359296 elements at offset 1276269408
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.23.attn_v.weight                               1024x2304 -> 1440 KB
+  [120/182] blk.24.ffn_gate.weight... 21233664 elements at offset 1277596512
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.24.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [121/182] blk.24.attn_k.weight... 2359296 elements at offset 1289540448
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.24.attn_k.weight                               1024x2304 -> 1440 KB
+  [122/182] blk.24.attn_output.weight... 4718592 elements at offset 1290867552
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.24.attn_output.weight                          2304x2048 -> 2880 KB
+  [123/182] blk.24.attn_q.weight... 4718592 elements at offset 1293521760
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.24.attn_q.weight                               2048x2304 -> 2880 KB
+  [124/182] blk.24.attn_v.weight... 2359296 elements at offset 1296175968
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.24.attn_v.weight                               1024x2304 -> 1440 KB
+  [125/182] blk.3.ffn_down.weight... 21233664 elements at offset 1298120544
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.3.ffn_down.weight                              2304x9216 -> 12960 KB
+  [126/182] blk.3.ffn_gate.weight... 21233664 elements at offset 1315538784
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.3.ffn_gate.weight                              9216x2304 -> 12960 KB
+  [127/182] blk.3.ffn_up.weight... 21233664 elements at offset 1327482720
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.3.ffn_up.weight                                9216x2304 -> 12960 KB
+  [128/182] blk.3.attn_k.weight... 2359296 elements at offset 1339454304
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.3.attn_k.weight                                1024x2304 -> 1440 KB
+  [129/182] blk.3.attn_output.weight... 4718592 elements at offset 1340781408
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.3.attn_output.weight                           2304x2048 -> 2880 KB
+  [130/182] blk.3.attn_q.weight... 4718592 elements at offset 1343435616
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.3.attn_q.weight                                2048x2304 -> 2880 KB
+  [131/182] blk.3.attn_v.weight... 2359296 elements at offset 1346089824
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.3.attn_v.weight                                1024x2304 -> 1440 KB
+  [132/182] blk.4.ffn_down.weight... 21233664 elements at offset 1347426144
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.4.ffn_down.weight                              2304x9216 -> 12960 KB
+  [133/182] blk.4.ffn_gate.weight... 21233664 elements at offset 1359370080
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.4.ffn_gate.weight                              9216x2304 -> 12960 KB
+  [134/182] blk.4.ffn_up.weight... 21233664 elements at offset 1371314016
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.4.ffn_up.weight                                9216x2304 -> 12960 KB
+  [135/182] blk.4.attn_k.weight... 2359296 elements at offset 1383285600
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.4.attn_k.weight                                1024x2304 -> 1440 KB
+  [136/182] blk.4.attn_output.weight... 4718592 elements at offset 1384612704
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.4.attn_output.weight                           2304x2048 -> 2880 KB
+  [137/182] blk.4.attn_q.weight... 4718592 elements at offset 1387266912
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.4.attn_q.weight                                2048x2304 -> 2880 KB
+  [138/182] blk.4.attn_v.weight... 2359296 elements at offset 1389921120
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.4.attn_v.weight                                1024x2304 -> 1440 KB
+  [139/182] blk.5.ffn_down.weight... 21233664 elements at offset 1391257440
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.5.ffn_down.weight                              2304x9216 -> 12960 KB
+  [140/182] blk.5.ffn_gate.weight... 21233664 elements at offset 1403201376
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.5.ffn_gate.weight                              9216x2304 -> 12960 KB
+  [141/182] blk.5.ffn_up.weight... 21233664 elements at offset 1415145312
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.5.ffn_up.weight                                9216x2304 -> 12960 KB
+  [142/182] blk.5.attn_k.weight... 2359296 elements at offset 1427116896
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.5.attn_k.weight                                1024x2304 -> 1440 KB
+  [143/182] blk.5.attn_output.weight... 4718592 elements at offset 1428444000
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.5.attn_output.weight                           2304x2048 -> 2880 KB
+  [144/182] blk.5.attn_q.weight... 4718592 elements at offset 1431098208
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.5.attn_q.weight                                2048x2304 -> 2880 KB
+  [145/182] blk.5.attn_v.weight... 2359296 elements at offset 1433752416
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.5.attn_v.weight                                1024x2304 -> 1440 KB
+  [146/182] blk.6.ffn_down.weight... 21233664 elements at offset 1435696992
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.6.ffn_down.weight                              2304x9216 -> 12960 KB
+  [147/182] blk.6.ffn_gate.weight... 21233664 elements at offset 1453115232
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.6.ffn_gate.weight                              9216x2304 -> 12960 KB
+  [148/182] blk.6.ffn_up.weight... 21233664 elements at offset 1465059168
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.6.ffn_up.weight                                9216x2304 -> 12960 KB
+  [149/182] blk.6.attn_k.weight... 2359296 elements at offset 1477030752
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.6.attn_k.weight                                1024x2304 -> 1440 KB
+  [150/182] blk.6.attn_output.weight... 4718592 elements at offset 1478357856
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.6.attn_output.weight                           2304x2048 -> 2880 KB
+  [151/182] blk.6.attn_q.weight... 4718592 elements at offset 1481012064
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.6.attn_q.weight                                2048x2304 -> 2880 KB
+  [152/182] blk.6.attn_v.weight... 2359296 elements at offset 1483666272
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.6.attn_v.weight                                1024x2304 -> 1440 KB
+  [153/182] blk.7.ffn_down.weight... 21233664 elements at offset 1485002592
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.7.ffn_down.weight                              2304x9216 -> 12960 KB
+  [154/182] blk.7.ffn_gate.weight... 21233664 elements at offset 1496946528
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.7.ffn_gate.weight                              9216x2304 -> 12960 KB
+  [155/182] blk.7.ffn_up.weight... 21233664 elements at offset 1508890464
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.7.ffn_up.weight                                9216x2304 -> 12960 KB
+  [156/182] blk.7.attn_k.weight... 2359296 elements at offset 1520862048
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.7.attn_k.weight                                1024x2304 -> 1440 KB
+  [157/182] blk.7.attn_output.weight... 4718592 elements at offset 1522189152
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.7.attn_output.weight                           2304x2048 -> 2880 KB
+  [158/182] blk.7.attn_q.weight... 4718592 elements at offset 1524843360
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.7.attn_q.weight                                2048x2304 -> 2880 KB
+  [159/182] blk.7.attn_v.weight... 2359296 elements at offset 1527497568
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.7.attn_v.weight                                1024x2304 -> 1440 KB
+  [160/182] blk.8.ffn_down.weight... 21233664 elements at offset 1529442144
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.8.ffn_down.weight                              2304x9216 -> 12960 KB
+  [161/182] blk.8.ffn_gate.weight... 21233664 elements at offset 1546860384
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.8.ffn_gate.weight                              9216x2304 -> 12960 KB
+  [162/182] blk.8.ffn_up.weight... 21233664 elements at offset 1558804320
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.8.ffn_up.weight                                9216x2304 -> 12960 KB
+  [163/182] blk.8.attn_k.weight... 2359296 elements at offset 1570775904
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.8.attn_k.weight                                1024x2304 -> 1440 KB
+  [164/182] blk.8.attn_output.weight... 4718592 elements at offset 1572103008
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.8.attn_output.weight                           2304x2048 -> 2880 KB
+  [165/182] blk.8.attn_q.weight... 4718592 elements at offset 1574757216
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.8.attn_q.weight                                2048x2304 -> 2880 KB
+  [166/182] blk.8.attn_v.weight... 2359296 elements at offset 1577411424
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.8.attn_v.weight                                1024x2304 -> 1440 KB
+  [167/182] blk.9.ffn_down.weight... 21233664 elements at offset 1579356000
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.9.ffn_down.weight                              2304x9216 -> 12960 KB
+  [168/182] blk.9.ffn_gate.weight... 21233664 elements at offset 1596774240
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.9.ffn_gate.weight                              9216x2304 -> 12960 KB
+  [169/182] blk.9.ffn_up.weight... 21233664 elements at offset 1608718176
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.9.ffn_up.weight                                9216x2304 -> 12960 KB
+  [170/182] blk.9.attn_k.weight... 2359296 elements at offset 1620689760
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.9.attn_k.weight                                1024x2304 -> 1440 KB
+  [171/182] blk.9.attn_output.weight... 4718592 elements at offset 1622016864
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.9.attn_output.weight                           2304x2048 -> 2880 KB
+  [172/182] blk.9.attn_q.weight... 4718592 elements at offset 1624671072
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.9.attn_q.weight                                2048x2304 -> 2880 KB
+  [173/182] blk.9.attn_v.weight... 2359296 elements at offset 1627325280
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.9.attn_v.weight                                1024x2304 -> 1440 KB
+  [174/182] blk.24.ffn_down.weight... 21233664 elements at offset 1629269856
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.24.ffn_down.weight                             2304x9216 -> 12960 KB
+  [175/182] blk.24.ffn_up.weight... 21233664 elements at offset 1646688096
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.24.ffn_up.weight                               9216x2304 -> 12960 KB
+  [176/182] blk.25.ffn_down.weight... 21233664 elements at offset 1658668896
+got 21233664 floats, tiling...
+  tiles: 72x36 fout=0x55da25ccd870
+  blk.25.ffn_down.weight                             2304x9216 -> 12960 KB
+  [177/182] blk.25.ffn_gate.weight... 21233664 elements at offset 1676087136
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.25.ffn_gate.weight                             9216x2304 -> 12960 KB
+  [178/182] blk.25.ffn_up.weight... 21233664 elements at offset 1688031072
+got 21233664 floats, tiling...
+  tiles: 288x9 fout=0x55da25ccd870
+  blk.25.ffn_up.weight                               9216x2304 -> 12960 KB
+  [179/182] blk.25.attn_k.weight... 2359296 elements at offset 1700002656
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.25.attn_k.weight                               1024x2304 -> 1440 KB
+  [180/182] blk.25.attn_output.weight... 4718592 elements at offset 1701329760
+got 4718592 floats, tiling...
+  tiles: 72x8 fout=0x55da25ccd870
+  blk.25.attn_output.weight                          2304x2048 -> 2880 KB
+  [181/182] blk.25.attn_q.weight... 4718592 elements at offset 1703983968
+got 4718592 floats, tiling...
+  tiles: 64x9 fout=0x55da25ccd870
+  blk.25.attn_q.weight                               2048x2304 -> 2880 KB
+  [182/182] blk.25.attn_v.weight... 2359296 elements at offset 1706638176
+got 2359296 floats, tiling...
+  tiles: 32x9 fout=0x55da25ccd870
+  blk.25.attn_v.weight                               1024x2304 -> 1440 KB
+
+=== DONE: models/Gemma-2-2B/gemma-2-2b-it.1bp (1206.6 MB) in 10 seconds ===

--- a/models/Mixtral-8x7B/convert.log
+++ b/models/Mixtral-8x7B/convert.log
@@ -1,0 +1,3729 @@
+GGUF opened: arch=llama tensors=995
+Model: H=4096 L=32 NH=32 NKV=8 HD=128 IM=14336 V=4096
+  tensor token_embd.weight: 32000x4096 tiled=81920000
+  tensor blk.0.ffn_gate.0.weight: 14336x4096 tiled=36700160
+  tensor blk.0.ffn_down.0.weight: 4096x14336 tiled=36700160
+  Total tensors: 930, data size: 27838.8 MB
+Quantizing 930 tensors...
+  [1/930] token_embd.weight... 131072000 elements at offset 780224
+got 131072000 floats, tiling...
+  tiles: 1000x16 fout=0x62871b2ea110
+  token_embd.weight                                  32000x4096 -> 80000 KB
+  [2/930] blk.0.ffn_gate.0.weight... 58720256 elements at offset 74508224
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_gate.0.weight                            14336x4096 -> 35840 KB
+  [3/930] blk.0.ffn_down.0.weight... 58720256 elements at offset 107538368
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.0.ffn_down.0.weight                            4096x14336 -> 35840 KB
+  [4/930] blk.0.ffn_up.0.weight... 58720256 elements at offset 140568512
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_up.0.weight                              14336x4096 -> 35840 KB
+  [5/930] blk.0.ffn_gate.1.weight... 58720256 elements at offset 173598656
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_gate.1.weight                            14336x4096 -> 35840 KB
+  [6/930] blk.0.ffn_down.1.weight... 58720256 elements at offset 206628800
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.0.ffn_down.1.weight                            4096x14336 -> 35840 KB
+  [7/930] blk.0.ffn_up.1.weight... 58720256 elements at offset 239658944
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_up.1.weight                              14336x4096 -> 35840 KB
+  [8/930] blk.0.ffn_gate.2.weight... 58720256 elements at offset 272689088
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_gate.2.weight                            14336x4096 -> 35840 KB
+  [9/930] blk.0.ffn_down.2.weight... 58720256 elements at offset 305719232
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.0.ffn_down.2.weight                            4096x14336 -> 35840 KB
+  [10/930] blk.0.ffn_up.2.weight... 58720256 elements at offset 338749376
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_up.2.weight                              14336x4096 -> 35840 KB
+  [11/930] blk.0.ffn_gate.3.weight... 58720256 elements at offset 371779520
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_gate.3.weight                            14336x4096 -> 35840 KB
+  [12/930] blk.0.ffn_down.3.weight... 58720256 elements at offset 404809664
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.0.ffn_down.3.weight                            4096x14336 -> 35840 KB
+  [13/930] blk.0.ffn_up.3.weight... 58720256 elements at offset 437839808
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_up.3.weight                              14336x4096 -> 35840 KB
+  [14/930] blk.0.ffn_gate.4.weight... 58720256 elements at offset 470869952
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_gate.4.weight                            14336x4096 -> 35840 KB
+  [15/930] blk.0.ffn_down.4.weight... 58720256 elements at offset 503900096
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.0.ffn_down.4.weight                            4096x14336 -> 35840 KB
+  [16/930] blk.0.ffn_up.4.weight... 58720256 elements at offset 536930240
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_up.4.weight                              14336x4096 -> 35840 KB
+  [17/930] blk.0.ffn_gate.5.weight... 58720256 elements at offset 569960384
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_gate.5.weight                            14336x4096 -> 35840 KB
+  [18/930] blk.0.ffn_down.5.weight... 58720256 elements at offset 602990528
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.0.ffn_down.5.weight                            4096x14336 -> 35840 KB
+  [19/930] blk.0.ffn_up.5.weight... 58720256 elements at offset 636020672
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_up.5.weight                              14336x4096 -> 35840 KB
+  [20/930] blk.0.ffn_gate.6.weight... 58720256 elements at offset 669050816
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_gate.6.weight                            14336x4096 -> 35840 KB
+  [21/930] blk.0.ffn_down.6.weight... 58720256 elements at offset 702080960
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.0.ffn_down.6.weight                            4096x14336 -> 35840 KB
+  [22/930] blk.0.ffn_up.6.weight... 58720256 elements at offset 735111104
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_up.6.weight                              14336x4096 -> 35840 KB
+  [23/930] blk.0.ffn_gate.7.weight... 58720256 elements at offset 768141248
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_gate.7.weight                            14336x4096 -> 35840 KB
+  [24/930] blk.0.ffn_down.7.weight... 58720256 elements at offset 801171392
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.0.ffn_down.7.weight                            4096x14336 -> 35840 KB
+  [25/930] blk.0.ffn_up.7.weight... 58720256 elements at offset 834201536
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.0.ffn_up.7.weight                              14336x4096 -> 35840 KB
+  [26/930] blk.0.ffn_gate_inp.weight... 32768 elements at offset 867231680
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.0.ffn_gate_inp.weight                             8x4096 -> 80 KB
+  [27/930] blk.0.attn_k.weight... 4194304 elements at offset 867329984
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.0.attn_k.weight                                1024x4096 -> 2560 KB
+  [28/930] blk.0.attn_output.weight... 16777216 elements at offset 871786432
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.0.attn_output.weight                           4096x4096 -> 10240 KB
+  [29/930] blk.0.attn_q.weight... 16777216 elements at offset 881223616
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.0.attn_q.weight                                4096x4096 -> 10240 KB
+  [30/930] blk.0.attn_v.weight... 4194304 elements at offset 890660800
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.0.attn_v.weight                                1024x4096 -> 2560 KB
+  [31/930] blk.1.ffn_gate.0.weight... 58720256 elements at offset 895117248
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_gate.0.weight                            14336x4096 -> 35840 KB
+  [32/930] blk.1.ffn_down.0.weight... 58720256 elements at offset 928147392
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.1.ffn_down.0.weight                            4096x14336 -> 35840 KB
+  [33/930] blk.1.ffn_up.0.weight... 58720256 elements at offset 961177536
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_up.0.weight                              14336x4096 -> 35840 KB
+  [34/930] blk.1.ffn_gate.1.weight... 58720256 elements at offset 994207680
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_gate.1.weight                            14336x4096 -> 35840 KB
+  [35/930] blk.1.ffn_down.1.weight... 58720256 elements at offset 1027237824
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.1.ffn_down.1.weight                            4096x14336 -> 35840 KB
+  [36/930] blk.1.ffn_up.1.weight... 58720256 elements at offset 1060267968
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_up.1.weight                              14336x4096 -> 35840 KB
+  [37/930] blk.1.ffn_gate.2.weight... 58720256 elements at offset 1093298112
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_gate.2.weight                            14336x4096 -> 35840 KB
+  [38/930] blk.1.ffn_down.2.weight... 58720256 elements at offset 1126328256
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.1.ffn_down.2.weight                            4096x14336 -> 35840 KB
+  [39/930] blk.1.ffn_up.2.weight... 58720256 elements at offset 1159358400
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_up.2.weight                              14336x4096 -> 35840 KB
+  [40/930] blk.1.ffn_gate.3.weight... 58720256 elements at offset 1192388544
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_gate.3.weight                            14336x4096 -> 35840 KB
+  [41/930] blk.1.ffn_down.3.weight... 58720256 elements at offset 1225418688
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.1.ffn_down.3.weight                            4096x14336 -> 35840 KB
+  [42/930] blk.1.ffn_up.3.weight... 58720256 elements at offset 1258448832
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_up.3.weight                              14336x4096 -> 35840 KB
+  [43/930] blk.1.ffn_gate.4.weight... 58720256 elements at offset 1291478976
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_gate.4.weight                            14336x4096 -> 35840 KB
+  [44/930] blk.1.ffn_down.4.weight... 58720256 elements at offset 1324509120
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.1.ffn_down.4.weight                            4096x14336 -> 35840 KB
+  [45/930] blk.1.ffn_gate_inp.weight... 32768 elements at offset 1357539264
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.1.ffn_gate_inp.weight                             8x4096 -> 80 KB
+  [46/930] blk.1.attn_k.weight... 4194304 elements at offset 1357604800
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.1.attn_k.weight                                1024x4096 -> 2560 KB
+  [47/930] blk.1.attn_output.weight... 16777216 elements at offset 1362061248
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.1.attn_output.weight                           4096x4096 -> 10240 KB
+  [48/930] blk.1.attn_q.weight... 16777216 elements at offset 1371498432
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.1.attn_q.weight                                4096x4096 -> 10240 KB
+  [49/930] blk.1.attn_v.weight... 4194304 elements at offset 1380935616
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.1.attn_v.weight                                1024x4096 -> 2560 KB
+  [50/930] blk.1.ffn_up.4.weight... 58720256 elements at offset 1385392064
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_up.4.weight                              14336x4096 -> 35840 KB
+  [51/930] blk.1.ffn_gate.5.weight... 58720256 elements at offset 1418422208
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_gate.5.weight                            14336x4096 -> 35840 KB
+  [52/930] blk.1.ffn_down.5.weight... 58720256 elements at offset 1451452352
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.1.ffn_down.5.weight                            4096x14336 -> 35840 KB
+  [53/930] blk.1.ffn_up.5.weight... 58720256 elements at offset 1484482496
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_up.5.weight                              14336x4096 -> 35840 KB
+  [54/930] blk.1.ffn_gate.6.weight... 58720256 elements at offset 1517512640
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_gate.6.weight                            14336x4096 -> 35840 KB
+  [55/930] blk.1.ffn_down.6.weight... 58720256 elements at offset 1550542784
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.1.ffn_down.6.weight                            4096x14336 -> 35840 KB
+  [56/930] blk.1.ffn_up.6.weight... 58720256 elements at offset 1583572928
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_up.6.weight                              14336x4096 -> 35840 KB
+  [57/930] blk.1.ffn_gate.7.weight... 58720256 elements at offset 1616603072
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_gate.7.weight                            14336x4096 -> 35840 KB
+  [58/930] blk.1.ffn_down.7.weight... 58720256 elements at offset 1649633216
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.1.ffn_down.7.weight                            4096x14336 -> 35840 KB
+  [59/930] blk.1.ffn_up.7.weight... 58720256 elements at offset 1682663360
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.1.ffn_up.7.weight                              14336x4096 -> 35840 KB
+  [60/930] blk.2.ffn_gate.0.weight... 58720256 elements at offset 1715726272
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_gate.0.weight                            14336x4096 -> 35840 KB
+  [61/930] blk.2.ffn_down.0.weight... 58720256 elements at offset 1748756416
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.2.ffn_down.0.weight                            4096x14336 -> 35840 KB
+  [62/930] blk.2.ffn_up.0.weight... 58720256 elements at offset 1781786560
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_up.0.weight                              14336x4096 -> 35840 KB
+  [63/930] blk.2.ffn_gate.1.weight... 58720256 elements at offset 1814816704
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_gate.1.weight                            14336x4096 -> 35840 KB
+  [64/930] blk.2.ffn_down.1.weight... 58720256 elements at offset 1847846848
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.2.ffn_down.1.weight                            4096x14336 -> 35840 KB
+  [65/930] blk.2.ffn_up.1.weight... 58720256 elements at offset 1880876992
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_up.1.weight                              14336x4096 -> 35840 KB
+  [66/930] blk.2.ffn_gate.2.weight... 58720256 elements at offset 1913907136
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_gate.2.weight                            14336x4096 -> 35840 KB
+  [67/930] blk.2.ffn_down.2.weight... 58720256 elements at offset 1946937280
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.2.ffn_down.2.weight                            4096x14336 -> 35840 KB
+  [68/930] blk.2.ffn_up.2.weight... 58720256 elements at offset 1979967424
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_up.2.weight                              14336x4096 -> 35840 KB
+  [69/930] blk.2.ffn_gate.3.weight... 58720256 elements at offset 2012997568
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_gate.3.weight                            14336x4096 -> 35840 KB
+  [70/930] blk.2.ffn_down.3.weight... 58720256 elements at offset 2046027712
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.2.ffn_down.3.weight                            4096x14336 -> 35840 KB
+  [71/930] blk.2.ffn_up.3.weight... 58720256 elements at offset 2079057856
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_up.3.weight                              14336x4096 -> 35840 KB
+  [72/930] blk.2.ffn_gate.4.weight... 58720256 elements at offset 2112088000
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_gate.4.weight                            14336x4096 -> 35840 KB
+  [73/930] blk.2.ffn_down.4.weight... 58720256 elements at offset 2145118144
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.2.ffn_down.4.weight                            4096x14336 -> 35840 KB
+  [74/930] blk.2.ffn_up.4.weight... 58720256 elements at offset 2178148288
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_up.4.weight                              14336x4096 -> 35840 KB
+  [75/930] blk.2.ffn_gate.5.weight... 58720256 elements at offset 2211178432
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_gate.5.weight                            14336x4096 -> 35840 KB
+  [76/930] blk.2.ffn_down.5.weight... 58720256 elements at offset 2244208576
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.2.ffn_down.5.weight                            4096x14336 -> 35840 KB
+  [77/930] blk.2.ffn_up.5.weight... 58720256 elements at offset 2277238720
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_up.5.weight                              14336x4096 -> 35840 KB
+  [78/930] blk.2.ffn_gate.6.weight... 58720256 elements at offset 2310268864
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_gate.6.weight                            14336x4096 -> 35840 KB
+  [79/930] blk.2.ffn_down.6.weight... 58720256 elements at offset 2343299008
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.2.ffn_down.6.weight                            4096x14336 -> 35840 KB
+  [80/930] blk.2.ffn_up.6.weight... 58720256 elements at offset 2376329152
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_up.6.weight                              14336x4096 -> 35840 KB
+  [81/930] blk.2.ffn_gate.7.weight... 58720256 elements at offset 2409359296
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_gate.7.weight                            14336x4096 -> 35840 KB
+  [82/930] blk.2.ffn_down.7.weight... 58720256 elements at offset 2442389440
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.2.ffn_down.7.weight                            4096x14336 -> 35840 KB
+  [83/930] blk.2.ffn_up.7.weight... 58720256 elements at offset 2475419584
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.2.ffn_up.7.weight                              14336x4096 -> 35840 KB
+  [84/930] blk.2.ffn_gate_inp.weight... 32768 elements at offset 2508449728
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.2.ffn_gate_inp.weight                             8x4096 -> 80 KB
+  [85/930] blk.2.attn_k.weight... 4194304 elements at offset 2508548032
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.2.attn_k.weight                                1024x4096 -> 2560 KB
+  [86/930] blk.2.attn_output.weight... 16777216 elements at offset 2513004480
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.2.attn_output.weight                           4096x4096 -> 10240 KB
+  [87/930] blk.2.attn_q.weight... 16777216 elements at offset 2522441664
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.2.attn_q.weight                                4096x4096 -> 10240 KB
+  [88/930] blk.2.attn_v.weight... 4194304 elements at offset 2531878848
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.2.attn_v.weight                                1024x4096 -> 2560 KB
+  [89/930] blk.3.ffn_gate.0.weight... 58720256 elements at offset 2536335296
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_gate.0.weight                            14336x4096 -> 35840 KB
+  [90/930] blk.3.ffn_down.0.weight... 58720256 elements at offset 2569365440
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.3.ffn_down.0.weight                            4096x14336 -> 35840 KB
+  [91/930] blk.3.ffn_up.0.weight... 58720256 elements at offset 2602395584
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_up.0.weight                              14336x4096 -> 35840 KB
+  [92/930] blk.3.ffn_gate.1.weight... 58720256 elements at offset 2635425728
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_gate.1.weight                            14336x4096 -> 35840 KB
+  [93/930] blk.3.ffn_down.1.weight... 58720256 elements at offset 2668455872
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.3.ffn_down.1.weight                            4096x14336 -> 35840 KB
+  [94/930] blk.3.ffn_up.1.weight... 58720256 elements at offset 2701486016
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_up.1.weight                              14336x4096 -> 35840 KB
+  [95/930] blk.3.ffn_gate.2.weight... 58720256 elements at offset 2734516160
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_gate.2.weight                            14336x4096 -> 35840 KB
+  [96/930] blk.3.ffn_gate_inp.weight... 32768 elements at offset 2767546304
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.3.ffn_gate_inp.weight                             8x4096 -> 80 KB
+  [97/930] blk.3.attn_k.weight... 4194304 elements at offset 2767611840
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.3.attn_k.weight                                1024x4096 -> 2560 KB
+  [98/930] blk.3.attn_output.weight... 16777216 elements at offset 2772068288
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.3.attn_output.weight                           4096x4096 -> 10240 KB
+  [99/930] blk.3.attn_q.weight... 16777216 elements at offset 2781505472
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.3.attn_q.weight                                4096x4096 -> 10240 KB
+  [100/930] blk.3.attn_v.weight... 4194304 elements at offset 2790942656
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.3.attn_v.weight                                1024x4096 -> 2560 KB
+  [101/930] blk.3.ffn_down.2.weight... 58720256 elements at offset 2795399104
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.3.ffn_down.2.weight                            4096x14336 -> 35840 KB
+  [102/930] blk.3.ffn_up.2.weight... 58720256 elements at offset 2828429248
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_up.2.weight                              14336x4096 -> 35840 KB
+  [103/930] blk.3.ffn_gate.3.weight... 58720256 elements at offset 2861459392
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_gate.3.weight                            14336x4096 -> 35840 KB
+  [104/930] blk.3.ffn_down.3.weight... 58720256 elements at offset 2894489536
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.3.ffn_down.3.weight                            4096x14336 -> 35840 KB
+  [105/930] blk.3.ffn_up.3.weight... 58720256 elements at offset 2927519680
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_up.3.weight                              14336x4096 -> 35840 KB
+  [106/930] blk.3.ffn_gate.4.weight... 58720256 elements at offset 2960549824
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_gate.4.weight                            14336x4096 -> 35840 KB
+  [107/930] blk.3.ffn_down.4.weight... 58720256 elements at offset 2993579968
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.3.ffn_down.4.weight                            4096x14336 -> 35840 KB
+  [108/930] blk.3.ffn_up.4.weight... 58720256 elements at offset 3026610112
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_up.4.weight                              14336x4096 -> 35840 KB
+  [109/930] blk.3.ffn_gate.5.weight... 58720256 elements at offset 3059640256
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_gate.5.weight                            14336x4096 -> 35840 KB
+  [110/930] blk.3.ffn_down.5.weight... 58720256 elements at offset 3092670400
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.3.ffn_down.5.weight                            4096x14336 -> 35840 KB
+  [111/930] blk.3.ffn_up.5.weight... 58720256 elements at offset 3125700544
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_up.5.weight                              14336x4096 -> 35840 KB
+  [112/930] blk.3.ffn_gate.6.weight... 58720256 elements at offset 3158730688
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_gate.6.weight                            14336x4096 -> 35840 KB
+  [113/930] blk.3.ffn_down.6.weight... 58720256 elements at offset 3191760832
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.3.ffn_down.6.weight                            4096x14336 -> 35840 KB
+  [114/930] blk.3.ffn_up.6.weight... 58720256 elements at offset 3224790976
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_up.6.weight                              14336x4096 -> 35840 KB
+  [115/930] blk.3.ffn_gate.7.weight... 58720256 elements at offset 3257821120
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_gate.7.weight                            14336x4096 -> 35840 KB
+  [116/930] blk.3.ffn_down.7.weight... 58720256 elements at offset 3290851264
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.3.ffn_down.7.weight                            4096x14336 -> 35840 KB
+  [117/930] blk.3.ffn_up.7.weight... 58720256 elements at offset 3323881408
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.3.ffn_up.7.weight                              14336x4096 -> 35840 KB
+  [118/930] blk.4.ffn_gate.0.weight... 58720256 elements at offset 3356944320
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_gate.0.weight                            14336x4096 -> 35840 KB
+  [119/930] blk.4.ffn_down.0.weight... 58720256 elements at offset 3389974464
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.4.ffn_down.0.weight                            4096x14336 -> 35840 KB
+  [120/930] blk.4.ffn_up.0.weight... 58720256 elements at offset 3423004608
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_up.0.weight                              14336x4096 -> 35840 KB
+  [121/930] blk.4.ffn_gate.1.weight... 58720256 elements at offset 3456034752
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_gate.1.weight                            14336x4096 -> 35840 KB
+  [122/930] blk.4.ffn_down.1.weight... 58720256 elements at offset 3489064896
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.4.ffn_down.1.weight                            4096x14336 -> 35840 KB
+  [123/930] blk.4.ffn_up.1.weight... 58720256 elements at offset 3522095040
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_up.1.weight                              14336x4096 -> 35840 KB
+  [124/930] blk.4.ffn_gate.2.weight... 58720256 elements at offset 3555125184
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_gate.2.weight                            14336x4096 -> 35840 KB
+  [125/930] blk.4.ffn_down.2.weight... 58720256 elements at offset 3588155328
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.4.ffn_down.2.weight                            4096x14336 -> 35840 KB
+  [126/930] blk.4.ffn_up.2.weight... 58720256 elements at offset 3621185472
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_up.2.weight                              14336x4096 -> 35840 KB
+  [127/930] blk.4.ffn_gate.3.weight... 58720256 elements at offset 3654215616
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_gate.3.weight                            14336x4096 -> 35840 KB
+  [128/930] blk.4.ffn_down.3.weight... 58720256 elements at offset 3687245760
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.4.ffn_down.3.weight                            4096x14336 -> 35840 KB
+  [129/930] blk.4.ffn_up.3.weight... 58720256 elements at offset 3720275904
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_up.3.weight                              14336x4096 -> 35840 KB
+  [130/930] blk.4.ffn_gate.4.weight... 58720256 elements at offset 3753306048
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_gate.4.weight                            14336x4096 -> 35840 KB
+  [131/930] blk.4.ffn_down.4.weight... 58720256 elements at offset 3786336192
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.4.ffn_down.4.weight                            4096x14336 -> 35840 KB
+  [132/930] blk.4.ffn_up.4.weight... 58720256 elements at offset 3819366336
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_up.4.weight                              14336x4096 -> 35840 KB
+  [133/930] blk.4.ffn_gate.5.weight... 58720256 elements at offset 3852396480
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_gate.5.weight                            14336x4096 -> 35840 KB
+  [134/930] blk.4.ffn_down.5.weight... 58720256 elements at offset 3885426624
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.4.ffn_down.5.weight                            4096x14336 -> 35840 KB
+  [135/930] blk.4.ffn_up.5.weight... 58720256 elements at offset 3918456768
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_up.5.weight                              14336x4096 -> 35840 KB
+  [136/930] blk.4.ffn_gate.6.weight... 58720256 elements at offset 3951486912
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_gate.6.weight                            14336x4096 -> 35840 KB
+  [137/930] blk.4.ffn_down.6.weight... 58720256 elements at offset 3984517056
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.4.ffn_down.6.weight                            4096x14336 -> 35840 KB
+  [138/930] blk.4.ffn_up.6.weight... 58720256 elements at offset 4017547200
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_up.6.weight                              14336x4096 -> 35840 KB
+  [139/930] blk.4.ffn_gate.7.weight... 58720256 elements at offset 4050577344
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_gate.7.weight                            14336x4096 -> 35840 KB
+  [140/930] blk.4.ffn_down.7.weight... 58720256 elements at offset 4083607488
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.4.ffn_down.7.weight                            4096x14336 -> 35840 KB
+  [141/930] blk.4.ffn_up.7.weight... 58720256 elements at offset 4116637632
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.4.ffn_up.7.weight                              14336x4096 -> 35840 KB
+  [142/930] blk.4.ffn_gate_inp.weight... 32768 elements at offset 4149667776
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.4.ffn_gate_inp.weight                             8x4096 -> 80 KB
+  [143/930] blk.4.attn_k.weight... 4194304 elements at offset 4149766080
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.4.attn_k.weight                                1024x4096 -> 2560 KB
+  [144/930] blk.4.attn_output.weight... 16777216 elements at offset 4154222528
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.4.attn_output.weight                           4096x4096 -> 10240 KB
+  [145/930] blk.4.attn_q.weight... 16777216 elements at offset 4163659712
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.4.attn_q.weight                                4096x4096 -> 10240 KB
+  [146/930] blk.4.attn_v.weight... 4194304 elements at offset 4173096896
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.4.attn_v.weight                                1024x4096 -> 2560 KB
+  [147/930] blk.5.ffn_gate_inp.weight... 32768 elements at offset 4177553344
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.5.ffn_gate_inp.weight                             8x4096 -> 80 KB
+  [148/930] blk.5.attn_k.weight... 4194304 elements at offset 4177618880
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.5.attn_k.weight                                1024x4096 -> 2560 KB
+  [149/930] blk.5.attn_output.weight... 16777216 elements at offset 4182075328
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.5.attn_output.weight                           4096x4096 -> 10240 KB
+  [150/930] blk.5.attn_q.weight... 16777216 elements at offset 4191512512
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.5.attn_q.weight                                4096x4096 -> 10240 KB
+  [151/930] blk.5.attn_v.weight... 4194304 elements at offset 4200949696
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.5.attn_v.weight                                1024x4096 -> 2560 KB
+  [152/930] blk.5.ffn_gate.0.weight... 58720256 elements at offset 4205406144
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_gate.0.weight                            14336x4096 -> 35840 KB
+  [153/930] blk.5.ffn_down.0.weight... 58720256 elements at offset 4238436288
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.5.ffn_down.0.weight                            4096x14336 -> 35840 KB
+  [154/930] blk.5.ffn_up.0.weight... 58720256 elements at offset 4271466432
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_up.0.weight                              14336x4096 -> 35840 KB
+  [155/930] blk.5.ffn_gate.1.weight... 58720256 elements at offset 4304496576
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_gate.1.weight                            14336x4096 -> 35840 KB
+  [156/930] blk.5.ffn_down.1.weight... 58720256 elements at offset 4337526720
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.5.ffn_down.1.weight                            4096x14336 -> 35840 KB
+  [157/930] blk.5.ffn_up.1.weight... 58720256 elements at offset 4370556864
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_up.1.weight                              14336x4096 -> 35840 KB
+  [158/930] blk.5.ffn_gate.2.weight... 58720256 elements at offset 4403587008
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_gate.2.weight                            14336x4096 -> 35840 KB
+  [159/930] blk.5.ffn_down.2.weight... 58720256 elements at offset 4436617152
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.5.ffn_down.2.weight                            4096x14336 -> 35840 KB
+  [160/930] blk.5.ffn_up.2.weight... 58720256 elements at offset 4469647296
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_up.2.weight                              14336x4096 -> 35840 KB
+  [161/930] blk.5.ffn_gate.3.weight... 58720256 elements at offset 4502677440
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_gate.3.weight                            14336x4096 -> 35840 KB
+  [162/930] blk.5.ffn_down.3.weight... 58720256 elements at offset 4535707584
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.5.ffn_down.3.weight                            4096x14336 -> 35840 KB
+  [163/930] blk.5.ffn_up.3.weight... 58720256 elements at offset 4568737728
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_up.3.weight                              14336x4096 -> 35840 KB
+  [164/930] blk.5.ffn_gate.4.weight... 58720256 elements at offset 4601767872
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_gate.4.weight                            14336x4096 -> 35840 KB
+  [165/930] blk.5.ffn_down.4.weight... 58720256 elements at offset 4634798016
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.5.ffn_down.4.weight                            4096x14336 -> 35840 KB
+  [166/930] blk.5.ffn_up.4.weight... 58720256 elements at offset 4667828160
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_up.4.weight                              14336x4096 -> 35840 KB
+  [167/930] blk.5.ffn_gate.5.weight... 58720256 elements at offset 4700858304
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_gate.5.weight                            14336x4096 -> 35840 KB
+  [168/930] blk.5.ffn_down.5.weight... 58720256 elements at offset 4733888448
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.5.ffn_down.5.weight                            4096x14336 -> 35840 KB
+  [169/930] blk.5.ffn_up.5.weight... 58720256 elements at offset 4766918592
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_up.5.weight                              14336x4096 -> 35840 KB
+  [170/930] blk.5.ffn_gate.6.weight... 58720256 elements at offset 4799948736
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_gate.6.weight                            14336x4096 -> 35840 KB
+  [171/930] blk.5.ffn_down.6.weight... 58720256 elements at offset 4832978880
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.5.ffn_down.6.weight                            4096x14336 -> 35840 KB
+  [172/930] blk.5.ffn_up.6.weight... 58720256 elements at offset 4866009024
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_up.6.weight                              14336x4096 -> 35840 KB
+  [173/930] blk.5.ffn_gate.7.weight... 58720256 elements at offset 4899039168
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_gate.7.weight                            14336x4096 -> 35840 KB
+  [174/930] blk.5.ffn_down.7.weight... 58720256 elements at offset 4932069312
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.5.ffn_down.7.weight                            4096x14336 -> 35840 KB
+  [175/930] blk.5.ffn_up.7.weight... 58720256 elements at offset 4965099456
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.5.ffn_up.7.weight                              14336x4096 -> 35840 KB
+  [176/930] blk.6.ffn_gate.0.weight... 58720256 elements at offset 4998162368
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_gate.0.weight                            14336x4096 -> 35840 KB
+  [177/930] blk.6.ffn_down.0.weight... 58720256 elements at offset 5031192512
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.6.ffn_down.0.weight                            4096x14336 -> 35840 KB
+  [178/930] blk.6.ffn_up.0.weight... 58720256 elements at offset 5064222656
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_up.0.weight                              14336x4096 -> 35840 KB
+  [179/930] blk.6.ffn_gate.1.weight... 58720256 elements at offset 5097252800
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_gate.1.weight                            14336x4096 -> 35840 KB
+  [180/930] blk.6.ffn_down.1.weight... 58720256 elements at offset 5130282944
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.6.ffn_down.1.weight                            4096x14336 -> 35840 KB
+  [181/930] blk.6.ffn_up.1.weight... 58720256 elements at offset 5163313088
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_up.1.weight                              14336x4096 -> 35840 KB
+  [182/930] blk.6.ffn_gate.2.weight... 58720256 elements at offset 5196343232
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_gate.2.weight                            14336x4096 -> 35840 KB
+  [183/930] blk.6.ffn_down.2.weight... 58720256 elements at offset 5229373376
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.6.ffn_down.2.weight                            4096x14336 -> 35840 KB
+  [184/930] blk.6.ffn_up.2.weight... 58720256 elements at offset 5262403520
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_up.2.weight                              14336x4096 -> 35840 KB
+  [185/930] blk.6.ffn_gate.3.weight... 58720256 elements at offset 5295433664
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_gate.3.weight                            14336x4096 -> 35840 KB
+  [186/930] blk.6.ffn_down.3.weight... 58720256 elements at offset 5328463808
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.6.ffn_down.3.weight                            4096x14336 -> 35840 KB
+  [187/930] blk.6.ffn_up.3.weight... 58720256 elements at offset 5361493952
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_up.3.weight                              14336x4096 -> 35840 KB
+  [188/930] blk.6.ffn_gate.4.weight... 58720256 elements at offset 5394524096
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_gate.4.weight                            14336x4096 -> 35840 KB
+  [189/930] blk.6.ffn_down.4.weight... 58720256 elements at offset 5427554240
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.6.ffn_down.4.weight                            4096x14336 -> 35840 KB
+  [190/930] blk.6.ffn_up.4.weight... 58720256 elements at offset 5460584384
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_up.4.weight                              14336x4096 -> 35840 KB
+  [191/930] blk.6.ffn_gate.5.weight... 58720256 elements at offset 5493614528
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_gate.5.weight                            14336x4096 -> 35840 KB
+  [192/930] blk.6.ffn_down.5.weight... 58720256 elements at offset 5526644672
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.6.ffn_down.5.weight                            4096x14336 -> 35840 KB
+  [193/930] blk.6.ffn_gate_inp.weight... 32768 elements at offset 5559674816
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.6.ffn_gate_inp.weight                             8x4096 -> 80 KB
+  [194/930] blk.6.attn_k.weight... 4194304 elements at offset 5559740352
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.6.attn_k.weight                                1024x4096 -> 2560 KB
+  [195/930] blk.6.attn_output.weight... 16777216 elements at offset 5564196800
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.6.attn_output.weight                           4096x4096 -> 10240 KB
+  [196/930] blk.6.attn_q.weight... 16777216 elements at offset 5573633984
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.6.attn_q.weight                                4096x4096 -> 10240 KB
+  [197/930] blk.6.attn_v.weight... 4194304 elements at offset 5583071168
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.6.attn_v.weight                                1024x4096 -> 2560 KB
+  [198/930] blk.6.ffn_up.5.weight... 58720256 elements at offset 5587527616
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_up.5.weight                              14336x4096 -> 35840 KB
+  [199/930] blk.6.ffn_gate.6.weight... 58720256 elements at offset 5620557760
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_gate.6.weight                            14336x4096 -> 35840 KB
+  [200/930] blk.6.ffn_down.6.weight... 58720256 elements at offset 5653587904
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.6.ffn_down.6.weight                            4096x14336 -> 35840 KB
+  [201/930] blk.6.ffn_up.6.weight... 58720256 elements at offset 5686618048
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_up.6.weight                              14336x4096 -> 35840 KB
+  [202/930] blk.6.ffn_gate.7.weight... 58720256 elements at offset 5719648192
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_gate.7.weight                            14336x4096 -> 35840 KB
+  [203/930] blk.6.ffn_down.7.weight... 58720256 elements at offset 5752678336
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.6.ffn_down.7.weight                            4096x14336 -> 35840 KB
+  [204/930] blk.6.ffn_up.7.weight... 58720256 elements at offset 5785708480
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.6.ffn_up.7.weight                              14336x4096 -> 35840 KB
+  [205/930] blk.7.ffn_gate.0.weight... 58720256 elements at offset 5818771392
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_gate.0.weight                            14336x4096 -> 35840 KB
+  [206/930] blk.7.ffn_down.0.weight... 58720256 elements at offset 5851801536
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.7.ffn_down.0.weight                            4096x14336 -> 35840 KB
+  [207/930] blk.7.ffn_up.0.weight... 58720256 elements at offset 5884831680
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_up.0.weight                              14336x4096 -> 35840 KB
+  [208/930] blk.7.ffn_gate.1.weight... 58720256 elements at offset 5917861824
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_gate.1.weight                            14336x4096 -> 35840 KB
+  [209/930] blk.7.ffn_down.1.weight... 58720256 elements at offset 5950891968
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.7.ffn_down.1.weight                            4096x14336 -> 35840 KB
+  [210/930] blk.7.ffn_up.1.weight... 58720256 elements at offset 5983922112
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_up.1.weight                              14336x4096 -> 35840 KB
+  [211/930] blk.7.ffn_gate.2.weight... 58720256 elements at offset 6016952256
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_gate.2.weight                            14336x4096 -> 35840 KB
+  [212/930] blk.7.ffn_down.2.weight... 58720256 elements at offset 6049982400
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.7.ffn_down.2.weight                            4096x14336 -> 35840 KB
+  [213/930] blk.7.ffn_up.2.weight... 58720256 elements at offset 6083012544
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_up.2.weight                              14336x4096 -> 35840 KB
+  [214/930] blk.7.ffn_gate.3.weight... 58720256 elements at offset 6116042688
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_gate.3.weight                            14336x4096 -> 35840 KB
+  [215/930] blk.7.ffn_down.3.weight... 58720256 elements at offset 6149072832
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.7.ffn_down.3.weight                            4096x14336 -> 35840 KB
+  [216/930] blk.7.ffn_up.3.weight... 58720256 elements at offset 6182102976
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_up.3.weight                              14336x4096 -> 35840 KB
+  [217/930] blk.7.ffn_gate.4.weight... 58720256 elements at offset 6215133120
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_gate.4.weight                            14336x4096 -> 35840 KB
+  [218/930] blk.7.ffn_down.4.weight... 58720256 elements at offset 6248163264
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.7.ffn_down.4.weight                            4096x14336 -> 35840 KB
+  [219/930] blk.7.ffn_up.4.weight... 58720256 elements at offset 6281193408
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_up.4.weight                              14336x4096 -> 35840 KB
+  [220/930] blk.7.ffn_gate.5.weight... 58720256 elements at offset 6314223552
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_gate.5.weight                            14336x4096 -> 35840 KB
+  [221/930] blk.7.ffn_down.5.weight... 58720256 elements at offset 6347253696
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.7.ffn_down.5.weight                            4096x14336 -> 35840 KB
+  [222/930] blk.7.ffn_up.5.weight... 58720256 elements at offset 6380283840
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_up.5.weight                              14336x4096 -> 35840 KB
+  [223/930] blk.7.ffn_gate.6.weight... 58720256 elements at offset 6413313984
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_gate.6.weight                            14336x4096 -> 35840 KB
+  [224/930] blk.7.ffn_down.6.weight... 58720256 elements at offset 6446344128
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.7.ffn_down.6.weight                            4096x14336 -> 35840 KB
+  [225/930] blk.7.ffn_up.6.weight... 58720256 elements at offset 6479374272
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_up.6.weight                              14336x4096 -> 35840 KB
+  [226/930] blk.7.ffn_gate.7.weight... 58720256 elements at offset 6512404416
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_gate.7.weight                            14336x4096 -> 35840 KB
+  [227/930] blk.7.ffn_down.7.weight... 58720256 elements at offset 6545434560
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.7.ffn_down.7.weight                            4096x14336 -> 35840 KB
+  [228/930] blk.7.ffn_up.7.weight... 58720256 elements at offset 6578464704
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.7.ffn_up.7.weight                              14336x4096 -> 35840 KB
+  [229/930] blk.7.ffn_gate_inp.weight... 32768 elements at offset 6611494848
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.7.ffn_gate_inp.weight                             8x4096 -> 80 KB
+  [230/930] blk.7.attn_k.weight... 4194304 elements at offset 6611593152
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.7.attn_k.weight                                1024x4096 -> 2560 KB
+  [231/930] blk.7.attn_output.weight... 16777216 elements at offset 6616049600
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.7.attn_output.weight                           4096x4096 -> 10240 KB
+  [232/930] blk.7.attn_q.weight... 16777216 elements at offset 6625486784
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.7.attn_q.weight                                4096x4096 -> 10240 KB
+  [233/930] blk.7.attn_v.weight... 4194304 elements at offset 6634923968
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.7.attn_v.weight                                1024x4096 -> 2560 KB
+  [234/930] blk.8.ffn_gate.0.weight... 58720256 elements at offset 6639380416
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_gate.0.weight                            14336x4096 -> 35840 KB
+  [235/930] blk.8.ffn_down.0.weight... 58720256 elements at offset 6672410560
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.8.ffn_down.0.weight                            4096x14336 -> 35840 KB
+  [236/930] blk.8.ffn_up.0.weight... 58720256 elements at offset 6705440704
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_up.0.weight                              14336x4096 -> 35840 KB
+  [237/930] blk.8.ffn_gate.1.weight... 58720256 elements at offset 6738470848
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_gate.1.weight                            14336x4096 -> 35840 KB
+  [238/930] blk.8.ffn_down.1.weight... 58720256 elements at offset 6771500992
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.8.ffn_down.1.weight                            4096x14336 -> 35840 KB
+  [239/930] blk.8.ffn_up.1.weight... 58720256 elements at offset 6804531136
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_up.1.weight                              14336x4096 -> 35840 KB
+  [240/930] blk.8.ffn_gate.2.weight... 58720256 elements at offset 6837561280
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_gate.2.weight                            14336x4096 -> 35840 KB
+  [241/930] blk.8.ffn_down.2.weight... 58720256 elements at offset 6870591424
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.8.ffn_down.2.weight                            4096x14336 -> 35840 KB
+  [242/930] blk.8.ffn_up.2.weight... 58720256 elements at offset 6903621568
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_up.2.weight                              14336x4096 -> 35840 KB
+  [243/930] blk.8.ffn_gate.3.weight... 58720256 elements at offset 6936651712
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_gate.3.weight                            14336x4096 -> 35840 KB
+  [244/930] blk.8.ffn_gate_inp.weight... 32768 elements at offset 6969681856
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.8.ffn_gate_inp.weight                             8x4096 -> 80 KB
+  [245/930] blk.8.attn_k.weight... 4194304 elements at offset 6969747392
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.8.attn_k.weight                                1024x4096 -> 2560 KB
+  [246/930] blk.8.attn_output.weight... 16777216 elements at offset 6974203840
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.8.attn_output.weight                           4096x4096 -> 10240 KB
+  [247/930] blk.8.attn_q.weight... 16777216 elements at offset 6983641024
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.8.attn_q.weight                                4096x4096 -> 10240 KB
+  [248/930] blk.8.attn_v.weight... 4194304 elements at offset 6993078208
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.8.attn_v.weight                                1024x4096 -> 2560 KB
+  [249/930] blk.10.ffn_gate.0.weight... 58720256 elements at offset 6997534656
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [250/930] blk.10.ffn_down.0.weight... 58720256 elements at offset 7030564800
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.10.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [251/930] blk.10.ffn_up.0.weight... 58720256 elements at offset 7063594944
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [252/930] blk.10.ffn_gate_inp.weight... 32768 elements at offset 7096625088
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.10.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [253/930] blk.10.attn_k.weight... 4194304 elements at offset 7096690624
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.10.attn_k.weight                               1024x4096 -> 2560 KB
+  [254/930] blk.10.attn_output.weight... 16777216 elements at offset 7101147072
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.10.attn_output.weight                          4096x4096 -> 10240 KB
+  [255/930] blk.10.attn_q.weight... 16777216 elements at offset 7110584256
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.10.attn_q.weight                               4096x4096 -> 10240 KB
+  [256/930] blk.10.attn_v.weight... 4194304 elements at offset 7120021440
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.10.attn_v.weight                               1024x4096 -> 2560 KB
+  [257/930] blk.8.ffn_down.3.weight... 58720256 elements at offset 7124477888
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.8.ffn_down.3.weight                            4096x14336 -> 35840 KB
+  [258/930] blk.8.ffn_up.3.weight... 58720256 elements at offset 7157508032
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_up.3.weight                              14336x4096 -> 35840 KB
+  [259/930] blk.8.ffn_gate.4.weight... 58720256 elements at offset 7190538176
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_gate.4.weight                            14336x4096 -> 35840 KB
+  [260/930] blk.8.ffn_down.4.weight... 58720256 elements at offset 7223568320
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.8.ffn_down.4.weight                            4096x14336 -> 35840 KB
+  [261/930] blk.8.ffn_up.4.weight... 58720256 elements at offset 7256598464
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_up.4.weight                              14336x4096 -> 35840 KB
+  [262/930] blk.8.ffn_gate.5.weight... 58720256 elements at offset 7289628608
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_gate.5.weight                            14336x4096 -> 35840 KB
+  [263/930] blk.8.ffn_down.5.weight... 58720256 elements at offset 7322658752
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.8.ffn_down.5.weight                            4096x14336 -> 35840 KB
+  [264/930] blk.8.ffn_up.5.weight... 58720256 elements at offset 7355688896
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_up.5.weight                              14336x4096 -> 35840 KB
+  [265/930] blk.8.ffn_gate.6.weight... 58720256 elements at offset 7388719040
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_gate.6.weight                            14336x4096 -> 35840 KB
+  [266/930] blk.8.ffn_down.6.weight... 58720256 elements at offset 7421749184
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.8.ffn_down.6.weight                            4096x14336 -> 35840 KB
+  [267/930] blk.8.ffn_up.6.weight... 58720256 elements at offset 7454779328
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_up.6.weight                              14336x4096 -> 35840 KB
+  [268/930] blk.8.ffn_gate.7.weight... 58720256 elements at offset 7487809472
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_gate.7.weight                            14336x4096 -> 35840 KB
+  [269/930] blk.8.ffn_down.7.weight... 58720256 elements at offset 7520839616
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.8.ffn_down.7.weight                            4096x14336 -> 35840 KB
+  [270/930] blk.8.ffn_up.7.weight... 58720256 elements at offset 7553869760
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.8.ffn_up.7.weight                              14336x4096 -> 35840 KB
+  [271/930] blk.9.ffn_gate.0.weight... 58720256 elements at offset 7586932672
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_gate.0.weight                            14336x4096 -> 35840 KB
+  [272/930] blk.9.ffn_down.0.weight... 58720256 elements at offset 7619962816
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.9.ffn_down.0.weight                            4096x14336 -> 35840 KB
+  [273/930] blk.9.ffn_up.0.weight... 58720256 elements at offset 7652992960
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_up.0.weight                              14336x4096 -> 35840 KB
+  [274/930] blk.9.ffn_gate.1.weight... 58720256 elements at offset 7686023104
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_gate.1.weight                            14336x4096 -> 35840 KB
+  [275/930] blk.9.ffn_down.1.weight... 58720256 elements at offset 7719053248
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.9.ffn_down.1.weight                            4096x14336 -> 35840 KB
+  [276/930] blk.9.ffn_up.1.weight... 58720256 elements at offset 7752083392
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_up.1.weight                              14336x4096 -> 35840 KB
+  [277/930] blk.9.ffn_gate.2.weight... 58720256 elements at offset 7785113536
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_gate.2.weight                            14336x4096 -> 35840 KB
+  [278/930] blk.9.ffn_down.2.weight... 58720256 elements at offset 7818143680
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.9.ffn_down.2.weight                            4096x14336 -> 35840 KB
+  [279/930] blk.9.ffn_up.2.weight... 58720256 elements at offset 7851173824
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_up.2.weight                              14336x4096 -> 35840 KB
+  [280/930] blk.9.ffn_gate.3.weight... 58720256 elements at offset 7884203968
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_gate.3.weight                            14336x4096 -> 35840 KB
+  [281/930] blk.9.ffn_down.3.weight... 58720256 elements at offset 7917234112
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.9.ffn_down.3.weight                            4096x14336 -> 35840 KB
+  [282/930] blk.9.ffn_up.3.weight... 58720256 elements at offset 7950264256
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_up.3.weight                              14336x4096 -> 35840 KB
+  [283/930] blk.9.ffn_gate.4.weight... 58720256 elements at offset 7983294400
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_gate.4.weight                            14336x4096 -> 35840 KB
+  [284/930] blk.9.ffn_down.4.weight... 58720256 elements at offset 8016324544
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.9.ffn_down.4.weight                            4096x14336 -> 35840 KB
+  [285/930] blk.9.ffn_up.4.weight... 58720256 elements at offset 8049354688
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_up.4.weight                              14336x4096 -> 35840 KB
+  [286/930] blk.9.ffn_gate.5.weight... 58720256 elements at offset 8082384832
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_gate.5.weight                            14336x4096 -> 35840 KB
+  [287/930] blk.9.ffn_down.5.weight... 58720256 elements at offset 8115414976
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.9.ffn_down.5.weight                            4096x14336 -> 35840 KB
+  [288/930] blk.9.ffn_up.5.weight... 58720256 elements at offset 8148445120
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_up.5.weight                              14336x4096 -> 35840 KB
+  [289/930] blk.9.ffn_gate.6.weight... 58720256 elements at offset 8181475264
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_gate.6.weight                            14336x4096 -> 35840 KB
+  [290/930] blk.9.ffn_down.6.weight... 58720256 elements at offset 8214505408
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.9.ffn_down.6.weight                            4096x14336 -> 35840 KB
+  [291/930] blk.9.ffn_up.6.weight... 58720256 elements at offset 8247535552
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_up.6.weight                              14336x4096 -> 35840 KB
+  [292/930] blk.9.ffn_gate.7.weight... 58720256 elements at offset 8280565696
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_gate.7.weight                            14336x4096 -> 35840 KB
+  [293/930] blk.9.ffn_down.7.weight... 58720256 elements at offset 8313595840
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.9.ffn_down.7.weight                            4096x14336 -> 35840 KB
+  [294/930] blk.9.ffn_up.7.weight... 58720256 elements at offset 8346625984
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.9.ffn_up.7.weight                              14336x4096 -> 35840 KB
+  [295/930] blk.9.ffn_gate_inp.weight... 32768 elements at offset 8379656128
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.9.ffn_gate_inp.weight                             8x4096 -> 80 KB
+  [296/930] blk.9.attn_k.weight... 4194304 elements at offset 8379754432
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.9.attn_k.weight                                1024x4096 -> 2560 KB
+  [297/930] blk.9.attn_output.weight... 16777216 elements at offset 8384210880
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.9.attn_output.weight                           4096x4096 -> 10240 KB
+  [298/930] blk.9.attn_q.weight... 16777216 elements at offset 8393648064
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.9.attn_q.weight                                4096x4096 -> 10240 KB
+  [299/930] blk.9.attn_v.weight... 4194304 elements at offset 8403085248
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.9.attn_v.weight                                1024x4096 -> 2560 KB
+  [300/930] blk.10.ffn_gate.1.weight... 58720256 elements at offset 8407541696
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [301/930] blk.10.ffn_down.1.weight... 58720256 elements at offset 8440571840
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.10.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [302/930] blk.10.ffn_up.1.weight... 58720256 elements at offset 8473601984
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [303/930] blk.10.ffn_gate.2.weight... 58720256 elements at offset 8506632128
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [304/930] blk.10.ffn_down.2.weight... 58720256 elements at offset 8539662272
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.10.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [305/930] blk.10.ffn_up.2.weight... 58720256 elements at offset 8572692416
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [306/930] blk.10.ffn_gate.3.weight... 58720256 elements at offset 8605722560
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [307/930] blk.10.ffn_down.3.weight... 58720256 elements at offset 8638752704
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.10.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [308/930] blk.10.ffn_up.3.weight... 58720256 elements at offset 8671782848
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [309/930] blk.10.ffn_gate.4.weight... 58720256 elements at offset 8704812992
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [310/930] blk.10.ffn_down.4.weight... 58720256 elements at offset 8737843136
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.10.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [311/930] blk.10.ffn_up.4.weight... 58720256 elements at offset 8770873280
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [312/930] blk.10.ffn_gate.5.weight... 58720256 elements at offset 8803903424
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [313/930] blk.10.ffn_down.5.weight... 58720256 elements at offset 8836933568
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.10.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [314/930] blk.10.ffn_up.5.weight... 58720256 elements at offset 8869963712
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [315/930] blk.10.ffn_gate.6.weight... 58720256 elements at offset 8902993856
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [316/930] blk.10.ffn_down.6.weight... 58720256 elements at offset 8936024000
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.10.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [317/930] blk.10.ffn_up.6.weight... 58720256 elements at offset 8969054144
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [318/930] blk.10.ffn_gate.7.weight... 58720256 elements at offset 9002084288
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [319/930] blk.10.ffn_down.7.weight... 58720256 elements at offset 9035114432
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.10.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [320/930] blk.10.ffn_up.7.weight... 58720256 elements at offset 9068144576
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.10.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [321/930] blk.11.ffn_gate.0.weight... 58720256 elements at offset 9101207488
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [322/930] blk.11.ffn_down.0.weight... 58720256 elements at offset 9134237632
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.11.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [323/930] blk.11.ffn_up.0.weight... 58720256 elements at offset 9167267776
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [324/930] blk.11.ffn_gate.1.weight... 58720256 elements at offset 9200297920
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [325/930] blk.11.ffn_down.1.weight... 58720256 elements at offset 9233328064
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.11.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [326/930] blk.11.ffn_up.1.weight... 58720256 elements at offset 9266358208
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [327/930] blk.11.ffn_gate.2.weight... 58720256 elements at offset 9299388352
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [328/930] blk.11.ffn_down.2.weight... 58720256 elements at offset 9332418496
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.11.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [329/930] blk.11.ffn_up.2.weight... 58720256 elements at offset 9365448640
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [330/930] blk.11.ffn_gate.3.weight... 58720256 elements at offset 9398478784
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [331/930] blk.11.ffn_down.3.weight... 58720256 elements at offset 9431508928
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.11.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [332/930] blk.11.ffn_up.3.weight... 58720256 elements at offset 9464539072
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [333/930] blk.11.ffn_gate.4.weight... 58720256 elements at offset 9497569216
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [334/930] blk.11.ffn_down.4.weight... 58720256 elements at offset 9530599360
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.11.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [335/930] blk.11.ffn_up.4.weight... 58720256 elements at offset 9563629504
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [336/930] blk.11.ffn_gate.5.weight... 58720256 elements at offset 9596659648
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [337/930] blk.11.ffn_down.5.weight... 58720256 elements at offset 9629689792
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.11.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [338/930] blk.11.ffn_up.5.weight... 58720256 elements at offset 9662719936
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [339/930] blk.11.ffn_gate.6.weight... 58720256 elements at offset 9695750080
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [340/930] blk.11.ffn_down.6.weight... 58720256 elements at offset 9728780224
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.11.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [341/930] blk.11.ffn_gate_inp.weight... 32768 elements at offset 9761810368
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.11.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [342/930] blk.11.attn_k.weight... 4194304 elements at offset 9761875904
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.11.attn_k.weight                               1024x4096 -> 2560 KB
+  [343/930] blk.11.attn_output.weight... 16777216 elements at offset 9766332352
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.11.attn_output.weight                          4096x4096 -> 10240 KB
+  [344/930] blk.11.attn_q.weight... 16777216 elements at offset 9775769536
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.11.attn_q.weight                               4096x4096 -> 10240 KB
+  [345/930] blk.11.attn_v.weight... 4194304 elements at offset 9785206720
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.11.attn_v.weight                               1024x4096 -> 2560 KB
+  [346/930] blk.11.ffn_up.6.weight... 58720256 elements at offset 9789663168
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [347/930] blk.11.ffn_gate.7.weight... 58720256 elements at offset 9822693312
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [348/930] blk.11.ffn_down.7.weight... 58720256 elements at offset 9855723456
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.11.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [349/930] blk.11.ffn_up.7.weight... 58720256 elements at offset 9888753600
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.11.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [350/930] blk.12.ffn_gate.0.weight... 58720256 elements at offset 9921816512
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [351/930] blk.12.ffn_down.0.weight... 58720256 elements at offset 9954846656
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.12.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [352/930] blk.12.ffn_up.0.weight... 58720256 elements at offset 9987876800
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [353/930] blk.12.ffn_gate.1.weight... 58720256 elements at offset 10020906944
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [354/930] blk.12.ffn_down.1.weight... 58720256 elements at offset 10053937088
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.12.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [355/930] blk.12.ffn_up.1.weight... 58720256 elements at offset 10086967232
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [356/930] blk.12.ffn_gate.2.weight... 58720256 elements at offset 10119997376
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [357/930] blk.12.ffn_down.2.weight... 58720256 elements at offset 10153027520
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.12.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [358/930] blk.12.ffn_up.2.weight... 58720256 elements at offset 10186057664
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [359/930] blk.12.ffn_gate.3.weight... 58720256 elements at offset 10219087808
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [360/930] blk.12.ffn_down.3.weight... 58720256 elements at offset 10252117952
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.12.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [361/930] blk.12.ffn_up.3.weight... 58720256 elements at offset 10285148096
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [362/930] blk.12.ffn_gate.4.weight... 58720256 elements at offset 10318178240
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [363/930] blk.12.ffn_down.4.weight... 58720256 elements at offset 10351208384
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.12.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [364/930] blk.12.ffn_up.4.weight... 58720256 elements at offset 10384238528
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [365/930] blk.12.ffn_gate.5.weight... 58720256 elements at offset 10417268672
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [366/930] blk.12.ffn_down.5.weight... 58720256 elements at offset 10450298816
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.12.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [367/930] blk.12.ffn_up.5.weight... 58720256 elements at offset 10483328960
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [368/930] blk.12.ffn_gate.6.weight... 58720256 elements at offset 10516359104
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [369/930] blk.12.ffn_down.6.weight... 58720256 elements at offset 10549389248
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.12.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [370/930] blk.12.ffn_up.6.weight... 58720256 elements at offset 10582419392
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [371/930] blk.12.ffn_gate.7.weight... 58720256 elements at offset 10615449536
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [372/930] blk.12.ffn_down.7.weight... 58720256 elements at offset 10648479680
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.12.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [373/930] blk.12.ffn_up.7.weight... 58720256 elements at offset 10681509824
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.12.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [374/930] blk.12.ffn_gate_inp.weight... 32768 elements at offset 10714539968
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.12.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [375/930] blk.12.attn_k.weight... 4194304 elements at offset 10714638272
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.12.attn_k.weight                               1024x4096 -> 2560 KB
+  [376/930] blk.12.attn_output.weight... 16777216 elements at offset 10719094720
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.12.attn_output.weight                          4096x4096 -> 10240 KB
+  [377/930] blk.12.attn_q.weight... 16777216 elements at offset 10728531904
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.12.attn_q.weight                               4096x4096 -> 10240 KB
+  [378/930] blk.12.attn_v.weight... 4194304 elements at offset 10737969088
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.12.attn_v.weight                               1024x4096 -> 2560 KB
+  [379/930] blk.13.ffn_gate.0.weight... 58720256 elements at offset 10742425536
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [380/930] blk.13.ffn_down.0.weight... 58720256 elements at offset 10775455680
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.13.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [381/930] blk.13.ffn_up.0.weight... 58720256 elements at offset 10808485824
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [382/930] blk.13.ffn_gate.1.weight... 58720256 elements at offset 10841515968
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [383/930] blk.13.ffn_down.1.weight... 58720256 elements at offset 10874546112
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.13.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [384/930] blk.13.ffn_up.1.weight... 58720256 elements at offset 10907576256
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [385/930] blk.13.ffn_gate.2.weight... 58720256 elements at offset 10940606400
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [386/930] blk.13.ffn_down.2.weight... 58720256 elements at offset 10973636544
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.13.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [387/930] blk.13.ffn_up.2.weight... 58720256 elements at offset 11006666688
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [388/930] blk.13.ffn_gate.3.weight... 58720256 elements at offset 11039696832
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [389/930] blk.13.ffn_down.3.weight... 58720256 elements at offset 11072726976
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.13.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [390/930] blk.13.ffn_up.3.weight... 58720256 elements at offset 11105757120
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [391/930] blk.13.ffn_gate.4.weight... 58720256 elements at offset 11138787264
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [392/930] blk.13.ffn_gate_inp.weight... 32768 elements at offset 11171817408
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.13.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [393/930] blk.13.attn_k.weight... 4194304 elements at offset 11171882944
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.13.attn_k.weight                               1024x4096 -> 2560 KB
+  [394/930] blk.13.attn_output.weight... 16777216 elements at offset 11176339392
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.13.attn_output.weight                          4096x4096 -> 10240 KB
+  [395/930] blk.13.attn_q.weight... 16777216 elements at offset 11185776576
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.13.attn_q.weight                               4096x4096 -> 10240 KB
+  [396/930] blk.13.attn_v.weight... 4194304 elements at offset 11195213760
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.13.attn_v.weight                               1024x4096 -> 2560 KB
+  [397/930] blk.13.ffn_down.4.weight... 58720256 elements at offset 11199670208
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.13.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [398/930] blk.13.ffn_up.4.weight... 58720256 elements at offset 11232700352
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [399/930] blk.13.ffn_gate.5.weight... 58720256 elements at offset 11265730496
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [400/930] blk.13.ffn_down.5.weight... 58720256 elements at offset 11298760640
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.13.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [401/930] blk.13.ffn_up.5.weight... 58720256 elements at offset 11331790784
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [402/930] blk.13.ffn_gate.6.weight... 58720256 elements at offset 11364820928
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [403/930] blk.13.ffn_down.6.weight... 58720256 elements at offset 11397851072
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.13.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [404/930] blk.13.ffn_up.6.weight... 58720256 elements at offset 11430881216
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [405/930] blk.13.ffn_gate.7.weight... 58720256 elements at offset 11463911360
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [406/930] blk.13.ffn_down.7.weight... 58720256 elements at offset 11496941504
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.13.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [407/930] blk.13.ffn_up.7.weight... 58720256 elements at offset 11529971648
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.13.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [408/930] blk.14.ffn_gate.0.weight... 58720256 elements at offset 11563034560
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [409/930] blk.14.ffn_down.0.weight... 58720256 elements at offset 11596064704
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.14.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [410/930] blk.14.ffn_up.0.weight... 58720256 elements at offset 11629094848
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [411/930] blk.14.ffn_gate.1.weight... 58720256 elements at offset 11662124992
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [412/930] blk.14.ffn_down.1.weight... 58720256 elements at offset 11695155136
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.14.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [413/930] blk.14.ffn_up.1.weight... 58720256 elements at offset 11728185280
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [414/930] blk.14.ffn_gate.2.weight... 58720256 elements at offset 11761215424
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [415/930] blk.14.ffn_down.2.weight... 58720256 elements at offset 11794245568
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.14.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [416/930] blk.14.ffn_up.2.weight... 58720256 elements at offset 11827275712
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [417/930] blk.14.ffn_gate.3.weight... 58720256 elements at offset 11860305856
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [418/930] blk.14.ffn_down.3.weight... 58720256 elements at offset 11893336000
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.14.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [419/930] blk.14.ffn_up.3.weight... 58720256 elements at offset 11926366144
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [420/930] blk.14.ffn_gate.4.weight... 58720256 elements at offset 11959396288
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [421/930] blk.14.ffn_down.4.weight... 58720256 elements at offset 11992426432
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.14.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [422/930] blk.14.ffn_up.4.weight... 58720256 elements at offset 12025456576
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [423/930] blk.14.ffn_gate.5.weight... 58720256 elements at offset 12058486720
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [424/930] blk.14.ffn_down.5.weight... 58720256 elements at offset 12091516864
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.14.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [425/930] blk.14.ffn_up.5.weight... 58720256 elements at offset 12124547008
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [426/930] blk.14.ffn_gate.6.weight... 58720256 elements at offset 12157577152
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [427/930] blk.14.ffn_down.6.weight... 58720256 elements at offset 12190607296
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.14.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [428/930] blk.14.ffn_up.6.weight... 58720256 elements at offset 12223637440
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [429/930] blk.14.ffn_gate.7.weight... 58720256 elements at offset 12256667584
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [430/930] blk.14.ffn_down.7.weight... 58720256 elements at offset 12289697728
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.14.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [431/930] blk.14.ffn_up.7.weight... 58720256 elements at offset 12322727872
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.14.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [432/930] blk.14.ffn_gate_inp.weight... 32768 elements at offset 12355758016
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.14.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [433/930] blk.14.attn_k.weight... 4194304 elements at offset 12355856320
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.14.attn_k.weight                               1024x4096 -> 2560 KB
+  [434/930] blk.14.attn_output.weight... 16777216 elements at offset 12360312768
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.14.attn_output.weight                          4096x4096 -> 10240 KB
+  [435/930] blk.14.attn_q.weight... 16777216 elements at offset 12369749952
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.14.attn_q.weight                               4096x4096 -> 10240 KB
+  [436/930] blk.14.attn_v.weight... 4194304 elements at offset 12379187136
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.14.attn_v.weight                               1024x4096 -> 2560 KB
+  [437/930] blk.15.ffn_gate.0.weight... 58720256 elements at offset 12383643584
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [438/930] blk.15.ffn_down.0.weight... 58720256 elements at offset 12416673728
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.15.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [439/930] blk.15.ffn_up.0.weight... 58720256 elements at offset 12449703872
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [440/930] blk.15.ffn_gate.1.weight... 58720256 elements at offset 12482734016
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [441/930] blk.15.ffn_down.1.weight... 58720256 elements at offset 12515764160
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.15.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [442/930] blk.15.ffn_up.1.weight... 58720256 elements at offset 12548794304
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [443/930] blk.15.ffn_gate_inp.weight... 32768 elements at offset 12581824448
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.15.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [444/930] blk.15.attn_k.weight... 4194304 elements at offset 12581889984
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.15.attn_k.weight                               1024x4096 -> 2560 KB
+  [445/930] blk.15.attn_output.weight... 16777216 elements at offset 12586346432
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.15.attn_output.weight                          4096x4096 -> 10240 KB
+  [446/930] blk.15.attn_q.weight... 16777216 elements at offset 12595783616
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.15.attn_q.weight                               4096x4096 -> 10240 KB
+  [447/930] blk.15.attn_v.weight... 4194304 elements at offset 12605220800
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.15.attn_v.weight                               1024x4096 -> 2560 KB
+  [448/930] blk.15.ffn_gate.2.weight... 58720256 elements at offset 12609677248
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [449/930] blk.15.ffn_down.2.weight... 58720256 elements at offset 12642707392
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.15.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [450/930] blk.15.ffn_up.2.weight... 58720256 elements at offset 12675737536
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [451/930] blk.15.ffn_gate.3.weight... 58720256 elements at offset 12708767680
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [452/930] blk.15.ffn_down.3.weight... 58720256 elements at offset 12741797824
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.15.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [453/930] blk.15.ffn_up.3.weight... 58720256 elements at offset 12774827968
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [454/930] blk.15.ffn_gate.4.weight... 58720256 elements at offset 12807858112
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [455/930] blk.15.ffn_down.4.weight... 58720256 elements at offset 12840888256
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.15.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [456/930] blk.15.ffn_up.4.weight... 58720256 elements at offset 12873918400
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [457/930] blk.15.ffn_gate.5.weight... 58720256 elements at offset 12906948544
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [458/930] blk.15.ffn_down.5.weight... 58720256 elements at offset 12939978688
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.15.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [459/930] blk.15.ffn_up.5.weight... 58720256 elements at offset 12973008832
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [460/930] blk.15.ffn_gate.6.weight... 58720256 elements at offset 13006038976
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [461/930] blk.15.ffn_down.6.weight... 58720256 elements at offset 13039069120
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.15.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [462/930] blk.15.ffn_up.6.weight... 58720256 elements at offset 13072099264
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [463/930] blk.15.ffn_gate.7.weight... 58720256 elements at offset 13105129408
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [464/930] blk.15.ffn_down.7.weight... 58720256 elements at offset 13138159552
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.15.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [465/930] blk.15.ffn_up.7.weight... 58720256 elements at offset 13171189696
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.15.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [466/930] blk.16.ffn_gate.0.weight... 58720256 elements at offset 13204252608
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [467/930] blk.16.ffn_down.0.weight... 58720256 elements at offset 13237282752
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.16.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [468/930] blk.16.ffn_up.0.weight... 58720256 elements at offset 13270312896
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [469/930] blk.16.ffn_gate.1.weight... 58720256 elements at offset 13303343040
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [470/930] blk.16.ffn_down.1.weight... 58720256 elements at offset 13336373184
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.16.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [471/930] blk.16.ffn_up.1.weight... 58720256 elements at offset 13369403328
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [472/930] blk.16.ffn_gate.2.weight... 58720256 elements at offset 13402433472
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [473/930] blk.16.ffn_down.2.weight... 58720256 elements at offset 13435463616
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.16.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [474/930] blk.16.ffn_up.2.weight... 58720256 elements at offset 13468493760
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [475/930] blk.16.ffn_gate.3.weight... 58720256 elements at offset 13501523904
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [476/930] blk.16.ffn_down.3.weight... 58720256 elements at offset 13534554048
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.16.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [477/930] blk.16.ffn_up.3.weight... 58720256 elements at offset 13567584192
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [478/930] blk.16.ffn_gate.4.weight... 58720256 elements at offset 13600614336
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [479/930] blk.16.ffn_down.4.weight... 58720256 elements at offset 13633644480
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.16.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [480/930] blk.16.ffn_up.4.weight... 58720256 elements at offset 13666674624
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [481/930] blk.16.ffn_gate.5.weight... 58720256 elements at offset 13699704768
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [482/930] blk.16.ffn_down.5.weight... 58720256 elements at offset 13732734912
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.16.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [483/930] blk.16.ffn_up.5.weight... 58720256 elements at offset 13765765056
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [484/930] blk.16.ffn_gate.6.weight... 58720256 elements at offset 13798795200
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [485/930] blk.16.ffn_down.6.weight... 58720256 elements at offset 13831825344
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.16.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [486/930] blk.16.ffn_up.6.weight... 58720256 elements at offset 13864855488
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [487/930] blk.16.ffn_gate.7.weight... 58720256 elements at offset 13897885632
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [488/930] blk.16.ffn_down.7.weight... 58720256 elements at offset 13930915776
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.16.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [489/930] blk.16.ffn_gate_inp.weight... 32768 elements at offset 13963945920
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.16.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [490/930] blk.16.attn_k.weight... 4194304 elements at offset 13964011456
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.16.attn_k.weight                               1024x4096 -> 2560 KB
+  [491/930] blk.16.attn_output.weight... 16777216 elements at offset 13968467904
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.16.attn_output.weight                          4096x4096 -> 10240 KB
+  [492/930] blk.16.attn_q.weight... 16777216 elements at offset 13977905088
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.16.attn_q.weight                               4096x4096 -> 10240 KB
+  [493/930] blk.16.attn_v.weight... 4194304 elements at offset 13987342272
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.16.attn_v.weight                               1024x4096 -> 2560 KB
+  [494/930] blk.16.ffn_up.7.weight... 58720256 elements at offset 13991798720
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.16.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [495/930] blk.17.ffn_gate.0.weight... 58720256 elements at offset 14024861632
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [496/930] blk.17.ffn_down.0.weight... 58720256 elements at offset 14057891776
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.17.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [497/930] blk.17.ffn_up.0.weight... 58720256 elements at offset 14090921920
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [498/930] blk.17.ffn_gate.1.weight... 58720256 elements at offset 14123952064
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [499/930] blk.17.ffn_down.1.weight... 58720256 elements at offset 14156982208
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.17.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [500/930] blk.17.ffn_up.1.weight... 58720256 elements at offset 14190012352
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [501/930] blk.17.ffn_gate.2.weight... 58720256 elements at offset 14223042496
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [502/930] blk.17.ffn_down.2.weight... 58720256 elements at offset 14256072640
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.17.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [503/930] blk.17.ffn_up.2.weight... 58720256 elements at offset 14289102784
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [504/930] blk.17.ffn_gate.3.weight... 58720256 elements at offset 14322132928
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [505/930] blk.17.ffn_down.3.weight... 58720256 elements at offset 14355163072
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.17.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [506/930] blk.17.ffn_up.3.weight... 58720256 elements at offset 14388193216
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [507/930] blk.17.ffn_gate.4.weight... 58720256 elements at offset 14421223360
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [508/930] blk.17.ffn_down.4.weight... 58720256 elements at offset 14454253504
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.17.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [509/930] blk.17.ffn_up.4.weight... 58720256 elements at offset 14487283648
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [510/930] blk.17.ffn_gate.5.weight... 58720256 elements at offset 14520313792
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [511/930] blk.17.ffn_down.5.weight... 58720256 elements at offset 14553343936
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.17.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [512/930] blk.17.ffn_up.5.weight... 58720256 elements at offset 14586374080
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [513/930] blk.17.ffn_gate.6.weight... 58720256 elements at offset 14619404224
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [514/930] blk.17.ffn_down.6.weight... 58720256 elements at offset 14652434368
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.17.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [515/930] blk.17.ffn_up.6.weight... 58720256 elements at offset 14685464512
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [516/930] blk.17.ffn_gate.7.weight... 58720256 elements at offset 14718494656
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [517/930] blk.17.ffn_down.7.weight... 58720256 elements at offset 14751524800
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.17.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [518/930] blk.17.ffn_up.7.weight... 58720256 elements at offset 14784554944
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.17.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [519/930] blk.17.ffn_gate_inp.weight... 32768 elements at offset 14817585088
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.17.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [520/930] blk.17.attn_k.weight... 4194304 elements at offset 14817683392
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.17.attn_k.weight                               1024x4096 -> 2560 KB
+  [521/930] blk.17.attn_output.weight... 16777216 elements at offset 14822139840
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.17.attn_output.weight                          4096x4096 -> 10240 KB
+  [522/930] blk.17.attn_q.weight... 16777216 elements at offset 14831577024
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.17.attn_q.weight                               4096x4096 -> 10240 KB
+  [523/930] blk.17.attn_v.weight... 4194304 elements at offset 14841014208
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.17.attn_v.weight                               1024x4096 -> 2560 KB
+  [524/930] blk.18.ffn_gate.0.weight... 58720256 elements at offset 14845470656
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [525/930] blk.18.ffn_down.0.weight... 58720256 elements at offset 14878500800
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.18.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [526/930] blk.18.ffn_up.0.weight... 58720256 elements at offset 14911530944
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [527/930] blk.18.ffn_gate.1.weight... 58720256 elements at offset 14944561088
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [528/930] blk.18.ffn_down.1.weight... 58720256 elements at offset 14977591232
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.18.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [529/930] blk.18.ffn_up.1.weight... 58720256 elements at offset 15010621376
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [530/930] blk.18.ffn_gate.2.weight... 58720256 elements at offset 15043651520
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [531/930] blk.18.ffn_down.2.weight... 58720256 elements at offset 15076681664
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.18.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [532/930] blk.18.ffn_up.2.weight... 58720256 elements at offset 15109711808
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [533/930] blk.18.ffn_gate.3.weight... 58720256 elements at offset 15142741952
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [534/930] blk.18.ffn_down.3.weight... 58720256 elements at offset 15175772096
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.18.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [535/930] blk.18.ffn_up.3.weight... 58720256 elements at offset 15208802240
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [536/930] blk.18.ffn_gate.4.weight... 58720256 elements at offset 15241832384
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [537/930] blk.18.ffn_down.4.weight... 58720256 elements at offset 15274862528
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.18.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [538/930] blk.18.ffn_up.4.weight... 58720256 elements at offset 15307892672
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [539/930] blk.18.ffn_gate.5.weight... 58720256 elements at offset 15340922816
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [540/930] blk.18.ffn_gate_inp.weight... 32768 elements at offset 15373952960
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.18.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [541/930] blk.18.attn_k.weight... 4194304 elements at offset 15374018496
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.18.attn_k.weight                               1024x4096 -> 2560 KB
+  [542/930] blk.18.attn_output.weight... 16777216 elements at offset 15378474944
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.18.attn_output.weight                          4096x4096 -> 10240 KB
+  [543/930] blk.18.attn_q.weight... 16777216 elements at offset 15387912128
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.18.attn_q.weight                               4096x4096 -> 10240 KB
+  [544/930] blk.18.attn_v.weight... 4194304 elements at offset 15397349312
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.18.attn_v.weight                               1024x4096 -> 2560 KB
+  [545/930] blk.18.ffn_down.5.weight... 58720256 elements at offset 15401805760
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.18.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [546/930] blk.18.ffn_up.5.weight... 58720256 elements at offset 15434835904
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [547/930] blk.18.ffn_gate.6.weight... 58720256 elements at offset 15467866048
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [548/930] blk.18.ffn_down.6.weight... 58720256 elements at offset 15500896192
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.18.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [549/930] blk.18.ffn_up.6.weight... 58720256 elements at offset 15533926336
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [550/930] blk.18.ffn_gate.7.weight... 58720256 elements at offset 15566956480
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [551/930] blk.18.ffn_down.7.weight... 58720256 elements at offset 15599986624
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.18.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [552/930] blk.18.ffn_up.7.weight... 58720256 elements at offset 15633016768
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.18.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [553/930] blk.19.ffn_gate.0.weight... 58720256 elements at offset 15666079680
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [554/930] blk.19.ffn_down.0.weight... 58720256 elements at offset 15699109824
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.19.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [555/930] blk.19.ffn_up.0.weight... 58720256 elements at offset 15732139968
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [556/930] blk.19.ffn_gate.1.weight... 58720256 elements at offset 15765170112
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [557/930] blk.19.ffn_down.1.weight... 58720256 elements at offset 15798200256
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.19.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [558/930] blk.19.ffn_up.1.weight... 58720256 elements at offset 15831230400
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [559/930] blk.19.ffn_gate.2.weight... 58720256 elements at offset 15864260544
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [560/930] blk.19.ffn_down.2.weight... 58720256 elements at offset 15897290688
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.19.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [561/930] blk.19.ffn_up.2.weight... 58720256 elements at offset 15930320832
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [562/930] blk.19.ffn_gate.3.weight... 58720256 elements at offset 15963350976
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [563/930] blk.19.ffn_down.3.weight... 58720256 elements at offset 15996381120
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.19.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [564/930] blk.19.ffn_up.3.weight... 58720256 elements at offset 16029411264
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [565/930] blk.19.ffn_gate.4.weight... 58720256 elements at offset 16062441408
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [566/930] blk.19.ffn_down.4.weight... 58720256 elements at offset 16095471552
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.19.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [567/930] blk.19.ffn_up.4.weight... 58720256 elements at offset 16128501696
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [568/930] blk.19.ffn_gate.5.weight... 58720256 elements at offset 16161531840
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [569/930] blk.19.ffn_down.5.weight... 58720256 elements at offset 16194561984
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.19.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [570/930] blk.19.ffn_up.5.weight... 58720256 elements at offset 16227592128
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [571/930] blk.19.ffn_gate.6.weight... 58720256 elements at offset 16260622272
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [572/930] blk.19.ffn_down.6.weight... 58720256 elements at offset 16293652416
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.19.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [573/930] blk.19.ffn_up.6.weight... 58720256 elements at offset 16326682560
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [574/930] blk.19.ffn_gate.7.weight... 58720256 elements at offset 16359712704
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [575/930] blk.19.ffn_down.7.weight... 58720256 elements at offset 16392742848
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.19.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [576/930] blk.19.ffn_up.7.weight... 58720256 elements at offset 16425772992
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.19.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [577/930] blk.19.ffn_gate_inp.weight... 32768 elements at offset 16458803136
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.19.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [578/930] blk.19.attn_k.weight... 4194304 elements at offset 16458901440
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.19.attn_k.weight                               1024x4096 -> 2560 KB
+  [579/930] blk.19.attn_output.weight... 16777216 elements at offset 16463357888
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.19.attn_output.weight                          4096x4096 -> 10240 KB
+  [580/930] blk.19.attn_q.weight... 16777216 elements at offset 16472795072
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.19.attn_q.weight                               4096x4096 -> 10240 KB
+  [581/930] blk.19.attn_v.weight... 4194304 elements at offset 16482232256
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.19.attn_v.weight                               1024x4096 -> 2560 KB
+  [582/930] blk.20.ffn_gate.0.weight... 58720256 elements at offset 16486688704
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [583/930] blk.20.ffn_down.0.weight... 58720256 elements at offset 16519718848
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.20.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [584/930] blk.20.ffn_up.0.weight... 58720256 elements at offset 16552748992
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [585/930] blk.20.ffn_gate.1.weight... 58720256 elements at offset 16585779136
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [586/930] blk.20.ffn_down.1.weight... 58720256 elements at offset 16618809280
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.20.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [587/930] blk.20.ffn_up.1.weight... 58720256 elements at offset 16651839424
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [588/930] blk.20.ffn_gate.2.weight... 58720256 elements at offset 16684869568
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [589/930] blk.20.ffn_down.2.weight... 58720256 elements at offset 16717899712
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.20.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [590/930] blk.20.ffn_up.2.weight... 58720256 elements at offset 16750929856
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [591/930] blk.20.ffn_gate_inp.weight... 32768 elements at offset 16783960000
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.20.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [592/930] blk.20.attn_k.weight... 4194304 elements at offset 16784025536
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.20.attn_k.weight                               1024x4096 -> 2560 KB
+  [593/930] blk.20.attn_output.weight... 16777216 elements at offset 16788481984
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.20.attn_output.weight                          4096x4096 -> 10240 KB
+  [594/930] blk.20.attn_q.weight... 16777216 elements at offset 16797919168
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.20.attn_q.weight                               4096x4096 -> 10240 KB
+  [595/930] blk.20.attn_v.weight... 4194304 elements at offset 16807356352
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.20.attn_v.weight                               1024x4096 -> 2560 KB
+  [596/930] blk.20.ffn_gate.3.weight... 58720256 elements at offset 16811812800
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [597/930] blk.20.ffn_down.3.weight... 58720256 elements at offset 16844842944
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.20.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [598/930] blk.20.ffn_up.3.weight... 58720256 elements at offset 16877873088
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [599/930] blk.20.ffn_gate.4.weight... 58720256 elements at offset 16910903232
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [600/930] blk.20.ffn_down.4.weight... 58720256 elements at offset 16943933376
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.20.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [601/930] blk.20.ffn_up.4.weight... 58720256 elements at offset 16976963520
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [602/930] blk.20.ffn_gate.5.weight... 58720256 elements at offset 17009993664
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [603/930] blk.20.ffn_down.5.weight... 58720256 elements at offset 17043023808
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.20.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [604/930] blk.20.ffn_up.5.weight... 58720256 elements at offset 17076053952
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [605/930] blk.20.ffn_gate.6.weight... 58720256 elements at offset 17109084096
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [606/930] blk.20.ffn_down.6.weight... 58720256 elements at offset 17142114240
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.20.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [607/930] blk.20.ffn_up.6.weight... 58720256 elements at offset 17175144384
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [608/930] blk.20.ffn_gate.7.weight... 58720256 elements at offset 17208174528
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [609/930] blk.20.ffn_down.7.weight... 58720256 elements at offset 17241204672
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.20.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [610/930] blk.20.ffn_up.7.weight... 58720256 elements at offset 17274234816
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.20.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [611/930] blk.21.ffn_gate.0.weight... 58720256 elements at offset 17307297728
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [612/930] blk.21.ffn_down.0.weight... 58720256 elements at offset 17340327872
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.21.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [613/930] blk.21.ffn_up.0.weight... 58720256 elements at offset 17373358016
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [614/930] blk.21.ffn_gate.1.weight... 58720256 elements at offset 17406388160
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [615/930] blk.21.ffn_down.1.weight... 58720256 elements at offset 17439418304
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.21.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [616/930] blk.21.ffn_up.1.weight... 58720256 elements at offset 17472448448
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [617/930] blk.21.ffn_gate.2.weight... 58720256 elements at offset 17505478592
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [618/930] blk.21.ffn_down.2.weight... 58720256 elements at offset 17538508736
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.21.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [619/930] blk.21.ffn_up.2.weight... 58720256 elements at offset 17571538880
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [620/930] blk.21.ffn_gate.3.weight... 58720256 elements at offset 17604569024
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [621/930] blk.21.ffn_down.3.weight... 58720256 elements at offset 17637599168
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.21.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [622/930] blk.21.ffn_up.3.weight... 58720256 elements at offset 17670629312
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [623/930] blk.21.ffn_gate.4.weight... 58720256 elements at offset 17703659456
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [624/930] blk.21.ffn_down.4.weight... 58720256 elements at offset 17736689600
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.21.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [625/930] blk.21.ffn_up.4.weight... 58720256 elements at offset 17769719744
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [626/930] blk.21.ffn_gate.5.weight... 58720256 elements at offset 17802749888
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [627/930] blk.21.ffn_down.5.weight... 58720256 elements at offset 17835780032
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.21.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [628/930] blk.21.ffn_up.5.weight... 58720256 elements at offset 17868810176
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [629/930] blk.21.ffn_gate.6.weight... 58720256 elements at offset 17901840320
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [630/930] blk.21.ffn_down.6.weight... 58720256 elements at offset 17934870464
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.21.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [631/930] blk.21.ffn_up.6.weight... 58720256 elements at offset 17967900608
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [632/930] blk.21.ffn_gate.7.weight... 58720256 elements at offset 18000930752
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [633/930] blk.21.ffn_down.7.weight... 58720256 elements at offset 18033960896
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.21.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [634/930] blk.21.ffn_up.7.weight... 58720256 elements at offset 18066991040
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.21.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [635/930] blk.21.ffn_gate_inp.weight... 32768 elements at offset 18100021184
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.21.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [636/930] blk.21.attn_k.weight... 4194304 elements at offset 18100119488
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.21.attn_k.weight                               1024x4096 -> 2560 KB
+  [637/930] blk.21.attn_output.weight... 16777216 elements at offset 18104575936
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.21.attn_output.weight                          4096x4096 -> 10240 KB
+  [638/930] blk.21.attn_q.weight... 16777216 elements at offset 18114013120
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.21.attn_q.weight                               4096x4096 -> 10240 KB
+  [639/930] blk.21.attn_v.weight... 4194304 elements at offset 18123450304
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.21.attn_v.weight                               1024x4096 -> 2560 KB
+  [640/930] blk.22.ffn_gate.0.weight... 58720256 elements at offset 18127906752
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [641/930] blk.22.ffn_down.0.weight... 58720256 elements at offset 18160936896
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.22.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [642/930] blk.22.ffn_gate_inp.weight... 32768 elements at offset 18193967040
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.22.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [643/930] blk.22.attn_k.weight... 4194304 elements at offset 18194032576
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.22.attn_k.weight                               1024x4096 -> 2560 KB
+  [644/930] blk.22.attn_output.weight... 16777216 elements at offset 18198489024
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.22.attn_output.weight                          4096x4096 -> 10240 KB
+  [645/930] blk.22.attn_q.weight... 16777216 elements at offset 18207926208
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.22.attn_q.weight                               4096x4096 -> 10240 KB
+  [646/930] blk.22.attn_v.weight... 4194304 elements at offset 18217363392
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.22.attn_v.weight                               1024x4096 -> 2560 KB
+  [647/930] blk.22.ffn_up.0.weight... 58720256 elements at offset 18221819840
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [648/930] blk.22.ffn_gate.1.weight... 58720256 elements at offset 18254849984
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [649/930] blk.22.ffn_down.1.weight... 58720256 elements at offset 18287880128
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.22.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [650/930] blk.22.ffn_up.1.weight... 58720256 elements at offset 18320910272
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [651/930] blk.22.ffn_gate.2.weight... 58720256 elements at offset 18353940416
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [652/930] blk.22.ffn_down.2.weight... 58720256 elements at offset 18386970560
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.22.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [653/930] blk.22.ffn_up.2.weight... 58720256 elements at offset 18420000704
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [654/930] blk.22.ffn_gate.3.weight... 58720256 elements at offset 18453030848
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [655/930] blk.22.ffn_down.3.weight... 58720256 elements at offset 18486060992
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.22.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [656/930] blk.22.ffn_up.3.weight... 58720256 elements at offset 18519091136
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [657/930] blk.22.ffn_gate.4.weight... 58720256 elements at offset 18552121280
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [658/930] blk.22.ffn_down.4.weight... 58720256 elements at offset 18585151424
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.22.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [659/930] blk.22.ffn_up.4.weight... 58720256 elements at offset 18618181568
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [660/930] blk.22.ffn_gate.5.weight... 58720256 elements at offset 18651211712
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [661/930] blk.22.ffn_down.5.weight... 58720256 elements at offset 18684241856
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.22.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [662/930] blk.22.ffn_up.5.weight... 58720256 elements at offset 18717272000
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [663/930] blk.22.ffn_gate.6.weight... 58720256 elements at offset 18750302144
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [664/930] blk.22.ffn_down.6.weight... 58720256 elements at offset 18783332288
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.22.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [665/930] blk.22.ffn_up.6.weight... 58720256 elements at offset 18816362432
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [666/930] blk.22.ffn_gate.7.weight... 58720256 elements at offset 18849392576
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [667/930] blk.22.ffn_down.7.weight... 58720256 elements at offset 18882422720
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.22.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [668/930] blk.22.ffn_up.7.weight... 58720256 elements at offset 18915452864
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.22.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [669/930] blk.23.ffn_gate.0.weight... 58720256 elements at offset 18948515776
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [670/930] blk.23.ffn_down.0.weight... 58720256 elements at offset 18981545920
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.23.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [671/930] blk.23.ffn_up.0.weight... 58720256 elements at offset 19014576064
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [672/930] blk.23.ffn_gate.1.weight... 58720256 elements at offset 19047606208
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [673/930] blk.23.ffn_down.1.weight... 58720256 elements at offset 19080636352
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.23.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [674/930] blk.23.ffn_up.1.weight... 58720256 elements at offset 19113666496
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [675/930] blk.23.ffn_gate.2.weight... 58720256 elements at offset 19146696640
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [676/930] blk.23.ffn_down.2.weight... 58720256 elements at offset 19179726784
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.23.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [677/930] blk.23.ffn_up.2.weight... 58720256 elements at offset 19212756928
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [678/930] blk.23.ffn_gate.3.weight... 58720256 elements at offset 19245787072
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [679/930] blk.23.ffn_down.3.weight... 58720256 elements at offset 19278817216
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.23.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [680/930] blk.23.ffn_up.3.weight... 58720256 elements at offset 19311847360
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [681/930] blk.23.ffn_gate.4.weight... 58720256 elements at offset 19344877504
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [682/930] blk.23.ffn_down.4.weight... 58720256 elements at offset 19377907648
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.23.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [683/930] blk.23.ffn_up.4.weight... 58720256 elements at offset 19410937792
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [684/930] blk.23.ffn_gate.5.weight... 58720256 elements at offset 19443967936
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [685/930] blk.23.ffn_down.5.weight... 58720256 elements at offset 19476998080
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.23.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [686/930] blk.23.ffn_up.5.weight... 58720256 elements at offset 19510028224
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [687/930] blk.23.ffn_gate.6.weight... 58720256 elements at offset 19543058368
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [688/930] blk.23.ffn_gate_inp.weight... 32768 elements at offset 19576088512
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.23.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [689/930] blk.23.attn_k.weight... 4194304 elements at offset 19576154048
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.23.attn_k.weight                               1024x4096 -> 2560 KB
+  [690/930] blk.23.attn_output.weight... 16777216 elements at offset 19580610496
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.23.attn_output.weight                          4096x4096 -> 10240 KB
+  [691/930] blk.23.attn_q.weight... 16777216 elements at offset 19590047680
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.23.attn_q.weight                               4096x4096 -> 10240 KB
+  [692/930] blk.23.attn_v.weight... 4194304 elements at offset 19599484864
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.23.attn_v.weight                               1024x4096 -> 2560 KB
+  [693/930] blk.23.ffn_down.6.weight... 58720256 elements at offset 19603941312
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.23.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [694/930] blk.23.ffn_up.6.weight... 58720256 elements at offset 19636971456
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [695/930] blk.23.ffn_gate.7.weight... 58720256 elements at offset 19670001600
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [696/930] blk.23.ffn_down.7.weight... 58720256 elements at offset 19703031744
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.23.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [697/930] blk.23.ffn_up.7.weight... 58720256 elements at offset 19736061888
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.23.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [698/930] blk.24.ffn_gate.0.weight... 58720256 elements at offset 19769124800
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [699/930] blk.24.ffn_down.0.weight... 58720256 elements at offset 19802154944
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.24.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [700/930] blk.24.ffn_up.0.weight... 58720256 elements at offset 19835185088
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [701/930] blk.24.ffn_gate.1.weight... 58720256 elements at offset 19868215232
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [702/930] blk.24.ffn_down.1.weight... 58720256 elements at offset 19901245376
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.24.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [703/930] blk.24.ffn_up.1.weight... 58720256 elements at offset 19934275520
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [704/930] blk.24.ffn_gate.2.weight... 58720256 elements at offset 19967305664
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [705/930] blk.24.ffn_down.2.weight... 58720256 elements at offset 20000335808
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.24.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [706/930] blk.24.ffn_up.2.weight... 58720256 elements at offset 20033365952
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [707/930] blk.24.ffn_gate.3.weight... 58720256 elements at offset 20066396096
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [708/930] blk.24.ffn_down.3.weight... 58720256 elements at offset 20099426240
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.24.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [709/930] blk.24.ffn_up.3.weight... 58720256 elements at offset 20132456384
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [710/930] blk.24.ffn_gate.4.weight... 58720256 elements at offset 20165486528
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [711/930] blk.24.ffn_down.4.weight... 58720256 elements at offset 20198516672
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.24.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [712/930] blk.24.ffn_up.4.weight... 58720256 elements at offset 20231546816
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [713/930] blk.24.ffn_gate.5.weight... 58720256 elements at offset 20264576960
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [714/930] blk.24.ffn_down.5.weight... 58720256 elements at offset 20297607104
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.24.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [715/930] blk.24.ffn_up.5.weight... 58720256 elements at offset 20330637248
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [716/930] blk.24.ffn_gate.6.weight... 58720256 elements at offset 20363667392
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [717/930] blk.24.ffn_down.6.weight... 58720256 elements at offset 20396697536
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.24.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [718/930] blk.24.ffn_up.6.weight... 58720256 elements at offset 20429727680
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [719/930] blk.24.ffn_gate.7.weight... 58720256 elements at offset 20462757824
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [720/930] blk.24.ffn_down.7.weight... 58720256 elements at offset 20495787968
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.24.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [721/930] blk.24.ffn_up.7.weight... 58720256 elements at offset 20528818112
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.24.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [722/930] blk.24.ffn_gate_inp.weight... 32768 elements at offset 20561848256
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.24.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [723/930] blk.24.attn_k.weight... 4194304 elements at offset 20561946560
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.24.attn_k.weight                               1024x4096 -> 2560 KB
+  [724/930] blk.24.attn_output.weight... 16777216 elements at offset 20566403008
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.24.attn_output.weight                          4096x4096 -> 10240 KB
+  [725/930] blk.24.attn_q.weight... 16777216 elements at offset 20575840192
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.24.attn_q.weight                               4096x4096 -> 10240 KB
+  [726/930] blk.24.attn_v.weight... 4194304 elements at offset 20585277376
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.24.attn_v.weight                               1024x4096 -> 2560 KB
+  [727/930] blk.25.ffn_gate.0.weight... 58720256 elements at offset 20589733824
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [728/930] blk.25.ffn_down.0.weight... 58720256 elements at offset 20622763968
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.25.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [729/930] blk.25.ffn_up.0.weight... 58720256 elements at offset 20655794112
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [730/930] blk.25.ffn_gate.1.weight... 58720256 elements at offset 20688824256
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [731/930] blk.25.ffn_down.1.weight... 58720256 elements at offset 20721854400
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.25.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [732/930] blk.25.ffn_up.1.weight... 58720256 elements at offset 20754884544
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [733/930] blk.25.ffn_gate.2.weight... 58720256 elements at offset 20787914688
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [734/930] blk.25.ffn_down.2.weight... 58720256 elements at offset 20820944832
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.25.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [735/930] blk.25.ffn_up.2.weight... 58720256 elements at offset 20853974976
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [736/930] blk.25.ffn_gate.3.weight... 58720256 elements at offset 20887005120
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [737/930] blk.25.ffn_down.3.weight... 58720256 elements at offset 20920035264
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.25.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [738/930] blk.25.ffn_up.3.weight... 58720256 elements at offset 20953065408
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [739/930] blk.25.ffn_gate_inp.weight... 32768 elements at offset 20986095552
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.25.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [740/930] blk.25.attn_k.weight... 4194304 elements at offset 20986161088
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.25.attn_k.weight                               1024x4096 -> 2560 KB
+  [741/930] blk.25.attn_output.weight... 16777216 elements at offset 20990617536
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.25.attn_output.weight                          4096x4096 -> 10240 KB
+  [742/930] blk.25.attn_q.weight... 16777216 elements at offset 21000054720
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.25.attn_q.weight                               4096x4096 -> 10240 KB
+  [743/930] blk.25.attn_v.weight... 4194304 elements at offset 21009491904
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.25.attn_v.weight                               1024x4096 -> 2560 KB
+  [744/930] blk.25.ffn_gate.4.weight... 58720256 elements at offset 21013948352
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [745/930] blk.25.ffn_down.4.weight... 58720256 elements at offset 21046978496
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.25.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [746/930] blk.25.ffn_up.4.weight... 58720256 elements at offset 21080008640
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [747/930] blk.25.ffn_gate.5.weight... 58720256 elements at offset 21113038784
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [748/930] blk.25.ffn_down.5.weight... 58720256 elements at offset 21146068928
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.25.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [749/930] blk.25.ffn_up.5.weight... 58720256 elements at offset 21179099072
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [750/930] blk.25.ffn_gate.6.weight... 58720256 elements at offset 21212129216
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [751/930] blk.25.ffn_down.6.weight... 58720256 elements at offset 21245159360
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.25.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [752/930] blk.25.ffn_up.6.weight... 58720256 elements at offset 21278189504
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [753/930] blk.25.ffn_gate.7.weight... 58720256 elements at offset 21311219648
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [754/930] blk.25.ffn_down.7.weight... 58720256 elements at offset 21344249792
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.25.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [755/930] blk.25.ffn_up.7.weight... 58720256 elements at offset 21377279936
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.25.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [756/930] blk.26.ffn_gate.0.weight... 58720256 elements at offset 21410342848
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [757/930] blk.26.ffn_down.0.weight... 58720256 elements at offset 21443372992
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.26.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [758/930] blk.26.ffn_up.0.weight... 58720256 elements at offset 21476403136
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [759/930] blk.26.ffn_gate.1.weight... 58720256 elements at offset 21509433280
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [760/930] blk.26.ffn_down.1.weight... 58720256 elements at offset 21542463424
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.26.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [761/930] blk.26.ffn_up.1.weight... 58720256 elements at offset 21575493568
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [762/930] blk.26.ffn_gate.2.weight... 58720256 elements at offset 21608523712
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [763/930] blk.26.ffn_down.2.weight... 58720256 elements at offset 21641553856
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.26.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [764/930] blk.26.ffn_up.2.weight... 58720256 elements at offset 21674584000
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [765/930] blk.26.ffn_gate.3.weight... 58720256 elements at offset 21707614144
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [766/930] blk.26.ffn_down.3.weight... 58720256 elements at offset 21740644288
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.26.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [767/930] blk.26.ffn_up.3.weight... 58720256 elements at offset 21773674432
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [768/930] blk.26.ffn_gate.4.weight... 58720256 elements at offset 21806704576
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [769/930] blk.26.ffn_down.4.weight... 58720256 elements at offset 21839734720
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.26.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [770/930] blk.26.ffn_up.4.weight... 58720256 elements at offset 21872764864
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [771/930] blk.26.ffn_gate.5.weight... 58720256 elements at offset 21905795008
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [772/930] blk.26.ffn_down.5.weight... 58720256 elements at offset 21938825152
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.26.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [773/930] blk.26.ffn_up.5.weight... 58720256 elements at offset 21971855296
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [774/930] blk.26.ffn_gate.6.weight... 58720256 elements at offset 22004885440
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [775/930] blk.26.ffn_down.6.weight... 58720256 elements at offset 22037915584
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.26.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [776/930] blk.26.ffn_up.6.weight... 58720256 elements at offset 22070945728
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [777/930] blk.26.ffn_gate.7.weight... 58720256 elements at offset 22103975872
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [778/930] blk.26.ffn_down.7.weight... 58720256 elements at offset 22137006016
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.26.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [779/930] blk.26.ffn_up.7.weight... 58720256 elements at offset 22170036160
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.26.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [780/930] blk.26.ffn_gate_inp.weight... 32768 elements at offset 22203066304
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.26.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [781/930] blk.26.attn_k.weight... 4194304 elements at offset 22203164608
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.26.attn_k.weight                               1024x4096 -> 2560 KB
+  [782/930] blk.26.attn_output.weight... 16777216 elements at offset 22207621056
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.26.attn_output.weight                          4096x4096 -> 10240 KB
+  [783/930] blk.26.attn_q.weight... 16777216 elements at offset 22217058240
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.26.attn_q.weight                               4096x4096 -> 10240 KB
+  [784/930] blk.26.attn_v.weight... 4194304 elements at offset 22226495424
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.26.attn_v.weight                               1024x4096 -> 2560 KB
+  [785/930] blk.27.ffn_gate.0.weight... 58720256 elements at offset 22230951872
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [786/930] blk.27.ffn_down.0.weight... 58720256 elements at offset 22263982016
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.27.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [787/930] blk.27.ffn_up.0.weight... 58720256 elements at offset 22297012160
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [788/930] blk.27.ffn_gate.1.weight... 58720256 elements at offset 22330042304
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [789/930] blk.27.ffn_down.1.weight... 58720256 elements at offset 22363072448
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.27.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [790/930] blk.27.ffn_gate_inp.weight... 32768 elements at offset 22396102592
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.27.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [791/930] blk.27.attn_k.weight... 4194304 elements at offset 22396168128
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.27.attn_k.weight                               1024x4096 -> 2560 KB
+  [792/930] blk.27.attn_output.weight... 16777216 elements at offset 22400624576
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.27.attn_output.weight                          4096x4096 -> 10240 KB
+  [793/930] blk.27.attn_q.weight... 16777216 elements at offset 22410061760
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.27.attn_q.weight                               4096x4096 -> 10240 KB
+  [794/930] blk.27.attn_v.weight... 4194304 elements at offset 22419498944
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.27.attn_v.weight                               1024x4096 -> 2560 KB
+  [795/930] blk.27.ffn_up.1.weight... 58720256 elements at offset 22423955392
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [796/930] blk.27.ffn_gate.2.weight... 58720256 elements at offset 22456985536
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [797/930] blk.27.ffn_down.2.weight... 58720256 elements at offset 22490015680
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.27.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [798/930] blk.27.ffn_up.2.weight... 58720256 elements at offset 22523045824
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [799/930] blk.27.ffn_gate.3.weight... 58720256 elements at offset 22556075968
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [800/930] blk.27.ffn_down.3.weight... 58720256 elements at offset 22589106112
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.27.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [801/930] blk.27.ffn_up.3.weight... 58720256 elements at offset 22622136256
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [802/930] blk.27.ffn_gate.4.weight... 58720256 elements at offset 22655166400
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [803/930] blk.27.ffn_down.4.weight... 58720256 elements at offset 22688196544
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.27.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [804/930] blk.27.ffn_up.4.weight... 58720256 elements at offset 22721226688
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [805/930] blk.27.ffn_gate.5.weight... 58720256 elements at offset 22754256832
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [806/930] blk.27.ffn_down.5.weight... 58720256 elements at offset 22787286976
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.27.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [807/930] blk.27.ffn_up.5.weight... 58720256 elements at offset 22820317120
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [808/930] blk.27.ffn_gate.6.weight... 58720256 elements at offset 22853347264
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [809/930] blk.27.ffn_down.6.weight... 58720256 elements at offset 22886377408
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.27.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [810/930] blk.27.ffn_up.6.weight... 58720256 elements at offset 22919407552
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [811/930] blk.27.ffn_gate.7.weight... 58720256 elements at offset 22952437696
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [812/930] blk.27.ffn_down.7.weight... 58720256 elements at offset 22985467840
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.27.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [813/930] blk.27.ffn_up.7.weight... 58720256 elements at offset 23018497984
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.27.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [814/930] blk.28.ffn_gate.0.weight... 58720256 elements at offset 23051560896
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [815/930] blk.28.ffn_down.0.weight... 58720256 elements at offset 23084591040
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.28.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [816/930] blk.28.ffn_up.0.weight... 58720256 elements at offset 23117621184
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [817/930] blk.28.ffn_gate.1.weight... 58720256 elements at offset 23150651328
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [818/930] blk.28.ffn_down.1.weight... 58720256 elements at offset 23183681472
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.28.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [819/930] blk.28.ffn_up.1.weight... 58720256 elements at offset 23216711616
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [820/930] blk.28.ffn_gate.2.weight... 58720256 elements at offset 23249741760
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [821/930] blk.28.ffn_down.2.weight... 58720256 elements at offset 23282771904
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.28.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [822/930] blk.28.ffn_up.2.weight... 58720256 elements at offset 23315802048
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [823/930] blk.28.ffn_gate.3.weight... 58720256 elements at offset 23348832192
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [824/930] blk.28.ffn_down.3.weight... 58720256 elements at offset 23381862336
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.28.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [825/930] blk.28.ffn_up.3.weight... 58720256 elements at offset 23414892480
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [826/930] blk.28.ffn_gate.4.weight... 58720256 elements at offset 23447922624
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [827/930] blk.28.ffn_down.4.weight... 58720256 elements at offset 23480952768
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.28.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [828/930] blk.28.ffn_up.4.weight... 58720256 elements at offset 23513982912
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [829/930] blk.28.ffn_gate.5.weight... 58720256 elements at offset 23547013056
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [830/930] blk.28.ffn_down.5.weight... 58720256 elements at offset 23580043200
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.28.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [831/930] blk.28.ffn_up.5.weight... 58720256 elements at offset 23613073344
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [832/930] blk.28.ffn_gate.6.weight... 58720256 elements at offset 23646103488
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [833/930] blk.28.ffn_down.6.weight... 58720256 elements at offset 23679133632
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.28.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [834/930] blk.28.ffn_up.6.weight... 58720256 elements at offset 23712163776
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [835/930] blk.28.ffn_gate.7.weight... 58720256 elements at offset 23745193920
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [836/930] blk.28.ffn_gate_inp.weight... 32768 elements at offset 23778224064
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.28.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [837/930] blk.28.attn_k.weight... 4194304 elements at offset 23778289600
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.28.attn_k.weight                               1024x4096 -> 2560 KB
+  [838/930] blk.28.attn_output.weight... 16777216 elements at offset 23782746048
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.28.attn_output.weight                          4096x4096 -> 10240 KB
+  [839/930] blk.28.attn_q.weight... 16777216 elements at offset 23792183232
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.28.attn_q.weight                               4096x4096 -> 10240 KB
+  [840/930] blk.28.attn_v.weight... 4194304 elements at offset 23801620416
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.28.attn_v.weight                               1024x4096 -> 2560 KB
+  [841/930] blk.28.ffn_down.7.weight... 58720256 elements at offset 23806076864
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.28.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [842/930] blk.28.ffn_up.7.weight... 58720256 elements at offset 23839107008
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.28.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [843/930] blk.29.ffn_gate.0.weight... 58720256 elements at offset 23872169920
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [844/930] blk.29.ffn_down.0.weight... 58720256 elements at offset 23905200064
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.29.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [845/930] blk.29.ffn_up.0.weight... 58720256 elements at offset 23938230208
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [846/930] blk.29.ffn_gate.1.weight... 58720256 elements at offset 23971260352
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [847/930] blk.29.ffn_down.1.weight... 58720256 elements at offset 24004290496
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.29.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [848/930] blk.29.ffn_up.1.weight... 58720256 elements at offset 24037320640
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [849/930] blk.29.ffn_gate.2.weight... 58720256 elements at offset 24070350784
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [850/930] blk.29.ffn_down.2.weight... 58720256 elements at offset 24103380928
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.29.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [851/930] blk.29.ffn_up.2.weight... 58720256 elements at offset 24136411072
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [852/930] blk.29.ffn_gate.3.weight... 58720256 elements at offset 24169441216
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [853/930] blk.29.ffn_down.3.weight... 58720256 elements at offset 24202471360
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.29.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [854/930] blk.29.ffn_up.3.weight... 58720256 elements at offset 24235501504
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [855/930] blk.29.ffn_gate.4.weight... 58720256 elements at offset 24268531648
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [856/930] blk.29.ffn_down.4.weight... 58720256 elements at offset 24301561792
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.29.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [857/930] blk.29.ffn_up.4.weight... 58720256 elements at offset 24334591936
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [858/930] blk.29.ffn_gate.5.weight... 58720256 elements at offset 24367622080
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [859/930] blk.29.ffn_down.5.weight... 58720256 elements at offset 24400652224
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.29.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [860/930] blk.29.ffn_up.5.weight... 58720256 elements at offset 24433682368
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [861/930] blk.29.ffn_gate.6.weight... 58720256 elements at offset 24466712512
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [862/930] blk.29.ffn_down.6.weight... 58720256 elements at offset 24499742656
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.29.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [863/930] blk.29.ffn_up.6.weight... 58720256 elements at offset 24532772800
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [864/930] blk.29.ffn_gate.7.weight... 58720256 elements at offset 24565802944
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [865/930] blk.29.ffn_down.7.weight... 58720256 elements at offset 24598833088
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.29.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [866/930] blk.29.ffn_up.7.weight... 58720256 elements at offset 24631863232
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.29.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [867/930] blk.29.ffn_gate_inp.weight... 32768 elements at offset 24664893376
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.29.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [868/930] blk.29.attn_k.weight... 4194304 elements at offset 24664991680
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.29.attn_k.weight                               1024x4096 -> 2560 KB
+  [869/930] blk.29.attn_output.weight... 16777216 elements at offset 24669448128
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.29.attn_output.weight                          4096x4096 -> 10240 KB
+  [870/930] blk.29.attn_q.weight... 16777216 elements at offset 24678885312
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.29.attn_q.weight                               4096x4096 -> 10240 KB
+  [871/930] blk.29.attn_v.weight... 4194304 elements at offset 24688322496
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.29.attn_v.weight                               1024x4096 -> 2560 KB
+  [872/930] blk.30.ffn_gate.0.weight... 58720256 elements at offset 24692778944
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [873/930] blk.30.ffn_down.0.weight... 58720256 elements at offset 24725809088
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.30.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [874/930] blk.30.ffn_up.0.weight... 58720256 elements at offset 24758839232
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [875/930] blk.30.ffn_gate.1.weight... 58720256 elements at offset 24791869376
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [876/930] blk.30.ffn_down.1.weight... 58720256 elements at offset 24824899520
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.30.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [877/930] blk.30.ffn_up.1.weight... 58720256 elements at offset 24857929664
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [878/930] blk.30.ffn_gate.2.weight... 58720256 elements at offset 24890959808
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [879/930] blk.30.ffn_down.2.weight... 58720256 elements at offset 24923989952
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.30.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [880/930] blk.30.ffn_up.2.weight... 58720256 elements at offset 24957020096
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [881/930] blk.30.ffn_gate.3.weight... 58720256 elements at offset 24990050240
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [882/930] blk.30.ffn_down.3.weight... 58720256 elements at offset 25023080384
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.30.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [883/930] blk.30.ffn_up.3.weight... 58720256 elements at offset 25056110528
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [884/930] blk.30.ffn_gate.4.weight... 58720256 elements at offset 25089140672
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [885/930] blk.30.ffn_down.4.weight... 58720256 elements at offset 25122170816
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.30.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [886/930] blk.30.ffn_up.4.weight... 58720256 elements at offset 25155200960
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [887/930] blk.30.ffn_gate_inp.weight... 32768 elements at offset 25188231104
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.30.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [888/930] blk.30.attn_k.weight... 4194304 elements at offset 25188296640
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.30.attn_k.weight                               1024x4096 -> 2560 KB
+  [889/930] blk.30.attn_output.weight... 16777216 elements at offset 25192753088
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.30.attn_output.weight                          4096x4096 -> 10240 KB
+  [890/930] blk.30.attn_q.weight... 16777216 elements at offset 25202190272
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.30.attn_q.weight                               4096x4096 -> 10240 KB
+  [891/930] blk.30.attn_v.weight... 4194304 elements at offset 25211627456
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.30.attn_v.weight                               1024x4096 -> 2560 KB
+  [892/930] output.weight... 131072000 elements at offset 25216083904
+got 131072000 floats, tiling...
+  tiles: 1000x16 fout=0x62871b2ea110
+  output.weight                                      32000x4096 -> 80000 KB
+  [893/930] blk.30.ffn_gate.5.weight... 58720256 elements at offset 25323603904
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [894/930] blk.30.ffn_down.5.weight... 58720256 elements at offset 25356634048
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.30.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [895/930] blk.30.ffn_up.5.weight... 58720256 elements at offset 25389664192
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [896/930] blk.30.ffn_gate.6.weight... 58720256 elements at offset 25422694336
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [897/930] blk.30.ffn_down.6.weight... 58720256 elements at offset 25455724480
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.30.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [898/930] blk.30.ffn_up.6.weight... 58720256 elements at offset 25488754624
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [899/930] blk.30.ffn_gate.7.weight... 58720256 elements at offset 25521784768
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [900/930] blk.30.ffn_down.7.weight... 58720256 elements at offset 25554814912
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.30.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [901/930] blk.30.ffn_up.7.weight... 58720256 elements at offset 25587845056
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.30.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [902/930] blk.31.ffn_gate.0.weight... 58720256 elements at offset 25620907968
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_gate.0.weight                           14336x4096 -> 35840 KB
+  [903/930] blk.31.ffn_down.0.weight... 58720256 elements at offset 25653938112
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.31.ffn_down.0.weight                           4096x14336 -> 35840 KB
+  [904/930] blk.31.ffn_up.0.weight... 58720256 elements at offset 25686968256
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_up.0.weight                             14336x4096 -> 35840 KB
+  [905/930] blk.31.ffn_gate.1.weight... 58720256 elements at offset 25719998400
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_gate.1.weight                           14336x4096 -> 35840 KB
+  [906/930] blk.31.ffn_down.1.weight... 58720256 elements at offset 25753028544
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.31.ffn_down.1.weight                           4096x14336 -> 35840 KB
+  [907/930] blk.31.ffn_up.1.weight... 58720256 elements at offset 25786058688
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_up.1.weight                             14336x4096 -> 35840 KB
+  [908/930] blk.31.ffn_gate.2.weight... 58720256 elements at offset 25819088832
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_gate.2.weight                           14336x4096 -> 35840 KB
+  [909/930] blk.31.ffn_down.2.weight... 58720256 elements at offset 25852118976
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.31.ffn_down.2.weight                           4096x14336 -> 35840 KB
+  [910/930] blk.31.ffn_up.2.weight... 58720256 elements at offset 25885149120
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_up.2.weight                             14336x4096 -> 35840 KB
+  [911/930] blk.31.ffn_gate.3.weight... 58720256 elements at offset 25918179264
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_gate.3.weight                           14336x4096 -> 35840 KB
+  [912/930] blk.31.ffn_down.3.weight... 58720256 elements at offset 25951209408
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.31.ffn_down.3.weight                           4096x14336 -> 35840 KB
+  [913/930] blk.31.ffn_up.3.weight... 58720256 elements at offset 25984239552
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_up.3.weight                             14336x4096 -> 35840 KB
+  [914/930] blk.31.ffn_gate.4.weight... 58720256 elements at offset 26017269696
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_gate.4.weight                           14336x4096 -> 35840 KB
+  [915/930] blk.31.ffn_down.4.weight... 58720256 elements at offset 26050299840
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.31.ffn_down.4.weight                           4096x14336 -> 35840 KB
+  [916/930] blk.31.ffn_up.4.weight... 58720256 elements at offset 26083329984
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_up.4.weight                             14336x4096 -> 35840 KB
+  [917/930] blk.31.ffn_gate.5.weight... 58720256 elements at offset 26116360128
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_gate.5.weight                           14336x4096 -> 35840 KB
+  [918/930] blk.31.ffn_down.5.weight... 58720256 elements at offset 26149390272
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.31.ffn_down.5.weight                           4096x14336 -> 35840 KB
+  [919/930] blk.31.ffn_up.5.weight... 58720256 elements at offset 26182420416
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_up.5.weight                             14336x4096 -> 35840 KB
+  [920/930] blk.31.ffn_gate.6.weight... 58720256 elements at offset 26215450560
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_gate.6.weight                           14336x4096 -> 35840 KB
+  [921/930] blk.31.ffn_down.6.weight... 58720256 elements at offset 26248480704
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.31.ffn_down.6.weight                           4096x14336 -> 35840 KB
+  [922/930] blk.31.ffn_up.6.weight... 58720256 elements at offset 26281510848
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_up.6.weight                             14336x4096 -> 35840 KB
+  [923/930] blk.31.ffn_gate.7.weight... 58720256 elements at offset 26314540992
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_gate.7.weight                           14336x4096 -> 35840 KB
+  [924/930] blk.31.ffn_down.7.weight... 58720256 elements at offset 26347571136
+got 58720256 floats, tiling...
+  tiles: 128x56 fout=0x62871b2ea110
+  blk.31.ffn_down.7.weight                           4096x14336 -> 35840 KB
+  [925/930] blk.31.ffn_up.7.weight... 58720256 elements at offset 26380601280
+got 58720256 floats, tiling...
+  tiles: 448x16 fout=0x62871b2ea110
+  blk.31.ffn_up.7.weight                             14336x4096 -> 35840 KB
+  [926/930] blk.31.ffn_gate_inp.weight... 32768 elements at offset 26413631424
+got 32768 floats, tiling...
+  tiles: 1x16 fout=0x62871b2ea110
+  blk.31.ffn_gate_inp.weight                            8x4096 -> 80 KB
+  [927/930] blk.31.attn_k.weight... 4194304 elements at offset 26413729728
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.31.attn_k.weight                               1024x4096 -> 2560 KB
+  [928/930] blk.31.attn_output.weight... 16777216 elements at offset 26418186176
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.31.attn_output.weight                          4096x4096 -> 10240 KB
+  [929/930] blk.31.attn_q.weight... 16777216 elements at offset 26427623360
+got 16777216 floats, tiling...
+  tiles: 128x16 fout=0x62871b2ea110
+  blk.31.attn_q.weight                               4096x4096 -> 10240 KB
+  [930/930] blk.31.attn_v.weight... 4194304 elements at offset 26437060544
+got 4194304 floats, tiling...
+  tiles: 32x16 fout=0x62871b2ea110
+  blk.31.attn_v.weight                               1024x4096 -> 2560 KB
+
+=== DONE: models/Mixtral-8x7B/mixtral-8x7b-instruct-v0.1.1bp (27838.8 MB) in 241 seconds ===

--- a/models/Phi-3-mini/convert.log
+++ b/models/Phi-3-mini/convert.log
@@ -1,0 +1,529 @@
+GGUF opened: arch=phi3 tensors=195
+Model: H=3072 L=32 NH=32 NKV=32 HD=96 IM=8192 V=3072
+  tensor token_embd.weight: 32064x3072 tiled=61562880
+  tensor blk.0.ffn_down.weight: 3072x8192 tiled=15728640
+  tensor blk.0.ffn_up.weight: 16384x3072 tiled=31457280
+  Total tensors: 130, data size: 2277.4 MB
+Quantizing 130 tensors...
+  [1/130] token_embd.weight... 98500608 elements at offset 737792
+got 98500608 floats, tiling...
+  tiles: 1002x12 fout=0x5aac9d4011b0
+  token_embd.weight                                  32064x3072 -> 60120 KB
+  [2/130] blk.0.ffn_down.weight... 25165824 elements at offset 56156672
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.0.ffn_down.weight                              3072x8192 -> 15360 KB
+  [3/130] blk.0.ffn_up.weight... 50331648 elements at offset 76800512
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.0.ffn_up.weight                                16384x3072 -> 30720 KB
+  [4/130] blk.0.attn_output.weight... 9437184 elements at offset 105124352
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.0.attn_output.weight                           3072x3072 -> 5760 KB
+  [5/130] blk.0.attn_qkv.weight... 28311552 elements at offset 110432768
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.0.attn_qkv.weight                              9216x3072 -> 17280 KB
+  [6/130] blk.1.ffn_down.weight... 25165824 elements at offset 129909248
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.1.ffn_down.weight                              3072x8192 -> 15360 KB
+  [7/130] blk.1.ffn_up.weight... 50331648 elements at offset 150553088
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.1.ffn_up.weight                                16384x3072 -> 30720 KB
+  [8/130] blk.1.attn_output.weight... 9437184 elements at offset 178876928
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.1.attn_output.weight                           3072x3072 -> 5760 KB
+  [9/130] blk.1.attn_qkv.weight... 28311552 elements at offset 184185344
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.1.attn_qkv.weight                              9216x3072 -> 17280 KB
+  [10/130] blk.10.ffn_down.weight... 25165824 elements at offset 203661824
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.10.ffn_down.weight                             3072x8192 -> 15360 KB
+  [11/130] blk.10.ffn_up.weight... 50331648 elements at offset 224305664
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.10.ffn_up.weight                               16384x3072 -> 30720 KB
+  [12/130] blk.10.attn_output.weight... 9437184 elements at offset 252629504
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.10.attn_output.weight                          3072x3072 -> 5760 KB
+  [13/130] blk.10.attn_qkv.weight... 28311552 elements at offset 257937920
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.10.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [14/130] blk.11.ffn_down.weight... 25165824 elements at offset 277414400
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.11.ffn_down.weight                             3072x8192 -> 15360 KB
+  [15/130] blk.11.ffn_up.weight... 50331648 elements at offset 298058240
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.11.ffn_up.weight                               16384x3072 -> 30720 KB
+  [16/130] blk.11.attn_output.weight... 9437184 elements at offset 326382080
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.11.attn_output.weight                          3072x3072 -> 5760 KB
+  [17/130] blk.11.attn_qkv.weight... 28311552 elements at offset 331690496
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.11.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [18/130] blk.12.ffn_down.weight... 25165824 elements at offset 351166976
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.12.ffn_down.weight                             3072x8192 -> 15360 KB
+  [19/130] blk.12.ffn_up.weight... 50331648 elements at offset 365322752
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.12.ffn_up.weight                               16384x3072 -> 30720 KB
+  [20/130] blk.12.attn_output.weight... 9437184 elements at offset 393646592
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.12.attn_output.weight                          3072x3072 -> 5760 KB
+  [21/130] blk.12.attn_qkv.weight... 28311552 elements at offset 398955008
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.12.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [22/130] blk.13.ffn_down.weight... 25165824 elements at offset 418431488
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.13.ffn_down.weight                             3072x8192 -> 15360 KB
+  [23/130] blk.13.ffn_up.weight... 50331648 elements at offset 432587264
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.13.ffn_up.weight                               16384x3072 -> 30720 KB
+  [24/130] blk.13.attn_output.weight... 9437184 elements at offset 460911104
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.13.attn_output.weight                          3072x3072 -> 5760 KB
+  [25/130] blk.13.attn_qkv.weight... 28311552 elements at offset 466219520
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.13.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [26/130] blk.14.ffn_down.weight... 25165824 elements at offset 485696000
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.14.ffn_down.weight                             3072x8192 -> 15360 KB
+  [27/130] blk.14.ffn_up.weight... 50331648 elements at offset 506339840
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.14.ffn_up.weight                               16384x3072 -> 30720 KB
+  [28/130] blk.14.attn_output.weight... 9437184 elements at offset 534663680
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.14.attn_output.weight                          3072x3072 -> 5760 KB
+  [29/130] blk.14.attn_qkv.weight... 28311552 elements at offset 539972096
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.14.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [30/130] blk.15.ffn_down.weight... 25165824 elements at offset 559448576
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.15.ffn_down.weight                             3072x8192 -> 15360 KB
+  [31/130] blk.15.ffn_up.weight... 50331648 elements at offset 573604352
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.15.ffn_up.weight                               16384x3072 -> 30720 KB
+  [32/130] blk.15.attn_output.weight... 9437184 elements at offset 601928192
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.15.attn_output.weight                          3072x3072 -> 5760 KB
+  [33/130] blk.15.attn_qkv.weight... 28311552 elements at offset 607236608
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.15.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [34/130] blk.16.ffn_down.weight... 25165824 elements at offset 626713088
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.16.ffn_down.weight                             3072x8192 -> 15360 KB
+  [35/130] blk.16.ffn_up.weight... 50331648 elements at offset 640868864
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.16.ffn_up.weight                               16384x3072 -> 30720 KB
+  [36/130] blk.16.attn_output.weight... 9437184 elements at offset 669192704
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.16.attn_output.weight                          3072x3072 -> 5760 KB
+  [37/130] blk.16.attn_qkv.weight... 28311552 elements at offset 674501120
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.16.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [38/130] blk.17.ffn_down.weight... 25165824 elements at offset 693977600
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.17.ffn_down.weight                             3072x8192 -> 15360 KB
+  [39/130] blk.17.ffn_up.weight... 50331648 elements at offset 714621440
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.17.ffn_up.weight                               16384x3072 -> 30720 KB
+  [40/130] blk.17.attn_output.weight... 9437184 elements at offset 742945280
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.17.attn_output.weight                          3072x3072 -> 5760 KB
+  [41/130] blk.17.attn_qkv.weight... 28311552 elements at offset 748253696
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.17.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [42/130] blk.18.ffn_down.weight... 25165824 elements at offset 767730176
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.18.ffn_down.weight                             3072x8192 -> 15360 KB
+  [43/130] blk.18.ffn_up.weight... 50331648 elements at offset 781885952
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.18.ffn_up.weight                               16384x3072 -> 30720 KB
+  [44/130] blk.18.attn_output.weight... 9437184 elements at offset 810209792
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.18.attn_output.weight                          3072x3072 -> 5760 KB
+  [45/130] blk.18.attn_qkv.weight... 28311552 elements at offset 815518208
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.18.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [46/130] blk.19.ffn_down.weight... 25165824 elements at offset 834994688
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.19.ffn_down.weight                             3072x8192 -> 15360 KB
+  [47/130] blk.19.ffn_up.weight... 50331648 elements at offset 849150464
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.19.ffn_up.weight                               16384x3072 -> 30720 KB
+  [48/130] blk.19.attn_output.weight... 9437184 elements at offset 877474304
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.19.attn_output.weight                          3072x3072 -> 5760 KB
+  [49/130] blk.19.attn_qkv.weight... 28311552 elements at offset 882782720
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.19.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [50/130] blk.2.ffn_down.weight... 25165824 elements at offset 902259200
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.2.ffn_down.weight                              3072x8192 -> 15360 KB
+  [51/130] blk.2.ffn_up.weight... 50331648 elements at offset 922903040
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.2.ffn_up.weight                                16384x3072 -> 30720 KB
+  [52/130] blk.2.attn_output.weight... 9437184 elements at offset 951226880
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.2.attn_output.weight                           3072x3072 -> 5760 KB
+  [53/130] blk.2.attn_qkv.weight... 28311552 elements at offset 956535296
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.2.attn_qkv.weight                              9216x3072 -> 17280 KB
+  [54/130] blk.20.ffn_down.weight... 25165824 elements at offset 976011776
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.20.ffn_down.weight                             3072x8192 -> 15360 KB
+  [55/130] blk.20.ffn_up.weight... 50331648 elements at offset 990167552
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.20.ffn_up.weight                               16384x3072 -> 30720 KB
+  [56/130] blk.20.attn_output.weight... 9437184 elements at offset 1018491392
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.20.attn_output.weight                          3072x3072 -> 5760 KB
+  [57/130] blk.20.attn_qkv.weight... 28311552 elements at offset 1023799808
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.20.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [58/130] blk.21.attn_output.weight... 9437184 elements at offset 1043264000
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.21.attn_output.weight                          3072x3072 -> 5760 KB
+  [59/130] blk.3.ffn_down.weight... 25165824 elements at offset 1048584704
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.3.ffn_down.weight                              3072x8192 -> 15360 KB
+  [60/130] blk.3.ffn_up.weight... 50331648 elements at offset 1062740480
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.3.ffn_up.weight                                16384x3072 -> 30720 KB
+  [61/130] blk.3.attn_output.weight... 9437184 elements at offset 1091064320
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.3.attn_output.weight                           3072x3072 -> 5760 KB
+  [62/130] blk.3.attn_qkv.weight... 28311552 elements at offset 1096372736
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.3.attn_qkv.weight                              9216x3072 -> 17280 KB
+  [63/130] blk.4.ffn_down.weight... 25165824 elements at offset 1115849216
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.4.ffn_down.weight                              3072x8192 -> 15360 KB
+  [64/130] blk.4.ffn_up.weight... 50331648 elements at offset 1136493056
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.4.ffn_up.weight                                16384x3072 -> 30720 KB
+  [65/130] blk.4.attn_output.weight... 9437184 elements at offset 1164816896
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.4.attn_output.weight                           3072x3072 -> 5760 KB
+  [66/130] blk.4.attn_qkv.weight... 28311552 elements at offset 1170125312
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.4.attn_qkv.weight                              9216x3072 -> 17280 KB
+  [67/130] blk.5.ffn_down.weight... 25165824 elements at offset 1189601792
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.5.ffn_down.weight                              3072x8192 -> 15360 KB
+  [68/130] blk.5.ffn_up.weight... 50331648 elements at offset 1203757568
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.5.ffn_up.weight                                16384x3072 -> 30720 KB
+  [69/130] blk.5.attn_output.weight... 9437184 elements at offset 1232081408
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.5.attn_output.weight                           3072x3072 -> 5760 KB
+  [70/130] blk.5.attn_qkv.weight... 28311552 elements at offset 1237389824
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.5.attn_qkv.weight                              9216x3072 -> 17280 KB
+  [71/130] blk.6.ffn_down.weight... 25165824 elements at offset 1256866304
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.6.ffn_down.weight                              3072x8192 -> 15360 KB
+  [72/130] blk.6.ffn_up.weight... 50331648 elements at offset 1271022080
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.6.ffn_up.weight                                16384x3072 -> 30720 KB
+  [73/130] blk.6.attn_output.weight... 9437184 elements at offset 1299345920
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.6.attn_output.weight                           3072x3072 -> 5760 KB
+  [74/130] blk.6.attn_qkv.weight... 28311552 elements at offset 1304654336
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.6.attn_qkv.weight                              9216x3072 -> 17280 KB
+  [75/130] blk.7.ffn_down.weight... 25165824 elements at offset 1324130816
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.7.ffn_down.weight                              3072x8192 -> 15360 KB
+  [76/130] blk.7.ffn_up.weight... 50331648 elements at offset 1344774656
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.7.ffn_up.weight                                16384x3072 -> 30720 KB
+  [77/130] blk.7.attn_output.weight... 9437184 elements at offset 1373098496
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.7.attn_output.weight                           3072x3072 -> 5760 KB
+  [78/130] blk.7.attn_qkv.weight... 28311552 elements at offset 1378406912
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.7.attn_qkv.weight                              9216x3072 -> 17280 KB
+  [79/130] blk.8.ffn_down.weight... 25165824 elements at offset 1397883392
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.8.ffn_down.weight                              3072x8192 -> 15360 KB
+  [80/130] blk.8.ffn_up.weight... 50331648 elements at offset 1412039168
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.8.ffn_up.weight                                16384x3072 -> 30720 KB
+  [81/130] blk.8.attn_output.weight... 9437184 elements at offset 1440363008
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.8.attn_output.weight                           3072x3072 -> 5760 KB
+  [82/130] blk.8.attn_qkv.weight... 28311552 elements at offset 1445671424
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.8.attn_qkv.weight                              9216x3072 -> 17280 KB
+  [83/130] blk.9.ffn_down.weight... 25165824 elements at offset 1465147904
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.9.ffn_down.weight                              3072x8192 -> 15360 KB
+  [84/130] blk.9.ffn_up.weight... 50331648 elements at offset 1479303680
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.9.ffn_up.weight                                16384x3072 -> 30720 KB
+  [85/130] blk.9.attn_output.weight... 9437184 elements at offset 1507627520
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.9.attn_output.weight                           3072x3072 -> 5760 KB
+  [86/130] blk.9.attn_qkv.weight... 28311552 elements at offset 1512935936
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.9.attn_qkv.weight                              9216x3072 -> 17280 KB
+  [87/130] output.weight... 98500608 elements at offset 1532400128
+got 98500608 floats, tiling...
+  tiles: 1002x12 fout=0x5aac9d4011b0
+  output.weight                                      32064x3072 -> 60120 KB
+  [88/130] blk.21.ffn_down.weight... 25165824 elements at offset 1613213696
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.21.ffn_down.weight                             3072x8192 -> 15360 KB
+  [89/130] blk.21.ffn_up.weight... 50331648 elements at offset 1633857536
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.21.ffn_up.weight                               16384x3072 -> 30720 KB
+  [90/130] blk.21.attn_qkv.weight... 28311552 elements at offset 1662181376
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.21.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [91/130] blk.22.ffn_down.weight... 25165824 elements at offset 1681657856
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.22.ffn_down.weight                             3072x8192 -> 15360 KB
+  [92/130] blk.22.ffn_up.weight... 50331648 elements at offset 1695813632
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.22.ffn_up.weight                               16384x3072 -> 30720 KB
+  [93/130] blk.22.attn_output.weight... 9437184 elements at offset 1724137472
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.22.attn_output.weight                          3072x3072 -> 5760 KB
+  [94/130] blk.22.attn_qkv.weight... 28311552 elements at offset 1729445888
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.22.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [95/130] blk.23.ffn_down.weight... 25165824 elements at offset 1748922368
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.23.ffn_down.weight                             3072x8192 -> 15360 KB
+  [96/130] blk.23.ffn_up.weight... 50331648 elements at offset 1763078144
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.23.ffn_up.weight                               16384x3072 -> 30720 KB
+  [97/130] blk.23.attn_output.weight... 9437184 elements at offset 1791401984
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.23.attn_output.weight                          3072x3072 -> 5760 KB
+  [98/130] blk.23.attn_qkv.weight... 28311552 elements at offset 1796710400
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.23.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [99/130] blk.24.ffn_down.weight... 25165824 elements at offset 1816186880
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.24.ffn_down.weight                             3072x8192 -> 15360 KB
+  [100/130] blk.24.ffn_up.weight... 50331648 elements at offset 1836830720
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.24.ffn_up.weight                               16384x3072 -> 30720 KB
+  [101/130] blk.24.attn_output.weight... 9437184 elements at offset 1865154560
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.24.attn_output.weight                          3072x3072 -> 5760 KB
+  [102/130] blk.24.attn_qkv.weight... 28311552 elements at offset 1870462976
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.24.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [103/130] blk.25.ffn_down.weight... 25165824 elements at offset 1889939456
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.25.ffn_down.weight                             3072x8192 -> 15360 KB
+  [104/130] blk.25.ffn_up.weight... 50331648 elements at offset 1904095232
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.25.ffn_up.weight                               16384x3072 -> 30720 KB
+  [105/130] blk.25.attn_output.weight... 9437184 elements at offset 1932419072
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.25.attn_output.weight                          3072x3072 -> 5760 KB
+  [106/130] blk.25.attn_qkv.weight... 28311552 elements at offset 1937727488
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.25.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [107/130] blk.26.ffn_down.weight... 25165824 elements at offset 1957203968
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.26.ffn_down.weight                             3072x8192 -> 15360 KB
+  [108/130] blk.26.ffn_up.weight... 50331648 elements at offset 1971359744
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.26.ffn_up.weight                               16384x3072 -> 30720 KB
+  [109/130] blk.26.attn_output.weight... 9437184 elements at offset 1999683584
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.26.attn_output.weight                          3072x3072 -> 5760 KB
+  [110/130] blk.26.attn_qkv.weight... 28311552 elements at offset 2004992000
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.26.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [111/130] blk.27.ffn_down.weight... 25165824 elements at offset 2024468480
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.27.ffn_down.weight                             3072x8192 -> 15360 KB
+  [112/130] blk.27.ffn_up.weight... 50331648 elements at offset 2045112320
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.27.ffn_up.weight                               16384x3072 -> 30720 KB
+  [113/130] blk.27.attn_output.weight... 9437184 elements at offset 2073436160
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.27.attn_output.weight                          3072x3072 -> 5760 KB
+  [114/130] blk.27.attn_qkv.weight... 28311552 elements at offset 2078744576
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.27.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [115/130] blk.28.ffn_down.weight... 25165824 elements at offset 2098221056
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.28.ffn_down.weight                             3072x8192 -> 15360 KB
+  [116/130] blk.28.ffn_up.weight... 50331648 elements at offset 2118864896
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.28.ffn_up.weight                               16384x3072 -> 30720 KB
+  [117/130] blk.28.attn_output.weight... 9437184 elements at offset 2147188736
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.28.attn_output.weight                          3072x3072 -> 5760 KB
+  [118/130] blk.28.attn_qkv.weight... 28311552 elements at offset 2152497152
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.28.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [119/130] blk.29.ffn_down.weight... 25165824 elements at offset 2171973632
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.29.ffn_down.weight                             3072x8192 -> 15360 KB
+  [120/130] blk.29.ffn_up.weight... 50331648 elements at offset 2192617472
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.29.ffn_up.weight                               16384x3072 -> 30720 KB
+  [121/130] blk.29.attn_output.weight... 9437184 elements at offset 2220941312
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.29.attn_output.weight                          3072x3072 -> 5760 KB
+  [122/130] blk.29.attn_qkv.weight... 28311552 elements at offset 2226249728
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.29.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [123/130] blk.30.ffn_down.weight... 25165824 elements at offset 2245726208
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.30.ffn_down.weight                             3072x8192 -> 15360 KB
+  [124/130] blk.30.ffn_up.weight... 50331648 elements at offset 2266370048
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.30.ffn_up.weight                               16384x3072 -> 30720 KB
+  [125/130] blk.30.attn_output.weight... 9437184 elements at offset 2294693888
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.30.attn_output.weight                          3072x3072 -> 5760 KB
+  [126/130] blk.30.attn_qkv.weight... 28311552 elements at offset 2300002304
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.30.attn_qkv.weight                             9216x3072 -> 17280 KB
+  [127/130] blk.31.ffn_down.weight... 25165824 elements at offset 2319478784
+got 25165824 floats, tiling...
+  tiles: 96x32 fout=0x5aac9d4011b0
+  blk.31.ffn_down.weight                             3072x8192 -> 15360 KB
+  [128/130] blk.31.ffn_up.weight... 50331648 elements at offset 2340122624
+got 50331648 floats, tiling...
+  tiles: 512x12 fout=0x5aac9d4011b0
+  blk.31.ffn_up.weight                               16384x3072 -> 30720 KB
+  [129/130] blk.31.attn_output.weight... 9437184 elements at offset 2368446464
+got 9437184 floats, tiling...
+  tiles: 96x12 fout=0x5aac9d4011b0
+  blk.31.attn_output.weight                          3072x3072 -> 5760 KB
+  [130/130] blk.31.attn_qkv.weight... 28311552 elements at offset 2373754880
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5aac9d4011b0
+  blk.31.attn_qkv.weight                             9216x3072 -> 17280 KB
+
+=== DONE: models/Phi-3-mini/Phi-3-mini-4k-instruct.1bp (2277.4 MB) in 20 seconds ===

--- a/models/catalog/README.md
+++ b/models/catalog/README.md
@@ -62,12 +62,12 @@ Converted via C++ toolchain (`tools/gguf_to_onebp.cpp`), zero Python at runtime.
 |-------|:------:|:--------:|---------|:------------:|
 | Granite-3.2-2B-Instruct | 2B | 1.5 GB | ZINC / NPU / HIP | granite (gemma) |
 
-### Laguna (poolside) — 3
-| Model | Params | 1BP Size | Backend | Architecture |
-|-------|:------:|:--------:|---------|:------------:|
-| Laguna-S-2.1 | 48×256ex | 73.5 GB | ZINC / NPU / HIP | laguna (MoE) |
-| Laguna-XS-2.1 | 40×256ex | 20.9 GB | ZINC / NPU / HIP | laguna (MoE) |
-| Laguna-S-2.1-DFlash (draft) | 6L dense | 665 MB | ZINC / NPU / HIP | dflash |
+### Laguna (MoE, poolside) — 3
+| Model | Params | 1BP Size | 1BP TQ2 Size | Backend | Architecture |
+|-------|:------:|:--------:|:------------:|---------|:------------:|
+| Laguna-S-2.1 | 48×256ex | 73.5 GB | 36.7 GB | ZINC / NPU / HIP | laguna (MoE) |
+| Laguna-XS-2.1 | 40×256ex | 20.9 GB | 10.5 GB | ZINC / NPU / HIP | laguna (MoE) |
+| Laguna-S-2.1-DFlash (draft) | 6L dense | 665 MB | 665 MB | ZINC / NPU / HIP | dflash |
 
 ### Zaya — 2
 | Model | Params | 1BP Size | Backend | Architecture |

--- a/models/catalog/README.md
+++ b/models/catalog/README.md
@@ -1,4 +1,4 @@
-# 1bit.systems Model Catalog — 40 Models (1BP)
+# 1bit.systems Model Catalog — 38 Models (1BP)
 
 All models available in **1BP format** — single-file, zero-config, memory-mappable.
 Converted via C++ toolchain (`tools/gguf_to_onebp.cpp`), zero Python at runtime.
@@ -27,14 +27,14 @@ Converted via C++ toolchain (`tools/gguf_to_onebp.cpp`), zero Python at runtime.
 | Mistral-7B-Instruct-v0.3 | 7B | 4.3 GB | ZINC / NPU / HIP | mistral |
 | Mixtral-8x7B-Instruct-v0.1 | 46.7B | 27.8 GB | ZINC / NPU / HIP | mistral (MoE) |
 
-### Gemma — 4
+### Gemma — 3
 | Model | Params | 1BP Size | Backend | Architecture |
 |-------|:------:|:--------:|---------|:------------:|
 | Gemma-2-2B-it | 2B | 1.2 GB | ZINC / NPU / HIP | gemma2 |
 | Gemma-3-4B-it | 4B | 1.9 GB | ZINC / NPU / HIP | gemma |
 | Gemma-3-1B-it | 1B | 447 MB | ZINC / NPU | gemma |
 
-### Phi — 3
+### Phi — 2
 | Model | Params | 1BP Size | Backend | Architecture |
 |-------|:------:|:--------:|---------|:------------:|
 | Phi-3-mini-4k-instruct | 3.8B | 2.3 GB | ZINC / NPU / HIP | phi3 |
@@ -107,7 +107,7 @@ Converted via C++ toolchain (`tools/gguf_to_onebp.cpp`), zero Python at runtime.
 | Qwen2-VL-2B | 2B | 781 MB | ZINC (vision) | qwen2vl ✅ |
 | Qwen3-VL-4B | 4B | 2.2 GB | ZINC (vision) | qwen2vl |
 
-## Total: 40 models
+## Total: 38 models
 All converted via C++ toolchain (`tools/gguf_to_onebp`).
 
 ## Conversion Pipeline (C++ only)

--- a/models/laguna-s-2.1-dflash/convert.log
+++ b/models/laguna-s-2.1-dflash/convert.log
@@ -1,0 +1,209 @@
+GGUF opened: arch=dflash tensors=76
+Model: H=3072 L=6 NH=72 NKV=8 HD=128 IM=12288 V=100352
+  tensor enc.aux_norm.weight: 6x3072 tiled=61440
+  tensor fc.weight: 3072x18432 tiled=35389440
+  tensor blk.0.attn_gate.weight: 72x3072 tiled=184320
+  Total tensors: 50, data size: 664.9 MB
+Quantizing 50 tensors...
+  [1/50] enc.aux_norm.weight... 18432 elements at offset 3682464
+got 18432 floats, tiling...
+  tiles: 1x12 fout=0x55a40e6c0730
+  enc.aux_norm.weight                                   6x3072 -> 60 KB
+  [2/50] fc.weight... 56623104 elements at offset 3768480
+got 56623104 floats, tiling...
+  tiles: 96x72 fout=0x55a40e6c0730
+  fc.weight                                          3072x18432 -> 34560 KB
+  [3/50] blk.0.attn_gate.weight... 221184 elements at offset 35631264
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x55a40e6c0730
+  blk.0.attn_gate.weight                               72x3072 -> 180 KB
+  [4/50] blk.0.attn_k.weight... 3145728 elements at offset 35755680
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.0.attn_k.weight                                1024x3072 -> 1920 KB
+  [5/50] blk.0.attn_output.weight... 28311552 elements at offset 37537952
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x55a40e6c0730
+  blk.0.attn_output.weight                           3072x9216 -> 17280 KB
+  [6/50] blk.0.attn_q.weight... 28311552 elements at offset 53463200
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x55a40e6c0730
+  blk.0.attn_q.weight                                9216x3072 -> 17280 KB
+  [7/50] blk.0.attn_v.weight... 3145728 elements at offset 69388960
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.0.attn_v.weight                                1024x3072 -> 1920 KB
+  [8/50] blk.0.ffn_down.weight... 37748736 elements at offset 71158432
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x55a40e6c0730
+  blk.0.ffn_down.weight                              3072x12288 -> 23040 KB
+  [9/50] blk.0.ffn_gate.weight... 37748736 elements at offset 92392096
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.0.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [10/50] blk.0.ffn_up.weight... 37748736 elements at offset 113638048
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.0.ffn_up.weight                                12288x3072 -> 23040 KB
+  [11/50] blk.1.attn_gate.weight... 221184 elements at offset 134871712
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x55a40e6c0730
+  blk.1.attn_gate.weight                               72x3072 -> 180 KB
+  [12/50] blk.1.attn_k.weight... 3145728 elements at offset 134996128
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.1.attn_k.weight                                1024x3072 -> 1920 KB
+  [13/50] blk.1.attn_output.weight... 28311552 elements at offset 136778400
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x55a40e6c0730
+  blk.1.attn_output.weight                           3072x9216 -> 17280 KB
+  [14/50] blk.1.attn_q.weight... 28311552 elements at offset 152703648
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x55a40e6c0730
+  blk.1.attn_q.weight                                9216x3072 -> 17280 KB
+  [15/50] blk.1.attn_v.weight... 3145728 elements at offset 168629408
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.1.attn_v.weight                                1024x3072 -> 1920 KB
+  [16/50] blk.1.ffn_down.weight... 37748736 elements at offset 170398880
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x55a40e6c0730
+  blk.1.ffn_down.weight                              3072x12288 -> 23040 KB
+  [17/50] blk.1.ffn_gate.weight... 37748736 elements at offset 191632544
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.1.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [18/50] blk.1.ffn_up.weight... 37748736 elements at offset 212878496
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.1.ffn_up.weight                                12288x3072 -> 23040 KB
+  [19/50] blk.2.attn_gate.weight... 221184 elements at offset 234112160
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x55a40e6c0730
+  blk.2.attn_gate.weight                               72x3072 -> 180 KB
+  [20/50] blk.2.attn_k.weight... 3145728 elements at offset 234236576
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.2.attn_k.weight                                1024x3072 -> 1920 KB
+  [21/50] blk.2.attn_output.weight... 28311552 elements at offset 236018848
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x55a40e6c0730
+  blk.2.attn_output.weight                           3072x9216 -> 17280 KB
+  [22/50] blk.2.attn_q.weight... 28311552 elements at offset 251944096
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x55a40e6c0730
+  blk.2.attn_q.weight                                9216x3072 -> 17280 KB
+  [23/50] blk.2.attn_v.weight... 3145728 elements at offset 267869856
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.2.attn_v.weight                                1024x3072 -> 1920 KB
+  [24/50] blk.2.ffn_down.weight... 37748736 elements at offset 270450336
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x55a40e6c0730
+  blk.2.ffn_down.weight                              3072x12288 -> 23040 KB
+  [25/50] blk.2.ffn_gate.weight... 37748736 elements at offset 301416096
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.2.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [26/50] blk.2.ffn_up.weight... 37748736 elements at offset 322662048
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.2.ffn_up.weight                                12288x3072 -> 23040 KB
+  [27/50] blk.3.attn_gate.weight... 221184 elements at offset 343895712
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x55a40e6c0730
+  blk.3.attn_gate.weight                               72x3072 -> 180 KB
+  [28/50] blk.3.attn_k.weight... 3145728 elements at offset 344020128
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.3.attn_k.weight                                1024x3072 -> 1920 KB
+  [29/50] blk.3.attn_output.weight... 28311552 elements at offset 345802400
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x55a40e6c0730
+  blk.3.attn_output.weight                           3072x9216 -> 17280 KB
+  [30/50] blk.3.attn_q.weight... 28311552 elements at offset 361727648
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x55a40e6c0730
+  blk.3.attn_q.weight                                9216x3072 -> 17280 KB
+  [31/50] blk.3.attn_v.weight... 3145728 elements at offset 377653408
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.3.attn_v.weight                                1024x3072 -> 1920 KB
+  [32/50] blk.3.ffn_down.weight... 37748736 elements at offset 379422880
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x55a40e6c0730
+  blk.3.ffn_down.weight                              3072x12288 -> 23040 KB
+  [33/50] blk.3.ffn_gate.weight... 37748736 elements at offset 400656544
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.3.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [34/50] blk.3.ffn_up.weight... 37748736 elements at offset 421902496
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.3.ffn_up.weight                                12288x3072 -> 23040 KB
+  [35/50] blk.4.attn_gate.weight... 221184 elements at offset 443136160
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x55a40e6c0730
+  blk.4.attn_gate.weight                               72x3072 -> 180 KB
+  [36/50] blk.4.attn_k.weight... 3145728 elements at offset 443260576
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.4.attn_k.weight                                1024x3072 -> 1920 KB
+  [37/50] blk.4.attn_output.weight... 28311552 elements at offset 445042848
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x55a40e6c0730
+  blk.4.attn_output.weight                           3072x9216 -> 17280 KB
+  [38/50] blk.4.attn_q.weight... 28311552 elements at offset 460968096
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x55a40e6c0730
+  blk.4.attn_q.weight                                9216x3072 -> 17280 KB
+  [39/50] blk.4.attn_v.weight... 3145728 elements at offset 476893856
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.4.attn_v.weight                                1024x3072 -> 1920 KB
+  [40/50] blk.4.ffn_down.weight... 37748736 elements at offset 478663328
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x55a40e6c0730
+  blk.4.ffn_down.weight                              3072x12288 -> 23040 KB
+  [41/50] blk.4.ffn_gate.weight... 37748736 elements at offset 499896992
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.4.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [42/50] blk.4.ffn_up.weight... 37748736 elements at offset 521142944
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.4.ffn_up.weight                                12288x3072 -> 23040 KB
+  [43/50] blk.5.attn_gate.weight... 221184 elements at offset 542376608
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x55a40e6c0730
+  blk.5.attn_gate.weight                               72x3072 -> 180 KB
+  [44/50] blk.5.attn_k.weight... 3145728 elements at offset 542501024
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.5.attn_k.weight                                1024x3072 -> 1920 KB
+  [45/50] blk.5.attn_output.weight... 28311552 elements at offset 544283296
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x55a40e6c0730
+  blk.5.attn_output.weight                           3072x9216 -> 17280 KB
+  [46/50] blk.5.attn_q.weight... 28311552 elements at offset 560208544
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x55a40e6c0730
+  blk.5.attn_q.weight                                9216x3072 -> 17280 KB
+  [47/50] blk.5.attn_v.weight... 3145728 elements at offset 576134304
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x55a40e6c0730
+  blk.5.attn_v.weight                                1024x3072 -> 1920 KB
+  [48/50] blk.5.ffn_down.weight... 37748736 elements at offset 578714784
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x55a40e6c0730
+  blk.5.ffn_down.weight                              3072x12288 -> 23040 KB
+  [49/50] blk.5.ffn_gate.weight... 37748736 elements at offset 609680544
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.5.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [50/50] blk.5.ffn_up.weight... 37748736 elements at offset 630926496
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x55a40e6c0730
+  blk.5.ffn_up.weight                                12288x3072 -> 23040 KB
+
+=== DONE: models/laguna-s-2.1-dflash/laguna-s-2.1-DFlash.1bp (664.9 MB) in 6 seconds ===

--- a/models/laguna-s-2.1-dflash/convert_tq2.log
+++ b/models/laguna-s-2.1-dflash/convert_tq2.log
@@ -1,0 +1,209 @@
+GGUF opened: arch=dflash tensors=76
+Model: H=3072 L=6 NH=72 NKV=8 HD=128 IM=12288 V=100352
+  tensor enc.aux_norm.weight: 6x3072 tiled=61440
+  tensor fc.weight: 3072x18432 tiled=35389440
+  tensor blk.0.attn_gate.weight: 72x3072 tiled=184320
+  Total tensors: 50, data size: 664.9 MB
+Quantizing 50 tensors...
+  [1/50] enc.aux_norm.weight... 18432 elements at offset 3682464
+got 18432 floats, tiling...
+  tiles: 1x12 fout=0x5f709c63e730
+  enc.aux_norm.weight                                   6x3072 -> 60 KB
+  [2/50] fc.weight... 56623104 elements at offset 3768480
+got 56623104 floats, tiling...
+  tiles: 96x72 fout=0x5f709c63e730
+  fc.weight                                          3072x18432 -> 34560 KB
+  [3/50] blk.0.attn_gate.weight... 221184 elements at offset 35631264
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x5f709c63e730
+  blk.0.attn_gate.weight                               72x3072 -> 180 KB
+  [4/50] blk.0.attn_k.weight... 3145728 elements at offset 35755680
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.0.attn_k.weight                                1024x3072 -> 1920 KB
+  [5/50] blk.0.attn_output.weight... 28311552 elements at offset 37537952
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x5f709c63e730
+  blk.0.attn_output.weight                           3072x9216 -> 17280 KB
+  [6/50] blk.0.attn_q.weight... 28311552 elements at offset 53463200
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5f709c63e730
+  blk.0.attn_q.weight                                9216x3072 -> 17280 KB
+  [7/50] blk.0.attn_v.weight... 3145728 elements at offset 69388960
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.0.attn_v.weight                                1024x3072 -> 1920 KB
+  [8/50] blk.0.ffn_down.weight... 37748736 elements at offset 71158432
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x5f709c63e730
+  blk.0.ffn_down.weight                              3072x12288 -> 23040 KB
+  [9/50] blk.0.ffn_gate.weight... 37748736 elements at offset 92392096
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.0.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [10/50] blk.0.ffn_up.weight... 37748736 elements at offset 113638048
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.0.ffn_up.weight                                12288x3072 -> 23040 KB
+  [11/50] blk.1.attn_gate.weight... 221184 elements at offset 134871712
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x5f709c63e730
+  blk.1.attn_gate.weight                               72x3072 -> 180 KB
+  [12/50] blk.1.attn_k.weight... 3145728 elements at offset 134996128
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.1.attn_k.weight                                1024x3072 -> 1920 KB
+  [13/50] blk.1.attn_output.weight... 28311552 elements at offset 136778400
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x5f709c63e730
+  blk.1.attn_output.weight                           3072x9216 -> 17280 KB
+  [14/50] blk.1.attn_q.weight... 28311552 elements at offset 152703648
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5f709c63e730
+  blk.1.attn_q.weight                                9216x3072 -> 17280 KB
+  [15/50] blk.1.attn_v.weight... 3145728 elements at offset 168629408
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.1.attn_v.weight                                1024x3072 -> 1920 KB
+  [16/50] blk.1.ffn_down.weight... 37748736 elements at offset 170398880
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x5f709c63e730
+  blk.1.ffn_down.weight                              3072x12288 -> 23040 KB
+  [17/50] blk.1.ffn_gate.weight... 37748736 elements at offset 191632544
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.1.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [18/50] blk.1.ffn_up.weight... 37748736 elements at offset 212878496
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.1.ffn_up.weight                                12288x3072 -> 23040 KB
+  [19/50] blk.2.attn_gate.weight... 221184 elements at offset 234112160
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x5f709c63e730
+  blk.2.attn_gate.weight                               72x3072 -> 180 KB
+  [20/50] blk.2.attn_k.weight... 3145728 elements at offset 234236576
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.2.attn_k.weight                                1024x3072 -> 1920 KB
+  [21/50] blk.2.attn_output.weight... 28311552 elements at offset 236018848
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x5f709c63e730
+  blk.2.attn_output.weight                           3072x9216 -> 17280 KB
+  [22/50] blk.2.attn_q.weight... 28311552 elements at offset 251944096
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5f709c63e730
+  blk.2.attn_q.weight                                9216x3072 -> 17280 KB
+  [23/50] blk.2.attn_v.weight... 3145728 elements at offset 267869856
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.2.attn_v.weight                                1024x3072 -> 1920 KB
+  [24/50] blk.2.ffn_down.weight... 37748736 elements at offset 270450336
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x5f709c63e730
+  blk.2.ffn_down.weight                              3072x12288 -> 23040 KB
+  [25/50] blk.2.ffn_gate.weight... 37748736 elements at offset 301416096
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.2.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [26/50] blk.2.ffn_up.weight... 37748736 elements at offset 322662048
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.2.ffn_up.weight                                12288x3072 -> 23040 KB
+  [27/50] blk.3.attn_gate.weight... 221184 elements at offset 343895712
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x5f709c63e730
+  blk.3.attn_gate.weight                               72x3072 -> 180 KB
+  [28/50] blk.3.attn_k.weight... 3145728 elements at offset 344020128
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.3.attn_k.weight                                1024x3072 -> 1920 KB
+  [29/50] blk.3.attn_output.weight... 28311552 elements at offset 345802400
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x5f709c63e730
+  blk.3.attn_output.weight                           3072x9216 -> 17280 KB
+  [30/50] blk.3.attn_q.weight... 28311552 elements at offset 361727648
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5f709c63e730
+  blk.3.attn_q.weight                                9216x3072 -> 17280 KB
+  [31/50] blk.3.attn_v.weight... 3145728 elements at offset 377653408
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.3.attn_v.weight                                1024x3072 -> 1920 KB
+  [32/50] blk.3.ffn_down.weight... 37748736 elements at offset 379422880
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x5f709c63e730
+  blk.3.ffn_down.weight                              3072x12288 -> 23040 KB
+  [33/50] blk.3.ffn_gate.weight... 37748736 elements at offset 400656544
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.3.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [34/50] blk.3.ffn_up.weight... 37748736 elements at offset 421902496
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.3.ffn_up.weight                                12288x3072 -> 23040 KB
+  [35/50] blk.4.attn_gate.weight... 221184 elements at offset 443136160
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x5f709c63e730
+  blk.4.attn_gate.weight                               72x3072 -> 180 KB
+  [36/50] blk.4.attn_k.weight... 3145728 elements at offset 443260576
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.4.attn_k.weight                                1024x3072 -> 1920 KB
+  [37/50] blk.4.attn_output.weight... 28311552 elements at offset 445042848
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x5f709c63e730
+  blk.4.attn_output.weight                           3072x9216 -> 17280 KB
+  [38/50] blk.4.attn_q.weight... 28311552 elements at offset 460968096
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5f709c63e730
+  blk.4.attn_q.weight                                9216x3072 -> 17280 KB
+  [39/50] blk.4.attn_v.weight... 3145728 elements at offset 476893856
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.4.attn_v.weight                                1024x3072 -> 1920 KB
+  [40/50] blk.4.ffn_down.weight... 37748736 elements at offset 478663328
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x5f709c63e730
+  blk.4.ffn_down.weight                              3072x12288 -> 23040 KB
+  [41/50] blk.4.ffn_gate.weight... 37748736 elements at offset 499896992
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.4.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [42/50] blk.4.ffn_up.weight... 37748736 elements at offset 521142944
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.4.ffn_up.weight                                12288x3072 -> 23040 KB
+  [43/50] blk.5.attn_gate.weight... 221184 elements at offset 542376608
+got 221184 floats, tiling...
+  tiles: 3x12 fout=0x5f709c63e730
+  blk.5.attn_gate.weight                               72x3072 -> 180 KB
+  [44/50] blk.5.attn_k.weight... 3145728 elements at offset 542501024
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.5.attn_k.weight                                1024x3072 -> 1920 KB
+  [45/50] blk.5.attn_output.weight... 28311552 elements at offset 544283296
+got 28311552 floats, tiling...
+  tiles: 96x36 fout=0x5f709c63e730
+  blk.5.attn_output.weight                           3072x9216 -> 17280 KB
+  [46/50] blk.5.attn_q.weight... 28311552 elements at offset 560208544
+got 28311552 floats, tiling...
+  tiles: 288x12 fout=0x5f709c63e730
+  blk.5.attn_q.weight                                9216x3072 -> 17280 KB
+  [47/50] blk.5.attn_v.weight... 3145728 elements at offset 576134304
+got 3145728 floats, tiling...
+  tiles: 32x12 fout=0x5f709c63e730
+  blk.5.attn_v.weight                                1024x3072 -> 1920 KB
+  [48/50] blk.5.ffn_down.weight... 37748736 elements at offset 578714784
+got 37748736 floats, tiling...
+  tiles: 96x48 fout=0x5f709c63e730
+  blk.5.ffn_down.weight                              3072x12288 -> 23040 KB
+  [49/50] blk.5.ffn_gate.weight... 37748736 elements at offset 609680544
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.5.ffn_gate.weight                              12288x3072 -> 23040 KB
+  [50/50] blk.5.ffn_up.weight... 37748736 elements at offset 630926496
+got 37748736 floats, tiling...
+  tiles: 384x12 fout=0x5f709c63e730
+  blk.5.ffn_up.weight                                12288x3072 -> 23040 KB
+
+=== DONE: models/laguna-s-2.1-dflash/laguna-s-2.1-DFlash-TQ2.1bp (664.9 MB) in 6 seconds ===


### PR DESCRIPTION
## Summary

Rebased and rescued the two genuinely real, never-merged branches out of the three "Tier 3" branches identified in this session's repo-wide branch audit (`feat/laguna-dflash-1bp-conversion` #853, `feat/new-model-families` #855, `feat/npu-attn-mamba2-gpu` #841 — all closed without merging, likely swept up in an unrelated cleanup pass, and all now conflicting with current `main` since it's moved substantially).

- **Laguna-S-2.1-DFlash 1BP conversion** (from #853): adds `models/laguna-s-2.1-dflash/{convert.log,convert_tq2.log}` and a TQ2 size column to the catalog's Laguna table (36.7 GB / 10.5 GB / 665 MB) — `main`'s catalog already listed the DFlash model row itself, but was missing the TQ2 conversion data.
- **New model conversion logs** (from #855): adds `models/{Gemma-2-2B,Phi-3-mini,Mixtral-8x7B}/convert.log` — real conversion provenance for 3 models. The catalog *rows* for these models (and every other model this branch's diff touched) turned out to already exist in `main` under different section groupings — resolved by keeping `main`'s table and adding only the genuinely new log files.
- **Model catalog count/section-header fixes**: while reconciling the conflicts, found and fixed two pre-existing count bugs unrelated to either source branch — `Gemma` section said 4 models but listed 3, `Phi` said 3 but listed 2. Total corrected from a stale 40 to the verified-by-counting 38 (every `###` section header count now sums exactly to the `## Total` line).
- **`feat/npu-attn-mamba2-gpu` (#841) — not included**: its cherry-pick produced a fully empty diff. Verified directly: `RuntimeAttnCtx`, `mamba2_gpu_decode_block`, and `NPU_ATTN` are all already present in `main` (`engine/npu/src/npu_engine_universal.cpp`, `src/mamba2_kernels.{h,hip}`, `src/zamba2_engine_hip.hip`) — that branch's real content already shipped independently. Nothing to rescue there.
- Also removed `docs/hn-post.md` and `docs/twitter-thread.md` (old pre-reorg paths bundled in #841's diff) — confirmed byte-identical to the current `docs/marketing/` copies, so just stale duplicates at the old location.

## Test plan
- [x] Verified every "new" model row against `main`'s existing catalog table before accepting it, to avoid re-introducing duplicates
- [x] Section-header counts now sum exactly to the stated total (was off by 2 before this PR, pre-existing bug)
- [x] `cmake --build build --target onebit_bin unified_server zaya_server` — clean (this PR is docs/data only, no source changes)
- [x] Confirmed `feat/npu-attn-mamba2-gpu`'s claimed additions already exist in `main` via `git grep` before excluding it

🤖 Generated with [Claude Code](https://claude.com/claude-code)