### PR TITLE
fix: async-signal-unsafe fprintf() and int overflow in v_cache offset (#992, #993)

### DIFF
--- a/src/zamba2_engine.cpp
+++ b/src/zamba2_engine.cpp
@@ -286,7 +286,7 @@ bool Zamba2Model::forward(int token_id, float* logits) {
             int hd = cfg.attn_head_dim;
             size_t kv_offset = (size_t)hyb_idx * 2 * max_seq * n_kv * hd;
             float* k_cache = kv_cache.data() + kv_offset;
-            float* v_cache = kv_cache.data() + kv_offset + max_seq * n_kv * hd;
+            float* v_cache = kv_cache.data() + kv_offset + (size_t)max_seq * n_kv * hd;
 
             std::vector<float> layer_out(d_model);
             forward_hybrid_layer(

--- a/tools/token_router.cpp
+++ b/tools/token_router.cpp
@@ -584,12 +584,12 @@ static NpuEngine npu;
 static GpuEngine gpu;
 static int server_fd = -1;
 
-static void cleanup(int sig = 0) {
-    fprintf(stderr, "\nShutdown...\n");
-    gpu.stop();
-    npu.stop();
-    if (server_fd >= 0) close(server_fd);
-    _exit(0);
+// Signal-safe handler: just set a flag. The main loop checks and does cleanup.
+// Never call fprintf/malloc/mutex from a signal handler — async-signal-unsafe.
+static volatile sig_atomic_t g_shutdown_requested = 0;
+
+static void cleanup(int) {
+    g_shutdown_requested = 1;
 }
 
 // ── Request Handling ──
@@ -981,8 +981,9 @@ int main(int argc, char** argv) {
     fprintf(stderr, "   Strategy: %s\n\n", (gpu.ready) ? "speculative decode" : "cascade fallback");
 
     // ── Accept loop ──
-    while (true) {
+    while (!g_shutdown_requested) {
         int cl = accept(server_fd, nullptr, nullptr);
+        if (g_shutdown_requested) break;
         if (cl < 0) {
             if (errno == EINTR) continue;
             break;
@@ -1023,6 +1024,10 @@ int main(int argc, char** argv) {
         }).detach();
     }
 
-    cleanup();
+    // Shutdown (safe — called from main loop, not signal handler)
+    fprintf(stderr, "\nShutdown...\n");
+    gpu.stop();
+    npu.stop();
+    if (server_fd >= 0) close(server_fd);
     return 0;
 }


### PR DESCRIPTION
Fixes two bugs from exhaustive GitNexus sweep:

**#992: token_router.cpp signal handler calls async-signal-unsafe functions**
`cleanup()` was installed as SIGINT/SIGTERM handler but called `fprintf()`, `gpu.stop()`, `npu.stop()` — none are async-signal-safe. Deadlocks if signal arrives during `malloc`. Changed to set `volatile sig_atomic_t` flag; actual shutdown moved to main loop.

**#993: zamba2_engine.cpp v_cache offset uses int multiplication**
`max_seq * n_kv * hd` computed in `int` before adding to `size_t kv_offset`. Cast to `size_t`.