### PR TITLE
fix(ci): stop production service around smoke test to avoid GPU contention

### DIFF
--- a/.github/workflows/end-to-end-smoke.yml
+++ b/.github/workflows/end-to-end-smoke.yml
@@ -27,6 +27,18 @@ jobs:
           cmake -B build -G Ninja
           cmake --build build --target unified_server -j$(nproc)
 
+      - name: Stop production service (issue #1036)
+        # This runner is the same box as the always-on production
+        # 1bit-systems.service (unified_server, port 8088). Every historical
+        # run of this workflow failed — the CI instance's health check never
+        # connected because it was contending with the production instance
+        # for the same physical GPU (both hold /dev/accel/accel0 /
+        # ROCm device access). Stop it for the duration of this job; restarted
+        # unconditionally in Cleanup below.
+        run: |
+          sudo systemctl stop 1bit-systems.service || true
+          sleep 2
+
       - name: Start server
         run: |
           rm -f /tmp/unified_server.lock
@@ -110,3 +122,4 @@ jobs:
         run: |
           pkill -f "unified_server.*8099" 2>/dev/null || true
           rm -f /tmp/unified_server.lock
+          sudo systemctl start 1bit-systems.service || true


### PR DESCRIPTION
## Summary

Closes #1036.

The \`End-to-End Smoke Test\` workflow has failed on 15/15 historical runs, across completely unrelated PRs — never tied to the actual change under test. Root cause: this runner (\`[self-hosted, strix-halo]\`) is the same physical box as the always-on production \`1bit-systems.service\` (\`unified_server\`, port 8088), and the workflow's own CI-spawned instance (port 8099) contends with it for the same GPU.

## Verification (done directly on this box, not just theorized)

- With production running: manually reproduced the workflow's exact \`unified_server\` invocation. Log showed it getting through tokenizer load + KV-cache allocation, then hanging indefinitely — never reached backend init, \`/v1/health\` never responded.
- With production stopped (\`sudo systemctl stop 1bit-systems.service\`): the same invocation initialized fully — hardware discovery, model load, backend init — and \`/v1/health\` returned \`{"status":"ok",...}\` within seconds.
- Restarted production afterward, confirmed it came back healthy (\`/v1/health\` → \`ok\`, ~30s reload).

## Fix

- Added a \"Stop production service\" step before \"Start server\", stopping \`1bit-systems.service\`.
- Cleanup (\`if: always()\`) now restarts it unconditionally, so it comes back even if an earlier step in the job fails.

## Test plan

- [x] Reproduced the failure and the fix manually on the actual runner box (see Verification above)
- [ ] This PR's own CI run of the (now self-referentially-fixed) smoke-test workflow should be the first one in its history to pass