### PR TITLE
fix: two real crashes when benchmark_all() runs incompatible backends

### DIFF
--- a/src/backend_manager.cpp
+++ b/src/backend_manager.cpp
@@ -5,6 +5,7 @@
 #include "backend_plugin.h"
 #include "backend_detect.h"
 #include "backend.h"
+#include "model_router.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -746,8 +747,35 @@ void BackendManager::benchmark_all(int tokens) {
     printf("║   Backend Manager — Benchmark Suite      ║\n");
     printf("╚══════════════════════════════════════════╝\n");
 
+    // Only speculatively init()/benchmark() a backend if the router
+    // considers it compatible with the currently loaded model's architecture
+    // (same table BackendManager::init() used to pick the active backend),
+    // or it already has a live instance (proved compatible by successfully
+    // init'ing already). The generic CPU tier is architecture-agnostic by
+    // design, so it's always eligible regardless of what the router lists.
+    // Without this, benchmark_all() would freely try e.g. the Zaya HIP
+    // kernels or the Zamba2 kernels against a Mamba1 model's weights —
+    // neither backend's init()/benchmark() is hardened against that, and
+    // both crashed with a real SIGSEGV (not a catchable C++ exception) when
+    // this was reproduced under gdb: an OOB vector read in zaya_destroy()
+    // and a segfault in mamba2_cpu_forward(), both on the agent-watchdog
+    // thread, both taking the whole process down with them.
+    auto route = select_backend_route(cfg_);
+    auto architecture_compatible = [&](const BackendInfo& info) {
+        if (info.tier == BackendTier::T3_CPU) return true;
+        if (info.instance) return true;
+        return std::find(route.backend_ids_in_order.begin(),
+                          route.backend_ids_in_order.end(),
+                          info.id) != route.backend_ids_in_order.end();
+    };
+
     for (auto& info : backends_) {
         if (!info.available) continue;
+
+        if (!architecture_compatible(info)) {
+            printf("  %s... ⏭️  (skipped — not compatible with loaded model architecture)\n", info.id.c_str());
+            continue;
+        }
 
         // Skip CPU_SCALAR if CPU_AVX512 already benchmarked
         // (they share the same CPUBackend code, only the above is meaningful)

--- a/src/zaya_engine.cpp
+++ b/src/zaya_engine.cpp
@@ -1003,7 +1003,14 @@ void zaya_destroy(ZayaState* s) {
     safe(s->d_partials);
     safe(s->d_qout); safe(s->d_kout); safe(s->d_vout); safe(s->d_skip_flag);
     safe(s->d_k_gather); safe(s->d_v_gather); safe(s->d_page_map);
-    for (int i = 0; i < eng.n_layers; i++) {
+    // Bound by s->lw's actual size, not eng.n_layers: zaya_destroy() can be
+    // called from an early-exit path in zaya_init() (missing weight files,
+    // no GPU, or a model-dimension mismatch) before s->lw is resized to
+    // eng.n_layers (that resize happens later, once init has actually
+    // committed to loading). Using eng.n_layers here read past the end of
+    // an empty/undersized vector, pulled garbage pointers out of it, and
+    // handed them to hipFree() — a real segfault, not just UB in theory.
+    for (size_t i = 0; i < s->lw.size(); i++) {
         auto& l = s->lw[i];
         safe(l.nw); safe(l.wq); safe(l.wk); safe(l.wv1); safe(l.wv2); safe(l.wo); safe(l.pan);
         safe(l.cdw); safe(l.cdb); safe(l.cgw); safe(l.cgb); safe(l.ks);


### PR DESCRIPTION
## Summary

Follow-up to #914. That PR fixed a genuine data race (per-backend `compute_mtx`), but reproducing the original `agent-watchdog` segfault under `gdb` after merging it showed the race wasn't the actual crash — the process was still dying, at the same code address, ~5 minutes into uptime (right at `AgentWatchdog`'s 5-minute reprofile point, `BackendManager::benchmark_all()`).

Root cause: `benchmark_all()` unconditionally `init()`s/`benchmark()`s **every** registered backend, regardless of whether that backend's architecture is compatible with the currently-loaded model. Reproduced live with a Mamba1 GGUF (`blackmamba-2.8b`) loaded, and caught two distinct real segfaults under `gdb` (not catchable C++ exceptions — the existing `try`/`catch` in `benchmark_all()` can't help here):

1. **`hip_gpu`** (Zaya1-8B-shaped kernels): `zaya_init()` correctly detects the model's embed size doesn't match its expected dimensions and refuses to load — but `zaya_destroy()`'s cleanup loop iterated `eng.n_layers` entries over `s->lw`, a `std::vector` only `resize()`d to that length *later* in `zaya_init()`. On this early-exit path `s->lw` was still empty, so the loop read out-of-bounds, pulled garbage pointers, and handed them to `hipFree()`. Fixed by bounding the loop to `s->lw.size()`.
2. **`zamba2_gpu`**: "successfully" loaded the same Mamba1 weights into its own incompatible layer format, then segfaulted inside `mamba2_cpu_forward` on the first benchmark `generate()` call.

Rather than patch each backend's forward/cleanup path defensively one at a time (there could be a third lurking in `cpu_avx512`/`vulkan_gpu`), this gates `benchmark_all()` on the same `select_backend_route()` table `BackendManager::init()` already uses to pick a compatible backend for the loaded model at startup. Only backends the router lists for this model (or ones that already have a live instance, having proven compatibility by successfully initializing, or the architecture-agnostic generic CPU tier) get benchmarked.

## Test plan
- [x] Reproduced both original crashes live under `gdb` with full backtraces (thread `agent-watchdog` → `BackendManager::benchmark_all` → `HIPBackend::init`/`zaya_init`/`zaya_destroy`, and → `Zamba2Backend::benchmark`/`generate` → `Zamba2Model::forward` → `mamba2_cpu_forward`)
- [x] Applied both fixes, clean rebuild
- [x] Re-ran the identical `gdb` repro past the 5-minute reprofile mark: all incompatible backends (`hip_gpu`, `zamba2_gpu`, `zinc_gpu`, `vulkan_gpu`, `npu_xrt`) now print `⏭️ (skipped — not compatible with loaded model architecture)`, `mamba1_gpu` (the actually active/compatible backend) re-benchmarks normally, process stays alive well past the point it crashed twice before
- [x] GitNexus `impact()` on `zaya_destroy`/`select_backend_route` — low risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)