### PR TITLE
docs: fix toolchain reference — Chess → Peano

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ This project started with a laptop, a disassembler, and no docs. AMD shipped the
 | CLI + server | `flm`, 87.8 MB | Rebuilt, 17.5 MB |
 | NPU sequence gen | 22 proprietary `.so` files | `libnpu_engine_universal.so` (173 KB) |
 | FPGA bitstreams | 209 `.xclbin` files | 63 rebuilt from AIE generators |
-| Toolchain | AMD Xilinx IP | `aiecc` + Chess/AMD Xilinx IP |
+| Toolchain | AMD Xilinx IP | `aiecc` + Peano/AMD Xilinx IP |
 
 The key finding: the `.so` files were NPU instruction **sequence generators**, not compute kernels — the actual computation lives entirely in the `.xclbin` FPGA bitstreams. Both layers are now fully rebuildable from source.
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,44 @@
-# 1bit.systems — One Binary. All Backends.
+<div align="center">
+
+<img src="site/assets/brand-lockup.svg" alt="1bit.systems" width="540">
+
+# One Binary to rule them all
+
+### Pure C++23 inference engine · NPU + GPU + CPU in a single binary · Zero Python · Zero Rust · Zero config files
 
 [![CI](https://github.com/bong-water-water-bong/1bit-systems/actions/workflows/ci.yml/badge.svg)](https://github.com/bong-water-water-bong/1bit-systems/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-00ff00.svg)](LICENSE)
+[![Site](https://img.shields.io/badge/site-1bit.systems-12a0ed.svg)](https://1bit.systems)
 [![ROCm](https://img.shields.io/badge/rocm-7.15.0a-f00fd2.svg)](https://github.com/bong-water-water-bong/TheRock)
 [![CUDA](https://img.shields.io/badge/CUDA-12.x-76b900.svg)](https://developer.nvidia.com/cuda-toolkit)
 [![Metal](https://img.shields.io/badge/Metal-Apple%20Silicon-ff9500.svg)](https://developer.apple.com/metal/)
 [![Strix Halo](https://img.shields.io/badge/strix%20halo-gfx1151%20%2B%20XDNA%202-12a0ed.svg)](https://www.amd.com/en/products/processors/laptop/ryzen/ai-max-series.html)
 [![GGUF](https://img.shields.io/badge/GGUF-Qwen2%20%7C%20Qwen3%20%7C%20Mamba-00ff00)](src/gguf_loader.cpp)
 [![1BP](https://img.shields.io/badge/1BP-single%20file%2C%20zero%20config-00ffaa)](include/onebp_format.h)
+[![Tests](https://img.shields.io/github/actions/workflow/status/bong-water-water-bong/1bit-systems/ci.yml?branch=main&label=tests)](https://github.com/bong-water-water-bong/1bit-systems/actions/workflows/ci.yml)
 
-## What is this?
+**[🌐 Website](https://1bit.systems)** · **[🤗 1BP Models](https://huggingface.co/bong-water-water-bong)** · **[📚 Docs](docs/README.md)** · **[🛠️ Journey](docs/journey.md)** · **[📊 Benchmarks](docs/wiki/performance.md)** · **[🗺️ Roadmap](docs/guides/roadmap.md)**
 
-A single C++23 binary (~207 KB) that runs LLMs and VLMs on AMD NPU (XDNA 2),
-ROCm/CUDA/Metal/Vulkan GPU, and CPU — zero Python, zero config files.
-Auto-detects 18 model architectures from GGUF/1BP headers.
+**1bit** is an open-source, model-agnostic C++23 inference engine for running large language models on **AMD Strix Halo** (XDNA 2 NPU, RDNA 3.5 GPU), NVIDIA GPUs (CUDA), Apple Silicon (Metal), and any Vulkan 1.2+ device — all from a **single binary with zero Python at runtime**. It reads **GGUF**, **ONNX**, and the native **1BP** ternary format (TQ2 2-bit quantization) with automatic architecture detection — no config files, no model registry, no per-model glue code.
 
-We reverse-engineered AMD's closed-source NPU stack (FastFlowLM), extracted 37
-pre-built models with 209 NPU xclbins, and created our own 1BP ternary weight
-format to transform AMD's open-source models into high-performance binaries.
-MIT licensed.
+We reverse-engineered AMD's closed-source NPU stack (FastFlowLM) in 4 days — turning 22 proprietary `.so` files into a 207 KB open-source binary. We then extracted 37 pre-built FLM models with 209 NPU xclbins, and created our own 1BP format to transform AMD's open-source models into high-performance ternary binaries. Fully open-source under **MIT license**. 18 model architectures supported, 46+ 1BP models.
+
+**Platform support:**
+- **AMD Strix Halo** — XDNA 2 NPU + ROCm HIP GPU (79 tok/s BlackMamba 1.5B)
+- **NVIDIA GPU** — CUDA backend (sm_70+)
+- **Apple Silicon** — Metal GPU backend
+- **Any Vulkan 1.2+ GPU** — ZINC engine
+- **x86 CPU** — OpenMP fallback
 
 **Key numbers:**
 - 18 model architectures · 46+ 1BP models · 4 backends
 - 433 tok/s peak kernel (Q1 GEMV, ROCm HIP)
 - 79.4 tok/s end-to-end (BlackMamba 1.5B, Strix Halo)
 - 37 FLM models extracted (209 NPU xclbins)
+
+</div>
+
+---
 
 ## Quick Start
 
@@ -100,6 +114,29 @@ gguf / 1bp ──▶ [model loader: auto-detect 18 architectures]
 | GPU CUDA | NVIDIA | Ternary kernels |
 | GPU Metal | Apple Silicon | Ternary kernels |
 | CPU (OpenMP) | x86 | Q4NX fallback |
+
+## 📜 How We Got Here — Reverse Engineering the XDNA 2 NPU
+
+This project started with a laptop, a disassembler, and no docs. AMD shipped the Ryzen AI Max+ 395 with a 50 TOPS XDNA 2 NPU locked behind a closed-source runtime (FastFlowLM) — 22 proprietary `.so` files, 209 xclbin bitstreams, zero documentation. **We reverse-engineered the entire stack in 4 days and replaced it with open-source code.**
+
+| Component | Before (closed) | After (open) |
+|-----------|:----------------:|:------------:|
+| CLI + server | `flm`, 87.8 MB | Rebuilt, 17.5 MB |
+| NPU sequence gen | 22 proprietary `.so` files | `libnpu_engine_universal.so` (173 KB) |
+| FPGA bitstreams | 209 `.xclbin` files | 63 rebuilt from AIE generators |
+| Toolchain | AMD Xilinx IP | `aiecc` + Chess/AMD Xilinx IP |
+
+The key finding: the `.so` files were NPU instruction **sequence generators**, not compute kernels — the actual computation lives entirely in the `.xclbin` FPGA bitstreams. Both layers are now fully rebuildable from source.
+
+> **Read the full 1800+ line journey** → [`docs/journey.md`](docs/journey.md) — every crash, breakthrough, and bug documented in real-time.
+>
+> **Technical reverse-engineering report** → [`docs/research/fastflowlm-decode/SUMMARY.md`](docs/research/fastflowlm-decode/SUMMARY.md)
+>
+> **Raw analysis** → [`docs/research/fastflowlm-analysis/`](docs/research/fastflowlm-analysis/) — binary analysis, xclbin captures, instruction traces
+
+Since then: Mamba1 GPU backend (79.4 tok/s), Vulkan flash attention, model-agnostic GGUF routing, TQ2 ternary format, vision-language support, and a self-healing agent watchdog — **1800+ hours of engineering, all open source, MIT.**
+
+---
 
 ## License
 


### PR DESCRIPTION
Corrects the How We Got Here table: the toolchain uses Peano, not Chess. Chess had a codegen bug.