### PR TITLE
fix: serialize backend compute calls to stop watchdog/generate() race

### DIFF
--- a/include/backend_manager.h
+++ b/include/backend_manager.h
@@ -53,6 +53,17 @@ struct BackendInfo {
 
     std::shared_ptr<Backend> instance;  // shared_ptr enables lock-free inference (fixes #96)
     void* plugin_handle;       // dlopen handle if loaded as plugin
+
+    // Guards actual compute calls (generate/reset/benchmark/init) on `instance`.
+    // generate() intentionally releases BackendManager::mtx_ during inference
+    // (fixes #96) so slow calls don't block bookkeeping, but that means mtx_
+    // alone can't stop AgentWatchdog's health_check()/benchmark_all() from
+    // calling reset()/benchmark()/init() on the same live instance concurrently
+    // with an in-flight generate() — a data race on the backend's internal
+    // state (e.g. HIPBackend's ZayaState/pos) that crashed the agent-watchdog
+    // thread inside zaya_init on 2026-07-24. shared_ptr so BackendInfo stays
+    // movable/copyable in the vector.
+    std::shared_ptr<std::mutex> compute_mtx = std::make_shared<std::mutex>();
 };
 
 // ── Fallback policy ──

--- a/src/backend_manager.cpp
+++ b/src/backend_manager.cpp
@@ -497,6 +497,7 @@ int BackendManager::generate(int token_id) {
     // actually ran the inference, not whatever select_backend() may have
     // switched to in the meantime (issue #357).
     std::shared_ptr<Backend> snap;
+    std::shared_ptr<std::mutex> compute_mtx;
     size_t snap_idx = 0;
     bool need_failover = false;
     size_t prev_idx = 0;
@@ -507,14 +508,19 @@ int BackendManager::generate(int token_id) {
         auto& info = backends_[active_idx_];
         if (info.functional && info.instance) {
             snap = info.instance;  // shared_ptr copy — keeps Backend alive
+            compute_mtx = info.compute_mtx;
         } else {
             need_failover = true;
             prev_idx = active_idx_;
         }
     }
 
-    // Phase 2: inference WITHOUT the lock — snap keeps the Backend alive.
+    // Phase 2: inference WITHOUT mtx_ — snap keeps the Backend alive.
+    // compute_mtx IS held here: it serializes against health_check()'s
+    // reset() and benchmark_all()'s benchmark()/init() on this same
+    // instance, which mtx_ alone can't do since it's released for this call.
     if (snap) {
+        std::lock_guard<std::mutex> compute_lock(*compute_mtx);
         auto t0 = std::chrono::high_resolution_clock::now();
         int result = -1;
         // A backend that throws (e.g. a missing Vulkan shader, a HIP fault)
@@ -708,8 +714,14 @@ bool BackendManager::health_check() {
 
     if (active_idx_ < backends_.size()) {
         auto& info = backends_[active_idx_];
-        // Simple probe: try reset
-        bool ok = b->reset();
+        // Simple probe: try reset. Hold compute_mtx — reset() mutates the
+        // same instance state (e.g. HIPBackend's ZayaState/pos) that a
+        // concurrent generate() call may be using via Phase 2's lock-free path.
+        bool ok;
+        {
+            std::lock_guard<std::mutex> compute_lock(*info.compute_mtx);
+            ok = b->reset();
+        }
         info.functional = ok;
         auto* pm = monitor_.for_backend(info.id);
         if (pm) pm->healthy = ok;
@@ -749,6 +761,12 @@ void BackendManager::benchmark_all(int tokens) {
 
         printf("  %s... ", info.id.c_str());
         fflush(stdout);
+
+        // Hold compute_mtx for init()/benchmark() below — if info.instance
+        // is already live (e.g. this is the currently-active backend), it
+        // may be in concurrent use via generate()'s lock-free Phase 2; this
+        // serializes against that instead of racing on shared instance state.
+        std::lock_guard<std::mutex> compute_lock(*info.compute_mtx);
 
         // Create instance if needed. init()/benchmark() may THROW (missing
         // Vulkan shader, driver fault, OOM) — a broken backend must be skipped,


### PR DESCRIPTION
## Summary
- `AgentWatchdog::run()` calls `BackendManager::health_check()` every 10s and `benchmark_all()` every 5min-stable, both of which invoke `reset()`/`benchmark()`/`init()` on the active backend instance.
- `BackendManager::generate()` deliberately releases its bookkeeping mutex during the actual `snap->generate()` call (fixes #96), so nothing serialized these two access paths against each other.
- On 2026-07-24 this raced twice in production: the `agent-watchdog` thread segfaulted inside `zaya_init` (confirmed via `journalctl -k` + `addr2line`/`nm` on the binary), immediately preceding two full-system hangs that required a cold reboot.
- Fix: add a per-backend `std::shared_ptr<std::mutex> compute_mtx` to `BackendInfo`, and hold it around the actual compute calls in `generate()`, `health_check()`, and `benchmark_all()` — independent of the existing `mtx_` bookkeeping lock, so it doesn't reintroduce blocking between unrelated backends/requests.

## Test plan
- [x] Clean build (`cmake --build . --target unified_server`)
- [x] GitNexus `detect_changes()` — low risk, 0 downstream-affected symbols
- [x] Restarted `1bit-systems.service` with the new binary — clean startup, GPU backend init, startup benchmark (which exercises the new lock in `benchmark_all()`) completed normally
- [x] Live `/v1/completions` request served successfully post-restart, confirming `generate()`'s new lock doesn't deadlock or hang
- [ ] Longer-term: watch for another `agent-watchdog` segfault/freeze recurrence over the next few sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)