### PR TITLE
fix(backend_manager): re-enable PILOT cross-layer prefetch, close #1021

### DIFF
--- a/src/backend_manager.cpp
+++ b/src/backend_manager.cpp
@@ -320,6 +320,19 @@ bool BackendManager::init(const ModelConfig& cfg, const std::string& weights_dir
 
 bool BackendManager::init_in_order(const ModelConfig& cfg, const std::string& weights_dir,
                                     const std::vector<size_t>& order) {
+    // Model reload safety (#1021): unified_server can call init()/init_in_order()
+    // again on an already-running BackendManager to reload/switch models. That
+    // replaces info.instance below, destroying the previous backend instance.
+    // PILOT's worker thread holds a raw pointer to whichever instance was active
+    // when it started and calls preload_layer() on it independent of mtx_ (which
+    // this function's caller already holds, but the worker thread doesn't need
+    // it). Stop the worker BEFORE any instance gets replaced, or a reload racing
+    // the worker thread is a use-after-free.
+    if (pilot_active_) {
+        pilot_.stop();
+        pilot_active_ = false;
+    }
+
     // Try each backend in the given order until one initializes.
     for (size_t idx : order) {
         auto& info = backends_[idx];
@@ -356,30 +369,25 @@ bool BackendManager::init_in_order(const ModelConfig& cfg, const std::string& we
             auto* pm = monitor_.for_backend(info.id);
             if (pm) pm->healthy = true;
 
-            // Initialize cross-layer prefetch pilot
-            // NOTE: Disabled — issue #932 (the original reason cited here) turned
-            // out to be an unrelated nlohmann::json UTF-8 serialization bug, fixed
-            // in #944 independent of PILOT. Re-investigated for #1021 and found a
-            // real, still-open hazard instead: PILOT's worker thread captures
-            // `raw` (this backend instance) and runs independently of
-            // BackendManager's mutexes. unified_server.cpp supports live model
-            // reload (mgr.init() called again on an already-running
-            // BackendManager, see tools/unified_server.cpp:125) — a reload
-            // replaces info.instance (destroying the old backend) with no
-            // coordination with PILOT's background thread, which can still be
-            // calling raw->preload_layer() on the now-freed instance. Needs
-            // pilot_.stop() (or equivalent) wired into the reload path in
-            // BackendManager::init()/init_in_order() before re-enabling this.
-            // if (raw) {
-            //     raw->set_pilot(&pilot_);
-            //     pilot_.init(cfg.num_layers, info.type,
-            //         [raw](int layer, PilotBackend pb) -> bool {
-            //             return raw->preload_layer(layer);
-            //         });
-            //     pilot_.start_worker();
-            //     pilot_active_ = true;
-            //     printf("  → PILOT prefetch active (%d layers)\n", cfg.num_layers);
-            // }
+            // Initialize cross-layer prefetch pilot (#1021).
+            // Previously disabled citing #932 (actually an unrelated JSON bug —
+            // see #944 — that never touched PILOT). Re-investigated: the real
+            // hazard was a reload racing PILOT's worker thread against
+            // info.instance being replaced/destroyed. Fixed above — this
+            // function stops any running pilot worker before touching any
+            // backend instance, so `raw` below can never outlive the worker
+            // that captured it.
+            if (raw) {
+                raw->set_pilot(&pilot_);
+                pilot_.init(cfg.num_layers, info.type,
+                    [raw](int layer, PilotBackend pb) -> bool {
+                        (void)pb;
+                        return raw->preload_layer(layer);
+                    });
+                pilot_.start_worker();
+                pilot_active_ = true;
+                printf("  → PILOT prefetch active (%d layers)\n", cfg.num_layers);
+            }
 
             return true;
         }

--- a/tests/test_backend.cpp
+++ b/tests/test_backend.cpp
@@ -8,6 +8,7 @@
 // run on a system with ROCm/Vulkan installed.
 
 #include "backend.h"
+#include "backend_manager.h"
 #include "simple_tokenizer.h"
 #include <cstdio>
 #include <cmath>
@@ -129,6 +130,34 @@ int main(int argc, char** argv) {
         for (int t : output_tokens) printf("%d ", t);
         printf("\n");
         printf("  Text: '%s'\n", gen_text.c_str());
+    }
+
+    // ── 6. PILOT reload safety (#1021) ──
+    // BackendManager::init_in_order() must stop() any running PILOT worker
+    // before replacing a backend instance, or a reload racing the worker
+    // thread's captured raw pointer is a use-after-free. Exercise the actual
+    // race window: run forward() a few times to get PILOT's worker actively
+    // preloading, then immediately reload (init() again) while it's live.
+    printf("\n─━─━─ 6. PILOT reload safety (#1021) ─━─━─\n");
+    {
+        auto& mgr = backend_manager();
+        mgr.discover();
+        mgr.set_strategy(SelectionStrategy::MANUAL);
+        std::vector<std::string> cpu_only = {"cpu_scalar"};
+        if (mgr.init(cfg, weights_dir, cpu_only)) {
+            printf("  ✅ first init OK\n");
+            for (int i = 0; i < 3; i++) mgr.forward(100, hidden);  // drive PILOT worker activity
+            auto t0 = std::chrono::high_resolution_clock::now();
+            bool reload_ok = mgr.init(cfg, weights_dir, cpu_only);  // reload while pilot is live
+            float reload_ms = std::chrono::duration<float, std::milli>(
+                std::chrono::high_resolution_clock::now() - t0).count();
+            printf("  %s reload while PILOT active: %.1f ms\n",
+                   reload_ok ? "✅" : "❌", reload_ms);
+            for (int i = 0; i < 3; i++) mgr.forward(100, hidden);  // still alive post-reload?
+            printf("  ✅ post-reload forward() survived — no crash, no hang\n");
+        } else {
+            printf("  ⚠️  first init failed — skipping (weights not found at %s)\n", weights_dir.c_str());
+        }
     }
 
     // ── Cleanup ──


### PR DESCRIPTION
## Summary

Closes #1021.

#1037 documented (without fixing) a real hazard: PILOT's worker thread captures a raw backend pointer, and unified_server's live model reload (\`mgr.init()\` called again on a running \`BackendManager\`) replaces that instance with no coordination — a genuine use-after-free, distinct from the originally-cited (and unrelated) #932.

## Fix

\`init_in_order()\` now stops any running PILOT worker (\`pilot_.stop()\`) before touching any backend instance, so a reload can never race the worker thread's captured pointer. With that guaranteed, re-enabled the PILOT init block that was commented out.

## Verification

Added a regression test (\`tests/test_backend.cpp\`, section 6) that exercises the actual race window — not just generic concurrency:
1. Init, run 3 \`forward()\` calls to get PILOT's worker actively preloading
2. Reload (\`init()\` again) immediately while it's live
3. Run 3 more \`forward()\` calls post-reload

Ran against the real ZAYA1-8B weights on this box:

\`\`\`
[PILOT] initialized: 40 layers, active=CPU, warmup=3 tokens
[PILOT] worker thread started
  → PILOT prefetch active (40 layers)
  ✅ first init OK
[PILOT] warmed up after 3 tokens
BackendManager: trying cpu_scalar ...
  → ✅ initialized successfully
[PILOT] initialized: 40 layers, active=CPU, warmup=3 tokens
[PILOT] worker thread started
  → PILOT prefetch active (40 layers)
  ✅ reload while PILOT active: 52649.8 ms
[PILOT] warmed up after 3 tokens
  ✅ post-reload forward() survived — no crash, no hang
\`\`\`

Clean stop/restart of the worker thread on reload, no crash, no hang, PILOT correctly re-warms up on the new instance.

## Test plan

- [x] `cmake --build build --target backend_manager` — builds clean
- [x] `cmake --build build --target test_backend` — builds clean
- [x] Ran `test_backend` against real ZAYA1-8B weights — reload-while-PILOT-active survives cleanly