### PR TITLE
fix(README): correct architecture diagram to show real binary layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,17 +91,29 @@ See the [Installation Guide](docs/wiki/Installation.md) for full instructions.
 ## Architecture
 
 ```
-gguf / 1bp ──▶ [model loader: auto-detect 18 architectures]
-                       │
-        ┌──────────────┼──────────────┐
-        ▼              ▼              ▼
-   NPU (XDNA 2)   GPU (ROCm)    GPU (Vulkan)
-   32 tiles,       Radeon 8060S   Radeon 8060S
-   50 TOPS
-        │              │              │
-        └──────────────┼──────────────┘
-                       ▼
-                 CPU (OpenMP)
+gguf · onnx · q4nx · 1bp · h1b ──▶ [model loader: auto-detect 19 architectures]
+                                    │
+                                    ▼
+                            [BackendManager
+                             profile + select
+                             fastest backend]
+                                    │
+                    ┌───────────────┼────────────────┐
+                    ▼               ▼                 ▼
+              NPU (XDNA 2)    GPU (ROCm HIP)   GPU (Vulkan ZINC)
+              32 tiles,        Radeon 8060S     Radeon 8060S
+              50 TOPS
+                    │               │                 │
+                    └───────┬───────┼──────┬──────────┘
+                            │       │      │
+                     ┌──────▼────┐  │  ┌───▼────────┐
+                     │ GPU CUDA  │  │  │ GPU Metal   │
+                     │ NVIDIA    │  │  │ Apple Silicon│
+                     │ sm70+     │  │  └─────────────┘
+                     └───────────┘  │
+                                     ▼
+                               CPU (OpenMP)
+                               x86 fallback
 ```
 
 **[→ Architecture deep-dive](docs/guides/architecture.md)** · **[→ NPU reverse-engineering story](docs/journey.md)**
@@ -113,7 +125,7 @@ gguf / 1bp ──▶ [model loader: auto-detect 18 architectures]
 | NPU (npu_engine_universal) | XDNA 2, 32 tiles | INT8 GEMM, FLM models |
 | GPU HIP (ROCm) | Radeon 8060S | Ternary GEMV, MoE, SSM |
 | GPU Vulkan (ZINC) | Radeon 8060S | Dense models, 1BP |
-| GPU CUDA | NVIDIA | Ternary kernels |
+| GPU CUDA | NVIDIA sm70+ | Ternary kernels |
 | GPU Metal | Apple Silicon | Ternary kernels |
 | CPU (OpenMP) | x86 | Q4NX fallback |
 


### PR DESCRIPTION
### **User description**
Updates the Architecture section to accurately reflect the actual binary:

**Before:** showed 3 input formats (gguf/1bp) → 3 backends (NPU/ROCm/Vulkan) + CPU

**After:**
- All 5 input formats: gguf, onnx, q4nx, 1bp, h1b
- BackendManager router (profile + select fastest) between loader and backends
- All 6 backends: NPU, ROCm HIP, Vulkan ZINC, CUDA, Metal, CPU
- Updated from 18 → 19 architectures


___

### **PR Type**
Documentation


___

### **Description**
- Updated architecture diagram to show all 5 input formats

- Added BackendManager router between loader and backends

- Expanded backend list to include CUDA and Metal

- Updated architecture count from 18 to 19


___

### Diagram Walkthrough


```mermaid
flowchart LR
  inputs["gguf · onnx · q4nx · 1bp · h1b"]
  loader["Model Loader: auto-detect 19 architectures"]
  router["BackendManager: profile + select fastest"]
  npu["NPU XDNA 2"]
  rocm["GPU ROCm HIP"]
  vulkan["GPU Vulkan ZINC"]
  cuda["GPU CUDA NVIDIA"]
  metal["GPU Metal Apple Silicon"]
  cpu["CPU OpenMP x86"]
  inputs --> loader
  loader --> router
  router --> npu
  router --> rocm
  router --> vulkan
  router --> cuda
  router --> metal
  router --> cpu
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Correct architecture diagram and backend list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated architecture ASCII diagram to show all 5 input formats (gguf, <br>onnx, q4nx, 1bp, h1b)<br> <li> Added BackendManager router node between model loader and backends<br> <li> Expanded backend list from 3 to 6 (added CUDA and Metal)<br> <li> Updated architecture count from 18 to 19<br> <li> Updated CUDA description to include sm70+ requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1098/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+24/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

