### PR TITLE
fix: .1bp catalog was structurally incapable of correct inference

### DIFF
--- a/engine/npu/CMakeLists.txt
+++ b/engine/npu/CMakeLists.txt
@@ -11,9 +11,16 @@ find_package(XRT QUIET)
 set(NPU_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(NPU_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-set(NPU_CXX_SOURCES
-    ${NPU_SRC_DIR}/xrt_wrapper.cpp
-)
+# xrt_wrapper.cpp (hand-rolled extern "C" wrappers around raw XRT symbols,
+# incl. the newer xrtHwContextCreate/xrtKernelOpen HW-context API) is not
+# referenced by any target below — they all use XRT's own official C++
+# headers (<xrt/xrt_device.h> etc.) directly instead. Left unlinked here:
+# the wrapper is written against a newer XRT API than what's installed on
+# this box (2.21.75 only exports the older xrtPLKernelOpen-style API, no
+# xrtHwContext* symbols at all — see issue #1023), so linking it in was a
+# pure liability with zero upside. If something starts actually using
+# XrtDevice/XrtKernel/etc., this needs the older-API rewrite instead.
+set(NPU_CXX_SOURCES)
 
 # ── npu_engine_universal (flagship — all ops: QKV, O, GU, D, attention) ──
 set(NPU_ENGINE_SOURCES
@@ -31,8 +38,14 @@ target_include_directories(npu_engine_universal PRIVATE
 )
 
 if(XRT_FOUND)
+    # find_package(XRT) does not export an XRT_CORE_LIBRARIES variable —
+    # linking against it silently links nothing, leaving xrtHwContextCreate/
+    # xrtKernelOpen/etc. undefined at link time (issue #1022/#1023
+    # investigation). find_library() for the real library, same pattern
+    # npu_engine_cb already uses successfully below.
+    find_library(XRT_COREUTIL xrt_coreutil)
     target_include_directories(npu_engine_universal PRIVATE ${XRT_INCLUDE_DIRS})
-    target_link_libraries(npu_engine_universal ${XRT_CORE_LIBRARIES})
+    target_link_libraries(npu_engine_universal ${XRT_COREUTIL})
     target_compile_definitions(npu_engine_universal PRIVATE -DXRT_ENABLE)
 endif()
 
@@ -156,8 +169,14 @@ if(HIPCC AND HIP_LIB_DIR)
         )
         
         add_dependencies(${target_name} ${target_name}_build)
-        
-        install(TARGETS ${target_name} DESTINATION bin)
+
+        # No install(TARGETS ...) here: ${target_name} is an IMPORTED
+        # executable (the real binary comes from the hipcc custom command
+        # above, not from CMake's own add_executable/link step), and
+        # install(TARGETS ...) is only valid for targets CMake itself
+        # builds. It already lands at ${TARGET_BIN} in the build dir,
+        # which is where this project actually consumes it from — see
+        # issue #1022.
     endmacro()
 
     add_npu_hip_target(npu_engine_fused npu_engine_fused)

--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -452,6 +452,35 @@ int main(int argc,char**argv){
             cfg.HD = oh.head_dim; cfg.IM = oh.intermediate_size;
             cfg.NV = oh.vocab_size; cfg.GQA = cfg.NH / cfg.NKV;
             cfg.XM = 128; cfg.has_lm_head = true;
+            // The rest of ModelConfig (model_tag, xclbin_*, gu_split, has_q_norm/
+            // has_k_norm) was never populated for the onebp path — it only ever
+            // set the handful of fields above, leaving model_tag empty and every
+            // xclbin_* dimension zero. That's invisible until NPU init actually
+            // tries to open "insts_i8_QKV_.txt" (empty tag) and fails. Mirror
+            // parse_q4nx_header()'s derivation below (same formulas, sourced
+            // from the onebp header instead of Q4NX JSON tile-row counts).
+            cfg.model_tag = model_tag;
+            cfg.rope_theta = oh.rope_theta() > 0 ? oh.rope_theta() : cfg.rope_theta;
+            {
+                std::vector<float> probe;
+                cfg.has_q_norm = onebp_model.get_tensor_f32("blk.0.attn_q_norm.weight", probe);
+                cfg.has_k_norm = onebp_model.get_tensor_f32("blk.0.attn_k_norm.weight", probe);
+            }
+            cfg.qkv_k_offset = cfg.NH * cfg.HD;
+            cfg.qkv_v_offset = cfg.NH * cfg.HD + cfg.NKV * cfg.HD;
+            cfg.qkv_total = cfg.NH * cfg.HD + 2 * cfg.NKV * cfg.HD;
+            cfg.xclbin_qkv_k = cfg.H;
+            cfg.xclbin_qkv_n = cfg.qkv_total;
+            cfg.xclbin_o_k = cfg.NH * cfg.HD;
+            cfg.xclbin_o_n = cfg.H;
+            cfg.gu_split = (cfg.IM * 2 > 14336);
+            if (cfg.gu_split) {
+                cfg.xclbin_g_k = cfg.H; cfg.xclbin_g_n = cfg.IM;
+                cfg.xclbin_u_k = cfg.H; cfg.xclbin_u_n = cfg.IM;
+            } else {
+                cfg.xclbin_gu_k = cfg.H; cfg.xclbin_gu_n = cfg.IM * 2;
+            }
+            cfg.xclbin_d_k = cfg.IM; cfg.xclbin_d_n = cfg.H;
         } else
     #endif
         cfg = parse_q4nx_header(mp,model_tag.c_str());
@@ -489,6 +518,29 @@ int main(int argc,char**argv){
     // Norm weights
     std::vector<uint64_t> in_off(NC),pa_off(NC),qn_off(NC),kn_off(NC),qp(NC),kp(NC),vp(NC),op(NC),gp(NC),up(NC),dp(NC);
     char bn[128];
+    std::vector<std::vector<float>> in_n(NC),pa_n(NC),qn_w(NC),kn_w(NC);
+    std::vector<float> fin_v;
+    int q_i8=0,k_i8=0,v_i8=0,o_i8=0,g_i8=0,u_i8=0,d_i8=0;
+#ifdef ONEBP_SUPPORT
+    if (is_onebp) {
+        // Same tensors, GGUF/onebp naming (blk.N.*) instead of the HF
+        // safetensors naming (model.layers.N.*) the jo()/JSON path below
+        // uses. get_tensor_f32 dequantizes Q4NX/TQ2 internally and returns
+        // the tensor's real shape — no separate "I8 tile rows" lookup needed.
+        for (int l = 0; l < NC; l++) {
+            snprintf(bn,128,"blk.%d.attn_norm.weight",l); onebp_model.get_tensor_f32(bn, in_n[l]);
+            snprintf(bn,128,"blk.%d.ffn_norm.weight",l); onebp_model.get_tensor_f32(bn, pa_n[l]);
+            if (cfg.has_q_norm) { snprintf(bn,128,"blk.%d.attn_q_norm.weight",l); onebp_model.get_tensor_f32(bn, qn_w[l]); }
+            if (cfg.has_k_norm) { snprintf(bn,128,"blk.%d.attn_k_norm.weight",l); onebp_model.get_tensor_f32(bn, kn_w[l]); }
+        }
+        onebp_model.get_tensor_f32("output_norm.weight", fin_v);
+        std::vector<float> lm_buf;
+        if (onebp_model.get_tensor_f32("output.weight", lm_buf)) {
+            lm_head_f32 = lm_buf;
+            fprintf(stderr,"  lm_head: %zu floats (loaded from 1BP output.weight)\n",lm_buf.size());
+        }
+    } else {
+#endif
     for(int l=0;l<NC;l++){
         snprintf(bn,128,"model.layers.%d.self_attn.q_proj.weight",l);qp[l]=jo(js,jl,bn);
         snprintf(bn,128,"model.layers.%d.self_attn.k_proj.weight",l);kp[l]=jo(js,jl,bn);
@@ -503,8 +555,8 @@ int main(int argc,char**argv){
         snprintf(bn,128,"model.layers.%d.self_attn.k_norm.weight",l);kn_off[l]=jo(js,jl,bn);}
     uint64_t no=jo(js,jl,"model.norm.weight");
     uint64_t lo=jo(js,jl,"lm_head.weight");
-    std::vector<std::vector<float>> in_n(NC,std::vector<float>(H)),pa_n(NC,std::vector<float>(H)),qn_w(NC,std::vector<float>(HD)),kn_w(NC,std::vector<float>(HD));
-    std::vector<float> fin_v(H);
+    for(int l=0;l<NC;l++)in_n[l].resize(H),pa_n[l].resize(H),qn_w[l].resize(HD),kn_w[l].resize(HD);
+    fin_v.resize(H);
     for(int l=0;l<NC;l++){auto iw=(const uint16_t*)(md+df+in_off[l]),pw=(const uint16_t*)(md+df+pa_off[l]);
         for(int i=0;i<H;i++){in_n[l][i]=bf16g(iw[i]);pa_n[l][i]=bf16g(pw[i]);}
         if(cfg.has_q_norm&&qn_off[l]){auto qq=(const uint16_t*)(md+df+qn_off[l]);for(int i=0;i<HD;i++)qn_w[l][i]=bf16g(qq[i]);}
@@ -513,8 +565,8 @@ int main(int argc,char**argv){
 
     // I8 tile rows
     auto gi8=[&](const char*k)->int{int r=0;find_tensor_info(js,jl,k,&r);return r;};
-    int q_i8=gi8("model.layers.0.self_attn.q_proj.weight"),k_i8=gi8("model.layers.0.self_attn.k_proj.weight"),v_i8=gi8("model.layers.0.self_attn.v_proj.weight");
-    int o_i8=gi8("model.layers.0.self_attn.o_proj.weight"),g_i8=gi8("model.layers.0.mlp.gate_proj.weight"),u_i8=gi8("model.layers.0.mlp.up_proj.weight"),d_i8=gi8("model.layers.0.mlp.down_proj.weight");
+    q_i8=gi8("model.layers.0.self_attn.q_proj.weight");k_i8=gi8("model.layers.0.self_attn.k_proj.weight");v_i8=gi8("model.layers.0.self_attn.v_proj.weight");
+    o_i8=gi8("model.layers.0.self_attn.o_proj.weight");g_i8=gi8("model.layers.0.mlp.gate_proj.weight");u_i8=gi8("model.layers.0.mlp.up_proj.weight");d_i8=gi8("model.layers.0.mlp.down_proj.weight");
     int lm_i8=gi8("lm_head.weight");
 
     // Load lm_head.weight separately — NOT tied to embed_tokens.weight for this model
@@ -522,6 +574,9 @@ int main(int argc,char**argv){
         lm_head_f32.assign(lm_raw,lm_raw+(size_t)lr*lc);free(lm_raw);
         fprintf(stderr,"  lm_head: %dx%d (loaded from JSON), using for final logits\n",lr,lc);
     }else{fprintf(stderr,"  lm_head: dequant failed, falling back to emb\n");}}
+#ifdef ONEBP_SUPPORT
+    }
+#endif
     if(lm_head_f32.empty()){fprintf(stderr,"  lm_head: using emb_f32 (tied embeddings)\n");}
     const float* lm_emb = lm_head_f32.empty() ? emb_f32.data() : lm_head_f32.data();
 
@@ -600,14 +655,37 @@ int main(int argc,char**argv){
     const int GUOUT=IM;                   // Gate/Up: out=IM, in=H
     const int DOUT=H,DIN=IM;              // Down: out=H, in=IM — dequant needs DIN
     for(int l=0;l<NC;l++){int qr,kr,vr,unused;
-        float*qw=dequant_i8_to_float_ex(i8p(qp[l]),q_i8,H,&qr,&unused),*kw=dequant_i8_to_float_ex(i8p(kp[l]),k_i8,H,&kr,&unused),*vw=dequant_i8_to_float_ex(i8p(vp[l]),v_i8,H,&vr,&unused);
+        float*qw,*kw,*vw,*ow,*gw,*uw,*dw;
+        std::vector<float> qw_v,kw_v,vw_v,ow_v,gw_v,uw_v,dw_v;
+        int gr,ur;
+#ifdef ONEBP_SUPPORT
+        if (is_onebp) {
+            // Tensors are already correctly shaped [out_features, in_features]
+            // by construction (that's how they're stored in the 1BP tensor
+            // index) — get_tensor_f32 dequantizes Q4NX/TQ2 and hands them back
+            // as-is, no separate row-count/offset bookkeeping needed.
+            snprintf(bn,128,"blk.%d.attn_q.weight",l); onebp_model.get_tensor_f32(bn, qw_v); qw=qw_v.data();
+            snprintf(bn,128,"blk.%d.attn_k.weight",l); onebp_model.get_tensor_f32(bn, kw_v); kw=kw_v.data();
+            snprintf(bn,128,"blk.%d.attn_v.weight",l); onebp_model.get_tensor_f32(bn, vw_v); vw=vw_v.data();
+            snprintf(bn,128,"blk.%d.attn_output.weight",l); onebp_model.get_tensor_f32(bn, ow_v); ow=ow_v.data();
+            snprintf(bn,128,"blk.%d.ffn_gate.weight",l); onebp_model.get_tensor_f32(bn, gw_v); gw=gw_v.data();
+            snprintf(bn,128,"blk.%d.ffn_up.weight",l); onebp_model.get_tensor_f32(bn, uw_v); uw=uw_v.data();
+            snprintf(bn,128,"blk.%d.ffn_down.weight",l); onebp_model.get_tensor_f32(bn, dw_v); dw=dw_v.data();
+            gr = ur = GUOUT;
+        } else {
+#endif
+        qw=dequant_i8_to_float_ex(i8p(qp[l]),q_i8,H,&qr,&unused);kw=dequant_i8_to_float_ex(i8p(kp[l]),k_i8,H,&kr,&unused);vw=dequant_i8_to_float_ex(i8p(vp[l]),v_i8,H,&vr,&unused);
+        {int or2,oc2;ow=dequant_i8_to_float_ex(i8p(op[l]),o_i8,OIN,&or2,&oc2);}
+        gw=dequant_i8_to_float_ex(i8p(gp[l]),g_i8,H,&gr,&unused);uw=dequant_i8_to_float_ex(i8p(up[l]),u_i8,H,&ur,&unused);
+        {int dr2,dc2;dw=dequant_i8_to_float_ex(i8p(dp[l]),d_i8,DIN,&dr2,&dc2);}
+#ifdef ONEBP_SUPPORT
+        }
+#endif
         int t=QOUT+KVOUT+KVOUT;std::vector<float>w((size_t)H*t);
         transpose_pack(qw,QOUT,H,w.data(),t,0); transpose_pack(kw,KVOUT,H,w.data(),t,QOUT); transpose_pack(vw,KVOUT,H,w.data(),t,QOUT+KVOUT);
-        cq.packB(l,w.data(),H,t,qsc[l]);free(qw);free(kw);free(vw);
-        int or2,oc2;float*ow=dequant_i8_to_float_ex(i8p(op[l]),o_i8,OIN,&or2,&oc2);
+        cq.packB(l,w.data(),H,t,qsc[l]);
         std::vector<float>wo((size_t)OIN*OOUT);transpose_pack(ow,OOUT,OIN,wo.data(),OOUT,0);
-        co.packB(l,wo.data(),OIN,OOUT,osc[l]);free(ow);
-        int gr,ur;float*gw=dequant_i8_to_float_ex(i8p(gp[l]),g_i8,H,&gr,&unused),*uw=dequant_i8_to_float_ex(i8p(up[l]),u_i8,H,&ur,&unused);
+        co.packB(l,wo.data(),OIN,OOUT,osc[l]);
         if(cfg.gu_split){
             std::vector<float>wg((size_t)H*gr);transpose_pack(gw,GUOUT,H,wg.data(),gr,0);
             cg.packB(l,wg.data(),H,gr,gsc[l]);
@@ -617,10 +695,17 @@ int main(int argc,char**argv){
             int t2=gr+ur;std::vector<float>w2((size_t)H*t2);
             transpose_pack(gw,GUOUT,H,w2.data(),t2,0);transpose_pack(uw,GUOUT,H,w2.data(),t2,GUOUT);
             cg.packB(l,w2.data(),H,t2,gsc[l]);
-        }free(gw);free(uw);
-        int dr2,dc2;float*dw=dequant_i8_to_float_ex(i8p(dp[l]),d_i8,DIN,&dr2,&dc2);
+        }
         std::vector<float>wd((size_t)DIN*DOUT);transpose_pack(dw,DOUT,DIN,wd.data(),DOUT,0);
-        cd.packB(l,wd.data(),DIN,DOUT,dsc[l]);free(dw);}
+        cd.packB(l,wd.data(),DIN,DOUT,dsc[l]);
+#ifdef ONEBP_SUPPORT
+        if (!is_onebp) {
+#endif
+        free(qw);free(kw);free(vw);free(ow);free(gw);free(uw);free(dw);
+#ifdef ONEBP_SUPPORT
+        }
+#endif
+    }
     fprintf(stderr,"  %.0fms\n\n",std::chrono::duration<double,std::milli>(std::chrono::steady_clock::now()-tp).count());
 
     // RoPE

--- a/tools/gguf_to_onebp.cpp
+++ b/tools/gguf_to_onebp.cpp
@@ -100,8 +100,12 @@ int main(int argc, char** argv) {
     gu("vocab_size", hdr.vocab_size);
     if (!hdr.vocab_size) {
         // Some GGUF files omit vocab_size — infer from token_embd.weight shape.
+        // GGUF ne[] convention: shape[0] = embedding_length (hidden), shape[1] =
+        // vocab_size — this used to read shape[0], silently writing hidden_size
+        // into the vocab_size field (e.g. 1024 instead of the real 151936).
         auto* emb = reader.tensor_info("token_embd.weight");
-        if (emb && emb->shape.size() >= 1) hdr.vocab_size = (int)emb->shape[0];
+        if (emb && emb->shape.size() >= 2) hdr.vocab_size = (int)emb->shape[1];
+        else if (emb && emb->shape.size() >= 1) hdr.vocab_size = (int)emb->shape[0];
     }
     if (!hdr.vocab_size) {
         // Fallback: try tokenizer.ggml.tokens array count
@@ -121,19 +125,34 @@ int main(int argc, char** argv) {
     FILE* fout = fopen(argv[2], "wb");
     if (!fout) { perror("fopen"); return 1; }
 
-    struct TInfo { std::string name; int rows, cols; uint64_t offset, tiled; };
+    // ndim=1 (norm weights, biases) are stored as raw float32 — no tiling/
+    // quantization, matching OnebpModel::get_tensor_f32's ndim==1 branch
+    // (a plain memcpy). Previously these were unconditionally dropped
+    // (shape.size() != 2 filtered out every 1D tensor), which meant every
+    // .1bp file ever produced was missing all its normalization weights —
+    // structurally incapable of correct inference. See issue #1023.
+    struct TInfo { std::string name; int ndim; int rows, cols; uint64_t offset, tiled; };
     std::vector<TInfo> tensors;
     uint64_t data_off = 0;
     int tr = 32, tc = 256, gs = 32;
 
     for (auto& tn : reader.tensor_names()) {
         auto* inf = reader.tensor_info(tn);
-        if (!inf || inf->shape.size() != 2) continue;
+        if (!inf) continue;
+        if (inf->shape.size() == 1) {
+            int len = (int)inf->shape[0];
+            if (len <= 0) continue;
+            uint64_t raw_bytes = (uint64_t)len * 4;  // f32, unquantized
+            tensors.push_back({tn, 1, 1, len, data_off, raw_bytes});
+            data_off += raw_bytes;
+            continue;
+        }
+        if (inf->shape.size() != 2) continue;
         int c = (int)inf->shape[0], r = (int)inf->shape[1];
         if (r <= 0 || c <= 0) continue;
         if ((uint64_t)r * (uint64_t)c > 200000000) continue;
         uint64_t tiled = onebp_tiled_size(r, c, tr, tc, gs, quant);
-        tensors.push_back({tn, r, c, data_off, tiled});
+        tensors.push_back({tn, 2, r, c, data_off, tiled});
         data_off += tiled;
         if (tensors.size() <= 3) printf("  tensor %s: %dx%d tiled=%lu\n", tn.c_str(), r, c, tiled);
     }
@@ -143,15 +162,26 @@ int main(int argc, char** argv) {
     // Write header NOW with correct tensor_count
     fwrite(&hdr, sizeof(hdr), 1, fout);
 
-    // Compute index size and fix up tensor offsets to account for header + index
+    // Offsets are written RELATIVE to the start of the data section — do NOT
+    // add header+index size here. OnebpModel's reader (onebp_loader.cpp)
+    // already does exactly that conversion itself ("Fix offsets: they are
+    // relative to data_start", t.file_offset += data_start), by design. This
+    // used to also add data_base here, so every stored offset was absolute
+    // already — the reader then added data_start a second time on top,
+    // landing every tensor read ~(header+index size) bytes past its real
+    // data, into the middle of whichever tensor happened to be there. That's
+    // why every dequantized value was garbage regardless of which model or
+    // even whether the tensor was 1D or 2D — confirmed by hand: reading the
+    // *true* (non-double-counted) offset for token_embd.weight lines up
+    // exactly with the scale bytes the quantizer actually wrote.
+    //
+    // dims[] is ndim*4 bytes, not always 8 — the reader parses exactly
+    // `ndim` uint32 dims per entry, so a fixed 8-byte assumption here would
+    // additionally desync every entry after the first ndim==1 tensor.
     uint64_t index_size = 0;
     for (auto& t : tensors) {
         uint32_t nl = std::min((uint32_t)t.name.size(), (uint32_t)63);
-        index_size += 4 + nl + 1 + 4 + 8 + 8 + 8;  // name_len + name + \0 + ndim + dims[2] + offset + bytes
-    }
-    uint64_t data_base = sizeof(OnebpHeader) + index_size;
-    for (auto& t : tensors) {
-        t.offset += data_base;
+        index_size += 4 + nl + 1 + 4 + (uint32_t)t.ndim * 4 + 8 + 8;  // name_len + name + \0 + ndim + dims[ndim] + offset + bytes
     }
 
     // Write tensor index
@@ -160,10 +190,15 @@ int main(int argc, char** argv) {
         fwrite(&nl, 4, 1, fout);
         fwrite(t.name.data(), 1, nl, fout);
         fwrite("\0", 1, 1, fout);
-        uint32_t nd = 2;
+        uint32_t nd = (uint32_t)t.ndim;
         fwrite(&nd, 4, 1, fout);
-        uint32_t d[2] = {(uint32_t)t.rows, (uint32_t)t.cols};
-        fwrite(d, 8, 1, fout);
+        if (t.ndim == 1) {
+            uint32_t d1 = (uint32_t)t.cols;  // length
+            fwrite(&d1, 4, 1, fout);
+        } else {
+            uint32_t d[2] = {(uint32_t)t.rows, (uint32_t)t.cols};
+            fwrite(d, 8, 1, fout);
+        }
         fwrite(&t.offset, 8, 1, fout);
         fwrite(&t.tiled, 8, 1, fout);
     }
@@ -183,6 +218,12 @@ int main(int argc, char** argv) {
         fflush(stdout);
         if (!reader.get_tensor_f32(ti.name, fw)) {
             printf("SKIP (get_tensor_f32 failed)\n"); continue;
+        }
+        if (ti.ndim == 1) {
+            // Raw, unquantized float32 — no tiling (norm weights, biases).
+            fwrite(fw.data(), 4, fw.size(), fout);
+            printf("  %-50s %4d     (raw f32) -> %zu KB\n", ti.name.c_str(), (int)fw.size(), ti.tiled / 1024);
+            continue;
         }
         printf("got %zu floats, tiling...\n", fw.size()); fflush(stdout);
         int R = ti.rows, C = ti.cols;


### PR DESCRIPTION
## Summary

Two independent, compounding bugs affected **every model in the 38-entry `.1bp` catalog** since the format's creation — confirmed by testing against a file converted with the completely untouched original code, so this predates this PR entirely:

1. **`gguf_to_onebp.cpp` dropped every 1D tensor** (`if (shape.size() != 2) continue`) — every normalization weight, every model, gone from every `.1bp` file ever produced.
2. **The real one — a double-counted file offset.** The index writer stored *absolute* tensor offsets (header+index size baked in), but the reader (`onebp_loader.cpp`, untouched) adds that same header+index size *again* per its own documented contract ("offsets are relative to data_start"). Every tensor read landed deep in the wrong place, reading whatever unrelated tensor's bytes happened to be there — explaining the astronomically-scaled garbage values (~1e23) regardless of model or tensor. Root-caused by hand: computed the true non-double-counted offset for `token_embd.weight` and confirmed the bytes there exactly matched the scale value the quantizer had actually written.

## Also fixed

- `vocab_size` inference fallback read the wrong GGUF shape dimension (hidden_size instead of real vocab_size)
- `npu_engine_universal.cpp`'s `.1bp` loading path only ever loaded token embeddings — every other tensor still went through the Q4NX-only JSON-offset lookup unconditionally, misreading the binary header and segfaulting. Added the missing branches.
- Same file's `is_onebp` path never populated `cfg.model_tag` or any xclbin dimension field, so NPU init failed looking for `insts_i8_QKV_.txt` (empty tag)
- `engine/npu/CMakeLists.txt`: `install(TARGETS ...)` on IMPORTED executables is invalid CMake, blocked reconfiguring the entire npu build tree
- Dead XRT link dependency (`xrt_wrapper.cpp`, unreferenced by any target, written against a newer XRT API than what's installed)

## Verification

- Rebuilt `npu_engine_universal` clean
- Confirmed real weight values decode correctly post-fix: was `1e23`-scale garbage, now `0.0025/-0.0018/-0.0105/...` (real transformer weight magnitudes)
- Got past NPU init and into real per-layer kernel execution for the first time (previously segfaulted before finishing model load)
- Re-converted and spot-checked **12 models** against the fixed converter (7 new catalog candidates + 5 existing entries including the ZAYA1-8B flagship) — every one decodes to sane values now

## Not fixed here, tracked separately

Per-layer NPU kernel *execution* itself is extremely slow or hung (>3 min for layer 1 of 28) — filed as #1029. That's a kernel-dispatch question; the data being fed into the kernels is now provably correct, which is what this PR is about.

Fixes #1023. Related: #1022, #1029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)