### PR TITLE
fix(npu): AttnCtx patch_value crash — xrt::ext::bo binds to the wrong operator() overload

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -60,6 +60,7 @@ jobs:
           g++ -std=c++23 -O3 -march=native -fopenmp -ffast-math \
             -o engine/npu/build/npu_engine_v12 \
             engine/npu/src/npu_engine_universal.cpp engine/npu/build/dequant_q4nx.o \
+            engine/npu/src/gemm_npu_instructions.cpp \
             npu-infer/src/flm_bridge.cpp \
             -Iengine/npu/include -Inpu-infer/include -Iinclude \
             -I/opt/xrt/include -Iengine/npu -I. \

--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -319,7 +319,20 @@ struct AttnCtx {
         bQ->sync(XCL_BO_SYNC_BO_TO_DEVICE);
         size_t kv_bytes = (size_t)cur_seq * NKV * HD;
         if (kv_bytes > 0) { bK->sync(XCL_BO_SYNC_BO_TO_DEVICE, kv_bytes, 0); bV->sync(XCL_BO_SYNC_BO_TO_DEVICE, kv_bytes, 0); }
-        return k->operator()(3, 0, 0, *bQ, *bK, *bV, *bOut);
+        // Explicit xrt::bo& casts: xrt::ext::bo derives from xrt::bo, and
+        // xrt::kernel::operator() has both a generic scalar template
+        // (set_arg(int, ArgType&&) -> set_arg_at_index(idx, &arg, sizeof(arg)))
+        // and a dedicated xrt::bo& overload. Passing the derived ext::bo
+        // directly resolves to the template (an exact-type match beats the
+        // derived-to-base binding the xrt::bo& overload needs), which patches
+        // sizeof(xrt::ext::bo) raw bytes of the C++ wrapper itself instead of
+        // the buffer handle -- the source of "patch_value() only supports
+        // 64-bit values or less" (issue #1066). Casting to xrt::bo& first
+        // makes both overloads equally-ranked identity matches, so the
+        // standard non-template-preferred tie-break selects the real one.
+        return k->operator()(3, 0, 0,
+            static_cast<xrt::bo&>(*bQ), static_cast<xrt::bo&>(*bK),
+            static_cast<xrt::bo&>(*bV), static_cast<xrt::bo&>(*bOut));
     }
     void fast_finish(xrt::run& r, float* out, int batch, float q_scale) { r.wait(); bOut->sync(XCL_BO_SYNC_BO_FROM_DEVICE);
         auto* out_i16 = (int16_t*)bOut->map(); float cs = q_scale * cur_kv_scale;
@@ -345,7 +358,20 @@ struct AttnCtx {
             q = (int)roundf(v * kv_is); v_i8[i] = (int8_t)(q > 127 ? 127 : (q < -127 ? -127 : q));
         }
         bK->sync(XCL_BO_SYNC_BO_TO_DEVICE); bV->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        return k->operator()(3, 0, 0, *bQ, *bK, *bV, *bOut);
+        // Explicit xrt::bo& casts: xrt::ext::bo derives from xrt::bo, and
+        // xrt::kernel::operator() has both a generic scalar template
+        // (set_arg(int, ArgType&&) -> set_arg_at_index(idx, &arg, sizeof(arg)))
+        // and a dedicated xrt::bo& overload. Passing the derived ext::bo
+        // directly resolves to the template (an exact-type match beats the
+        // derived-to-base binding the xrt::bo& overload needs), which patches
+        // sizeof(xrt::ext::bo) raw bytes of the C++ wrapper itself instead of
+        // the buffer handle -- the source of "patch_value() only supports
+        // 64-bit values or less" (issue #1066). Casting to xrt::bo& first
+        // makes both overloads equally-ranked identity matches, so the
+        // standard non-template-preferred tie-break selects the real one.
+        return k->operator()(3, 0, 0,
+            static_cast<xrt::bo&>(*bQ), static_cast<xrt::bo&>(*bK),
+            static_cast<xrt::bo&>(*bV), static_cast<xrt::bo&>(*bOut));
     }
     void finish_all(xrt::run& r, float* out, int batch, float q_scale, float kv_scale) {
         (void)kv_scale; r.wait(); bOut->sync(XCL_BO_SYNC_BO_FROM_DEVICE);


### PR DESCRIPTION
## Summary

Closes #1066. `xrt::ext::bo` derives from `xrt::bo`, and `xrt::kernel::operator()` (inherited by `xrt::ext::kernel`) has both a generic scalar template (`set_arg(int, ArgType&&)` → `set_arg_at_index(idx, &arg, sizeof(arg))`) and a dedicated `xrt::bo&` overload. Per C++ overload resolution, passing an `xrt::ext::bo&` picks the **template** — an exact-type match beats the derived-to-base binding the `xrt::bo&` overload needs — so it patches `sizeof(xrt::ext::bo)` raw bytes of the C++ wrapper object itself instead of the real buffer handle. That's the actual source of `patch_value() only supports 64-bit values or less`.

Fix: explicit `static_cast<xrt::bo&>` on each argument at both `AttnCtx` call sites (`launch()`, `launch_all()`) — this makes both overloads equally-ranked identity matches, so the standard non-template-preferred tie-break correctly selects the buffer-handling overload.

## Also resolves the last blocker from #1060

Ran a full end-to-end smoke test against the real `qwen3_0_6b.q4nx` model after this fix: **28-layer prefill + 5-token decode completes cleanly (exit 0)** — no crash, no hang, varying token IDs each step, device healthy throughout (`xrt-smi examine` clean).

This also appears to resolve #1060 (I8Ctx GEMM-dispatch hang) — that issue was filed 2026-07-28T14:36Z, and commit `88bc7f99f` (2026-07-28T18:00Z, already on `main`) landed a matching per-layer-BO sync fix (#1061) afterward but was never re-verified end-to-end. This is the first full clean run since. Leaving #1060 open with a comment rather than closing it directly, since I didn't fix it myself in this PR — just providing evidence it no longer reproduces.

## Test plan

- [x] Rebuilt `npu_engine_universal` clean
- [x] `xrt-smi examine` health check before/after
- [x] Full run against real `qwen3_0_6b.q4nx`: prefill (28 layers) + decode (5 tokens), exit 0, no crash/hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)
