### PR TITLE
fix: tolerate invalid UTF-8 in completion JSON responses (#931, #932)

### DIFF
--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -1036,7 +1036,12 @@ int main(int argc, char** argv) {
             response["per_token_backend"] = gen_result["per_token_backend"];
         }
 
-        res.set_content(response.dump(2), "application/json");
+        // error_handler_t::replace: decoded model text isn't guaranteed valid
+        // UTF-8 (byte-level BPE tokenizers like blackmamba's GPT-NeoX-20B
+        // .htok can decode to a stray byte sequence at a token boundary) --
+        // strict (default) dump() throws type_error.316, which previously
+        // escaped as an uncaught exception -> empty 500, no app-level log line.
+        res.set_content(response.dump(2, ' ', false, json::error_handler_t::replace), "application/json");
         add_cors(res);
 
         // Log to stdout
@@ -1115,7 +1120,8 @@ int main(int argc, char** argv) {
         response["backend_used"] = gen_result["backend_used"];
 
         res.set_header("X-Backend-Id", gen_result.value("backend_used", "unknown"));
-        res.set_content(response.dump(2), "application/json");
+        // See error_handler_t::replace note on the /v1/chat/completions handler above.
+        res.set_content(response.dump(2, ' ', false, json::error_handler_t::replace), "application/json");
         add_cors(res);
     });
 


### PR DESCRIPTION
## What

`nlohmann::json`'s `dump()` defaults to strict UTF-8 validation and throws `type_error.316` when serializing a string containing invalid byte sequences. The new blackmamba `.htok` byte-level BPE decode (#928) occasionally produces one — a known GPT-2/GPT-NeoX byte-BPE gotcha at token boundaries — and that exception escaped both try-catch blocks in the `/v1/completions` and `/v1/chat/completions` handlers, surfacing as a bare empty HTTP 500 with no app-level log line.

## How found

Live gdb catchpoint on `__cxa_throw` during real HTTP traffic against the running production instance — not reproducible by reading the code alone, since every explicit `catch` block in the handler looked correct. The throw actually originates inside `nlohmann::json`'s own serializer, downstream of both catches.

Confirmed rate: ~5% of sequential real `/v1/completions` requests failed this way before the fix.

## Fix

Both completion response paths now call `dump(2, ' ', false, json::error_handler_t::replace)` instead of the default strict `dump(2)`, substituting U+FFFD for invalid sequences instead of throwing.

## Test plan

- [x] Clean rebuild
- [x] 120 sequential real `/v1/completions` requests against `blackmamba-2.8b` on `mamba1_gpu`: 0 failures (previously ~5%)
- [x] 5 rounds of 5-concurrent requests (25 total): 0 failures, no hang
- [x] Same server PID throughout all testing (0 restarts), 12,752+ cumulative inferences, 0 backend failures
- [x] Closes #931, #932 (both re-verified live as part of this same testing pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)