### PR TITLE
fix(site): force hero H1 line break instead of relying on text-wrap:balance

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -211,7 +211,7 @@
     <div>
       <span class="eyebrow">AMD Strix Halo · Ryzen AI Max+ 395</span>
       <div style="margin-top:14px;"><span class="pill warn" style="font-size:12px;height:28px;padding:0 14px;"><span class="dot"></span>⚡ One binary to rule them all</span></div>
-      <h1><span class="g">40 models.</span> 9 backends. One binary.</h1>
+      <h1><span class="g">40 models.</span><br>9 backends. One binary.</h1>
       <p style="margin-top:2px;font-size:clamp(22px,2.8vw,34px);font-weight:800;letter-spacing:-.025em;line-height:1.04;color:var(--blue);">Model-agnostic inference. Zero Python. MIT.</p>
       <p class="sub">Drop any GGUF model — auto-detects architecture, quantization, and routes to NPU (XDNA 2), GPU (ROCm/Vulkan), or CPU. No config files. No model registry.</p>
       <div class="cta-row">


### PR DESCRIPTION
## Summary

- The hero heading `40 models. 9 backends. One binary.` had no explicit line break — `text-wrap:balance` on the `<h1>` decided the wrap point itself.
- `text-wrap: balance` is a heuristic multi-pass layout algorithm; its chosen break point can vary by browser engine/version and web-font load timing. That's why "9" intermittently rendered at the end of line 1 with "40 models." instead of starting line 2 — the content never changed, the heuristic's guess did.
- Fix: force the break explicitly with `<br>` so it no longer depends on layout timing.

## Test plan

- [x] Confirmed no other occurrence of this H1 pattern exists elsewhere in `site/`
- [ ] Visual check on the deployed preview that the H1 now renders as two lines consistently