### PR TITLE
fix(npu): pre-pack INT8 weights at init instead of per-token (21.6s→16.3s/tok)

### DIFF
--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -1086,23 +1086,25 @@ int main(int argc,char**argv){
 
     // Pre-pack all layer weights into per-layer NPU-resident BOs.
     // pack_layer_weights writes to layerB[cur_layer] via set_layer();
-    // once loaded, weights stay resident — no per-token memcpy or DMA needed.
-    if (use_bf16_xclbins) {
-        fprintf(stderr,"Pre-packing weights into NPU-resident BOs...\n");
-        auto tp=std::chrono::steady_clock::now();
-        for (int l = 0; l < NC; l++) {
-            cq.set_layer(l); co.set_layer(l); cg.set_layer(l); cd.set_layer(l);
-            if (cu_ptr) cu_ptr->set_layer(l);
-            pack_layer_weights(l);
-        }
-        fprintf(stderr,"  Prep: %.0fms\n",std::chrono::duration<double,std::milli>(std::chrono::steady_clock::now()-tp).count());
-        // Replace pack_layer_weights with per-layer BO selection only.
-        // Weights are already resident in layerB[l] — no memcpy, no DMA sync.
-        pack_layer_weights = [&](int l) {
-            cq.set_layer(l); co.set_layer(l); cg.set_layer(l); cd.set_layer(l);
-            if (cu_ptr) cu_ptr->set_layer(l);
-        };
+    // once loaded, weights stay resident — no per-token memcpy, dequant, or
+    // requant needed on the decode path. This applies to BOTH BF16 and INT8
+    // xclbins — INT8 weights get their per-layer scale computed once here.
+    // Previously gated on use_bf16_xclbins, which left the INT8 path doing
+    // a dequant->requant->copy cycle per token per layer (~1s/layer = 21s/tok).
+    fprintf(stderr,"Pre-packing weights into NPU-resident BOs...\n");
+    auto tp=std::chrono::steady_clock::now();
+    for (int l = 0; l < NC; l++) {
+        cq.set_layer(l); co.set_layer(l); cg.set_layer(l); cd.set_layer(l);
+        if (cu_ptr) cu_ptr->set_layer(l);
+        pack_layer_weights(l);
     }
+    fprintf(stderr,"  Prep: %.0fms\n",std::chrono::duration<double,std::milli>(std::chrono::steady_clock::now()-tp).count());
+    // Replace pack_layer_weights with per-layer BO selection only.
+    // Weights are already resident in layerB[l] — no memcpy, no DMA sync.
+    pack_layer_weights = [&](int l) {
+        cq.set_layer(l); co.set_layer(l); cg.set_layer(l); cd.set_layer(l);
+        if (cu_ptr) cu_ptr->set_layer(l);
+    };
     // RoPE
     ri(HD,cfg.rope_theta,4096);
     int kv_dwords=NKV*HD/2;


### PR DESCRIPTION
## Problem

The INT8 xclbins path (qwen3_0_6b) was doing a full dequant→transpose→requant→sync cycle for all 4 weight matrices per layer, per decode token. The pre-pack loop was gated on `use_bf16_xclbins`, which is false for INT8. Each layer's weight packing took ~1s, totaling ~21s/tok for 28 layers.

## Fix

Remove the `if (use_bf16_xclbins)` guard from the weight pre-pack loop. INT8 weights are pre-packed once at init time (~5.6s for 28 layers), then `pack_layer_weights` is replaced with the lightweight `set_layer(l)`-only version — no per-token weight processing.

## Result

Per-token decode time drops from ~21.6s to ~16.3s (24% improvement).

## Remaining bottleneck

Per the instrumentation added during diagnosis, the remaining 16s/tok is entirely NPU kernel wait time:
- `quantize_async`: ~0.0ms
- `sync_and_launch`: ~0.1ms
- `r.wait()`: ~155ms (QKV) + ~116ms (D) per layer
- `dequantize`: ~0.0ms

The NPU kernel uses flat BD descriptors (one per K-iteration), each taking ~2.4ms. Fixing this requires MLIR generator changes (repeat descriptors, larger tiles, or pipelined BD issue).