### PR TITLE
fix(ci): switch PR Agent to DeepSeek natively, fix silent MAX_TOKENS failure

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -24,8 +24,7 @@ jobs:
       - name: PR Agent
         uses: qodo-ai/pr-agent@d82f7d3e696cd00822694aaa3096265d3889f3f1  # v0.34
         env:
-          OPENAI_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_API_BASE: "https://api.opencode.ai/v1"
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           # SECURITY: GITHUB_TOKEN with contents:write scope is passed to the
           # third-party action qodo-ai/pr-agent. Mitigation: the job-level `if`
           # guard above restricts execution to same-repo PRs only; external

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,7 +1,7 @@
 [pr_agent]
-model = "opencode/glm-5.2"
-model_turbo = "opencode/glm-5.2"
-fallback_models = ["deepseek/deepseek-chat", "openai/gpt-4o-mini"]
+model = "deepseek/deepseek-chat"
+model_turbo = "deepseek/deepseek-chat"
+fallback_models = []
 verbosity_level = 2
 publish_output = true
 publish_output_progress = false
@@ -34,13 +34,12 @@ push_changelog_changes = true
 enable_help_text = false
 
 [config]
-model = "opencode/glm-5.2"
-fallback_models = ["deepseek/deepseek-chat", "openai/gpt-4o-mini"]
+model = "deepseek/deepseek-chat"
+fallback_models = []
 ignore_pr_labels = []
-# None of the above models are registered in pr-agent's internal MAX_TOKENS
+# deepseek/deepseek-chat isn't registered in pr-agent's internal MAX_TOKENS
 # table, so every review/description/suggestion call was throwing
-# "Ensure {model} is defined in MAX_TOKENS ... or set a positive value for
-# it in config.custom_model_max_tokens" and failing silently on every PR
-# since this file was added. 128000 is safe for all three models' real
-# context windows.
-custom_model_max_tokens = 128000
+# "Ensure deepseek/deepseek-chat is defined in MAX_TOKENS ... or set a
+# positive value for it in config.custom_model_max_tokens" and failing
+# silently on every PR. 64000 matches DeepSeek-V3's published context window.
+custom_model_max_tokens = 64000

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -37,3 +37,10 @@ enable_help_text = false
 model = "opencode/glm-5.2"
 fallback_models = ["deepseek/deepseek-chat", "openai/gpt-4o-mini"]
 ignore_pr_labels = []
+# None of the above models are registered in pr-agent's internal MAX_TOKENS
+# table, so every review/description/suggestion call was throwing
+# "Ensure {model} is defined in MAX_TOKENS ... or set a positive value for
+# it in config.custom_model_max_tokens" and failing silently on every PR
+# since this file was added. 128000 is safe for all three models' real
+# context windows.
+custom_model_max_tokens = 128000


### PR DESCRIPTION
## Summary
- PR Agent has been silently failing on every PR since it was added — confirmed on #1050 (2026-07-27) and #1084 (2026-07-29), both just got the generic `Failed to generate code suggestions for PR` comment.
- Root cause: `.pr_agent.toml` used `opencode/glm-5.2` (routed through an opencode.ai gateway) with `deepseek/deepseek-chat` and `openai/gpt-4o-mini` as fallbacks — none of the three are registered in pr-agent's internal `MAX_TOKENS` table, and `custom_model_max_tokens` was never set, so `get_max_tokens()` throws for every model in the chain and the whole call fails.
- Fix: switch to `deepseek/deepseek-chat` as the sole model via litellm's native DeepSeek provider (`DEEPSEEK_API_KEY`, already present as a repo secret — no new secret needed), drop the `OPENAI_KEY`/`OPENAI_API_BASE` gateway env vars, and set `custom_model_max_tokens = 64000` (DeepSeek-V3's real published context window).

## Testing
- Validated both edited files parse cleanly (`tomllib`, `yaml.safe_load`).
- Could not fully dry-run the PR Agent container locally since it needs to run inside the actual GitHub Actions job — this PR itself will exercise it live once opened (same-repo PR, so the `if` guard lets it fire).