### PR TITLE
fix(npu): replace 12 absolute symlinks with relative ones

### DIFF
--- a/engine/npu/include/buffer.hpp
+++ b/engine/npu/include/buffer.hpp
@@ -1,1 +1,1 @@
-/home/bcloud/1bit-systems/npu-infer/include/buffer.hpp
+../../../npu-infer/include/buffer.hpp

--- a/engine/npu/include/npu_utils/debug_utils.hpp
+++ b/engine/npu/include/npu_utils/debug_utils.hpp
@@ -1,1 +1,1 @@
-/home/bcloud/1bit-systems/npu-infer/include/npu_utils/debug_utils.hpp
+../../../../npu-infer/include/npu_utils/debug_utils.hpp

--- a/engine/npu/include/npu_utils/instr_utils/npu_cmd.hpp
+++ b/engine/npu/include/npu_utils/instr_utils/npu_cmd.hpp
@@ -1,1 +1,1 @@
-/home/bcloud/1bit-systems/npu-infer/include/npu_utils/instr_utils/npu_cmd.hpp
+../../../../../npu-infer/include/npu_utils/instr_utils/npu_cmd.hpp

--- a/engine/npu/include/npu_utils/instr_utils/npu_cmd_ddr.hpp
+++ b/engine/npu/include/npu_utils/instr_utils/npu_cmd_ddr.hpp
@@ -1,1 +1,1 @@
-/home/bcloud/1bit-systems/npu-infer/include/npu_utils/instr_utils/npu_cmd_ddr.hpp
+../../../../../npu-infer/include/npu_utils/instr_utils/npu_cmd_ddr.hpp

--- a/engine/npu/include/npu_utils/instr_utils/npu_cmd_issue_token.hpp
+++ b/engine/npu/include/npu_utils/instr_utils/npu_cmd_issue_token.hpp
@@ -1,1 +1,1 @@
-/home/bcloud/1bit-systems/npu-infer/include/npu_utils/instr_utils/npu_cmd_issue_token.hpp
+../../../../../npu-infer/include/npu_utils/instr_utils/npu_cmd_issue_token.hpp

--- a/engine/npu/include/npu_utils/instr_utils/npu_cmd_maskwrite.hpp
+++ b/engine/npu/include/npu_utils/instr_utils/npu_cmd_maskwrite.hpp
@@ -1,1 +1,1 @@
-/home/bcloud/1bit-systems/npu-infer/include/npu_utils/instr_utils/npu_cmd_maskwrite.hpp
+../../../../../npu-infer/include/npu_utils/instr_utils/npu_cmd_maskwrite.hpp

--- a/engine/npu/include/npu_utils/instr_utils/npu_cmd_preemption.hpp
+++ b/engine/npu/include/npu_utils/instr_utils/npu_cmd_preemption.hpp
@@ -1,1 +1,1 @@
-/home/bcloud/1bit-systems/npu-infer/include/npu_utils/instr_utils/npu_cmd_preemption.hpp
+../../../../../npu-infer/include/npu_utils/instr_utils/npu_cmd_preemption.hpp

--- a/engine/npu/include/npu_utils/instr_utils/npu_cmd_wait.hpp
+++ b/engine/npu/include/npu_utils/instr_utils/npu_cmd_wait.hpp
@@ -1,1 +1,1 @@
-/home/bcloud/1bit-systems/npu-infer/include/npu_utils/instr_utils/npu_cmd_wait.hpp
+../../../../../npu-infer/include/npu_utils/instr_utils/npu_cmd_wait.hpp

--- a/engine/npu/include/npu_utils/instr_utils/npu_cmd_write.hpp
+++ b/engine/npu/include/npu_utils/instr_utils/npu_cmd_write.hpp
@@ -1,1 +1,1 @@
-/home/bcloud/1bit-systems/npu-infer/include/npu_utils/instr_utils/npu_cmd_write.hpp
+../../../../../npu-infer/include/npu_utils/instr_utils/npu_cmd_write.hpp

--- a/engine/npu/include/npu_utils/instr_utils/npu_cmd_write_dma.hpp
+++ b/engine/npu/include/npu_utils/instr_utils/npu_cmd_write_dma.hpp
@@ -1,1 +1,1 @@
-/home/bcloud/1bit-systems/npu-infer/include/npu_utils/instr_utils/npu_cmd_write_dma.hpp
+../../../../../npu-infer/include/npu_utils/instr_utils/npu_cmd_write_dma.hpp

--- a/engine/npu/include/npu_utils/npu_instr_utils.hpp
+++ b/engine/npu/include/npu_utils/npu_instr_utils.hpp
@@ -1,1 +1,1 @@
-/home/bcloud/1bit-systems/npu-infer/include/npu_utils/npu_instr_utils.hpp
+../../../../npu-infer/include/npu_utils/npu_instr_utils.hpp

--- a/engine/npu/include/utils/debug_utils.hpp
+++ b/engine/npu/include/utils/debug_utils.hpp
@@ -1,1 +1,1 @@
-/home/bcloud/1bit-systems/npu-infer/include/npu_utils/debug_utils.hpp
+../../../../npu-infer/include/npu_utils/debug_utils.hpp


### PR DESCRIPTION
## Summary
- Closes #1085. 12 git-tracked symlinks under `engine/npu/include/` pointed at absolute paths on one specific machine (`/home/bcloud/1bit-systems/npu-infer/include/...`) — same failure class as #1043, reintroduced since. These break on any clone other than that exact box.
- Converted each to a relative symlink instead of a real-file copy, so the two engines keep sharing one source of truth for these headers rather than risking drift between duplicated copies.
- (A 13th absolute symlink from the original scan, `models/model.q4nx`, turned out to be gitignored/untracked — not part of the actual repo-portability issue, so left alone here.)

## Testing
- `bash scripts/check-no-absolute-symlinks.sh` → clean.
- Verified each new relative symlink resolves to the exact same real file as the old absolute one (`os.path.realpath` before/after comparison) before touching git.
- `backend_manager` (transitively includes several of these headers via `npu_engine_universal.cpp`) builds clean.