### PR TITLE
docs(backend_manager): correct PILOT's disable-site reasoning, document real hazard

### DIFF
--- a/src/backend_manager.cpp
+++ b/src/backend_manager.cpp
@@ -357,9 +357,19 @@ bool BackendManager::init_in_order(const ModelConfig& cfg, const std::string& we
             if (pm) pm->healthy = true;
 
             // Initialize cross-layer prefetch pilot
-            // NOTE: Disabled pending investigation of heap corruption (issue #932).
-            // The worker thread calling preload_layer() may race with httplib
-            // completion handlers. Re-enable when the root cause is found.
+            // NOTE: Disabled — issue #932 (the original reason cited here) turned
+            // out to be an unrelated nlohmann::json UTF-8 serialization bug, fixed
+            // in #944 independent of PILOT. Re-investigated for #1021 and found a
+            // real, still-open hazard instead: PILOT's worker thread captures
+            // `raw` (this backend instance) and runs independently of
+            // BackendManager's mutexes. unified_server.cpp supports live model
+            // reload (mgr.init() called again on an already-running
+            // BackendManager, see tools/unified_server.cpp:125) — a reload
+            // replaces info.instance (destroying the old backend) with no
+            // coordination with PILOT's background thread, which can still be
+            // calling raw->preload_layer() on the now-freed instance. Needs
+            // pilot_.stop() (or equivalent) wired into the reload path in
+            // BackendManager::init()/init_in_order() before re-enabling this.
             // if (raw) {
             //     raw->set_pilot(&pilot_);
             //     pilot_.init(cfg.num_layers, info.type,


### PR DESCRIPTION
## Summary

Addresses #1021 (does not close it — the underlying hazard is still unfixed, see below).

The comment disabling PILOT prefetch blamed issue #932. Checked: #932 was actually an unrelated \`nlohmann::json\` UTF-8 serialization bug in the completions response path, fixed in #944 without touching PILOT or \`backend_manager.cpp\` at all. The two were just disabled/discovered in the same time window.

Investigated whether PILOT is actually safe to re-enable now that #932 is closed. Findings:

- PILOT's own internal synchronization (\`preload_mutex_\`, atomics) is solid.
- The only backend implementing \`preload_layer()\` (CPU) is pure read-only \`__builtin_prefetch\` — no shared mutable state, safe under concurrent reads.
- **But**: \`unified_server.cpp\` supports live model reload (\`mgr.init()\` called again on an already-running \`BackendManager\` — see \`tools/unified_server.cpp:125\`'s own doc comment). A reload replaces \`info.instance\`, destroying the old backend, with zero coordination with PILOT's background worker thread — which captured a raw pointer to that instance at first init and can still be calling \`preload_layer()\` on it. That's a genuine use-after-free, independent of #932, and still unaddressed in the codebase today.

## Decision

Don't re-enable PILOT in this PR — the real fix needs \`pilot_.stop()\` (or equivalent) wired into the model-reload path in \`BackendManager::init()\`/\`init_in_order()\` before it's safe, and that's a big enough change to deserve its own PR with its own reload-under-load stress test (not just concurrent-completions-on-one-model, which is what #932's validation covered and wouldn't have caught this). This PR only fixes the stale/misleading comment so the next person doesn't re-enable PILOT on the mistaken belief that #932 being closed makes it safe.

## Test plan

- [x] `cmake --build build --target backend_manager` — builds clean (comment-only change)