### PR TITLE
fix: bug sweep cycle 3 — SSRF, XSS, hardcoded MoE dims, systemd hardening, more (#1001-#1010)

### DIFF
--- a/integrations/comfyui/__init__.py
+++ b/integrations/comfyui/__init__.py
@@ -22,6 +22,7 @@ import json
 import os
 import base64
 import io
+from urllib.parse import urlparse
 import httpx
 from PIL import Image
 import numpy as np
@@ -31,6 +32,32 @@ import torch
 DEFAULT_UNIFIED_URL = "http://127.0.0.1:8088/v1"
 DEFAULT_IMAGE_URL   = "http://127.0.0.1:8089/v1"
 DEFAULT_AUDIO_URL   = "http://127.0.0.1:8090/v1"
+
+# ComfyUI's threat model is untrusted shared workflow JSON — a workflow can set
+# server_url to an arbitrary value. Without an allowlist that's an SSRF
+# primitive (internal metadata endpoints, internal admin APIs, etc). Default
+# to loopback-only; operators who genuinely run the 1bit server on another
+# host can opt in via ONEBIT_ALLOWED_SERVER_HOSTS (comma-separated hostnames).
+# See #1004.
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+_EXTRA_ALLOWED_HOSTS = {
+    h.strip() for h in os.environ.get("ONEBIT_ALLOWED_SERVER_HOSTS", "").split(",") if h.strip()
+}
+MAX_DECODED_IMAGE_BYTES = 64 * 1024 * 1024  # 64 MB cap on server-returned images
+
+def validate_server_url(server_url: str) -> str:
+    """Reject server_url values that aren't loopback / operator-allowlisted (SSRF guard)."""
+    parsed = urlparse(server_url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"server_url must be http(s): {server_url!r}")
+    host = (parsed.hostname or "").lower()
+    if host not in _LOOPBACK_HOSTS and host not in _EXTRA_ALLOWED_HOSTS:
+        raise ValueError(
+            f"server_url host {host!r} is not allowed. Only loopback hosts "
+            f"({sorted(_LOOPBACK_HOSTS)}) are permitted by default — set "
+            f"ONEBIT_ALLOWED_SERVER_HOSTS to allow other hosts."
+        )
+    return server_url
 
 # ─── Helper: image to base64 ──────────────────────────────────────
 def pil_to_base64(img: Image.Image, format: str = "PNG") -> str:
@@ -72,6 +99,7 @@ class OneBP_LLM_Generate:
         messages.append({"role": "user", "content": prompt})
         
         try:
+            validate_server_url(server_url)
             with httpx.Client(timeout=120.0) as client:
                 resp = client.post(
                     f"{server_url}/chat/completions",
@@ -87,7 +115,7 @@ class OneBP_LLM_Generate:
                 text = data["choices"][0]["message"]["content"]
         except Exception as e:
             text = f"[ERROR: {e}]"
-        
+
         return (text,)
 
 # ═══════════════════════════════════════════════════════════════════
@@ -122,13 +150,13 @@ class OneBP_VLM_Understand:
             img_np = image[0].cpu().numpy()
             if img_np.shape[-1] == 1:
                 img_np = np.squeeze(img_np, axis=-1)
-            img_pil = Image.fromarray((img_np * 255).astype(np.uint8))
+            img_pil = Image.fromarray(np.clip(img_np * 255, 0, 255).astype(np.uint8))
         else:
             img_pil = image
-        
+
         b64 = pil_to_base64(img_pil, "PNG")
         data_url = f"data:image/png;base64,{b64}"
-        
+
         messages = [
             {
                 "role": "user",
@@ -138,8 +166,9 @@ class OneBP_VLM_Understand:
                 ]
             }
         ]
-        
+
         try:
+            validate_server_url(server_url)
             with httpx.Client(timeout=120.0) as client:
                 resp = client.post(
                     f"{server_url}/chat/completions",
@@ -206,6 +235,7 @@ class OneBP_Image_Generate:
             params["lora_strengths"] = [lora_strength]
         
         try:
+            validate_server_url(server_url)
             with httpx.Client(timeout=300.0) as client:
                 resp = client.post(
                     f"{server_url}/images/generations",
@@ -213,11 +243,14 @@ class OneBP_Image_Generate:
                 )
                 resp.raise_for_status()
                 data = resp.json()
-                
-                # Decode base64 image
+
+                # Decode base64 image (size-capped against decompression-bomb responses)
                 b64 = data["data"][0]["b64_json"]
                 img_bytes = base64.b64decode(b64)
+                if len(img_bytes) > MAX_DECODED_IMAGE_BYTES:
+                    raise ValueError(f"decoded image too large: {len(img_bytes)} bytes")
                 img_pil = Image.open(io.BytesIO(img_bytes))
+                img_pil.load()
                 
                 # Convert to ComfyUI tensor
                 img_np = np.array(img_pil.convert("RGB")).astype(np.float32) / 255.0
@@ -255,6 +288,7 @@ class OneBP_TTS:
     
     def synthesize(self, text, voice, server_url=DEFAULT_AUDIO_URL):
         try:
+            validate_server_url(server_url)
             with httpx.Client(timeout=60.0) as client:
                 resp = client.post(
                     f"{server_url}/audio/speech",
@@ -300,6 +334,7 @@ class OneBP_LoRA_Loader:
     
     def load_lora(self, lora_path, model, server_url=DEFAULT_UNIFIED_URL):
         try:
+            validate_server_url(server_url)
             with httpx.Client(timeout=30.0) as client:
                 resp = client.post(
                     f"{server_url}/lora/load",

--- a/integrations/vllm-toolbox/npu-companion.service
+++ b/integrations/vllm-toolbox/npu-companion.service
@@ -2,8 +2,13 @@
 Description=1bit-systems NPU Companion — Speculative Decoding Draft Model
 After=network.target
 
+# Requires a dedicated non-root service user with NPU/GPU device access, e.g.:
+#   useradd --system --no-create-home --gid render npu-companion
+
 [Service]
 Type=simple
+User=npu-companion
+Group=render
 ExecStart=/usr/bin/python3 /opt/1bit-systems/integrations/vllm-toolbox/npu-companion.py
 Restart=always
 RestartSec=5
@@ -14,6 +19,18 @@ Environment=OMP_PLACES=cores
 DeviceAllow=/dev/accel/accel0 rw
 DeviceAllow=/dev/dri/renderD128 rw
 SupplementaryGroups=render
+
+# Sandboxing (#1005: unit previously ran as root with no hardening)
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=false
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+CapabilityBoundingSet=
 
 [Install]
 WantedBy=multi-user.target

--- a/kernels/zaya_moe_batch_union.hip
+++ b/kernels/zaya_moe_batch_union.hip
@@ -245,7 +245,7 @@ __global__ void batched_moe_union_kernel(
         __half* moe_b = moe_out + (size_t)b * h_dim;
         for (int i = tx; i < h_dim; i += blockDim.x) {
             float s = 0;
-            const __half* w = dn + ((size_t)expert * H + i) * (size_t)n_ff;
+            const __half* w = dn + ((size_t)expert * h_dim + i) * (size_t)n_ff;
             for (int j = 0; j < n_ff; j++)
                 s += __half2float(gate_up_buf[j]) * __half2float(w[j]);
             moe_b[i] = __float2half(s);
@@ -407,7 +407,7 @@ __global__ void batched_moe_fused_kernel(
         __half* moe_b = moe_out + (size_t)b * h_dim;
         for (int i = tx; i < h_dim; i += blockDim.x) {
             float s = 0;
-            const __half* w = dn + ((size_t)my_expert * H + i) * (size_t)n_ff;
+            const __half* w = dn + ((size_t)my_expert * h_dim + i) * (size_t)n_ff;
             for (int j = 0; j < n_ff; j++)
                 s += __half2float(gate_up_tmp[j]) * __half2float(w[j]);
             moe_b[i] = __float2half(s);
@@ -566,7 +566,7 @@ __global__ void moe_sorted_expert_kernel(
         __half* moe_b = moe_out + (size_t)b * h_dim;
         for (int i = tx; i < h_dim; i += blockDim.x) {
             float s = 0;
-            const __half* w = dn + ((size_t)expert * H + i) * (size_t)n_ff;
+            const __half* w = dn + ((size_t)expert * h_dim + i) * (size_t)n_ff;
             for (int j = 0; j < n_ff; j++)
                 s += __half2float(gate_up_buf[j]) * __half2float(w[j]);
             moe_b[i] = __float2half(s);
@@ -588,14 +588,15 @@ __global__ void moe_modskip_passthrough_kernel(
     const __half* __restrict__ hs,       // [B, h_dim]
     const int*   __restrict__ expert_idx, // [B]
     int skip_expert,
-    int B)
+    int B,
+    int h_dim)
 {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i >= B * H) return;
-    int b = i / H;
-    int h = i % H;
+    if (i >= B * h_dim) return;
+    int b = i / h_dim;
+    int h = i % h_dim;
     if (expert_idx[b] == skip_expert) {
-        moe_out[b * (size_t)H + h] = hs[b * (size_t)H + h];
+        moe_out[b * (size_t)h_dim + h] = hs[b * (size_t)h_dim + h];
     }
 }
 

--- a/kernels/zaya_moe_expert_ffn.hip
+++ b/kernels/zaya_moe_expert_ffn.hip
@@ -13,51 +13,52 @@
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
 
-#define H        2048
-#define N_EXP    16
-#define N_FF     2048
 #define WMMA_M   16
 #define WMMA_THREADS 128
 
-// ── WMMA gate_up: tmp[2*N_FF] = hs[H] @ gu[expert, 2*N_FF, H]^T ──
-// Launch with ((2*N_FF + WMMA_M - 1) / WMMA_M, 1) blocks, WMMA_THREADS threads
+// ── WMMA gate_up: tmp[2*n_ff] = hs[h_dim] @ gu[expert, 2*n_ff, h_dim]^T ──
+// Launch with ((2*n_ff + WMMA_M - 1) / WMMA_M, 1) blocks, WMMA_THREADS threads
 // Each block handles WMMA_M output rows of the gate_up projection.
-// Weights read from gu_base + expert * 2 * N_FF * H (GPU-computed address).
+// Weights read from gu_base + expert * 2 * n_ff * h_dim (GPU-computed address).
+// h_dim/n_ff/n_exp are runtime model dimensions (NOT compile-time constants) —
+// see #1001: this used to be hardcoded to 2048/2048/16, silently corrupting
+// any model with different dimensions.
 // If skip_flag is set, outputs zeros and returns early.
 __launch_bounds__(128) __global__ void wmma_gateup_kernel(
-    __half* __restrict__ tmp,               // [2*N_FF] gate_up output
-    const __half* __restrict__ hs,          // [H] hidden state
-    const __half* __restrict__ gu_base,     // [N_EXP, 2*N_FF, H] all expert weights
+    __half* __restrict__ tmp,               // [2*n_ff] gate_up output
+    const __half* __restrict__ hs,          // [h_dim] hidden state
+    const __half* __restrict__ gu_base,     // [n_exp, 2*n_ff, h_dim] all expert weights
     const int*    __restrict__ d_expert_idx, // GPU pointer to selected expert
-    const int*    __restrict__ d_skip_flag)  // GPU pointer: 1 = skip FFN, output zeros
+    const int*    __restrict__ d_skip_flag,  // GPU pointer: 1 = skip FFN, output zeros
+    int h_dim, int n_ff, int n_exp)
 {
     int row_block = blockIdx.x;
     int row = row_block * WMMA_M;
 
     if (*d_skip_flag) {
         // Skip: zero output and return — no CPU sync needed
-        if (row < 2 * N_FF) {
+        if (row < 2 * n_ff) {
             for (int j = 0; j < WMMA_M; j++)
-                if (row + j < 2 * N_FF)
+                if (row + j < 2 * n_ff)
                     tmp[row + j] = __float2half(0.0f);
         }
         return;
     }
 
     int expert = *d_expert_idx;
-    if (expert >= N_EXP) return;
+    if (expert >= n_exp) return;
 
     // Compute pointer to this expert's gate_up weights
-    const __half* gu = gu_base + (size_t)expert * 2 * N_FF * H;
+    const __half* gu = gu_base + (size_t)expert * 2 * n_ff * h_dim;
 
     float acc[WMMA_M] = {0.0f};
     int tx = threadIdx.x;
 
-    // Tiled GEMV: acc[j] = sum_k hs[k] * gu[(row+j)*H + k]
-    for (int k = tx; k < H; k += WMMA_THREADS) {
+    // Tiled GEMV: acc[j] = sum_k hs[k] * gu[(row+j)*h_dim + k]
+    for (int k = tx; k < h_dim; k += WMMA_THREADS) {
         float v_hs = (float)hs[k];
         for (int j = 0; j < WMMA_M; j++)
-            acc[j] += v_hs * (float)gu[(row + j) * (size_t)H + k];
+            acc[j] += v_hs * (float)gu[(row + j) * (size_t)h_dim + k];
     }
 
     // Warp-level reduction across WMMA_M accumulator lanes
@@ -83,48 +84,50 @@ __launch_bounds__(128) __global__ void wmma_gateup_kernel(
                 acc[j] += __shfl_xor_sync(0xffffffffULL, acc[j], o);
         if (lane == 0)
             for (int j = 0; j < WMMA_M; j++)
-                if (row + j < 2 * N_FF)
+                if (row + j < 2 * n_ff)
                     tmp[row + j] = __float2half(acc[j]);
     }
 }
 
-// ── WMMA down: out[H] = moe_in[N_FF] @ dn[expert, H, N_FF]^T ──
-// Launch with ((H + WMMA_M - 1) / WMMA_M, 1) blocks, WMMA_THREADS threads
+// ── WMMA down: out[h_dim] = moe_in[n_ff] @ dn[expert, h_dim, n_ff]^T ──
+// Launch with ((h_dim + WMMA_M - 1) / WMMA_M, 1) blocks, WMMA_THREADS threads
 // Takes silu'd gate_up as input, writes expert FFN output.
+// h_dim/n_ff/n_exp are runtime model dimensions — see #1001.
 // If skip_flag is set, outputs zeros and returns early.
 __launch_bounds__(128) __global__ void wmma_down_kernel(
-    __half* __restrict__ out,               // [H] expert output
-    const __half* __restrict__ moe_in,      // [N_FF] SiLU'd gate_up
-    const __half* __restrict__ dn_base,     // [N_EXP, H, N_FF] all expert weights
+    __half* __restrict__ out,               // [h_dim] expert output
+    const __half* __restrict__ moe_in,      // [n_ff] SiLU'd gate_up
+    const __half* __restrict__ dn_base,     // [n_exp, h_dim, n_ff] all expert weights
     const int*    __restrict__ d_expert_idx, // GPU pointer to selected expert
-    const int*    __restrict__ d_skip_flag)  // GPU pointer: 1 = skip FFN, output zeros
+    const int*    __restrict__ d_skip_flag,  // GPU pointer: 1 = skip FFN, output zeros
+    int h_dim, int n_ff, int n_exp)
 {
     int row_block = blockIdx.x;
     int row = row_block * WMMA_M;
 
     if (*d_skip_flag) {
         // Skip: zero output and return
-        if (row < H) {
+        if (row < h_dim) {
             for (int j = 0; j < WMMA_M; j++)
-                if (row + j < H)
+                if (row + j < h_dim)
                     out[row + j] = __float2half(0.0f);
         }
         return;
     }
 
     int expert = *d_expert_idx;
-    if (expert >= N_EXP) return;
+    if (expert >= n_exp) return;
 
-    const __half* dn = dn_base + (size_t)expert * H * N_FF;
+    const __half* dn = dn_base + (size_t)expert * h_dim * n_ff;
 
     float acc[WMMA_M] = {0.0f};
     int tx = threadIdx.x;
 
-    // Tiled GEMV: acc[j] = sum_k in[k] * dn[(row+j)*N_FF + k]
-    for (int k = tx; k < N_FF; k += WMMA_THREADS) {
+    // Tiled GEMV: acc[j] = sum_k in[k] * dn[(row+j)*n_ff + k]
+    for (int k = tx; k < n_ff; k += WMMA_THREADS) {
         float v_in = (float)moe_in[k];
         for (int j = 0; j < WMMA_M; j++)
-            acc[j] += v_in * (float)dn[(row + j) * (size_t)N_FF + k];
+            acc[j] += v_in * (float)dn[(row + j) * (size_t)n_ff + k];
     }
 
     for (int j = 0; j < WMMA_M; j++)
@@ -147,7 +150,7 @@ __launch_bounds__(128) __global__ void wmma_down_kernel(
                 acc[j] += __shfl_xor_sync(0xffffffffULL, acc[j], o);
         if (lane == 0)
             for (int j = 0; j < WMMA_M; j++)
-                if (row + j < H)
+                if (row + j < h_dim)
                     out[row + j] = __float2half(acc[j]);
     }
 }

--- a/kernels/zaya_persistent_moe.hip
+++ b/kernels/zaya_persistent_moe.hip
@@ -205,9 +205,22 @@ __launch_bounds__(128) __global__ void persistent_moe_kernel(
             int row = row_block * WMMA_M;
             if (row >= H) return;
 
-            // Wait for gate-up to finish before reading
+            // Wait for gate-up to finish before reading.
+            // Bounded timeout (#1010, same pattern/rationale as the Phase 1
+            // wait above, issue #405): this grid can far exceed the device's
+            // concurrent wave capacity, so a down-block can be scheduled
+            // before its layer's gate_up blocks even start running — an
+            // unbounded wait here starves those gate_up blocks and hangs
+            // the GPU.
             if (is_down) {
-                while (load_flag(done_flags, layer, 1) == 0) { __threadfence_block(); }
+                const int PHASE2_MAX_SPINS = 1000000;
+                for (int _tries = 0; load_flag(done_flags, layer, 1) == 0; _tries++) {
+                    if (_tries >= PHASE2_MAX_SPINS) {
+                        if (tx == 0) moe_layer[0] = __float2half(__builtin_nanf(""));
+                        return;
+                    }
+                    for (volatile int _spin = 0; _spin < 32; _spin++) {}
+                }
                 __threadfence();
             }
 

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -8,7 +8,10 @@ url="https://1bit.systems"
 license=('MIT')
 depends=('libxrt' 'gcc-libs')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/bong-water-water-bong/1bit-systems/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+# sha256 of the v$pkgver release tarball — must be regenerated on every
+# pkgver bump (`curl -fsSL <source URL> | sha256sum`). #1008: 'SKIP' was
+# previously used, which disables integrity verification entirely.
+sha256sums=('d0660ea9f6e31995299354c222e975d53483d25caa057209eb257c048004bda1')
 
 package() {
   cd "$srcdir/1bit-systems-$pkgver"

--- a/packaging/mobile.sh
+++ b/packaging/mobile.sh
@@ -10,6 +10,7 @@ echo ""
 
 PORT="${1:-8080}"
 NGROK_AUTH="${BIT_NGROK_AUTH:-}"
+NGROK_URL=""
 
 # Step 1: Check NPU server
 echo "📡 Checking NPU server on port $PORT..."

--- a/packaging/model-download.sh
+++ b/packaging/model-download.sh
@@ -78,7 +78,23 @@ download_model() {
   # Download with progress bar
   curl -fL --progress-bar "$URL" -o "$OUTFILE" || die "Download failed"
 
-  # Verify
+  # Verify integrity (#1008: multi-GB weights were previously accepted with
+  # zero integrity check — a corrupted or mismatched upstream asset would go
+  # completely undetected)
+  local SHA256
+  SHA256="$(get_field "$M" 5)"
+  if [ -n "$SHA256" ]; then
+    local ACTUAL
+    ACTUAL="$(sha256sum "$OUTFILE" | cut -d' ' -f1)"
+    if [ "$ACTUAL" != "$SHA256" ]; then
+      rm -f "$OUTFILE"
+      die "sha256 mismatch for ${NAME}: expected ${SHA256}, got ${ACTUAL}. Deleted corrupted download."
+    fi
+    say "sha256 verified: ${SHA256}"
+  else
+    warn "No sha256 recorded for ${NAME} in the model registry — integrity NOT verified."
+  fi
+
   local SIZE
   SIZE=$(stat -c%s "$OUTFILE" 2>/dev/null || stat -f%z "$OUTFILE" 2>/dev/null)
   say "Downloaded: $(numfmt --to=iec $SIZE) — saved to ${OUTFILE}"

--- a/packaging/npu-install.sh
+++ b/packaging/npu-install.sh
@@ -82,7 +82,7 @@ done
 # ── Add to PATH ──
 if [[ ":$PATH:" != *":${HOME}/.local/bin:"* ]]; then
   SHELL_CONFIG="${HOME}/.bashrc"
-  [ -n "$ZSH_VERSION" ] && SHELL_CONFIG="${HOME}/.zshrc"
+  [ -n "${ZSH_VERSION:-}" ] && SHELL_CONFIG="${HOME}/.zshrc"
   echo 'export PATH="$HOME/.local/bin:$PATH"' >> "${SHELL_CONFIG}"
   say "Added ~/.local/bin to PATH in ${SHELL_CONFIG}"
 fi

--- a/site/_headers
+++ b/site/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://img.shields.io https://github.com; font-src 'self'; connect-src 'self' https://1bit.systems; media-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://img.shields.io https://github.com https://avatars.githubusercontent.com; font-src 'self'; connect-src 'self' https://1bit.systems; media-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin

--- a/site/analytics/index.html
+++ b/site/analytics/index.html
@@ -88,6 +88,8 @@ const GREEN='#3fb950',BLUE='#58a6ff',ORANGE='#d2991d',PURPLE='#a371f7',RED='#f85
 function fmt(n){return n.toLocaleString()}
 function fmtBytes(b){if(b>1e9)return (b/1e9).toFixed(1)+' GB';if(b>1e6)return (b/1e6).toFixed(1)+' MB';if(b>1e3)return (b/1e3).toFixed(1)+' KB';return b+' B'}
 function pct(a,b){return b>0?(a/b*100).toFixed(1):'0'}
+// Escape untrusted text (e.g. GitHub profile fields) before interpolating into innerHTML — #1002
+function esc(s){return String(s==null?'':s).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
 
 // GitHub data
 const ghRepo = {"stars":9,"forks":4,"watchers":0,"open_issues":9};
@@ -173,9 +175,9 @@ document.getElementById('stargazers-list').innerHTML =
   `<h2 style="margin-bottom:12px">${ghStargazers.length} Stargazers</h2>
   <div class="stargazers">${ghStargazers.map(s=>{
     const loc=stargazerLocations[s.login]||{};
-    return `<a href="${s.html_url}" target="_blank" class="stargazer" title="${loc.location||''} ${loc.company||''}">
-      <img src="${s.avatar_url}" class="avatar" width="32" height="32" loading="lazy">
-      <div><strong>${s.login}</strong>${loc.name?`<br><small style="color:var(--muted)">${loc.name}</small>`:''}${loc.location?`<br><small style="color:var(--blue)">📍 ${loc.location}</small>`:''}${loc.company?`<br><small style="color:var(--orange)">🏢 ${loc.company}</small>`:''}${loc.bio?`<br><small style="color:var(--muted)">${loc.bio.slice(0,60)}</small>`:''}</div>
+    return `<a href="${esc(s.html_url)}" target="_blank" class="stargazer" title="${esc(loc.location||'')} ${esc(loc.company||'')}">
+      <img src="${esc(s.avatar_url)}" class="avatar" width="32" height="32" loading="lazy">
+      <div><strong>${esc(s.login)}</strong>${loc.name?`<br><small style="color:var(--muted)">${esc(loc.name)}</small>`:''}${loc.location?`<br><small style="color:var(--blue)">📍 ${esc(loc.location)}</small>`:''}${loc.company?`<br><small style="color:var(--orange)">🏢 ${esc(loc.company)}</small>`:''}${loc.bio?`<br><small style="color:var(--muted)">${esc(loc.bio.slice(0,60))}</small>`:''}</div>
     </a>`;
   }).join('')}</div>
   <div class="card" style="margin-top:16px"><div class="label">Known Locations</div>

--- a/site/mobile.sh
+++ b/site/mobile.sh
@@ -10,6 +10,7 @@ echo ""
 
 PORT="${1:-8080}"
 NGROK_AUTH="${BIT_NGROK_AUTH:-}"
+NGROK_URL=""
 
 # Step 1: Check NPU server
 echo "📡 Checking NPU server on port $PORT..."

--- a/site/s/index.html
+++ b/site/s/index.html
@@ -87,6 +87,8 @@ const GREEN='#3fb950',BLUE='#58a6ff',ORANGE='#d2991d',PURPLE='#a371f7',RED='#f85
 
 function fmt(n){return n.toLocaleString()}
 function fmtBytes(b){if(b>1e9)return (b/1e9).toFixed(1)+' GB';if(b>1e6)return (b/1e6).toFixed(1)+' MB';if(b>1e3)return (b/1e3).toFixed(1)+' KB';return b+' B'}
+// Escape untrusted text (e.g. GitHub profile fields) before interpolating into innerHTML — #1002
+function esc(s){return String(s==null?'':s).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
 function pct(a,b){return b>0?(a/b*100).toFixed(1):'0'}
 
 // GitHub data
@@ -173,9 +175,9 @@ document.getElementById('stargazers-list').innerHTML =
   `<h2 style="margin-bottom:12px">${ghStargazers.length} Stargazers</h2>
   <div class="stargazers">${ghStargazers.map(s=>{
     const loc=stargazerLocations[s.login]||{};
-    return `<a href="${s.html_url}" target="_blank" class="stargazer" title="${loc.location||''} ${loc.company||''}">
-      <img src="${s.avatar_url}" class="avatar" width="32" height="32" loading="lazy">
-      <div><strong>${s.login}</strong>${loc.name?`<br><small style="color:var(--muted)">${loc.name}</small>`:''}${loc.location?`<br><small style="color:var(--blue)">📍 ${loc.location}</small>`:''}${loc.company?`<br><small style="color:var(--orange)">🏢 ${loc.company}</small>`:''}${loc.bio?`<br><small style="color:var(--muted)">${loc.bio.slice(0,60)}</small>`:''}</div>
+    return `<a href="${esc(s.html_url)}" target="_blank" class="stargazer" title="${esc(loc.location||'')} ${esc(loc.company||'')}">
+      <img src="${esc(s.avatar_url)}" class="avatar" width="32" height="32" loading="lazy">
+      <div><strong>${esc(s.login)}</strong>${loc.name?`<br><small style="color:var(--muted)">${esc(loc.name)}</small>`:''}${loc.location?`<br><small style="color:var(--blue)">📍 ${esc(loc.location)}</small>`:''}${loc.company?`<br><small style="color:var(--orange)">🏢 ${esc(loc.company)}</small>`:''}${loc.bio?`<br><small style="color:var(--muted)">${esc(loc.bio.slice(0,60))}</small>`:''}</div>
     </a>`;
   }).join('')}</div>
   <div class="card" style="margin-top:16px"><div class="label">Known Locations</div>

--- a/src/zaya_engine.cpp
+++ b/src/zaya_engine.cpp
@@ -510,11 +510,11 @@ void zaya_forward(ZayaState* s, int token_id, float* logits_out) {
             const int gb=(2*eng.n_ff+WMMA_M-1)/WMMA_M;
             const int db=(eng.h+WMMA_M-1)/WMMA_M;
             const int sb=(eng.n_ff+BLK-1)/BLK;
-            wmma_gateup_kernel<<<gb,WMMA_THREADS,0,s->st>>>(s->d_tmp,s->d_hs,l.gu,s->d_expert_idx,s->d_skip_flag);
+            wmma_gateup_kernel<<<gb,WMMA_THREADS,0,s->st>>>(s->d_tmp,s->d_hs,l.gu,s->d_expert_idx,s->d_skip_flag,eng.h,eng.n_ff,eng.n_exp);
             HIP_CHECK(hipGetLastError());
             silu_mul_k<<<sb,BLK,0,s->st>>>(s->d_ao,s->d_tmp,s->d_tmp+eng.n_ff,eng.n_ff);
             HIP_CHECK(hipGetLastError());
-            wmma_down_kernel<<<db,WMMA_THREADS,0,s->st>>>(s->d_tmp,s->d_ao,l.dn,s->d_expert_idx,s->d_skip_flag);
+            wmma_down_kernel<<<db,WMMA_THREADS,0,s->st>>>(s->d_tmp,s->d_ao,l.dn,s->d_expert_idx,s->d_skip_flag,eng.h,eng.n_ff,eng.n_exp);
             HIP_CHECK(hipGetLastError());
             residual_scale_k<<<g1,BLK,0,s->st>>>(s->d_tmp,s->d_hs,l.pmhss,l.pmhsb,l.pmrss,l.pmrsb,eng.h);
             HIP_CHECK(hipGetLastError());
@@ -605,11 +605,11 @@ int zaya_forward_greedy(ZayaState* s, int token_id) {
             const int gb=(2*eng.n_ff+WMMA_M-1)/WMMA_M;
             const int db=(eng.h+WMMA_M-1)/WMMA_M;
             const int sb=(eng.n_ff+BLK-1)/BLK;
-            wmma_gateup_kernel<<<gb,WMMA_THREADS,0,s->st>>>(s->d_tmp,s->d_hs,l.gu,s->d_expert_idx,s->d_skip_flag);
+            wmma_gateup_kernel<<<gb,WMMA_THREADS,0,s->st>>>(s->d_tmp,s->d_hs,l.gu,s->d_expert_idx,s->d_skip_flag,eng.h,eng.n_ff,eng.n_exp);
             HIP_CHECK(hipGetLastError());
             silu_mul_k<<<sb,BLK,0,s->st>>>(s->d_ao,s->d_tmp,s->d_tmp+eng.n_ff,eng.n_ff);
             HIP_CHECK(hipGetLastError());
-            wmma_down_kernel<<<db,WMMA_THREADS,0,s->st>>>(s->d_tmp,s->d_ao,l.dn,s->d_expert_idx,s->d_skip_flag);
+            wmma_down_kernel<<<db,WMMA_THREADS,0,s->st>>>(s->d_tmp,s->d_ao,l.dn,s->d_expert_idx,s->d_skip_flag,eng.h,eng.n_ff,eng.n_exp);
             HIP_CHECK(hipGetLastError());
             residual_scale_k<<<g1,BLK,0,s->st>>>(s->d_tmp,s->d_hs,l.pmhss,l.pmhsb,l.pmrss,l.pmrsb,eng.h);
             HIP_CHECK(hipGetLastError());
@@ -735,7 +735,7 @@ void zaya_forward_batch(ZayaState* s, const int* token_ids, float* logits_out, i
                 // These skip the expert FFN entirely (out = hs, identity).
                 if (s->d_expert_counts) {  // always true, keeps compiler happy
                     moe_modskip_passthrough_kernel<<<(B + 255) / 256, 256, 0, s->st>>>(
-                        s->d_tmp, s->d_hs, s->d_expert_idx, eng.n_exp, B);
+                        s->d_tmp, s->d_hs, s->d_expert_idx, eng.n_exp, B, eng.h);
                 HIP_CHECK(hipGetLastError());
                 }
             } else {

--- a/tests/zaya_gpu_decode.cpp
+++ b/tests/zaya_gpu_decode.cpp
@@ -795,9 +795,9 @@ int main(int argc, char** argv) {
                 encode_expert_cache_kernel<<<1, 32, 0, stream>>>(d_prev_rs + (size_t)il * RTR_H, d_expert_idx, RTR_H);
                 {
                     const int gb = (2 * N_FF + 15) / 16, db = (H + 15) / 16, sb = (N_FF + BLK - 1) / BLK;
-                    wmma_gateup_kernel<<<gb, 128, 0, stream>>>(d_tmp, d_hs, l.gu, d_expert_idx, d_skip_flag);
+                    wmma_gateup_kernel<<<gb, 128, 0, stream>>>(d_tmp, d_hs, l.gu, d_expert_idx, d_skip_flag, H, N_FF, N_EXP);
                     silu_mul_k<<<sb, BLK, 0, stream>>>(d_ao, d_tmp, d_tmp + N_FF, N_FF);
-                    wmma_down_kernel<<<db, 128, 0, stream>>>(d_tmp, d_ao, l.dn, d_expert_idx, d_skip_flag);
+                    wmma_down_kernel<<<db, 128, 0, stream>>>(d_tmp, d_ao, l.dn, d_expert_idx, d_skip_flag, H, N_FF, N_EXP);
                 }
                 // Post-MLP residual scale
                 residual_scale_k<<<g1, BLK, 0, stream>>>(d_tmp, d_hs, l.pmhss, l.pmhsb, l.pmrss, l.pmrsb, H);

--- a/tools/run_trace_validate.sh
+++ b/tools/run_trace_validate.sh
@@ -19,7 +19,10 @@ HF_MODEL="${HF_MODEL:-$HOME/.cache/huggingface/hub/models--Qwen--Qwen3-0.6B/snap
 NPU_MODEL="${NPU_MODEL:-$HOME/.config/flm/models/Qwen3-0.6B-NPU2/model.q4nx}"
 PROMPT="${PROMPT:-Hi}"
 REF_DIR="/tmp/trace_hf"
-NPU_DIR="/tmp/trace_npu"
+# NPU_DIR is created later via mktemp right before the sudo-privileged write
+# (#1009: a fixed, predictable /tmp path here was a TOCTOU symlink race —
+# rm -rf as the invoking user followed by sudo writing through the same path
+# lets a local attacker swap in a symlink between the two).
 # shellcheck disable=SC2034
 SUMMARY="/tmp/trace_compare.csv"
 
@@ -61,7 +64,7 @@ echo "  Built: npu_engine_trace"
 # ── Step 3: Run NPU engine with --trace ──
 echo ""
 echo "=== Step 3: Running NPU engine with --trace ==="
-rm -rf "$NPU_DIR"
+NPU_DIR="$(mktemp -d "${TMPDIR:-/tmp}/trace_npu.XXXXXX")"
 echo "$TOKENS" | tr ',' '\n' > /tmp/trace_tokens.txt
 
 sudo ./npu_engine_trace "$NPU_MODEL" 1 /tmp/trace_tokens.txt --trace "$NPU_DIR" \

--- a/workers/auth-url/src/index.js
+++ b/workers/auth-url/src/index.js
@@ -19,12 +19,6 @@
 // Set these via wrangler secret or env vars.
 // For verification: the part after /auth/ before .html
 
-const VERIFICATION_FILES = {
-  // Google Search Console — file method
-  // Create a file like "google123abc456def.html" at /auth/google123abc456def.html
-  // OR use the meta tag method already in index.html
-};
-
 // OAuth callback relay config
 const OAUTH_CALLBACKS = {};
 
@@ -38,7 +32,7 @@ const ALLOWED_REDIRECT_DOMAINS = [
 
 // ─── Router ──────────────────────────────────────────────────────────────────
 
-async function handleRequest(request) {
+async function handleRequest(request, env) {
   const url = new URL(request.url);
   const { pathname, searchParams } = url;
   const method = request.method;
@@ -105,9 +99,6 @@ async function handleRequest(request) {
     const provider = callbackMatch[1];
     const code = searchParams.get('code');
     const state = searchParams.get('state');
-
-    // Log the callback (for debugging)
-    console.log(`OAuth callback from ${provider}: code=${code?.slice(0, 10)}..., state=${state?.slice(0, 10)}...`);
 
     // Return a JSON response — the client-side app handles the rest
     return new Response(
@@ -209,10 +200,12 @@ async function handleRequest(request) {
       });
     }
 
-    // Generic verification — serve from env
-    const envCode = typeof VERIFICATION_CODES !== 'undefined'
-      ? VERIFICATION_CODES[fileId]
-      : null;
+    // Generic verification — serve from env (VERIFICATION_CODES binding/var, #1003)
+    let verificationCodes = env && env.VERIFICATION_CODES;
+    if (typeof verificationCodes === 'string') {
+      try { verificationCodes = JSON.parse(verificationCodes); } catch { verificationCodes = null; }
+    }
+    const envCode = verificationCodes ? verificationCodes[fileId] : null;
     if (envCode) {
       return new Response(envCode, {
         status: 200,
@@ -247,7 +240,7 @@ async function handleRequest(request) {
 export default {
   async fetch(request, env, ctx) {
     try {
-      return await handleRequest(request);
+      return await handleRequest(request, env);
     } catch (err) {
       console.error('Auth URL Worker error:', err);
       return new Response(

--- a/workers/auth-url/wrangler.toml
+++ b/workers/auth-url/wrangler.toml
@@ -6,6 +6,7 @@ compatibility_date = "2026-07-26"
 routes = [
   { pattern = "1bit.systems/auth/*", zone_id = "fb8da40a864cd0c59bf39b689024624e" },
   { pattern = "1bit.systems/google*.html", zone_id = "fb8da40a864cd0c59bf39b689024624e" },
+  { pattern = "1bit.systems/bing*.html", zone_id = "fb8da40a864cd0c59bf39b689024624e" },
   { pattern = "1bit.systems/BingSiteAuth.xml", zone_id = "fb8da40a864cd0c59bf39b689024624e" },
   { pattern = "1bit.systems/yandex*.html", zone_id = "fb8da40a864cd0c59bf39b689024624e" },
   { pattern = "1bit.systems/pinterest*.html", zone_id = "fb8da40a864cd0c59bf39b689024624e" }


### PR DESCRIPTION
## Summary

Parallel GitNexus-guided bug hunt across four areas of the codebase not covered by the previous sweep (`jarvis/rust/workers`, `spec-decode/ck-prefill/kernels`, `integrations/adapters/experimental`, `site/packaging/scripts`), followed by fixes for every confirmed bug. Full build + test verification before and after.

## Fixes

- **#1001** (highest severity — correctness): `zaya_moe_expert_ffn.hip` / `zaya_moe_batch_union.hip` had `H=2048`/`N_EXP=16`/`N_FF=2048` baked in as compile-time macros in the **live GPU MoE decode path**, silently corrupting inference for any model with different dimensions — directly contradicts this engine's model-agnostic goal. Threaded `h_dim`/`n_ff`/`n_exp` through as runtime kernel params (found and fixed 3 more leaked-macro pointer-arithmetic sites beyond the one originally scoped, in `batched_moe_union_kernel`, `batched_moe_fused_kernel`, and `moe_sorted_expert_kernel`).
- **#1002** (security): stored XSS in `site/analytics/index.html` + `site/s/index.html` — GitHub stargazer profile fields (bio/name/company) were interpolated into `innerHTML` unescaped. Added an `esc()` helper, applied to every untrusted field.
- **#1003**: `workers/auth-url` — `env` was never passed into `handleRequest`, so `VERIFICATION_CODES` was permanently unreachable; removed the orphaned `VERIFICATION_FILES`; added the missing `bing*.html` route; dropped unnecessary OAuth code/state logging.
- **#1004** (security): `integrations/comfyui` — SSRF via unrestricted `server_url` widget (now loopback-only by default, opt-in via `ONEBIT_ALLOWED_SERVER_HOSTS`), capped decoded image size against decompression-bomb responses, fixed pixel-value wraparound on the tensor→image cast.
- **#1005** (security): `npu-companion.service` ran as root with zero sandboxing — added a dedicated service user + standard systemd hardening directives (`NoNewPrivileges`, `ProtectSystem=strict`, etc).
- **#1006**: `site/_headers` CSP `img-src` was missing `avatars.githubusercontent.com`, silently breaking every stargazer avatar image.
- **#1007**: `mobile.sh` / `npu-install.sh` crashed under `set -u` on the common path (no ngrok installed / plain bash) — unbound `NGROK_URL` / `ZSH_VERSION`.
- **#1008** (security): `model-download.sh` never checked sha256 (registry had none populated); `aur/PKGBUILD` used `sha256sums=('SKIP')`. Added verification logic + pinned the real v1.0.0 tarball hash.
- **#1009** (security): `run_trace_validate.sh` had a TOCTOU symlink race between an unprivileged `rm -rf` and a `sudo`-privileged write through the same fixed `/tmp` path. Switched to `mktemp -d`.
- **#1010**: `zaya_persistent_moe.hip`'s Phase-2 gate_up→down handoff spun forever with no timeout (currently dead/unwired code, but a live GPU-hang risk the moment it's enabled) — applied the same bounded-timeout pattern already used for the Phase-1 wait (issue #405).

## Test plan

- [x] Full clean rebuild (346/346 targets) before starting
- [x] `ctest` 19/19 passing (3 skipped, missing hardware model files) before starting
- [x] Rebuilt after the #1001 MoE kernel fix — clean, 19/19 tests still pass
- [x] Rebuilt after the #1010 kernel fix — clean
- [x] Syntax-checked all shell scripts (`bash -n`), the Python file (`ast.parse`), and all JS (`node --check`, including inline `<script>` blocks)
- [x] `gitnexus detect_changes` — risk: low, no affected execution flows
- [x] Verified this branch's staged diff contains *only* these 18 files (repo has unrelated concurrent in-progress changes from another process that must not be swept into this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)