### PR TITLE
fix(README): update stale reverse-engineering section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,20 +135,21 @@ This project started with a laptop, a disassembler, and no docs. AMD shipped the
 
 | Component | Before (closed) | After (open) |
 |-----------|:----------------:|:------------:|
-| CLI + server | `flm`, 87.8 MB | Rebuilt, 17.5 MB |
-| NPU sequence gen | 22 proprietary `.so` files | `libnpu_engine_universal.so` (173 KB) |
-| FPGA bitstreams | 209 `.xclbin` files | 63 rebuilt from AIE generators |
+| CLI + server | `flm`, 87.8 MB | Rebuilt, 282 KB (zaya_server) |
+| NPU sequence gen | 22 proprietary `.so` files | `libnpu_engine_universal.so` (open-source C++23) |
+| NPU bitstreams | 209 `.xclbin` files | 287 xclbins (63 rebuilt from AIE generators + 209 FLM-extracted + 15 BF16 perf) |
 | Toolchain | AMD Xilinx IP | `aiecc` + Peano/AMD Xilinx IP |
+| Model extraction | N/A | 37 pre-built FLM models extracted, 46+ 1BP models published |
 
 The key finding: the `.so` files were NPU instruction **sequence generators**, not compute kernels — the actual computation lives entirely in the `.xclbin` FPGA bitstreams. Both layers are now fully rebuildable from source.
 
-> **Read the full 1800+ line journey** → [`docs/journey.md`](docs/journey.md) — every crash, breakthrough, and bug documented in real-time.
+> **Read the full 1900+ line journey** → [`docs/journey.md`](docs/journey.md) — every crash, breakthrough, and bug documented in real-time.
 >
 > **Technical reverse-engineering report** → [`docs/research/fastflowlm-decode/SUMMARY.md`](docs/research/fastflowlm-decode/SUMMARY.md)
 >
 > **Raw analysis** → [`docs/research/fastflowlm-analysis/`](docs/research/fastflowlm-analysis/) — binary analysis, xclbin captures, instruction traces
 
-Since then: Mamba1 GPU backend (79.4 tok/s), Vulkan flash attention, model-agnostic GGUF routing, TQ2 ternary format, vision-language support, and a self-healing agent watchdog — **1800+ hours of engineering, all open source, MIT.**
+Since then: Mamba1 GPU backend (79.4 tok/s), Vulkan flash attention, model-agnostic GGUF routing, TQ2 ternary format, **37 FLM models extracted and integrated** (DeepSeek-R1, Gemma4, Qwen3.5 Omni, Whisper, 20+ more — all running on NPU), **per-group INT8 quantization** (+3 tok/s quality fix, #1074), **NPU runtime instruction generator** (#1054), **incremental K/V attention** (#1053), **Moonshot Kimi family** reverse-engineering (Gated MLA MoE), **NPU fused engine** (oplayer=30/31/32), and a self-healing agent watchdog — **1900+ hours of engineering, all open source, MIT.**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -91,17 +91,29 @@ See the [Installation Guide](docs/wiki/Installation.md) for full instructions.
 ## Architecture
 
 ```
-gguf / 1bp ──▶ [model loader: auto-detect 18 architectures]
-                       │
-        ┌──────────────┼──────────────┐
-        ▼              ▼              ▼
-   NPU (XDNA 2)   GPU (ROCm)    GPU (Vulkan)
-   32 tiles,       Radeon 8060S   Radeon 8060S
-   50 TOPS
-        │              │              │
-        └──────────────┼──────────────┘
-                       ▼
-                 CPU (OpenMP)
+gguf · onnx · q4nx · 1bp · h1b ──▶ [model loader: auto-detect 19 architectures]
+                                    │
+                                    ▼
+                            [BackendManager
+                             profile + select
+                             fastest backend]
+                                    │
+                    ┌───────────────┼────────────────┐
+                    ▼               ▼                 ▼
+              NPU (XDNA 2)    GPU (ROCm HIP)   GPU (Vulkan ZINC)
+              32 tiles,        Radeon 8060S     Radeon 8060S
+              50 TOPS
+                    │               │                 │
+                    └───────┬───────┼──────┬──────────┘
+                            │       │      │
+                     ┌──────▼────┐  │  ┌───▼────────┐
+                     │ GPU CUDA  │  │  │ GPU Metal   │
+                     │ NVIDIA    │  │  │ Apple Silicon│
+                     │ sm70+     │  │  └─────────────┘
+                     └───────────┘  │
+                                     ▼
+                               CPU (OpenMP)
+                               x86 fallback
 ```
 
 **[→ Architecture deep-dive](docs/guides/architecture.md)** · **[→ NPU reverse-engineering story](docs/journey.md)**
@@ -113,7 +125,7 @@ gguf / 1bp ──▶ [model loader: auto-detect 18 architectures]
 | NPU (npu_engine_universal) | XDNA 2, 32 tiles | INT8 GEMM, FLM models |
 | GPU HIP (ROCm) | Radeon 8060S | Ternary GEMV, MoE, SSM |
 | GPU Vulkan (ZINC) | Radeon 8060S | Dense models, 1BP |
-| GPU CUDA | NVIDIA | Ternary kernels |
+| GPU CUDA | NVIDIA sm70+ | Ternary kernels |
 | GPU Metal | Apple Silicon | Ternary kernels |
 | CPU (OpenMP) | x86 | Q4NX fallback |
 


### PR DESCRIPTION
### **User description**
Updates the reverse-engineering comparison table and 'Since then' list:

- Server: 87.8 MB → **282 KB** (not 17.5 MB)
- xclbins: 63 rebuilt → **287 total** (63 rebuilt + 209 FLM-extracted + 15 BF16)
- Journey: 1800+ → **1900+** lines
- Hours: 1800+ → **1900+** hours
- Added Model extraction row (37 FLM models, 46+ 1BP)
- 'Since then' now includes: FLM extraction, per-group INT8 (#1074), NPU instr gen (#1054), incremental KV (#1053), Kimi MoE, fused engine


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Update architecture diagram to show all 5 input formats and 6 backends

- Refresh reverse-engineering comparison table with accurate numbers

- Expand accomplishments list with recent NPU features and integrations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  inputs["5 input formats: gguf, onnx, q4nx, 1bp, h1b"]
  loader["Model Loader: 19 architectures"]
  manager["BackendManager: profile + select"]
  npu["NPU XDNA2: 32 tiles, 50 TOPS"]
  rocm["GPU ROCm HIP: Radeon 8060S"]
  vulkan["GPU Vulkan ZINC: Radeon 8060S"]
  cuda["GPU CUDA: NVIDIA sm70+"]
  metal["GPU Metal: Apple Silicon"]
  cpu["CPU OpenMP: x86 fallback"]
  inputs --> loader --> manager
  manager --> npu & rocm & vulkan
  npu & rocm & vulkan --> cuda & metal & cpu
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Refresh architecture diagram and reverse-engineering stats</code></dd></summary>
<hr>

README.md

<ul><li>Updated architecture diagram to show all 5 input formats (gguf, onnx, <br>q4nx, 1bp, h1b), BackendManager router, and all 6 backends (NPU, ROCm, <br>Vulkan, CUDA, Metal, CPU)<br> <li> Updated comparison table with accurate numbers: 282 KB server binary, <br>287 xclbins, 1900+ line journey<br> <li> Added Model extraction row (37 FLM models, 46+ 1BP)<br> <li> Expanded 'Since then' list with FLM extraction, per-group INT8, NPU <br>instr gen, incremental KV, Kimi MoE, fused engine</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1099/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+30/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

