### PR TITLE
cleanup: remove placeholder GSC meta tag (already verified)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -8,7 +8,6 @@
 <!-- Google Search Console: verify at https://search.google.com/search-console -->
 <!-- Add site (URL prefix: https://1bit.systems), choose HTML tag method, -->
 <!-- then replace the content value below with your GSC-provided code: -->
-<meta name="google-site-verification" content="YOUR_GSC_CODE_HERE">
 <meta name="keywords" content="AMD Strix Halo, NPU inference, 1-bit LLM, ternary inference, TQ2 quantization, 1BP format, BitNet, local AI, model-agnostic inference engine, NPU GPU fused engine, ROCm, XDNA 2, open source NPU driver, FastFlowLM alternative, GGUF inference, Zyphra Zamba2, C++ LLM inference, AI inference without Python">
 <meta property="og:title" content="1bit.systems — Open-Source NPU+GPU+CPU Inference Engine | AMD Strix Halo, Local LLMs">
 <meta property="og:description" content="Mamba1 GPU backend live: BlackMamba 1.5B @ 79.4 tok/s on AMD Strix Halo. NPU (XDNA 2), Vulkan, ROCm HIP, CPU. Model-agnostic GGUF/ONNX/1BP. Zero Python. MIT.">


### PR DESCRIPTION
Removes the `YOUR_GSC_CODE_HERE` placeholder meta tag from index.html. GSC was already verified via DNS in a previous session — the placeholder tag is redundant.