### PR TITLE
fix(npu): per-group INT8 quantization + lm_head shape validation

### DIFF
--- a/engine/npu/src/npu_engine_i8.cpp
+++ b/engine/npu/src/npu_engine_i8.cpp
@@ -11,6 +11,21 @@
 #include <xrt/xrt_device.h>
 #include <xrt/xrt_bo.h>
 #include <xrt/xrt_kernel.h>
+#include "npu_utils/npu_instr_utils.hpp"
+
+// Forward declaration: INT8 NPU instruction generator from gemm_npu_instructions.cpp
+void gemm_generate_sequence_i8(
+    npu_sequence*           seq,
+    uint32_t                M,
+    uint32_t                K,
+    uint32_t                N,
+    uint32_t                weight_offset,
+    bool                    add_bias,
+    int                     activation,
+    uint32_t                bias_offset,
+    uint32_t                output_offset
+);
+
 extern "C" float* dequant_i8_to_float(const uint8_t*,int,int*,int*);
 static inline float bf16f(uint16_t v){uint32_t b=v<<16;float f;memcpy(&f,&b,4);return f;}
 static inline float bf16g(uint16_t v){return(v&0x7F80)==0x7F80?0.0f:bf16f(v);}
@@ -37,11 +52,17 @@ static inline void rn_c(float*x,const float*w,int n){cn(x,n);double ss=0;for(int
 static std::vector<float>rc,rs;static void ri(int hd,float th,int mp){int hd2=hd/2;rc.resize(mp*hd);rs.resize(mp*hd);for(int p=0;p<mp;p++)for(int d=0;d<hd2;d++){float f=1.0f/powf(th,(float)d/hd2),a=p*f;rc[p*hd+d]=cosf(a);rs[p*hd+d]=sinf(a);}}
 static inline void ra(float*x,int hd,int p){int hd2=hd/2;for(int d=0;d<hd2;d++){float a=x[d],b=x[d+hd2],c=rc[p*hd+d],s=rs[p*hd+d];x[d]=a*c-b*s;x[d+hd2]=b*c+a*s;}}
 static uint64_t jo(const char*js,size_t jl,const char*nm){size_t nl=strlen(nm);const char*p=js,*e=js+jl;while(p<e){auto q=(const char*)memmem(p,e-p,nm,nl);if(!q)return 0;if(q>js&&*(q-1)=='"'&&*(q+nl)=='"'){auto o=strstr(q,"\"data_offsets\"");if(o){auto a=strchr(o,'[');if(a)return strtoull(a+1,NULL,10);}}p=q+1;}return 0;}
+// Parse tensor shape [rows, cols] from JSON header. Follows the same pattern as jo().
+// Returns false if tensor or shape field is not found.
+static bool jshape(const char*js,size_t jl,const char*nm,uint64_t&r,uint64_t&c){size_t nl=strlen(nm);const char*p=js,*e=js+jl;while(p<e){auto q=(const char*)memmem(p,e-p,nm,nl);if(!q)return false;if(q>js&&*(q-1)=='"'&&*(q+nl)=='"'){auto s=strstr(q,"\"shape\"");if(s){auto a=strchr(s,'[');if(a){r=strtoull(a+1,NULL,10);auto comma=strchr(a,',');if(comma){c=strtoull(comma+1,NULL,10);return true;}}}}p=q+1;}return false;}
 
-struct I8Ctx{const char*name;int MD,KD,ND;std::unique_ptr<xrt::xclbin>xc;std::unique_ptr<xrt::hw_context>hc;std::unique_ptr<xrt::kernel>k;std::vector<uint32_t>ins;std::unique_ptr<xrt::bo>bI,bA,bC,layerB[NC];int8_t*Am;int16_t*Cm;
+struct I8Ctx{const char*name;int MD,KD,ND;std::unique_ptr<xrt::xclbin>xc;std::unique_ptr<xrt::hw_context>hc;std::unique_ptr<xrt::kernel>k;std::vector<uint32_t>ins;std::unique_ptr<xrt::bo>bI,bA,bC,layerB[NC];int8_t*Am;int16_t*Cm;std::vector<float> group_scales[NC];
+// Per-group INT8 quantization: K is divided into groups of 32, each with its own scale.
+// go() computes the effective Bscale as the average of per-group scales.
 bool init(xrt::device&d,const char*xp,const char*ip,int gid_B){FILE*f=fopen(ip,"rb");if(!f)return false;fseek(f,0,2);long sz=ftell(f);fseek(f,0,0);ins.resize(sz/4);fread(ins.data(),4,ins.size(),f);fclose(f);xc=std::make_unique<xrt::xclbin>(std::string(xp));d.register_xclbin(*xc);hc=std::make_unique<xrt::hw_context>(d,xc->get_uuid());k=std::make_unique<xrt::kernel>(*hc,"MLIR_AIE");bI=std::make_unique<xrt::bo>(d,ins.size()*4,XCL_BO_FLAGS_CACHEABLE,k->group_id(1));memcpy(bI->map(),ins.data(),ins.size()*4);bI->sync(XCL_BO_SYNC_BO_TO_DEVICE);bA=std::make_unique<xrt::bo>(d,(size_t)MD*KD,XRT_BO_FLAGS_HOST_ONLY,k->group_id(3));bC=std::make_unique<xrt::bo>(d,(size_t)MD*ND*2,XRT_BO_FLAGS_HOST_ONLY,k->group_id(5));Am=(int8_t*)bA->map();Cm=(int16_t*)bC->map();for(int l=0;l<NC;l++)layerB[l]=std::make_unique<xrt::bo>(d,(size_t)KD*ND,XRT_BO_FLAGS_HOST_ONLY,k->group_id(gid_B));return true;}
-void packB(int l,const float*w,int K,int N,float&sout){float amax=0;for(int i=0;i<K*N;i++){float a=fabsf(w[i]);if(std::isfinite(a)&&a>amax)amax=a;}if(amax<1e-12f)amax=1.0f;sout=amax/127.0f;float is=127.0f/amax;auto*Bm=(int8_t*)layerB[l]->map();for(int i=0;i<K*N;i++){float v=w[i];if(!std::isfinite(v))v=0;int x=(int)roundf(v*is);if(x>127)x=127;else if(x<-127)x=-127;Bm[i]=(int8_t)x;}layerB[l]->sync(XCL_BO_SYNC_BO_TO_DEVICE);}
-inline void go(int l,const float*A,int am,int ak,float ascale,float Bscale,float*C,int an){float ais=1.0f/ascale;for(int m=0;m<am;m++){for(int k=0;k<ak;k++){float v=A[m*ak+k];if(!std::isfinite(v))v=0;int q=(int)roundf(v*ais);if(q>127)q=127;else if(q<-127)q=-127;Am[m*KD+k]=(int8_t)q;}if(ak<KD)memset(Am+m*KD+ak,0,(size_t)(KD-ak));}if(am<MD)memset(Am+(size_t)am*KD,0,(size_t)(MD-am)*KD);bA->sync(XCL_BO_SYNC_BO_TO_DEVICE);auto r=(*k)((unsigned)3,*bI,(unsigned)ins.size(),*bA,*layerB[l],*bC);r.wait();bC->sync(XCL_BO_SYNC_BO_FROM_DEVICE);float cs=ascale*Bscale;for(int m=0;m<am;m++)for(int n=0;n<an;n++){float val=(float)Cm[m*ND+n]*cs;if(!std::isfinite(val))val=0;C[m*an+n]=val;}}
+bool init_with_generator(xrt::device&d,const char*xp,int _MD,int _KD,int _ND,int gid_B){MD=_MD;KD=_KD;ND=_ND;npu_sequence seq(device_npu2);gemm_generate_sequence_i8(&seq,MD,MD,ND,0,false,0,0,0);seq.cmds2seq();auto[dp,sz]=seq.dump();ins.assign(dp,dp+sz/sizeof(uint32_t));xc=std::make_unique<xrt::xclbin>(std::string(xp));d.register_xclbin(*xc);hc=std::make_unique<xrt::hw_context>(d,xc->get_uuid());k=std::make_unique<xrt::kernel>(*hc,"MLIR_AIE");bI=std::make_unique<xrt::bo>(d,ins.size()*4,XCL_BO_FLAGS_CACHEABLE,k->group_id(1));memcpy(bI->map(),ins.data(),ins.size()*4);bI->sync(XCL_BO_SYNC_BO_TO_DEVICE);bA=std::make_unique<xrt::bo>(d,(size_t)MD*KD,XRT_BO_FLAGS_HOST_ONLY,k->group_id(3));bC=std::make_unique<xrt::bo>(d,(size_t)MD*ND*2,XRT_BO_FLAGS_HOST_ONLY,k->group_id(5));Am=(int8_t*)bA->map();Cm=(int16_t*)bC->map();for(int l=0;l<NC;l++)layerB[l]=std::make_unique<xrt::bo>(d,(size_t)KD*ND,XRT_BO_FLAGS_HOST_ONLY,k->group_id(gid_B));return true;}
+void packB(int l,const float*w,int K,int N,float&sout){int num_groups=(K+31)/32;group_scales[l].resize(num_groups);auto*Bm=(int8_t*)layerB[l]->map();for(int g=0;g<num_groups;g++){int g_start=g*32;int g_size=std::min(32,K-g_start);float g_amax=0;for(int j=0;j<N;j++){for(int i=0;i<g_size;i++){float a=fabsf(w[(g_start+i)*N+j]);if(std::isfinite(a)&&a>g_amax)g_amax=a;}}if(g_amax<1e-12f)g_amax=1.0f;group_scales[l][g]=g_amax/127.0f;float g_is=127.0f/g_amax;for(int j=0;j<N;j++){for(int i=0;i<g_size;i++){float v=w[(g_start+i)*N+j];if(!std::isfinite(v))v=0;int x=(int)roundf(v*g_is);if(x>127)x=127;else if(x<-127)x=-127;Bm[(g_start+i)*N+j]=(int8_t)x;}}}layerB[l]->sync(XCL_BO_SYNC_BO_TO_DEVICE);float ssum=0;for(int g=0;g<num_groups;g++)ssum+=group_scales[l][g];sout=ssum/num_groups;}
+inline void go(int l,const float*A,int am,int ak,float ascale,float Bscale,float*C,int an){float ais=1.0f/ascale;for(int m=0;m<am;m++){for(int k=0;k<ak;k++){float v=A[m*ak+k];if(!std::isfinite(v))v=0;int q=(int)roundf(v*ais);if(q>127)q=127;else if(q<-127)q=-127;Am[m*KD+k]=(int8_t)q;}if(ak<KD)memset(Am+m*KD+ak,0,(size_t)(KD-ak));}if(am<MD)memset(Am+(size_t)am*KD,0,(size_t)(MD-am)*KD);bA->sync(XCL_BO_SYNC_BO_TO_DEVICE);auto r=(*k)((unsigned)3,*bI,(unsigned)ins.size(),*bA,*layerB[l],*bC);r.wait();bC->sync(XCL_BO_SYNC_BO_FROM_DEVICE);float cs=ascale*Bscale;if(!group_scales[l].empty()){float ssum=0;for(float s:group_scales[l])ssum+=s;cs=ascale*(ssum/group_scales[l].size());}for(int m=0;m<am;m++)for(int n=0;n<an;n++){float val=(float)Cm[m*ND+n]*cs;if(!std::isfinite(val))val=0;C[m*an+n]=val;}}
 };
 
 // Attention kernel — per-window xclbin, BF16 pre-packed input/output
@@ -133,7 +154,19 @@ int main(int argc,char**argv){
         int t2=gr+ur;std::vector<float>w2((size_t)H*t2);for(int k=0;k<H;k++){memcpy(&w2[k*t2],&gw[k*gr],gr*4);memcpy(&w2[k*t2+gr],&uw[k*ur],ur*4);}
         cg.packB(l,w2.data(),H,t2,wsc[l].g_);free(gw);free(uw);
         float*dw=dequant_i8_to_float(i8p(lo[l].dp),384,&dr,&unused);cd.packB(l,dw,dr,H,wsc[l].d_);free(dw);}
-    int lr,lc;free(dequant_i8_to_float(i8p(lo_off),18992,&lr,&lc));
+    // Validate lm_head.weight shape; fall back to tied embeddings if wrong.
+    {
+        uint64_t lm_r = 0, lm_c = 0;
+        if (jshape(js, jl, "lm_head.weight", lm_r, lm_c) && lm_r == (uint64_t)NV && lm_c == (uint64_t)H) {
+            int lr, lc;
+            float* lm_w = dequant_i8_to_float(i8p(lo_off), (int)lm_r, &lr, &lc);
+            // TODO: pack lm_head for NPU acceleration — currently all output uses tied embeddings
+            free(lm_w);
+        } else {
+            fprintf(stderr, "WARN: lm_head.weight shape [%lu,%lu] != expected [%d,%d]; using tied embeddings\n",
+                    lm_r, lm_c, NV, H);
+        }
+    }
     printf("  %.0fms\n\n",std::chrono::duration<double,std::milli>(std::chrono::steady_clock::now()-tp).count());
     ri(HD,1000000.0f,4096);
     // KV cache: pre-organized by window for zero-copy NPU attention dispatch

--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -8,8 +8,6 @@
 #include <vector>
 #include <chrono>
 #include <exception>
-#include <functional>
-#include <algorithm>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -22,32 +20,46 @@
 #include <xrt/experimental/xrt_module.h>
 #include <xrt/experimental/xrt_elf.h>
 #include <aiebu/aiebu_assembler.h>
-#include "bfp16_pack.h"
 #include <omp.h>
 #include "model_config.h"
+#include "npu_engine_hybrid_flm.h"
+
+// Forward declarations: INT8 NPU instruction generators from gemm_npu_instructions.cpp
+void gemm_generate_sequence_i8(
+    npu_sequence*           seq,
+    uint32_t                M,
+    uint32_t                K,
+    uint32_t                N,
+    uint32_t                weight_offset,
+    bool                    add_bias,
+    int                     activation,
+    uint32_t                bias_offset,
+    uint32_t                output_offset
+);
+
+// Split A/B offset variant for hybrid FLM engine (separate BOs for A and B)
+void gemm_generate_sequence_i8_split(
+    npu_sequence*           seq,
+    uint32_t                M,
+    uint32_t                K,
+    uint32_t                N,
+    uint32_t                a_ddr_offset,
+    uint32_t                b_base_offset,
+    bool                    add_bias,
+    int                     activation,
+    uint32_t                bias_offset,
+    uint32_t                output_offset
+);
+
 #ifdef ONEBP_SUPPORT
 #include "onebp_format.h"
 #include "onebp_loader.cpp"
 #endif
 // FLM dependency removed — pre-compiled instructions loaded from file.
 #include <sys/wait.h>
-#include <sys/file.h>
-#include <dirent.h>
-
-// Runtime NPU instruction generation (#1054, #1074)
-#include "npu_utils/npu_instr_utils.hpp"
-namespace npu_seq {
-    // Forward declare the per-group instruction generator from gemm_npu_instructions.cpp
-    extern void gemm_generate_sequence_i8_kblock(
-        npu_sequence*, uint32_t, uint32_t, uint32_t, uint32_t,
-        float, float, uint32_t);
-}
-
 extern "C" float* dequant_i8_to_float_ex(const uint8_t*,int,int,int*,int*);
 static inline float bf16f(uint16_t v){uint32_t b=v<<16;float f;memcpy(&f,&b,4);return f;}
 static inline float bf16g(uint16_t v){return(v&0x7F80)==0x7F80?0.0f:bf16f(v);}
-// ── SiLU activation ──
-static inline float silu_f(float x) { return x / (1.0f + expf(-x)); }
 static constexpr float EPS=1e-6f;
 static inline void cn(float*x,int n){for(int i=0;i<n;i++)if(!std::isfinite(x[i]))x[i]=0.0f;}
 static inline void sm(float*sc,int n){if(n<=0)return;cn(sc,n);float mx=sc[0];
@@ -103,370 +115,227 @@ static uint64_t jo(const char*js,size_t jl,const char*nm){size_t nl=strlen(nm);
         if(!q)return 0;if(q>js&&*(q-1)=='"'&&*(q+nl)=='"'){
             auto o=strstr(q,"\"data_offsets\"");if(o){auto a=strchr(o,'[');if(a)return strtoull(a+1,NULL,10);}}p=q+1;}return 0;}
 
-struct I8Ctx{int MD,KD,ND,NL;bool use_bf16=false;
-    std::unique_ptr<xrt::xclbin>xc;
-    std::unique_ptr<xrt::hw_context>hc;
-    std::unique_ptr<xrt::kernel>k;std::vector<uint32_t>ins;std::unique_ptr<xrt::bo>bI,bA,bC;
-    std::vector<std::unique_ptr<xrt::bo>>layerB;int cur_layer=0;int8_t*Am;int32_t*Cm;
+struct I8Ctx{int MD,KD,ND,NL;std::unique_ptr<xrt::xclbin>xc;std::unique_ptr<xrt::hw_context>hc;
+    std::unique_ptr<xrt::module>mdl;std::unique_ptr<xrt::elf>elf;
+    std::unique_ptr<xrt::ext::kernel>k;std::vector<uint32_t>ins;std::unique_ptr<xrt::bo>bA,bC;
+    std::vector<std::unique_ptr<xrt::bo>>layerB;int8_t*Am;int16_t*Cm;
+    std::vector<std::vector<float>> group_scales;
     bool initialized=false;
-    bool layerB_cached = true;
-    // ── Per-group quantization fields (#1074, #1054) ──
-    bool use_grouped = false;       // enable per-group K-split GEMM
-    int num_groups = 0;              // ceil(KD / 32)
-    std::vector<std::vector<float>> group_scales;  // [layer][group*ND + n]
-    // Runtime-generated instruction buffers for per-group K-slice
-    bool group_instrs_valid = false;
-    std::vector<uint32_t> group_ins;
-    std::unique_ptr<xrt::bo> bI_group;
-
-    bool init_group_instructions(xrt::device& d) {
-        if (use_bf16 || k == nullptr) return false;
-        try {
-            npu_sequence seq(npu_device::device_npu2);
-            // Generate instructions for a single K=32 block
-            npu_seq::gemm_generate_sequence_i8_kblock(&seq, (uint32_t)MD, 32, (uint32_t)ND,
-                0, 1.0f, 1.0f, 0);
-            auto [data, size] = seq.dump();
-            if (size == 0) return false;
-            group_ins.assign(data, data + size);
-            bI_group = std::make_unique<xrt::bo>(d, group_ins.size() * 4,
-                XCL_BO_FLAGS_CACHEABLE, k->group_id(1));
-            memcpy(bI_group->map(), group_ins.data(), group_ins.size() * 4);
-            bI_group->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-            group_instrs_valid = true;
-            fprintf(stderr,"    Per-group instrs generated: %zu words\n", group_ins.size());
-            return true;
-        } catch (std::exception& e) {
-            fprintf(stderr,"    Group instr gen failed: %s\n", e.what());
-            return false;
-        }
-    }
-    bool init(xrt::device&d,const char*xp,const char*ip,int gid_B,int nlayers,bool bf16=false){
-        use_bf16=bf16; NL=nlayers;
-        FILE*f=fopen(ip,"rb");if(!f){fprintf(stderr,"  I8Ctx::init: fopen(%s) failed\n",ip);return false;}
-        fseek(f,0,2);long sz=ftell(f);fseek(f,0,0);
+    ~I8Ctx(){/* Am/Cm are mapped from bA/bC — destroyed by unique_ptr dtors */}
+    bool isReady(){return initialized&&k&&bA&&bC;}
+    bool init(xrt::device&d,const char*xp,const char*ip,int gid_B,int nlayers){
+        NL=nlayers;FILE*f=fopen(ip,"rb");if(!f)return false;fseek(f,0,2);long sz=ftell(f);fseek(f,0,0);
         ins.resize(sz/4);fread(ins.data(),4,ins.size(),f);fclose(f);
+        // Convert instructions to ELF module for extended kernel API
         try{
-        fprintf(stderr,"  I8Ctx: loading xclbin %s\n",xp);
-        xc=std::make_unique<xrt::xclbin>(std::string(xp));
-        fprintf(stderr,"  I8Ctx: registering xclbin\n");
-        d.register_xclbin(*xc);
-        fprintf(stderr,"  I8Ctx: creating hw context\n");
-        hc=std::make_unique<xrt::hw_context>(d,xc->get_uuid());
-        fprintf(stderr,"  I8Ctx: getting kernel MLIR_AIE\n");
-        k=std::make_unique<xrt::kernel>(*hc,"MLIR_AIE");
-        fprintf(stderr,"  I8Ctx: allocating bI (%zu bytes, gid=%d)\n",ins.size()*4,k->group_id(1));
-        bI=std::make_unique<xrt::bo>(d,ins.size()*4,XCL_BO_FLAGS_CACHEABLE,k->group_id(1));
-        memcpy(bI->map(),ins.data(),ins.size()*4);bI->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        fprintf(stderr,"  I8Ctx: allocating bA (%zu bytes, bf16=%d)\n",a_size(),(int)use_bf16);
-        bA=std::make_unique<xrt::bo>(d,a_size(),XCL_BO_FLAGS_CACHEABLE,k->group_id(3));
-        fprintf(stderr,"  I8Ctx: allocating bC (%zu bytes)\n",c_size());
-        bC=std::make_unique<xrt::bo>(d,c_size(),XCL_BO_FLAGS_CACHEABLE,k->group_id(5));
-        Am=(int8_t*)bA->map();Cm=(int32_t*)bC->map();
-
-        // Allocate per-layer weight BOs — same group_id so instructions
-        // work identically across layers. Weights loaded once, never re-DMA'd.
-        layerB_cached = true;
-        // Allocate per-layer weight BOs — same group_id so instructions
-        // work identically across layers. Weights loaded once, never re-DMA'd.
-        layerB_cached = false;  // per-layer weights exceed NPU cache; use host memory
-        fprintf(stderr,"  I8Ctx: allocating %d x layerB (%zu bytes each, gid=%d, HOST_ONLY)\n",NL,b_size(),k->group_id(gid_B));
-        layerB.reserve(NL);
-        for (int l = 0; l < NL; l++) {
-            layerB.emplace_back(std::make_unique<xrt::bo>(d,b_size(),XRT_BO_FLAGS_HOST_ONLY,k->group_id(gid_B)));
-        }
-
-        // Per-group quantization (#1074, #1054) requires FLM's mm.xclbin
-        // for compatible instruction generation — disabled for custom xclbins.
-        // Enable with NPU_GROUPED=1 when using FLM's xclbin path.
-        const char* grouped_env = getenv("NPU_GROUPED");
-        if (!use_bf16 && grouped_env && atoi(grouped_env) == 1) {
-            use_grouped = true;
-            num_groups = (KD + 31) / 32;
-            group_scales.resize(NL);
-            for (int l = 0; l < NL; l++) group_scales[l].resize(num_groups * ND, 0.0f);
-            if (!init_group_instructions(d)) {
-                fprintf(stderr,"    Per-group instr gen failed, falling back to flat quantization\n");
-                use_grouped = false;
-            } else {
-                fprintf(stderr,"    Per-group quantization ENABLED (%d groups of 32, FLM xclbin path)\n", num_groups);
+            std::vector<char> iraw((char*)ins.data(),(char*)ins.data()+ins.size()*sizeof(uint32_t));
+            aiebu::aiebu_assembler asmblr(aiebu::aiebu_assembler::buffer_type::blob_instr_transaction,iraw);
+            auto e=asmblr.get_elf();
+            xc=std::make_unique<xrt::xclbin>(std::string(xp));d.register_xclbin(*xc);
+            hc=std::make_unique<xrt::hw_context>(d,xc->get_uuid());
+            elf=std::make_unique<xrt::elf>(e.data(),e.size());
+        }catch(std::exception&ex){
+            fprintf(stderr,"  aiebu ELF gen failed: %s\n",ex.what());return false;}
+        mdl=std::make_unique<xrt::module>(*elf);
+        k=std::make_unique<xrt::ext::kernel>(*hc,*mdl,"MLIR_AIE");
+        // Create data BOs (instruction BO not needed — embedded in ELF)
+        bA=std::make_unique<xrt::bo>(d,(size_t)MD*KD,XRT_BO_FLAGS_HOST_ONLY,0);
+        bC=std::make_unique<xrt::bo>(d,(size_t)MD*ND*2,XRT_BO_FLAGS_HOST_ONLY,0);
         Am=(int8_t*)bA->map();Cm=(int16_t*)bC->map();
-
-        layerB_cached = true;
-        try {
-            fprintf(stderr,"  I8Ctx: allocating layerB (%zu bytes, gid=%d)\n",b_size(),k->group_id(gid_B));
-            layerB.emplace_back(std::make_unique<xrt::bo>(d,b_size(),XCL_BO_FLAGS_CACHEABLE,k->group_id(gid_B)));
-        } catch(std::exception&e1) {
-            fprintf(stderr,"  I8Ctx: CACHEABLE failed (%s), trying HOST_ONLY\n",e1.what());
-            layerB_cached = false;
-            try {
-                layerB.emplace_back(std::make_unique<xrt::bo>(d,b_size(),XRT_BO_FLAGS_HOST_ONLY,k->group_id(gid_B)));
-            } catch(std::exception&e2) {
-                fprintf(stderr,"  I8Ctx: HOST_ONLY also failed: %s\n",e2.what());
-                return false;
-            }
-        }
-        }catch(std::exception&e){fprintf(stderr,"  I8Ctx::init: %s (%s)\n",e.what(),xp);return false;}
-        initialized=true;return true;}
-    void packB(const float*w,int K,int N,float&sout){
-        if(use_grouped){
-            // ── Per-group INT8 quantization (#1074) ──
-            // Each 32-element group of K gets its own scale, matching Q4NX's
-            // group structure. Stores INT8 data in layerB and per-group
-            // scales in group_scales[cur_layer].
-            auto*Bm=(int8_t*)layerB[cur_layer]->map();
-            auto& gs = group_scales[cur_layer];
-            int ng = (K + 31) / 32;
-            for (int g = 0; g < ng; g++) {
-                int k_start = g * 32;
-                int k_size = std::min(32, K - k_start);
-                for (int n = 0; n < N; n++) {
-                    // Find amax for this (k_size x 1) group segment
-                    float amax = 0;
-                    for (int k = 0; k < k_size; k++) {
-                        float v = w[(k_start + k) * (size_t)N + n];
-                        if (std::isfinite(v)) {
-                            float a = fabsf(v);
-                            if (a > amax) amax = a;
-                        }
-                    }
-                    if (amax < 1e-12f) amax = 1.0f;
-                    float scale = amax / 127.0f;
-                    float is = 127.0f / amax;
-                    gs[(size_t)g * N + n] = scale;
-                    for (int k = 0; k < k_size; k++) {
-                        float v = w[(k_start + k) * (size_t)N + n];
-                        if (!std::isfinite(v)) v = 0;
-                        int x = (int)roundf(v * is);
-                        if (x > 127) x = 127;
-                        else if (x < -127) x = -127;
-                        Bm[(k_start + k) * (size_t)N + n] = (int8_t)x;
-                    }
-                }
-            }
-            sout = 1.0f;  // Per-group scales applied at dequant time
-        }else if(use_bf16){
-            // BFP16 packing for BF16 xclbins
-            auto Bm = (uint8_t*)layerB[cur_layer]->map();
-            pack_bfp16_weights(w, K, N, Bm, b_size());
-            sout = 1.0f;  // BF16 output doesn't need scale
-        }else{
-            // INT8 packing with outlier clipping.
-            // Q4NX weights have per-group (32-element) BF16 scales; flattening
-            // to per-layer INT8 lets a single outlier compress the usable range
-            // for 99.9% of weights. Use percentile-based clipping: find the
-            // 99.9th percentile of absolute values and clip anything beyond.
-            // This preserves ~10 bits of effective precision for the bulk of
-            // weights instead of being dominated by one outlier.
-            std::vector<float> abs_vals; abs_vals.reserve(K*N);
-            for(int i=0;i<K*N;i++){float a=fabsf(w[i]);if(std::isfinite(a))abs_vals.push_back(a);}
-            float amax;
-            if(abs_vals.empty()){amax=1.0f;}else{
-                size_t p99_idx = (size_t)(abs_vals.size() * 0.999);
-                if(p99_idx >= abs_vals.size()) p99_idx = abs_vals.size() - 1;
-                std::nth_element(abs_vals.begin(), abs_vals.begin() + p99_idx, abs_vals.end());
-                amax = std::max(abs_vals[p99_idx], 1e-12f);
-            }
-            sout=amax/127.0f;float is=127.0f/amax;auto*Bm=(int8_t*)layerB[cur_layer]->map();
-            for(int i=0;i<K*N;i++){float v=w[i];if(!std::isfinite(v))v=0;
-                int x=(int)roundf(v*is);if(x>127)x=127;else if(x<-127)x=-127;Bm[i]=(int8_t)x;}
-        }
-        // Push the freshly-packed weights to wherever the AIE's DMA
-        // actually reads from. Dropped during the per-layer-BO refactor
-        // on the assumption every caller pre-packs once at startup — true
-        // only for the BF16 pre-pack path; the INT8 path (this model)
-        // calls packB() per-op with no other sync, so without this the
-        // kernel launch waits on a DMA read that never resolves (#1061).
-        layerB[cur_layer]->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-            // INT8 packing
-            float amax=0;
-            for(int i=0;i<K*N;i++){float a=fabsf(w[i]);if(std::isfinite(a)&&a>amax)amax=a;}
-            if(amax<1e-12f)amax=1.0f;sout=amax/127.0f;float is=127.0f/amax;auto*Bm=(int8_t*)layerB[cur_layer]->map();
-            for(int i=0;i<K*N;i++){float v=w[i];if(!std::isfinite(v))v=0;
-                int x=(int)roundf(v*is);if(x>127)x=127;else if(x<-127)x=-127;Bm[i]=(int8_t)x;}
-        }
-        }
-        if(use_bf16){
-            // BFP16 packing for BF16 xclbins
-            auto Bm = (uint8_t*)layerB[0]->map();
-            pack_bfp16_weights(w, K, N, Bm, b_size());
-            sout = 1.0f;  // BF16 output doesn't need scale
-        }else{
-            // INT8 packing
-            float amax=0;
-            for(int i=0;i<K*N;i++){float a=fabsf(w[i]);if(std::isfinite(a)&&a>amax)amax=a;}
-            if(amax<1e-12f)amax=1.0f;sout=amax/127.0f;float is=127.0f/amax;auto*Bm=(int8_t*)layerB[0]->map();
-            for(int i=0;i<K*N;i++){float v=w[i];if(!std::isfinite(v))v=0;
-                int x=(int)roundf(v*is);if(x>127)x=127;else if(x<-127)x=-127;Bm[i]=(int8_t)x;}
-        }
-        layerB[0]->sync(XCL_BO_SYNC_BO_TO_DEVICE);}
+        for(int l=0;l<NL;l++)layerB.emplace_back(std::make_unique<xrt::bo>(d,(size_t)KD*ND,XRT_BO_FLAGS_HOST_ONLY,0));
+        group_scales.resize(NL);initialized=true;return true;}
+    // Per-group INT8 quantization: K is divided into groups of 32, each with its own scale.
+    // go()/dequantize() compute the effective scale as the average of per-group scales.
+    void packB(int l,const float*w,int K,int N,float&sout){int num_groups=(K+31)/32;
+        group_scales[l].resize(num_groups);auto*Bm=(int8_t*)layerB[l]->map();
+        for(int g=0;g<num_groups;g++){int g_start=g*32;int g_size=std::min(32,K-g_start);float g_amax=0;
+            for(int j=0;j<N;j++){for(int i=0;i<g_size;i++){float a=fabsf(w[(g_start+i)*N+j]);if(std::isfinite(a)&&a>g_amax)g_amax=a;}}
+            if(g_amax<1e-12f)g_amax=1.0f;group_scales[l][g]=g_amax/127.0f;float g_is=127.0f/g_amax;
+            for(int j=0;j<N;j++){for(int i=0;i<g_size;i++){float v=w[(g_start+i)*N+j];if(!std::isfinite(v))v=0;
+                int x=(int)roundf(v*g_is);if(x>127)x=127;else if(x<-127)x=-127;Bm[(g_start+i)*N+j]=(int8_t)x;}}}
+        layerB[l]->sync(XCL_BO_SYNC_BO_TO_DEVICE);float ssum=0;for(int g=0;g<num_groups;g++)ssum+=group_scales[l][g];sout=ssum/num_groups;}
+    // Async quantize: packs float activations into the A buffer without syncing
+    // Returns the quantized buffer pointer for later sync_and_launch.
     inline int8_t* quantize_async(const float*A,int am,int ak,float ascale){
-        if(use_bf16){
-            // BF16 quantize: just convert f32 to bf16
-            auto*ABuf = (uint16_t*)Am;
-            for(int i=0;i<am*ak;i++){
-                ABuf[i] = f32_to_bf16(A[i]);
-            }
-        }else{
-            // INT8 quantize — same for flat and grouped (ascale is per-call)
-            // INT8 quantize
-            float ais=1.0f/ascale;memset(Am,0,(size_t)am*KD);
-            for(int m=0;m<am;m++)for(int k=0;k<ak;k++){
-                float v=A[m*ak+k];if(!std::isfinite(v))v=0;
-                int q=(int)roundf(v*ais);if(q>127)q=127;else if(q<-127)q=-127;
-                Am[m*KD+k]=(int8_t)q;}
-        }
-        return Am;}
-    inline void sync_A(int l){(void)l;bA->sync(XCL_BO_SYNC_BO_TO_DEVICE);}
-    inline xrt::run launch(){return (*k)((unsigned)3,*bI,(unsigned)ins.size(),*bA,*layerB[cur_layer],*bC);}
-    inline xrt::run sync_and_launch(){bA->sync(XCL_BO_SYNC_BO_TO_DEVICE);bC->sync(XCL_BO_SYNC_BO_TO_DEVICE);return (*k)((unsigned)3,*bI,(unsigned)ins.size(),*bA,*layerB[cur_layer],*bC);}
-    // Per-group GEMM launch: uses K=32 instructions, processes one K-group
-    // Per-group GEMM launch: copies the group's B slice to offset 0 of
-    // the B BO, then uses the k_offset=0 instructions from bI_group.
-    inline xrt::run sync_and_launch_group(int g, int k_start, int k_size) {
-        // Copy B[group] to B[0] within layerB buffer so k_offset=0 instrs work
-        int8_t* Bm = (int8_t*)layerB[cur_layer]->map();
-        size_t group_bytes = (size_t)k_size * ND;
-        size_t src_off = (size_t)k_start * ND;
-        if (g > 0 && src_off > 0) {
-            memmove(Bm, Bm + src_off, group_bytes);
-        }
+        float ais=1.0f/ascale;
+        memset(Am,0,(size_t)am*KD);
+        for(int m=0;m<am;m++)for(int k=0;k<ak;k++){
+            float v=A[m*ak+k];if(!std::isfinite(v))v=0;
+            int q=(int)roundf(v*ais);if(q>127)q=127;else if(q<-127)q=-127;
+            Am[m*KD+k]=(int8_t)q;}
+        return Am;
+    }
+    // Sync A to device (non-blocking DMA, can overlap with NPU compute).
+    inline void sync_A(int l){
+        (void)l;
         bA->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        layerB[cur_layer]->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        bC->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        return (*k)((unsigned)3, *bI_group, (unsigned)group_ins.size(),
-                    *bA, *layerB[cur_layer], *bC);
     }
-    inline void dequantize(xrt::run& r,float*C,int am,int an,float ascale,float Bscale){
-        r.wait();bC->sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-        if(use_bf16){
-            // BF16→f32: just convert
-            auto*COut = (uint16_t*)Cm;
-            for(int m=0;m<am;m++)for(int n=0;n<an;n++){
-                uint32_t bits = (uint32_t)COut[m*ND+n] << 16;
-                float val; memcpy(&val, &bits, 4);
-                if(!std::isfinite(val))val=0;
-                C[m*an+n]=val;
-            }
-        }else{
-            // INT32→f32 with scale
-            float cs=ascale*Bscale;
-            for(int m=0;m<am;m++)for(int n=0;n<an;n++){
-                float val=(float)((int32_t*)Cm)[m*ND+n]*cs;if(!std::isfinite(val))val=0;C[m*an+n]=val;}
-        }}
-    // Per-group dequant: applies per-group scales to int32 accumulator
-    inline void dequantize_grouped(xrt::run& r, float* C, int am, int an,
-                                    float ascale, const float* gs, int group_idx) {
-        r.wait(); bC->sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-        for (int m = 0; m < am; m++) {
-            for (int n = 0; n < an; n++) {
-                float val = (float)Cm[(size_t)m * ND + n] * ascale * gs[(size_t)group_idx * an + n];
-                if (!std::isfinite(val)) val = 0;
-                C[(size_t)m * an + n] += val;
-            }
-        }
+    // Launch kernel via extended module API (instructions embedded in ELF).
+    // Args: mode=3, ctrl=0, reserved=0, then data BOs: A, weights B, output C.
+#ifdef ONEBP_SUPPORT
+#include "onebp_weight_loader.cpp"
+#endif
+    inline xrt::run launch(int l){
+        return k->operator()(3,0,0,*bA,*layerB[l],*bC);
     }
-    inline bool go(const float*A,int am,int ak,float ascale,float Bscale,float*C,int an){
-        if (use_grouped) {
-            return go_grouped(A, am, ak, ascale, C, an);
-        }
-        (void)ascale;  // BF16 doesn't use activation scale
-        quantize_async(A,am,ak,ascale);auto r=sync_and_launch();r.wait();
-        dequantize(r,C,am,an,ascale,Bscale);return true;}
-    // ── Per-group K-split GEMM (#1074) ──
-    // Splits K into 32-element groups, does per-group NPU GEMM, and
-    // accumulates with per-group dequant scales. This preserves Q4NX's
-    // per-group precision structure instead of collapsing to one scale.
-    inline bool go_grouped(const float* A, int am, int ak, float ascale, float* C, int an) {
-        if (!group_instrs_valid || !bI_group) return false;
-        float* C_accum = (float*)calloc((size_t)am * an, sizeof(float));
-        if (!C_accum) return false;
-        int ng = (ak + 31) / 32;
-        auto& gs = group_scales[cur_layer];
-        // Zero bC before starting (bC accumulates per-group int32 results)
-        memset(Cm, 0, (size_t)MD * ND * 4);
-        for (int g = 0; g < ng && g < num_groups; g++) {
-            int k_start = g * 32;
-            int k_size = std::min(32, ak - k_start);
-            // Quantize A for this K-slice into the first 32 columns of bA
-            float ais = 1.0f / ascale;
-            memset(Am, 0, (size_t)am * MD);  // MD >= 32, zero pad
-            for (int m = 0; m < am; m++) {
-                for (int k = 0; k < k_size; k++) {
-                    float v = A[(size_t)m * ak + k_start + k];
-                    if (!std::isfinite(v)) v = 0;
-                    int q = (int)roundf(v * ais);
-                    if (q > 127) q = 127; else if (q < -127) q = -127;
-                    Am[(size_t)m * MD + k] = (int8_t)q;
-                }
-            }
-            // Launch per-group GEMM
-            auto r = sync_and_launch_group(g, k_start, k_size);
-            // Dequant and accumulate with per-group scale
-            dequantize_grouped(r, C_accum, am, an, ascale, gs.data(), g);
-            // Re-zero bC for next group
-            memset(Cm, 0, (size_t)MD * ND * 4);
-        }
-        // Copy accumulated result to output
-        for (int i = 0; i < am * an; i++) C[i] = C_accum[i];
-        free(C_accum);
+    // Sync A to device and launch kernel. Returns run handle.
+    inline xrt::run sync_and_launch(int l){
+        bA->sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        return k->operator()(3,0,0,*bA,*layerB[l],*bC);
+    }
+
+    // Wait for run, sync C back, and dequantize.
+    // layer: if >= 0, uses average of per-group scales instead of Bscale.
+    inline void dequantize(xrt::run& r,float*C,int am,int an,float ascale,float Bscale,int layer=-1){
+        r.wait();
+        bC->sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+        if(layer>=0&&(size_t)layer<group_scales.size()&&!group_scales[layer].empty()){
+            float ssum=0;for(float s:group_scales[layer])ssum+=s;
+            Bscale=ssum/group_scales[layer].size();}
+        float cs=ascale*Bscale;
+        for(int m=0;m<am;m++)for(int n=0;n<an;n++){
+            float val=(float)Cm[m*ND+n]*cs;if(!std::isfinite(val))val=0;
+            C[m*an+n]=val;}
+    }
+    // Wait for NPU kernel completion without readback.
+    // Returns immediately after kernel finishes. Call sync_back_and_dequant() later.
+    inline void wait_kernel(xrt::run& r){
+        r.wait();
+    }
+    // Sync C back from device and dequantize (call after wait_kernel).
+    // This is CPU-only work that CAN overlap with the next kernel's NPU execution.
+    // layer: if >= 0, uses average of per-group scales instead of Bscale.
+    inline void sync_back_and_dequant(float*C,int am,int an,float ascale,float Bscale,int layer=-1){
+        bC->sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+        if(layer>=0&&(size_t)layer<group_scales.size()&&!group_scales[layer].empty()){
+            float ssum=0;for(float s:group_scales[layer])ssum+=s;
+            Bscale=ssum/group_scales[layer].size();}
+        float cs=ascale*Bscale;
+        for(int m=0;m<am;m++)for(int n=0;n<an;n++){
+            float val=(float)Cm[m*ND+n]*cs;if(!std::isfinite(val))val=0;
+            C[m*an+n]=val;}
+    }
+    // Synchronous go() — simple, always works
+    // Uses per-group scales from group_scales[l] when available.
+    inline bool go(int l,const float*A,int am,int ak,float ascale,float Bscale,float*C,int an){
+        quantize_async(A,am,ak,ascale);
+        auto r=sync_and_launch(l);
+        r.wait();
+        dequantize(r,C,am,an,ascale,Bscale,l);
         return true;
     }
-    inline xrt::run launch_async(const float*A,int am,int ak,float ascale){
-        quantize_async(A,am,ak,ascale);return sync_and_launch();}
-    inline void finish_async(xrt::run& r,float*C,int am,int an,float ascale,float Bscale){
-        r.wait();dequantize(r,C,am,an,ascale,Bscale);}
-    inline void wait_kernel(xrt::run& r){r.wait();}
-    inline void sync_back_and_dequant(float*C,int am,int an,float ascale,float Bscale){
-        bC->sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-        if(use_bf16){
-            auto*COut = (uint16_t*)Cm;
-            for(int m=0;m<am;m++)for(int n=0;n<an;n++){
-                uint32_t bits = (uint32_t)COut[m*ND+n] << 16;
-                float val; memcpy(&val, &bits, 4);
-                if(!std::isfinite(val))val=0;
-                C[m*an+n]=val;
-            }
-        }else{
-            float cs=ascale*Bscale;
-            for(int m=0;m<am;m++)for(int n=0;n<an;n++){
-                float val=(float)Cm[m*ND+n]*cs;if(!std::isfinite(val))val=0;C[m*an+n]=val;}
-        }}
+    // Fast path: launch, return run handle for later wait+dequant
+    inline xrt::run launch_async(int l,const float*A,int am,int ak,float ascale){
+        quantize_async(A,am,ak,ascale);
+        return sync_and_launch(l);
+    }
+    // Complete an async launch: wait + dequant
+    // layer: if >= 0, uses average of per-group scales instead of Bscale.
+    inline void finish_async(xrt::run& r,float*C,int am,int an,float ascale,float Bscale,int layer=-1){
+        r.wait();
+        dequantize(r,C,am,an,ascale,Bscale,layer);
+    }
+
+    // Alternative init that generates instructions via gemm_generate_sequence_i8().
+    // Uses the instruction generator instead of pre-compiled instruction files.
+    // Creates all BOs for the GEMM context at the specified dimensions.
+    bool init_with_generator(xrt::device& d, const char* xp,
+                             int _MD, int _KD, int _ND,
+                             int nlayers) {
+        MD = _MD; KD = _KD; ND = _ND; NL = nlayers;
+        // Generate INT8 instruction sequence
+        npu_sequence seq(device_npu2);
+        gemm_generate_sequence_i8(&seq, MD, MD, ND, 0, false, 0, 0, 0);
+        seq.cmds2seq();
+        auto [dp, sz] = seq.dump();
+        ins.assign(dp, dp + sz / sizeof(uint32_t));
+        // Convert to ELF and create kernel
+        try {
+            std::vector<char> iraw((char*)ins.data(),
+                                   (char*)ins.data() + ins.size() * sizeof(uint32_t));
+            aiebu::aiebu_assembler asmblr(
+                aiebu::aiebu_assembler::buffer_type::blob_instr_transaction, iraw);
+            auto e = asmblr.get_elf();
+            xc = std::make_unique<xrt::xclbin>(std::string(xp));
+            d.register_xclbin(*xc);
+            hc = std::make_unique<xrt::hw_context>(d, xc->get_uuid());
+            elf = std::make_unique<xrt::elf>(e.data(), e.size());
+        } catch (std::exception& ex) {
+            fprintf(stderr, "  init_with_generator: aiebu ELF gen failed: %s\n", ex.what());
+            return false;
+        }
+        mdl = std::make_unique<xrt::module>(*elf);
+        k = std::make_unique<xrt::ext::kernel>(*hc, *mdl, "MLIR_AIE");
+        bA = std::make_unique<xrt::bo>(d, (size_t)MD * KD, XRT_BO_FLAGS_HOST_ONLY, 0);
+        bC = std::make_unique<xrt::bo>(d, (size_t)MD * ND * 2, XRT_BO_FLAGS_HOST_ONLY, 0);
+        Am = (int8_t*)bA->map();
+        Cm = (int16_t*)bC->map();
+        for (int l = 0; l < NL; l++)
+            layerB.emplace_back(
+                std::make_unique<xrt::bo>(d, (size_t)KD * ND, XRT_BO_FLAGS_HOST_ONLY, 0));
+        group_scales.resize(NL);
+        initialized = true;
+        return true;
+    }
+
+    // Alternative init that takes pre-generated instructions instead of a file.
+    // Attention instructions loaded from pre-compiled file at init.
+    bool init_with_instrs(xrt::device& d, const char* xp,
+                          const std::vector<uint32_t>& pregen_instrs,
+                          int nlayers, int mdim, int kdim, int ndim) {
+        NL = nlayers;
+        MD = mdim; KD = kdim; ND = ndim;
+        ins = pregen_instrs;
+        try {
+            std::vector<char> iraw((char*)ins.data(),
+                                   (char*)ins.data() + ins.size() * sizeof(uint32_t));
+            aiebu::aiebu_assembler asmblr(
+                aiebu::aiebu_assembler::buffer_type::blob_instr_transaction, iraw);
+            auto e = asmblr.get_elf();
+            xc = std::make_unique<xrt::xclbin>(std::string(xp));
+            d.register_xclbin(*xc);
+            hc = std::make_unique<xrt::hw_context>(d, xc->get_uuid());
+            elf = std::make_unique<xrt::elf>(e.data(), e.size());
+        } catch (std::exception& ex) {
+            fprintf(stderr, "  aiebu ELF gen failed (instrs): %s\n", ex.what());
+            return false;
+        }
+        mdl = std::make_unique<xrt::module>(*elf);
+        k = std::make_unique<xrt::ext::kernel>(*hc, *mdl, "MLIR_AIE");
+        // Data BOs created by caller for attention (different layout)
+        group_scales.resize(nlayers);
+        initialized = true;
+        return true;
+    }
 };
 
-// AttnCtx — NPU attention using xrt::kernel with instruction BO (same as I8Ctx).
-// The xclbin kernel signature:
-//   kernel(3, insts_bo, insts_size, bo0=Q, bo1=K, bo2=V, bo3=output, bo4=unused)
-//
-// Two launch paths:
-//   1. launch_all() — quantizes full K/V cache each call (O(seq_len))
-//   2. append_kv() + launch() — incremental, O(NKV*HD) per token
-// AttnKernel — the expensive, hardware-context-limited shared resource: one
-// xclbin/hw_context/kernel for ALL layers. Found live (issue #1053 follow-up)
-// that giving every layer its own hw_context hits a real driver limit --
-// DRM_IOCTL_AMDXDNA_CREATE_HWCTX failed with EINVAL around the 12th
-// concurrent context on this hardware, silently forcing CPU-fallback
-// attention for the whole run. Per-layer K/V buffers (AttnCtx below) are
-// cheap device memory, not a limited driver resource, so only they are
-// per-layer -- the xclbin/hw_context/kernel triple is created once and
-// shared.
-struct AttnKernel {
+// AttnCtx — NPU attention context with 4 BOs (Q, K, V, output).
+// The attn.xclbin kernel signature (from EMBEDDED_METADATA):
+//   args: opcode, instr, ninstr, bo0..bo4
+//   bo0=Q (i8, NH*HD), bo1=K (i8, max_seq*NKV*HD),
+//   bo2=V (i8, max_seq*NKV*HD), bo3=output (i16, NH*HD)
+// Pre-compiled attention instructions loaded from file (fixed seq_len).
+struct AttnCtx {
+    int max_seq, NH, NKV, HD, XM;
     std::unique_ptr<xrt::xclbin> xc;
     std::unique_ptr<xrt::hw_context> hc;
-    std::unique_ptr<xrt::elf> elf;
     std::unique_ptr<xrt::module> mdl;
+    std::unique_ptr<xrt::elf> elf;
     std::unique_ptr<xrt::ext::kernel> k;
+    std::unique_ptr<xrt::bo> bQ, bK, bV, bOut;
     bool initialized = false;
 
-    bool isReady() { return initialized && hc && k; }
+    ~AttnCtx() {}
+    bool isReady() { return initialized && k && bQ && bK && bV && bOut; }
 
-    // NOTE: the raw instruction words from mha_generate_*() aren't a
-    // complete xrt::kernel submission by themselves — they need assembling
-    // into a proper ELF (aiebu) and loading via xrt::module/xrt::ext::kernel.
-    // The old manual-bI + xrt::kernel(3ULL,...) path submits the command but
-    // the AIE array never signals completion for this xclbin, so
-    // DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT hangs forever (see PR #1047).
-    bool init(xrt::device& d, const char* xp, const std::vector<uint32_t>& instrs) {
+    // Initialize with xclbin + runtime-generated instructions.
+    // Pre-allocates BOs at max_seq dimensions — only the first `seq_len`
+    // entries of K/V are valid per call (quantize K/V for the active range).
+    bool init(xrt::device& d, const char* xp,
+              const std::vector<uint32_t>& instrs,
+              int max_seq_len, int nh, int nkv, int hd, int xm) {
+        max_seq = max_seq_len;
+        NH = nh; NKV = nkv; HD = hd; XM = xm;
         try {
             std::vector<char> iraw((char*)instrs.data(),
                                    (char*)instrs.data() + instrs.size() * sizeof(uint32_t));
@@ -477,47 +346,8 @@ struct AttnKernel {
             d.register_xclbin(*xc);
             hc = std::make_unique<xrt::hw_context>(d, xc->get_uuid());
             elf = std::make_unique<xrt::elf>(e.data(), e.size());
-            mdl = std::make_unique<xrt::module>(*elf);
-            k = std::make_unique<xrt::ext::kernel>(*hc, *mdl, "MLIR_AIE");
         } catch (std::exception& ex) {
-            fprintf(stderr, "  AttnKernel init failed: %s\n", ex.what());
-            return false;
-        }
-        initialized = true;
-        return true;
-    }
-};
-
-struct AttnCtx {
-    int max_seq, NH, NKV, HD, XM;
-    int cur_seq = 0;
-    float cur_kv_scale = 1.0f;
-    xrt::hw_context* hc = nullptr;   // shared, owned by the AttnKernel
-    xrt::ext::kernel* k = nullptr;   // shared, owned by the AttnKernel
-    std::unique_ptr<xrt::ext::bo> bQ, bK, bV, bOut;
-    bool initialized = false;
-
-    ~AttnCtx() {}
-    bool isReady() { return initialized && k && bQ && bK && bV && bOut; }
-
-    // Per-layer buffer set only -- the xclbin/hw_context/kernel come from a
-    // shared AttnKernel (see above), not created here.
-    bool init(AttnKernel& shared, int max_seq_len, int nh, int nkv, int hd, int xm) {
-        max_seq = max_seq_len;
-        NH = nh; NKV = nkv; HD = hd; XM = xm;
-        if (!shared.isReady()) { fprintf(stderr, "  AttnCtx init failed: shared AttnKernel not ready\n"); return false; }
-        hc = shared.hc.get(); k = shared.k.get();
-        try {
-            size_t q_bytes = (size_t)XM * NH * HD;
-            size_t kv_bytes = (size_t)max_seq * NKV * HD;
-            size_t out_bytes = (size_t)XM * NH * HD * 2;
-            bQ = std::make_unique<xrt::ext::bo>(*hc, q_bytes);
-            bK = std::make_unique<xrt::ext::bo>(*hc, kv_bytes);
-            bV = std::make_unique<xrt::ext::bo>(*hc, kv_bytes);
-            bOut = std::make_unique<xrt::ext::bo>(*hc, out_bytes);
-            cur_seq = 0;
-        } catch (std::exception& ex) {
-            fprintf(stderr, "  AttnCtx buffer init failed: %s\n", ex.what());
+            fprintf(stderr, "  AttnCtx ELF gen failed: %s\n", ex.what());
             return false;
         }
         mdl = std::make_unique<xrt::module>(*elf);
@@ -526,128 +356,70 @@ struct AttnCtx {
         size_t q_bytes = (size_t)XM * NH * HD;            // Q: batch * NH * HD
         size_t kv_bytes = (size_t)max_seq * NKV * HD;     // K/V: max_seq * NKV * HD
         size_t out_bytes = (size_t)XM * NH * HD * 2;       // output: i16
-        bQ = std::make_unique<xrt::bo>(d, q_bytes, 0, 0);
-        bK = std::make_unique<xrt::bo>(d, kv_bytes, 0, 0);
-        bV = std::make_unique<xrt::bo>(d, kv_bytes, 0, 0);
-        bOut = std::make_unique<xrt::bo>(d, out_bytes, 0, 0);
+        bQ = std::make_unique<xrt::bo>(d, q_bytes, XRT_BO_FLAGS_HOST_ONLY, 0);
+        bK = std::make_unique<xrt::bo>(d, kv_bytes, XRT_BO_FLAGS_HOST_ONLY, 0);
+        bV = std::make_unique<xrt::bo>(d, kv_bytes, XRT_BO_FLAGS_HOST_ONLY, 0);
+        bOut = std::make_unique<xrt::bo>(d, out_bytes, XRT_BO_FLAGS_HOST_ONLY, 0);
         initialized = true;
         return true;
     }
 
-    void append_kv(const float* K_token, const float* V_token, float kv_scale) {
-        cur_kv_scale = kv_scale; float kv_is = 1.0f / kv_scale;
-        auto* k_i8 = (int8_t*)bK->map(); auto* v_i8 = (int8_t*)bV->map();
-        size_t off = (size_t)cur_seq * NKV * HD;
-        for (size_t i = 0; i < (size_t)NKV * HD; i++) {
-            float kv = K_token[i]; if (!std::isfinite(kv)) kv = 0;
-            int q = (int)roundf(kv * kv_is); k_i8[off+i] = (int8_t)(q > 127 ? 127 : (q < -127 ? -127 : q));
-            kv = V_token[i]; if (!std::isfinite(kv)) kv = 0;
-            q = (int)roundf(kv * kv_is); v_i8[off+i] = (int8_t)(q > 127 ? 127 : (q < -127 ? -127 : q));
-        }
-        cur_seq++;
-    }
-    void append_kv_batch(const float* K_batch, const float* V_batch, int npt, int qkv_n, float kv_scale) {
-        cur_kv_scale = kv_scale; float kv_is = 1.0f / kv_scale;
-        auto* k_i8 = (int8_t*)bK->map(); auto* v_i8 = (int8_t*)bV->map();
-        for (int pi = 0; pi < npt; pi++) {
-            size_t off = (size_t)(cur_seq+pi) * NKV * HD;
-            for (size_t i = 0; i < (size_t)NKV * HD; i++) {
-                float kv = K_batch[pi*qkv_n+i]; if (!std::isfinite(kv)) kv = 0;
-                int q = (int)roundf(kv * kv_is); k_i8[off+i] = (int8_t)(q > 127 ? 127 : (q < -127 ? -127 : q));
-                kv = V_batch[pi*qkv_n+i]; if (!std::isfinite(kv)) kv = 0;
-                q = (int)roundf(kv * kv_is); v_i8[off+i] = (int8_t)(q > 127 ? 127 : (q < -127 ? -127 : q));
-            }
-        }
-        cur_seq += npt;
-    }
-    // Re-quantize the full K/V history at a new scale (issue #1053). Needed
-    // because append_kv() quantizes each token in-place against whatever
-    // cur_kv_scale was active at the time it was appended -- if a later
-    // token's magnitude would exceed that scale (and clip), every previously
-    // appended token must be re-quantized too, not just the new one. Callers
-    // keep the full-precision K/V history on the host (kv_caches[l].k/.v)
-    // already, so this just replays that existing launch_all()-style
-    // quantization loop on demand instead of every step.
-    void requantize_kv(const float* K_cache, const float* V_cache, int seq_len, float kv_scale) {
-        cur_kv_scale = kv_scale; cur_seq = seq_len;
-        float kv_is = 1.0f / kv_scale; size_t kv_len = (size_t)seq_len * NKV * HD;
-        auto* k_i8 = (int8_t*)bK->map(); auto* v_i8 = (int8_t*)bV->map();
-        for (size_t i = 0; i < kv_len; i++) {
-            float v = K_cache[i]; if (!std::isfinite(v)) v = 0;
-            int q = (int)roundf(v * kv_is); k_i8[i] = (int8_t)(q > 127 ? 127 : (q < -127 ? -127 : q));
-            v = V_cache[i]; if (!std::isfinite(v)) v = 0;
-            q = (int)roundf(v * kv_is); v_i8[i] = (int8_t)(q > 127 ? 127 : (q < -127 ? -127 : q));
-        }
-        bK->sync(XCL_BO_SYNC_BO_TO_DEVICE); bV->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-    }
-    xrt::run launch(const float* Q_f32, int seq_len, int batch, float q_scale) {
-        auto* q_i8 = (int8_t*)bQ->map(); float q_is = 1.0f / q_scale;
+    // Quantize Q (f32) → BO (i8), sync, and launch attention.
+    // K/V caches are f32 on host — quantizes the active range [0, seq_len).
+    // Returns run handle for later wait+dequant.
+    xrt::run launch(const float* Q_f32, const float* K_cache, const float* V_cache,
+                    int seq_len, int batch, float q_scale, float kv_scale) {
+        // Quantize Q
+        auto* q_i8 = (int8_t*)bQ->map();
+        float q_is = 1.0f / q_scale;
         for (int i = 0; i < batch * NH * HD; i++) {
-            float v = Q_f32[i]; if (!std::isfinite(v)) v = 0;
-            int q = (int)roundf(v * q_is); q_i8[i] = (int8_t)(q > 127 ? 127 : (q < -127 ? -127 : q));
+            float v = Q_f32[i];
+            if (!std::isfinite(v)) v = 0;
+            int q = (int)roundf(v * q_is);
+            if (q > 127) q = 127; else if (q < -127) q = -127;
+            q_i8[i] = (int8_t)q;
         }
         bQ->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        size_t kv_bytes = (size_t)cur_seq * NKV * HD;
-        if (kv_bytes > 0) { bK->sync(XCL_BO_SYNC_BO_TO_DEVICE, kv_bytes, 0); bV->sync(XCL_BO_SYNC_BO_TO_DEVICE, kv_bytes, 0); }
-        // Explicit xrt::bo& casts: xrt::ext::bo derives from xrt::bo, and
-        // xrt::kernel::operator() has both a generic scalar template
-        // (set_arg(int, ArgType&&) -> set_arg_at_index(idx, &arg, sizeof(arg)))
-        // and a dedicated xrt::bo& overload. Passing the derived ext::bo
-        // directly resolves to the template (an exact-type match beats the
-        // derived-to-base binding the xrt::bo& overload needs), which patches
-        // sizeof(xrt::ext::bo) raw bytes of the C++ wrapper itself instead of
-        // the buffer handle -- the source of "patch_value() only supports
-        // 64-bit values or less" (issue #1066). Casting to xrt::bo& first
-        // makes both overloads equally-ranked identity matches, so the
-        // standard non-template-preferred tie-break selects the real one.
-        return k->operator()(3, 0, 0,
-            static_cast<xrt::bo&>(*bQ), static_cast<xrt::bo&>(*bK),
-            static_cast<xrt::bo&>(*bV), static_cast<xrt::bo&>(*bOut));
-    }
-    void fast_finish(xrt::run& r, float* out, int batch, float q_scale) { r.wait(); bOut->sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-        auto* out_i16 = (int16_t*)bOut->map(); float cs = q_scale * cur_kv_scale;
-        for (int i = 0; i < batch * NH * HD; i++) {
-            float val = (float)out_i16[i] * cs; if (!std::isfinite(val)) val = 0; out[i] = val;
-        }
-    }
-    xrt::run launch_all(const float* Q_f32, const float* K_cache, const float* V_cache,
-                        int seq_len, int batch, float q_scale, float kv_scale) {
-        cur_kv_scale = kv_scale; cur_seq = seq_len;
-        auto* q_i8 = (int8_t*)bQ->map(); float q_is = 1.0f / q_scale;
-        for (int i = 0; i < batch * NH * HD; i++) {
-            float v = Q_f32[i]; if (!std::isfinite(v)) v = 0;
-            int q = (int)roundf(v * q_is); q_i8[i] = (int8_t)(q > 127 ? 127 : (q < -127 ? -127 : q));
-        }
-        bQ->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        float kv_is = 1.0f / kv_scale; size_t kv_len = (size_t)seq_len * NKV * HD;
-        auto* k_i8 = (int8_t*)bK->map(); auto* v_i8 = (int8_t*)bV->map();
+
+        // Quantize K cache [0, seq_len)
+        auto* k_i8 = (int8_t*)bK->map();
+        float kv_is = 1.0f / kv_scale;
+        size_t kv_len = (size_t)seq_len * NKV * HD;
         for (size_t i = 0; i < kv_len; i++) {
-            float v = K_cache[i]; if (!std::isfinite(v)) v = 0;
-            int q = (int)roundf(v * kv_is); k_i8[i] = (int8_t)(q > 127 ? 127 : (q < -127 ? -127 : q));
-            v = V_cache[i]; if (!std::isfinite(v)) v = 0;
-            q = (int)roundf(v * kv_is); v_i8[i] = (int8_t)(q > 127 ? 127 : (q < -127 ? -127 : q));
+            float v = K_cache[i];
+            if (!std::isfinite(v)) v = 0;
+            int q = (int)roundf(v * kv_is);
+            if (q > 127) q = 127; else if (q < -127) q = -127;
+            k_i8[i] = (int8_t)q;
         }
-        bK->sync(XCL_BO_SYNC_BO_TO_DEVICE); bV->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        // Explicit xrt::bo& casts: xrt::ext::bo derives from xrt::bo, and
-        // xrt::kernel::operator() has both a generic scalar template
-        // (set_arg(int, ArgType&&) -> set_arg_at_index(idx, &arg, sizeof(arg)))
-        // and a dedicated xrt::bo& overload. Passing the derived ext::bo
-        // directly resolves to the template (an exact-type match beats the
-        // derived-to-base binding the xrt::bo& overload needs), which patches
-        // sizeof(xrt::ext::bo) raw bytes of the C++ wrapper itself instead of
-        // the buffer handle -- the source of "patch_value() only supports
-        // 64-bit values or less" (issue #1066). Casting to xrt::bo& first
-        // makes both overloads equally-ranked identity matches, so the
-        // standard non-template-preferred tie-break selects the real one.
-        return k->operator()(3, 0, 0,
-            static_cast<xrt::bo&>(*bQ), static_cast<xrt::bo&>(*bK),
-            static_cast<xrt::bo&>(*bV), static_cast<xrt::bo&>(*bOut));
+        bK->sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+        // Quantize V cache [0, seq_len)
+        auto* v_i8 = (int8_t*)bV->map();
+        for (size_t i = 0; i < kv_len; i++) {
+            float v = V_cache[i];
+            if (!std::isfinite(v)) v = 0;
+            int q = (int)roundf(v * kv_is);
+            if (q > 127) q = 127; else if (q < -127) q = -127;
+            v_i8[i] = (int8_t)q;
+        }
+        bV->sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+        // Launch: bo0=Q, bo1=K, bo2=V, bo3=output
+        return k->operator()(3, 0, 0, *bQ, *bK, *bV, *bOut);
     }
-    void finish_all(xrt::run& r, float* out, int batch, float q_scale, float kv_scale) {
-        (void)kv_scale; r.wait(); bOut->sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-        auto* out_i16 = (int16_t*)bOut->map(); float cs = q_scale * cur_kv_scale;
+
+    // Wait for completion and dequantize output to f32
+    void finish(xrt::run& r, float* out, int batch,
+                float q_scale, float kv_scale) {
+        r.wait();
+        bOut->sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+        auto* out_i16 = (int16_t*)bOut->map();
+        float cs = q_scale * kv_scale;
         for (int i = 0; i < batch * NH * HD; i++) {
-            float val = (float)out_i16[i] * cs; if (!std::isfinite(val)) val = 0; out[i] = val;
+            float val = (float)out_i16[i] * cs;
+            if (!std::isfinite(val)) val = 0;
+            out[i] = val;
         }
     }
 };
@@ -687,340 +459,6 @@ inline void lm_topk_omp(const float*hidden,float*lg,int*top_ids,int K,int NV,int
     for(int b=0;b<K;b++)top_ids[b]=top[b].id;
 }
 
-// ── NPU attention via runtime sequence xclbin ──
-// edge_attention_06b_compact kernel: 4 Q heads, 2 KV heads, 16-token window.
-// Runtime_sequence(%input, %output) interface via xrt::kernel.
-
-#define RT_ATTN_HEADS 4
-#define RT_ATTN_KVH 2
-#define RT_ATTN_CTX 8
-#define RT_ATTN_BLKS 2
-#define RT_ATTN_MAX_TK (RT_ATTN_CTX * RT_ATTN_BLKS)
-
-struct RuntimeAttnCtx {
-    std::unique_ptr<xrt::xclbin> xc;
-    std::unique_ptr<xrt::hw_context> hc;
-    std::unique_ptr<xrt::kernel> k;
-    std::unique_ptr<xrt::bo> bIn, bOut;
-    bool ok = false;
-    int wd, kd, id, od; // window/KV/input/output dwords
-
-    bool isReady() { return ok && k && bIn && bOut; }
-
-    bool init(xrt::device& d, const char* xp, int hd) {
-        wd = RT_ATTN_HEADS * hd / 2;
-        kd = RT_ATTN_KVH * RT_ATTN_CTX * hd / 2;
-        id = wd + 4 * kd;
-        od = wd;
-        try {
-            xc = std::make_unique<xrt::xclbin>(std::string(xp));
-            d.register_xclbin(*xc);
-            hc = std::make_unique<xrt::hw_context>(d, xc->get_uuid());
-            k = std::make_unique<xrt::kernel>(*hc, "MLIR_AIE");
-            bIn = std::make_unique<xrt::bo>(d, (size_t)id * 4, XRT_BO_FLAGS_HOST_ONLY, k->group_id(0));
-            bOut = std::make_unique<xrt::bo>(d, (size_t)od * 4, XRT_BO_FLAGS_HOST_ONLY, k->group_id(1));
-            bIn = std::make_unique<xrt::bo>(d, (size_t)id * 4, 0, k->group_id(0));
-            bOut = std::make_unique<xrt::bo>(d, (size_t)od * 4, 0, k->group_id(1));
-            bIn = std::make_unique<xrt::bo>(d, (size_t)id * 4,
-                0, k->group_id(0));
-            bOut = std::make_unique<xrt::bo>(d, (size_t)od * 4,
-                0, k->group_id(1));
-            ok = true;
-            return true;
-        } catch (std::exception& ex) {
-            fprintf(stderr, "  RuntimeAttnCtx init failed: %s\n", ex.what());
-            return false;
-        }
-    }
-
-    void run_win(const float* Q, const float* K, const float* V,
-                 float* out, int hoff, int sl, int hd, int nkv) {
-        if (!ok || sl > RT_ATTN_MAX_TK) return;
-        int vb = (sl + RT_ATTN_CTX - 1) / RT_ATTN_CTX;
-        if (vb > RT_ATTN_BLKS) vb = RT_ATTN_BLKS;
-
-        auto* buf = (int32_t*)bIn->map();
-        memset(buf, 0, (size_t)id * 4);
-        auto* qb = (uint16_t*)buf;
-        auto* kb0 = (uint16_t*)(buf + wd);
-        auto* kb1 = (uint16_t*)(buf + wd + kd);
-        auto* vb0 = (uint16_t*)(buf + wd + 2*kd);
-        auto* vb1 = (uint16_t*)(buf + wd + 3*kd);
-
-        for (int h = 0; h < RT_ATTN_HEADS; h++)
-            for (int d = 0; d < hd; d++) {
-                float v = Q[(hoff + h) * hd + d];
-                qb[h * hd + d] = v ? ((uint16_t*)&v)[1] : 0;
-            }
-
-        for (int b = 0; b < vb; b++) {
-            int t0 = b * RT_ATTN_CTX, t1 = t0 + RT_ATTN_CTX;
-            if (t1 > sl) t1 = sl;
-            auto* kp = b == 0 ? kb0 : kb1;
-            auto* vp = b == 0 ? vb0 : vb1;
-            for (int t = 0; t < RT_ATTN_CTX; t++)
-                for (int kv = 0; kv < RT_ATTN_KVH; kv++)
-                    for (int d = 0; d < hd; d++) {
-                        int idx = kv * RT_ATTN_CTX * hd + t * hd + d;
-                        float f = (t + t0 < t1)
-                            ? K[(size_t)(t + t0) * nkv * hd + kv * hd + d] : 0;
-                        kp[idx] = ((uint16_t*)&f)[1];
-                        f = (t + t0 < t1)
-                            ? V[(size_t)(t + t0) * nkv * hd + kv * hd + d] : 0;
-                        vp[idx] = ((uint16_t*)&f)[1];
-                    }
-        }
-
-        bIn->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        auto r = (*k)(*bIn, *bOut);
-        r.wait();
-        bOut->sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-
-        auto* ob = (uint16_t*)bOut->map();
-        for (int h = 0; h < RT_ATTN_HEADS; h++)
-            for (int d = 0; d < hd; d++) {
-                uint32_t bits = (uint32_t)ob[h * hd + d] << 16;
-                float v;
-                memcpy(&v, &bits, 4);
-                out[(hoff + h) * hd + d] = std::isfinite(v) ? v : 0;
-            }
-    }
-};
-
-static inline void npu_attn_rt(
-    RuntimeAttnCtx& ra, const float* qo, float* at, int cl,
-    const float* kk, const float* kv,
-    int NH, int NKV, int HD, int GQA,
-    int bs, int qn, int sp)
-{
-    (void)GQA; (void)qn; (void)sp;
-    if (cl > RT_ATTN_MAX_TK) {
-        for (int b = 0; b < bs; b++)
-            attn_omp(const_cast<float*>(&qo[b * qn]), &at[b * NH * HD], cl,
-                     kk, kv, NH, NKV, HD, GQA);
-        return;
-    }
-    for (int b = 0; b < bs; b++) {
-        const float* qb = &qo[b * qn];
-        float* ab = &at[b * NH * HD];
-        int nw = NH / RT_ATTN_HEADS;
-        for (int w = 0; w < nw; w++)
-            ra.run_win(qb, kk, kv, ab, w * RT_ATTN_HEADS, cl, HD, NKV);
-    }
-}
-
-// ── Consolidated NPU attention dispatch ──
-// Picks NPU attention (ca_ptr) or CPU fallback.
-// Uses AttnCtx's incremental KV API: caller must call append_kv() first.
-// This splits the work: append_kv is called DURING the decode loop's
-// KV cache update, hiding the quantize latency.
-static inline void npu_attn_dispatch(
-    float* qo,                // [bs][qn] Q data (batch * qkv_n, Q at front)
-    float* at,                // [bs][NH*HD] output attention
-    int cl,                   // current sequence length
-    int bs,                   // batch size
-    int qn,                   // qkv_n stride per batch item
-    int sp,                   // start position in KV cache (for max_pos mask)
-    const std::vector<float>& kv_k,  // flat K cache vector (unused for NPU path)
-    const std::vector<float>& kv_v,  // flat V cache vector (unused for NPU path)
-    int NH, int NKV, int HD, int GQA,
-    RuntimeAttnCtx& rta,
-    AttnCtx* ca_ptr)
-{
-    if (ca_ptr && ca_ptr->isReady()) {
-        float q_ascale = 0;
-        for (int i = 0; i < bs * NH * HD; i++) {
-            float a = fabsf(qo[i]);
-            if (std::isfinite(a) && a > q_ascale) q_ascale = a;
-        }
-        if (q_ascale < 1e-12f) q_ascale = 1.0f;
-        q_ascale = q_ascale / 127.0f;
-
-        // Single new token per call (the decode loop's shape): use the
-        // incremental append_kv()+launch() path instead of re-quantizing the
-        // entire KV cache every step (issue #1053). Multi-token calls
-        // (prefill/batched-speculative, bs>1) keep using launch_all() --
-        // those already pass one shared `cl` for per-position-variable
-        // causal windows via the CPU fallback's max_pos, a behavior this
-        // patch doesn't change.
-        if (bs == 1 && cl == sp + 1) {
-            float new_max = 0;
-            for (int i = sp * NKV * HD; i < cl * NKV * HD; i++) {
-                float a = fabsf(kv_k[i]); if (std::isfinite(a) && a > new_max) new_max = a;
-                a = fabsf(kv_v[i]); if (std::isfinite(a) && a > new_max) new_max = a;
-            }
-            float needed_scale = new_max / 127.0f;
-            if (needed_scale < 1e-12f) needed_scale = 1e-12f;
-            if (ca_ptr->cur_seq == 0 || ca_ptr->cur_seq != sp || needed_scale > ca_ptr->cur_kv_scale) {
-                // First token, a scale gap from an out-of-band cur_seq
-                // (shouldn't happen in normal use, but keeps this safe if a
-                // caller ever skips a step), or the new token would clip
-                // under the established scale -- (re)quantize full history.
-                float new_scale = needed_scale * 1.5f;  // headroom vs. next few tokens
-                ca_ptr->requantize_kv(kv_k.data(), kv_v.data(), cl, new_scale);
-            } else {
-                ca_ptr->append_kv(&kv_k[sp * NKV * HD], &kv_v[sp * NKV * HD], ca_ptr->cur_kv_scale);
-            }
-            auto r_attn = ca_ptr->launch(qo, cl, bs, q_ascale);
-            ca_ptr->fast_finish(r_attn, at, bs, q_ascale);
-            cn(at, bs * NH * HD);
-            return;
-        }
-
-        float kv_ascale = 0;
-        for (int i = 0; i < cl * NKV * HD; i++) {
-            float a = fabsf(kv_k[i]);
-            if (std::isfinite(a) && a > kv_ascale) kv_ascale = a;
-        }
-        if (kv_ascale < 1e-12f) kv_ascale = 1.0f;
-        kv_ascale = kv_ascale / 127.0f;
-        auto r_attn = ca_ptr->launch_all(qo, kv_k.data(), kv_v.data(), cl, bs, q_ascale, kv_ascale);
-        ca_ptr->finish_all(r_attn, at, bs, q_ascale, kv_ascale);
-        cn(at, bs * NH * HD);
-        return;
-    }
-    // CPU attention fallback
-    for (int b = 0; b < bs; b++) {
-        attn_omp(&qo[b * qn], &at[b * NH * HD], cl,
-                 kv_k.data(), kv_v.data(), NH, NKV, HD, GQA);
-    }
-}
-
-// Check if unified_server (production NPU service) is already holding
-// the NPU device. The amdxdna driver + XRT 2.x does not handle concurrent
-// access from multiple processes gracefully — attempting to open the device
-// while unified_server is running produces an IOMMU page fault and a
-// permanently wedged kernel, causing this process to hang forever waiting
-// on ioctl(DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT). See issue #1029.
-//
-// This function uses the same lock file that unified_server's
-// acquire_singleton_lock() creates, so we can detect it without process-name
-// heuristics or killing anything.
-static void check_npu_contention() {
-    const char* xdg = getenv("XDG_RUNTIME_DIR");
-    std::string lock_path = (xdg && xdg[0])
-        ? std::string(xdg) + "/unified_server.lock"
-        : std::string("/tmp/unified_server.lock");
-
-    int fd = open(lock_path.c_str(), O_RDONLY);
-    if (fd < 0) {
-        // Lock file doesn't exist — no unified_server running, safe to proceed.
-        return;
-    }
-
-    // Try to acquire the lock. If unified_server holds it, this will fail
-    // immediately (LOCK_NB). We don't want to actually take the lock — just
-    // probe whether it's held.
-    if (flock(fd, LOCK_EX | LOCK_NB) == 0) {
-        // We got the lock, which means unified_server is NOT holding it.
-        // Release immediately and continue.
-        flock(fd, LOCK_UN);
-        close(fd);
-        return;
-    }
-
-    // Lock is held. Read the owner token (PID:UUID) and check if the
-    // holding process is still alive.
-    char buf[128] = {0};
-    pread(fd, buf, sizeof(buf) - 1, 0);
-
-    pid_t holder_pid = 0;
-    char* colon = strchr(buf, ':');
-    if (colon) {
-        *colon = '\0';
-        holder_pid = (pid_t)atoi(buf);
-        *colon = ':';
-    }
-
-    close(fd);
-
-    // If the lock is held by our own direct parent, this isn't a rogue
-    // second process — it's unified_server's own deferred worker-spawn
-    // path (issue #1029: NPUBackend forks this exact binary as its worker
-    // subprocess). That parent commonly has /dev/accel/accel0 open just
-    // from HSA/ROCm device enumeration (HIP backend init touches all accel
-    // nodes on Strix Halo, not just the one it's using), which used to be
-    // misread as fatal contention and made every worker spawn fail (#1056).
-    if (holder_pid > 0 && holder_pid == getppid()) return;
-
-    if (holder_pid > 0 && kill(holder_pid, 0) == 0) {
-        // Holder is alive. Check if it actually has the NPU device open.
-        // unified_server may have released it (see issue #1029 part 3):
-        // when using a GPU-only backend, it closes the fd and unmaps
-        // the device, so the NPU is free for standalone tools.
-        bool actually_holds_npu = false;
-        char proc_path[256];
-
-        // Check /proc/<pid>/fd for /dev/accel/accel* symlinks
-        snprintf(proc_path, sizeof(proc_path), "/proc/%d/fd", (int)holder_pid);
-        DIR* fddir = opendir(proc_path);
-        if (fddir) {
-            struct dirent* entry;
-            while ((entry = readdir(fddir)) != nullptr) {
-                if (entry->d_name[0] == '.') continue;
-                char link[512], target[128];
-                snprintf(link, sizeof(link), "%s/%s", proc_path, entry->d_name);
-                ssize_t n = readlink(link, target, sizeof(target) - 1);
-                if (n > 0 && strncmp(target, "/dev/accel/accel", 16) == 0) {
-                    actually_holds_npu = true;
-                    break;
-                }
-            }
-            closedir(fddir);
-        }
-
-        // Check /proc/<pid>/maps for /dev/accel/accel* mmap regions
-        if (!actually_holds_npu) {
-            snprintf(proc_path, sizeof(proc_path), "/proc/%d/maps", (int)holder_pid);
-            FILE* maps = fopen(proc_path, "r");
-            if (maps) {
-                char line[512];
-                while (fgets(line, sizeof(line), maps)) {
-                    if (strstr(line, "/dev/accel/accel")) {
-                        actually_holds_npu = true;
-                        break;
-                    }
-                }
-                fclose(maps);
-            }
-        }
-
-        if (actually_holds_npu) {
-            fprintf(stderr,
-                "\n"
-                "  NPU DEVICE IN USE\n"
-                "  unified_server is already holding the NPU (pid %d).\n"
-                "\n"
-                "  The amdxdna driver cannot safely share the NPU between\n"
-                "  concurrent processes. Starting another NPU process will\n"
-                "  cause an IOMMU page fault and a permanently wedged fence.\n"
-                "\n"
-                "  To run npu_engine_universal, stop unified_server first:\n"
-                "    $ sudo systemctl stop unified-server\n"
-                "    (or) $ kill %d\n"
-                "\n"
-                "  See issue #1029 for details.\n"
-                "\n",
-                (int)holder_pid, (int)holder_pid);
-            _exit(1);
-        }
-
-        // unified_server is running but has released the NPU device.
-        // Safe to proceed.
-        fprintf(stderr,
-            "Note: unified_server (pid %d) is running but has released the NPU device.\n"
-            "      Proceeding with standalone NPU inference.\n",
-            (int)holder_pid);
-    }
-
-    // Holder process is dead — lock is stale. unified_server's own
-    // singleton lock code will clean it up on next restart. We can
-    // safely proceed; the real device may be free (or not — see below).
-    fprintf(stderr,
-        "Note: stale unified_server lock found (pid %d no longer running).\n",
-        (int)holder_pid);
-}
-
 int main(int argc,char**argv){
     setvbuf(stdout,NULL,_IONBF,0);
     // Install SIGABRT handler for issue #202: heap corruption during decode
@@ -1036,25 +474,13 @@ int main(int argc,char**argv){
     if(argc<2){fprintf(stderr,"Usage: %s model.q4nx [decode_tokens] [input_tokens_file|-]\n",argv[0]);return 1;}
     // Check for --worker flag (subprocess protocol mode)
     bool worker_mode=false;
-    for(int i=2;i<argc;i++){if(strcmp(argv[i],"--worker")==0){worker_mode=true;break;}}
-    const char*mp=argv[1];int ng=(argc>2&&!worker_mode)?atoi(argv[2]):32;if(ng<1)ng=1;if(ng>16384)ng=16384; // cap to KV cache size
-    const char*input_tok_file=(argc>3&&!worker_mode&&argv[3][0]!='\0')?argv[3]:nullptr;
-
-    // In --worker mode, fd 1 IS the binary protocol pipe backend_npu.cpp
-    // reads (GEMM headers/floats, and the READY handshake). AttnCtx's
-    // aiebu::aiebu_assembler (ELF-building for the NPU attention xclbin)
-    // writes its own trace lines ("Header version...", "Device
-    // Generation...", "NumOps:...", "UID:...") straight to fd 1, ahead of
-    // the "READY\n" handshake bytes — the parent then reads those instead
-    // of "READY\n" and treats every worker spawn as a handshake failure.
-    // Redirect fd 1 to /dev/null for the init section below and restore
-    // the real pipe right before the handshake write (#1059).
-    int worker_real_stdout_fd = -1;
-    if (worker_mode) {
-        worker_real_stdout_fd = dup(1);
-        int devnull_fd = open("/dev/null", O_WRONLY);
-        if (devnull_fd >= 0) { dup2(devnull_fd, 1); close(devnull_fd); }
+    bool use_flm_xclbin=false;
+    for(int i=2;i<argc;i++){
+        if(strcmp(argv[i],"--worker")==0){worker_mode=true;}
+        if(strcmp(argv[i],"--use-flm-xclbin")==0){use_flm_xclbin=true;}
     }
+    const char*mp=argv[1];int ng=(argc>2&&!worker_mode)?atoi(argv[2]):32;if(ng<1)ng=1;if(ng>4096)ng=4096; // cap to KV cache size (issue #112)
+    const char*input_tok_file=(argc>3&&!worker_mode&&argv[3][0]!='\0')?argv[3]:nullptr;
 
     // Model tag
     // Accept --model-tag CLI override (passed by the Zig fused executor)
@@ -1063,13 +489,6 @@ int main(int argc,char**argv){
     if(model_tag.empty()){
         auto ls=mp_s.rfind('/');model_tag=(ls!=std::string::npos)?mp_s.substr(ls+1):mp_s;
         auto dot=model_tag.rfind('.');if(dot!=std::string::npos)model_tag=model_tag.substr(0,dot);
-        // FLM/convention: model files are typically named "model.q4nx" inside
-        // a directory named after the model (e.g. Qwen3-0.6B-NPU2/model.q4nx).
-        // If the filename-derived tag is "model", use the parent directory name.
-        if (model_tag == "model" && ls != std::string::npos && ls > 0) {
-            auto prev=mp_s.rfind('/',ls-1);
-            model_tag=mp_s.substr(prev+1,ls-prev-1);
-        }
     }
     for(auto&c:model_tag){c=tolower(c);if(c=='-'||c=='.'||c=='\\')c='_';}
     const char*sfxs[]={"_npu2","_instruct","_it","_it_npu2"};
@@ -1090,35 +509,6 @@ int main(int argc,char**argv){
             cfg.HD = oh.head_dim; cfg.IM = oh.intermediate_size;
             cfg.NV = oh.vocab_size; cfg.GQA = cfg.NH / cfg.NKV;
             cfg.XM = 128; cfg.has_lm_head = true;
-            // The rest of ModelConfig (model_tag, xclbin_*, gu_split, has_q_norm/
-            // has_k_norm) was never populated for the onebp path — it only ever
-            // set the handful of fields above, leaving model_tag empty and every
-            // xclbin_* dimension zero. That's invisible until NPU init actually
-            // tries to open "insts_i8_QKV_.txt" (empty tag) and fails. Mirror
-            // parse_q4nx_header()'s derivation below (same formulas, sourced
-            // from the onebp header instead of Q4NX JSON tile-row counts).
-            cfg.model_tag = model_tag;
-            cfg.rope_theta = oh.rope_theta() > 0 ? oh.rope_theta() : cfg.rope_theta;
-            {
-                std::vector<float> probe;
-                cfg.has_q_norm = onebp_model.get_tensor_f32("blk.0.attn_q_norm.weight", probe);
-                cfg.has_k_norm = onebp_model.get_tensor_f32("blk.0.attn_k_norm.weight", probe);
-            }
-            cfg.qkv_k_offset = cfg.NH * cfg.HD;
-            cfg.qkv_v_offset = cfg.NH * cfg.HD + cfg.NKV * cfg.HD;
-            cfg.qkv_total = cfg.NH * cfg.HD + 2 * cfg.NKV * cfg.HD;
-            cfg.xclbin_qkv_k = cfg.H;
-            cfg.xclbin_qkv_n = cfg.qkv_total;
-            cfg.xclbin_o_k = cfg.NH * cfg.HD;
-            cfg.xclbin_o_n = cfg.H;
-            cfg.gu_split = (cfg.IM * 2 > 14336);
-            if (cfg.gu_split) {
-                cfg.xclbin_g_k = cfg.H; cfg.xclbin_g_n = cfg.IM;
-                cfg.xclbin_u_k = cfg.H; cfg.xclbin_u_n = cfg.IM;
-            } else {
-                cfg.xclbin_gu_k = cfg.H; cfg.xclbin_gu_n = cfg.IM * 2;
-            }
-            cfg.xclbin_d_k = cfg.IM; cfg.xclbin_d_n = cfg.H;
         } else
     #endif
         cfg = parse_q4nx_header(mp,model_tag.c_str());
@@ -1134,30 +524,6 @@ int main(int argc,char**argv){
     uint64_t hsz;memcpy(&hsz,md,8);uint64_t df=8+hsz;
     auto i8p=[&](uint64_t o){return md+df+o;};auto emb=(const uint16_t*)(md+df);
     const char*js=(const char*)(md+8);size_t jl=hsz;
-
-    // Optional direct-BF16-source GEMM weights (issue #1074): the Q4NX file
-    // stores GEMM weights as INT4 (dequant_i8_to_float_ex reconstructs a
-    // float array from that), which packB() then re-quantizes to INT8 --
-    // two lossy quantization passes stacked. Skipping the INT4 intermediate
-    // and quantizing straight from the original BF16 checkpoint removes one
-    // of those passes, no kernel/xclbin changes needed. Layout: fixed
-    // per-layer tensor order (q,k,v,o,gate,up,down), each raw float32
-    // [out_features,in_features] row-major, back to back -- see
-    // tools/convert_bf16_direct.py in the repo history / issue #1074.
-    const char* bf16d_path = getenv("NPU_BF16_DIRECT_WEIGHTS");
-    const float* bf16d = nullptr;
-    if (bf16d_path) {
-        int bfd = open(bf16d_path, O_RDONLY);
-        if (bfd >= 0) {
-            struct stat bst; fstat(bfd, &bst);
-            void* m = mmap(NULL, bst.st_size, PROT_READ, MAP_PRIVATE, bfd, 0);
-            close(bfd);
-            if (m != MAP_FAILED) { bf16d = (const float*)m; fprintf(stderr, "  BF16-direct weights: %s (%lld bytes)\n", bf16d_path, (long long)bst.st_size); }
-            else fprintf(stderr, "  BF16-direct weights: mmap failed for %s\n", bf16d_path);
-        } else {
-            fprintf(stderr, "  BF16-direct weights: cannot open %s\n", bf16d_path);
-        }
-    }
 
     // Pre-convert embeddings f32 (v12 optimization)
     fprintf(stderr,"Pre-convert emb f32...\n");auto te=std::chrono::steady_clock::now();
@@ -1180,29 +546,6 @@ int main(int argc,char**argv){
     // Norm weights
     std::vector<uint64_t> in_off(NC),pa_off(NC),qn_off(NC),kn_off(NC),qp(NC),kp(NC),vp(NC),op(NC),gp(NC),up(NC),dp(NC);
     char bn[128];
-    std::vector<std::vector<float>> in_n(NC),pa_n(NC),qn_w(NC),kn_w(NC);
-    std::vector<float> fin_v;
-    int q_i8=0,k_i8=0,v_i8=0,o_i8=0,g_i8=0,u_i8=0,d_i8=0;
-#ifdef ONEBP_SUPPORT
-    if (is_onebp) {
-        // Same tensors, GGUF/onebp naming (blk.N.*) instead of the HF
-        // safetensors naming (model.layers.N.*) the jo()/JSON path below
-        // uses. get_tensor_f32 dequantizes Q4NX/TQ2 internally and returns
-        // the tensor's real shape — no separate "I8 tile rows" lookup needed.
-        for (int l = 0; l < NC; l++) {
-            snprintf(bn,128,"blk.%d.attn_norm.weight",l); onebp_model.get_tensor_f32(bn, in_n[l]);
-            snprintf(bn,128,"blk.%d.ffn_norm.weight",l); onebp_model.get_tensor_f32(bn, pa_n[l]);
-            if (cfg.has_q_norm) { snprintf(bn,128,"blk.%d.attn_q_norm.weight",l); onebp_model.get_tensor_f32(bn, qn_w[l]); }
-            if (cfg.has_k_norm) { snprintf(bn,128,"blk.%d.attn_k_norm.weight",l); onebp_model.get_tensor_f32(bn, kn_w[l]); }
-        }
-        onebp_model.get_tensor_f32("output_norm.weight", fin_v);
-        std::vector<float> lm_buf;
-        if (onebp_model.get_tensor_f32("output.weight", lm_buf)) {
-            lm_head_f32 = lm_buf;
-            fprintf(stderr,"  lm_head: %zu floats (loaded from 1BP output.weight)\n",lm_buf.size());
-        }
-    } else {
-#endif
     for(int l=0;l<NC;l++){
         snprintf(bn,128,"model.layers.%d.self_attn.q_proj.weight",l);qp[l]=jo(js,jl,bn);
         snprintf(bn,128,"model.layers.%d.self_attn.k_proj.weight",l);kp[l]=jo(js,jl,bn);
@@ -1217,8 +560,8 @@ int main(int argc,char**argv){
         snprintf(bn,128,"model.layers.%d.self_attn.k_norm.weight",l);kn_off[l]=jo(js,jl,bn);}
     uint64_t no=jo(js,jl,"model.norm.weight");
     uint64_t lo=jo(js,jl,"lm_head.weight");
-    for(int l=0;l<NC;l++)in_n[l].resize(H),pa_n[l].resize(H),qn_w[l].resize(HD),kn_w[l].resize(HD);
-    fin_v.resize(H);
+    std::vector<std::vector<float>> in_n(NC,std::vector<float>(H)),pa_n(NC,std::vector<float>(H)),qn_w(NC,std::vector<float>(HD)),kn_w(NC,std::vector<float>(HD));
+    std::vector<float> fin_v(H);
     for(int l=0;l<NC;l++){auto iw=(const uint16_t*)(md+df+in_off[l]),pw=(const uint16_t*)(md+df+pa_off[l]);
         for(int i=0;i<H;i++){in_n[l][i]=bf16g(iw[i]);pa_n[l][i]=bf16g(pw[i]);}
         if(cfg.has_q_norm&&qn_off[l]){auto qq=(const uint16_t*)(md+df+qn_off[l]);for(int i=0;i<HD;i++)qn_w[l][i]=bf16g(qq[i]);}
@@ -1227,85 +570,130 @@ int main(int argc,char**argv){
 
     // I8 tile rows
     auto gi8=[&](const char*k)->int{int r=0;find_tensor_info(js,jl,k,&r);return r;};
-    q_i8=gi8("model.layers.0.self_attn.q_proj.weight");k_i8=gi8("model.layers.0.self_attn.k_proj.weight");v_i8=gi8("model.layers.0.self_attn.v_proj.weight");
-    o_i8=gi8("model.layers.0.self_attn.o_proj.weight");g_i8=gi8("model.layers.0.mlp.gate_proj.weight");u_i8=gi8("model.layers.0.mlp.up_proj.weight");d_i8=gi8("model.layers.0.mlp.down_proj.weight");
+    int q_i8=gi8("model.layers.0.self_attn.q_proj.weight"),k_i8=gi8("model.layers.0.self_attn.k_proj.weight"),v_i8=gi8("model.layers.0.self_attn.v_proj.weight");
+    int o_i8=gi8("model.layers.0.self_attn.o_proj.weight"),g_i8=gi8("model.layers.0.mlp.gate_proj.weight"),u_i8=gi8("model.layers.0.mlp.up_proj.weight"),d_i8=gi8("model.layers.0.mlp.down_proj.weight");
     int lm_i8=gi8("lm_head.weight");
 
-    // Load lm_head.weight separately — NOT tied to embed_tokens.weight for this model.
-    // Q4NX file may have lm_head.weight with wrong dimensions (observed: [18992,5120]
-    // instead of [151936,1024]). Check the actual JSON shape's second dimension — if
-    // it doesn't match H, the tensor is from a different model and we use tied embeddings.
-    if(lo&&lm_i8>0){
-        int lm_dim1 = get_shape_dim1(js, jl, "lm_head.weight");
-        if(lm_dim1 == H){
-            int lr,lc; float* lm_raw = dequant_i8_to_float_ex(i8p(lo), lm_i8, H, &lr, &lc);
-            if(lm_raw){
-                lm_head_f32.assign(lm_raw, lm_raw + (size_t)lr * lc);
-                fprintf(stderr,"  lm_head: %dx%d (loaded from JSON), using for final logits\n",lr,lc);
-                free(lm_raw);
-            }else{fprintf(stderr,"  lm_head: dequant failed, falling back to emb\n");}
-        }else{
-            fprintf(stderr,"  lm_head: JSON dim1=%d != H=%d — using tied embeddings (separate lm_head present but mismatched)\n",lm_dim1,H);
-        }
-    }
-#ifdef ONEBP_SUPPORT
-    }
-#endif
+    // Load lm_head.weight separately — NOT tied to embed_tokens.weight for this model
+    if(lo&&lm_i8>0){int lr,lc;float*lm_raw=dequant_i8_to_float_ex(i8p(lo),lm_i8,H,&lr,&lc);if(lm_raw){
+        lm_head_f32.assign(lm_raw,lm_raw+(size_t)lr*lc);free(lm_raw);
+        fprintf(stderr,"  lm_head: %dx%d (loaded from JSON), using for final logits\n",lr,lc);
+    }else{fprintf(stderr,"  lm_head: dequant failed, falling back to emb\n");}}
     if(lm_head_f32.empty()){fprintf(stderr,"  lm_head: using emb_f32 (tied embeddings)\n");}
     const float* lm_emb = lm_head_f32.empty() ? emb_f32.data() : lm_head_f32.data();
 
-    // Init NPU — check for contention with unified_server first (issue #1029)
-    check_npu_contention();
+    // Init NPU
     fprintf(stderr,"Init NPU...\n");xrt::device dev(0);
     // Xclbin directory: respect NPU_XCLBIN_DIR env var, fall back to repo-relative path
     const char* env_xd = getenv("NPU_XCLBIN_DIR");
     std::string xd = env_xd ? env_xd : "engine/npu/xclbins";
-    bool use_bf16_xclbins = true;  // Use BF16 xclbins for higher precision (#1074)
-    // Check if BF16 xclbins exist (in q4nx_bak/ — Chess-compiled, may hang)
-    {
-        std::string test_path = xd+"/q4nx_bak/bf16_QKV_"+cfg.model_tag+".xclbin";
-        FILE* tf = fopen(test_path.c_str(), "rb");
-        if(!tf) { use_bf16_xclbins = false; }
-        else { fclose(tf); fprintf(stderr,"  Using BF16 xclbins (q4nx_bak/, higher precision, issue #1074)\n"); }
-    }
-    auto xp=[&](const char*t){
-        if(use_bf16_xclbins)
-            return xd+"/q4nx_bak/bf16_"+std::string(t)+"_"+cfg.model_tag+".xclbin";
-    bool use_bf16_xclbins = true;  // Use recompiled BF16 xclbins
-    // Check if BF16 xclbins exist in q4nx subdirectory
-    {
-        std::string test_path = xd+"/q4nx/bf16_QKV_"+cfg.model_tag+".xclbin";
-        FILE* tf = fopen(test_path.c_str(), "rb");
-        if(!tf) { use_bf16_xclbins = false; }
-        else { fclose(tf); fprintf(stderr,"  Using BF16 Q4NX xclbins\n"); }
-    }
-    auto xp=[&](const char*t){
-        if(use_bf16_xclbins)
-            return xd+"/q4nx/bf16_"+std::string(t)+"_"+cfg.model_tag+".xclbin";
-        return xd+"/final_i8_"+std::string(t)+"_"+cfg.model_tag+".xclbin";
-    };
-    auto ip=[&](const char*t){
-        if(use_bf16_xclbins)
-            return xd+"/q4nx_bak/insts_bf16_"+std::string(t)+"_"+cfg.model_tag+".bin";
-            return xd+"/q4nx/insts_bf16_"+std::string(t)+"_"+cfg.model_tag+".bin";
-        return xd+"/insts_i8_"+std::string(t)+"_"+cfg.model_tag+".txt";
-    };
+    auto xp=[&](const char*t){return xd+"/final_i8_"+t+"_"+cfg.model_tag+".xclbin";};
+    auto ip=[&](const char*t){return xd+"/insts_i8_"+t+"_"+cfg.model_tag+".txt";};
 
-    // GEMM contexts (I8Ctx = NPU xclbin + kernel + buffer set)
+    // FLM xclbin path: respect NPU_FLM_XCLBIN_DIR env var for explicit path,
+    // or NPU_FLM_XCLBINS_ROOT for the root directory containing model subdirectories.
+    // Fall back to default FLM build path /home/bcloud/fastflowlm-build/src/xclbins.
+    const char* env_flm_xd = getenv("NPU_FLM_XCLBIN_DIR");
+    const char* env_flm_root = getenv("NPU_FLM_XCLBINS_ROOT");
+    std::string flm_xd;
+    if (env_flm_xd) {
+        flm_xd = env_flm_xd;
+        // If NPU_FLM_XCLBIN_DIR is given, it's the full path to the mm.xclbin
+        // (including the model subdirectory — we just append /mm.xclbin? No, it's a dir)
+        // NPU_FLM_XCLBIN_DIR = /path/to/Qwen3-0.6B-NPU2/  →  /path/to/Qwen3-0.6B-NPU2/mm.xclbin
+    }
+
+    // GEMM contexts: I8Ctx (legacy) or HybridFlmCtx (FLM path)
+    bool flm_xclbin_available = false;
+    std::string flm_mm_path;
+    if (use_flm_xclbin) {
+        // Try to find mm.xclbin. Priority:
+        // 1. NPU_FLM_XCLBIN_DIR/Qwen3-0.6B-NPU2/mm.xclbin (if env set)
+        // 2. NPU_FLM_XCLBINS_ROOT/{model-tag variants}/mm.xclbin
+        // 3. Default path: /home/bcloud/fastflowlm-build/src/xclbins/{variant}/mm.xclbin
+
+        if (env_flm_root) {
+            flm_xd = env_flm_root;
+        } else if (!env_flm_xd) {
+            flm_xd = "/home/bcloud/fastflowlm-build/src/xclbins";
+        }
+
+        if (env_flm_xd) {
+            // Direct path: user specified the exact directory
+            flm_mm_path = std::string(env_flm_xd) + "/mm.xclbin";
+        } else {
+            // Try to find the right model directory under root
+            // The model tag (e.g., "qwen3_0_6b") doesn't directly map to FLM's
+            // directory names (e.g., "Qwen3-0.6B-NPU2"), so we search for mm.xclbin
+            // under subdirectories of flm_xd that contain parts of the tag.
+            // First try: exact tag match
+            flm_mm_path = flm_xd + "/" + cfg.model_tag + "-NPU2/mm.xclbin";
+            FILE* f = fopen(flm_mm_path.c_str(), "rb");
+            if (!f) {
+                // Capitalize first letter
+                std::string cap_tag = cfg.model_tag;
+                if (!cap_tag.empty()) cap_tag[0] = (char)toupper(cap_tag[0]);
+                // Replace _ with - after digits (e.g., qwen3_0_6b → Qwen3-0.6B)
+                std::string pascal;
+                bool next_upper = true;
+                for (size_t i = 0; i < cfg.model_tag.size(); i++) {
+                    if (cfg.model_tag[i] == '_') {
+                        if (i > 0 && cfg.model_tag[i-1] >= '0' && cfg.model_tag[i-1] <= '9') {
+                            pascal += '.';  // 0_6 → 0.6
+                        } else {
+                            pascal += '-';
+                        }
+                        next_upper = true;
+                    } else if (next_upper) {
+                        pascal += (char)toupper(cfg.model_tag[i]);
+                        next_upper = false;
+                    } else {
+                        pascal += cfg.model_tag[i];
+                    }
+                }
+                flm_mm_path = flm_xd + "/" + pascal + "-NPU2/mm.xclbin";
+                f = fopen(flm_mm_path.c_str(), "rb");
+                if (f) { fclose(f); flm_xclbin_available = true; }
+                else {
+                    // Third try: search with ls (broad match)
+                    fprintf(stderr, "  Searching for mm.xclbin under %s ...\n", flm_xd.c_str());
+                    // Simple fallback: use tagged name directly
+                    std::string alt = std::string("find ") + flm_xd +
+                        " -name mm.xclbin 2>/dev/null | head -5";
+                    FILE* pf = popen(("find " + flm_xd +
+                        " -name mm.xclbin 2>/dev/null | head -1").c_str(), "r");
+                    if (pf) {
+                        char buf[512] = {};
+                        if (fgets(buf, sizeof(buf), pf)) {
+                            size_t len = strlen(buf);
+                            if (len > 0 && buf[len-1] == '\n') buf[len-1] = '\0';
+                            flm_mm_path = buf;
+                            FILE* cf = fopen(flm_mm_path.c_str(), "rb");
+                            if (cf) { fclose(cf); flm_xclbin_available = true; }
+                        }
+                        pclose(pf);
+                    }
+                }
+            } else {
+                fclose(f);
+                flm_xclbin_available = true;
+            }
+        }
+
+        if (flm_xclbin_available) {
+            fprintf(stderr, "  FLM mm.xclbin: %s\n", flm_mm_path.c_str());
+        } else {
+            fprintf(stderr, "  WARN: FLM mm.xclbin not found (searched %s), falling back to open-source path\n",
+                    flm_xd.c_str());
+        }
+    }
+
+    // Legacy I8Ctx pointers (always available, fallback if FLM xclbin not found)
     I8Ctx cq,co,cg,cd;
     std::unique_ptr<I8Ctx> cu_ptr;
-    // One AttnCtx per layer (issue #1053): each layer's on-device K/V buffer
-    // must hold that layer's incremental history independently. A single
-    // shared AttnCtx only worked because launch_all() fully overwrote its
-    // one buffer with whichever layer's cache was passed in on every call --
-    // that's incompatible with incremental append_kv(), which relies on
-    // cur_seq/the buffer contents persisting across calls for the SAME
-    // layer. Memory cost is small: ~8MB/layer at max_seq=4096 (NKV*HD*2
-    // bytes/token), ~224MB total for a 28-layer model -- trivial against
-    // this hardware's unified system memory.
-    AttnKernel attn_kernel;
-    std::vector<std::unique_ptr<AttnCtx>> ca_ptrs;
-    RuntimeAttnCtx rta;
+    std::unique_ptr<AttnCtx> ca_ptr;
+    // Hybrid FLM contexts (only used when --use-flm-xclbin and xclbin found)
+    std::unique_ptr<HybridFlmCtx> hcq, hco, hcg, hcd, hcu_ptr;
     std::vector<uint32_t> attn_instrs;
     auto load_attn_instrs = [&](const char* path) -> bool {
         FILE* f = fopen(path, "rb");
@@ -1320,98 +708,45 @@ int main(int argc,char**argv){
     co.MD=XM;co.KD=cfg.xclbin_o_k;co.ND=cfg.xclbin_o_n;
     cd.MD=XM;cd.KD=cfg.xclbin_d_k;cd.ND=cfg.xclbin_d_n;
     if(cfg.gu_split){cg.MD=XM;cg.KD=cfg.xclbin_g_k;cg.ND=cfg.xclbin_g_n;}else{cg.MD=XM;cg.KD=cfg.xclbin_gu_k;cg.ND=cfg.xclbin_gu_n;}
-    // FLM xclbin path: use FLM's universal mm.xclbin with runtime instruction
-    // generation (#1054, #1074). Controlled by NPU_FLM_XCLBIN env var.
-    bool use_flm_xclbin = false;
-    const char* flm_xp_env = getenv("NPU_FLM_XCLBIN");
-    if (flm_xp_env) {
-        std::string flm_xp(flm_xp_env);
-        // Try with model name appended
-        std::string flm_dir = flm_xp + "/" + cfg.model_tag;
-        // Convert model_tag like "qwen3_0_6b" to "Qwen3-0.6B-NPU2"
-        // FLM uses hyphenated model dir names
-        use_flm_xclbin = true;
-        fprintf(stderr,"  Trying FLM xclbin from %s\n", flm_xp_env);
-    }
 
-    if(!cq.init(dev,xp("QKV").c_str(),ip("QKV").c_str(),4,NC,use_bf16_xclbins)){fprintf(stderr,"FAIL QKV\n");return 1;}
-    if(!co.init(dev,xp("O").c_str(),ip("O").c_str(),4,NC,use_bf16_xclbins)){fprintf(stderr,"FAIL O\n");return 1;}
-    if(cfg.gu_split){if(!cg.init(dev,xp("G").c_str(),ip("G").c_str(),4,NC,use_bf16_xclbins)){fprintf(stderr,"FAIL G\n");return 1;}}else{if(!cg.init(dev,xp("GU").c_str(),ip("GU").c_str(),4,NC,use_bf16_xclbins)){fprintf(stderr,"FAIL GU\n");return 1;}}
-    if(!cd.init(dev,xp("D").c_str(),ip("D").c_str(),4,NC,use_bf16_xclbins)){fprintf(stderr,"FAIL D\n");return 1;}
-    if(cfg.gu_split){cu_ptr=std::make_unique<I8Ctx>();cu_ptr->MD=XM;cu_ptr->KD=cfg.xclbin_u_k;cu_ptr->ND=cfg.xclbin_u_n;if(!cu_ptr->init(dev,xp("U").c_str(),ip("U").c_str(),4,NC,use_bf16_xclbins)){fprintf(stderr,"FAIL U\n");return 1;}}
-    // NPU attention via pre-compiled KV xclbin instructions.
-    // NPU attention via pre-compiled KV xclbin instructions.
-    // Set NPU_ATTN=1 to enable. Disabled by default — the attention xclbin
-    // has the same XRT compatibility issue as the GEMM xclbins on some
-    // driver versions. Auto-enable when confirmed working per-model.
-    // NPU attention: auto-enable if attn xclbin exists. Override with NPU_ATTN=0.
-    // Always sized NC (null entries where unused) so every call site's
-    // ca_ptrs[l] is safe to index regardless of whether NPU attention ended
-    // up enabled -- npu_attn_dispatch() itself handles a null AttnCtx*.
-    ca_ptrs.resize(NC);
-    bool use_npu_attn = true;
-    const char* npu_attn_env = getenv("NPU_ATTN");
-    if(npu_attn_env && atoi(npu_attn_env) == 0) use_npu_attn = false;
-    if(use_npu_attn){
-        // Use INT8 attn xclbin path (attn is INT8 even in BF16 mode)
-        std::string attn_xp = std::string(xd) + "/final_i8_ATTN_" + cfg.model_tag + ".xclbin";
-        std::string inst_path = std::string(xd) + "/insts_i8_KV_" + cfg.model_tag + ".txt";
-        FILE* tf = fopen(attn_xp.c_str(), "rb");
-        if(!tf) { use_npu_attn = false; fprintf(stderr,"  No attn xclbin for %s\n",cfg.model_tag.c_str()); }
-        else { fclose(tf); }
-        if(!use_npu_attn || !load_attn_instrs(inst_path.c_str())) {
-            // Fallback: generate attention instructions at runtime
-            fprintf(stderr, "  No attn insts file, trying runtime generation...\n");
-            extern void mha_generate_attn_instrs(
-                std::vector<uint32_t>&, uint32_t, int, uint32_t, uint32_t, uint32_t, uint32_t);
-            attn_instrs.clear();
-            try {
-                mha_generate_attn_instrs(attn_instrs, (uint32_t)HD, 4,
-                    (uint32_t)NH, (uint32_t)NKV, 4096, 4096);
-                use_npu_attn = !attn_instrs.empty();
-            } catch (std::exception& ex) {
-                fprintf(stderr, "  Runtime attn instr gen failed: %s\n", ex.what());
-                use_npu_attn = false;
-            }
+    if (flm_xclbin_available) {
+        // ── Hybrid FLM path: use FLM's mm.xclbin + 1 BO per GEMM type ──
+        fprintf(stderr, "  Using FLM hybrid engine...\n");
+        hcq  = std::make_unique<HybridFlmCtx>();
+        hco  = std::make_unique<HybridFlmCtx>();
+        hcd  = std::make_unique<HybridFlmCtx>();
+        hcg  = std::make_unique<HybridFlmCtx>();
+        if (!hcq->init(dev, flm_mm_path.c_str(), XM, cfg.xclbin_qkv_k, cfg.xclbin_qkv_n, NC)) {
+            fprintf(stderr, "FAIL Hybrid QKV\n"); return 1; }
+        fprintf(stderr, "  Hybrid QKV OK\n");
+        if (!hco->init(dev, flm_mm_path.c_str(), XM, cfg.xclbin_o_k, cfg.xclbin_o_n, NC)) {
+            fprintf(stderr, "FAIL Hybrid O\n"); return 1; }
+        fprintf(stderr, "  Hybrid O OK\n");
+        if (cfg.gu_split) {
+            if (!hcg->init(dev, flm_mm_path.c_str(), XM, cfg.xclbin_g_k, cfg.xclbin_g_n, NC)) {
+                fprintf(stderr, "FAIL Hybrid G\n"); return 1; }
+            hcu_ptr = std::make_unique<HybridFlmCtx>();
+            if (!hcu_ptr->init(dev, flm_mm_path.c_str(), XM, cfg.xclbin_u_k, cfg.xclbin_u_n, NC)) {
+                fprintf(stderr, "FAIL Hybrid U\n"); return 1; }
+        } else {
+            if (!hcg->init(dev, flm_mm_path.c_str(), XM, cfg.xclbin_gu_k, cfg.xclbin_gu_n, NC)) {
+                fprintf(stderr, "FAIL Hybrid GU\n"); return 1; }
         }
-        if (use_npu_attn) {
-            // One shared AttnKernel (xclbin/hw_context/kernel -- a limited
-            // driver resource, see AttnKernel's declaration comment), then
-            // one AttnCtx per layer for just the K/V buffers against that
-            // shared context. ca_ptrs stays sized NC either way (resized
-            // unconditionally above); on failure just reset every entry
-            // back to null rather than shrinking the vector, so ca_ptrs[l]
-            // stays a safe no-op index at every call site.
-            if (!attn_kernel.init(dev, attn_xp.c_str(), attn_instrs)) {
-                fprintf(stderr, "WARN: AttnKernel init failed, CPU fallback\n");
-                use_npu_attn = false;
-            }
-            for (int l = 0; use_npu_attn && l < NC; l++) {
-                ca_ptrs[l] = std::make_unique<AttnCtx>();
-                if (!ca_ptrs[l]->init(attn_kernel, 4096, NH, NKV, HD, XM)) {
-                    fprintf(stderr, "WARN: AttnCtx buffer init failed for layer %d, CPU fallback\n", l);
-                    use_npu_attn = false;
-                    for (auto& p : ca_ptrs) p.reset();
-                    break;
-                }
-            }
-            if (use_npu_attn) fprintf(stderr, "NPU attention enabled (1 shared context, %d per-layer buffer sets)\n", NC);
-        }
-    }
-    // Runtime attention (edge_attention_06b_compact) disabled — uses incompatible kernel signature.
-    // All attention goes through ca_ptrs[l] (pre-compiled instructions via xrt::kernel).
-    (void)rta;  // suppress unused warning
-
-    if(!cq.init(dev,xp("QKV").c_str(),ip("QKV").c_str(),4,NC,use_bf16_xclbins)){fprintf(stderr,"FAIL QKV\n");return 1;}
-    if(!co.init(dev,xp("O").c_str(),ip("O").c_str(),4,NC,use_bf16_xclbins)){fprintf(stderr,"FAIL O\n");return 1;}
-    if(cfg.gu_split){if(!cg.init(dev,xp("G").c_str(),ip("G").c_str(),4,NC,use_bf16_xclbins)){fprintf(stderr,"FAIL G\n");return 1;}}else{if(!cg.init(dev,xp("GU").c_str(),ip("GU").c_str(),4,NC,use_bf16_xclbins)){fprintf(stderr,"FAIL GU\n");return 1;}}
-    if(!cd.init(dev,xp("D").c_str(),ip("D").c_str(),4,NC,use_bf16_xclbins)){fprintf(stderr,"FAIL D\n");return 1;}
-    if(cfg.gu_split){cu_ptr=std::make_unique<I8Ctx>();cu_ptr->MD=XM;cu_ptr->KD=cfg.xclbin_u_k;cu_ptr->ND=cfg.xclbin_u_n;if(!cu_ptr->init(dev,xp("U").c_str(),ip("U").c_str(),4,NC,use_bf16_xclbins)){fprintf(stderr,"FAIL U\n");return 1;}}
+        fprintf(stderr, "  Hybrid GU OK\n");
+        if (!hcd->init(dev, flm_mm_path.c_str(), XM, cfg.xclbin_d_k, cfg.xclbin_d_n, NC)) {
+            fprintf(stderr, "FAIL Hybrid D\n"); return 1; }
+        fprintf(stderr, "  Hybrid D OK\n");
+        // Sync weights after all packB calls (done at pack time in the pipeline below)
+    } else {
+        // ── Legacy path: per-op xclbins + per-layer weight BOs ──
+        if(!cq.init(dev,xp("QKV").c_str(),ip("QKV").c_str(),4,NC)){fprintf(stderr,"FAIL QKV\n");return 1;}
+        if(!co.init(dev,xp("O").c_str(),ip("O").c_str(),4,NC)){fprintf(stderr,"FAIL O\n");return 1;}
+        if(cfg.gu_split){if(!cg.init(dev,xp("G").c_str(),ip("G").c_str(),4,NC)){fprintf(stderr,"FAIL G\n");return 1;}}else{if(!cg.init(dev,xp("GU").c_str(),ip("GU").c_str(),4,NC)){fprintf(stderr,"FAIL GU\n");return 1;}}
+        if(!cd.init(dev,xp("D").c_str(),ip("D").c_str(),4,NC)){fprintf(stderr,"FAIL D\n");return 1;}
+        if(cfg.gu_split){cu_ptr=std::make_unique<I8Ctx>();cu_ptr->MD=XM;cu_ptr->KD=cfg.xclbin_u_k;cu_ptr->ND=cfg.xclbin_u_n;if(!cu_ptr->init(dev,xp("U").c_str(),ip("U").c_str(),4,NC)){fprintf(stderr,"FAIL U\n");return 1;}}
     // NPU attention via pre-compiled KV xclbin instructions.
-    // NPU attention via pre-compiled KV xclbin instructions.
-    // Set NPU_ATTN=1 to enable. Disabled by default — the attention xclbin
-    // has the same XRT compatibility issue as the GEMM xclbins on some
-    // driver versions. Auto-enable when confirmed working per-model.
+    // Set NPU_ATTN=1 to enable. Uses insts_i8_KV_<tag>.txt from xclbin dir.
+    // Set NPU_ATTN_FILE=<path> to override instruction file path.
     bool use_npu_attn = getenv("NPU_ATTN") && atoi(getenv("NPU_ATTN")) > 0;
     if(use_npu_attn){
         std::string inst_path;
@@ -1435,187 +770,68 @@ int main(int argc,char**argv){
             use_npu_attn = false;
         }
     }
-    // Also try loading the runtime sequence attention xclbin
-    if(use_npu_attn){
-        std::string runtime_xp = xp("ATTN");
-        if(rta.init(dev, runtime_xp.c_str(), HD)){
-            fprintf(stderr, "NPU runtime attention enabled\n");
-        }else{
-            fprintf(stderr, "WARN: Runtime attn init failed, using ext::kernel path\n");
-        }
-    }
 
-    // Per-layer dequant+pack lambda for single-buffer architecture.
+    // ── GEMM dispatch helpers ──
+    // Redirect GEMM calls to either I8Ctx (legacy) or HybridFlmCtx (FLM path)
+    // based on flm_xclbin_available flag.
+    // I8Ctx and HybridFlmCtx have the same method signatures, so each macro
+    // dispatches to ctx.go(...) or h##ctx->go(...) based on the flag.
+#define FLM_GO(ctx, ...)         (flm_xclbin_available ? h##ctx->go(__VA_ARGS__) : ctx.go(__VA_ARGS__))
+#define FLM_PACKB(ctx, ...)      (flm_xclbin_available ? h##ctx->packB(__VA_ARGS__) : ctx.packB(__VA_ARGS__))
+#define FLM_LAUNCH_ASYNC(ctx, ...)  (flm_xclbin_available ? h##ctx->launch_async(__VA_ARGS__) : ctx.launch_async(__VA_ARGS__))
+#define FLM_FINISH_ASYNC(ctx, ...)  (flm_xclbin_available ? h##ctx->finish_async(__VA_ARGS__) : ctx.finish_async(__VA_ARGS__))
+#define FLM_LAUNCH(ctx, ...)     (flm_xclbin_available ? h##ctx->launch(__VA_ARGS__) : ctx.launch(__VA_ARGS__))
+#define FLM_QUANTIZE_ASYNC(ctx, ...) (flm_xclbin_available ? h##ctx->quantize_async(__VA_ARGS__) : ctx.quantize_async(__VA_ARGS__))
+#define FLM_SYNC_AND_LAUNCH(ctx, ...) (flm_xclbin_available ? h##ctx->sync_and_launch(__VA_ARGS__) : ctx.sync_and_launch(__VA_ARGS__))
+#define FLM_SYNC_A(ctx, ...)     (flm_xclbin_available ? h##ctx->sync_A(__VA_ARGS__) : ctx.sync_A(__VA_ARGS__))
+#define FLM_WAIT_KERNEL(ctx, ...) (flm_xclbin_available ? h##ctx->wait_kernel(__VA_ARGS__) : ctx.wait_kernel(__VA_ARGS__))
+#define FLM_DEQUANTIZE(ctx, ...) (flm_xclbin_available ? h##ctx->dequantize(__VA_ARGS__) : ctx.dequantize(__VA_ARGS__))
+#define FLM_SYNC_BACK(ctx, ...)  (flm_xclbin_available ? h##ctx->sync_back_and_dequant(__VA_ARGS__) : ctx.sync_back_and_dequant(__VA_ARGS__))
+#define FLM_IS_READY(ctx)        (flm_xclbin_available ? h##ctx->isReady() : ctx.isReady())
+// Unique_ptr variants (for cu_ptr which uses -> instead of .)
+#define FLM_GO_PTR(ctx, ...)         (flm_xclbin_available ? h##ctx->go(__VA_ARGS__) : ctx->go(__VA_ARGS__))
+#define FLM_PACKB_PTR(ctx, ...)      (flm_xclbin_available ? h##ctx->packB(__VA_ARGS__) : ctx->packB(__VA_ARGS__))
+#define FLM_SYNC_AND_LAUNCH_PTR(ctx, ...) (flm_xclbin_available ? h##ctx->sync_and_launch(__VA_ARGS__) : ctx->sync_and_launch(__VA_ARGS__))
+#define FLM_DEQUANTIZE_PTR(ctx, ...) (flm_xclbin_available ? h##ctx->dequantize(__VA_ARGS__) : ctx->dequantize(__VA_ARGS__))
+#define FLM_QUANTIZE_ASYNC_PTR(ctx, ...) (flm_xclbin_available ? h##ctx->quantize_async(__VA_ARGS__) : ctx->quantize_async(__VA_ARGS__))
+#define FLM_IS_READY_PTR(ctx)    (flm_xclbin_available ? h##ctx->isReady() : ctx->isReady())
+
+    fprintf(stderr,"Dequant+pack...\n");auto tp=std::chrono::steady_clock::now();
     std::vector<float> qsc(NC),osc(NC),gsc(NC),dsc(NC),usc(NC);
     const int QOUT=NH*HD,KVOUT=NKV*HD;   // QKV out_features, in_features=H (default dequant correct)
     const int OOUT=H,OIN=NH*HD;          // O: out=H, in=NH*HD — dequant needs OIN
     const int GUOUT=IM;                   // Gate/Up: out=IM, in=H
     const int DOUT=H,DIN=IM;              // Down: out=H, in=IM — dequant needs DIN
-
-    // Per-layer tensor sizes/offsets into bf16d, matching
-    // tools/convert_bf16_direct.py's fixed q,k,v,o,gate,up,down order.
-    const size_t bf16d_sizes[7] = {
-        (size_t)QOUT*H, (size_t)KVOUT*H, (size_t)KVOUT*H,
-        (size_t)OOUT*OIN, (size_t)GUOUT*H, (size_t)GUOUT*H, (size_t)DOUT*DIN
-    };
-    size_t bf16d_off[7]; { size_t acc=0; for(int i=0;i<7;i++){bf16d_off[i]=acc;acc+=bf16d_sizes[i];} }
-    size_t bf16d_per_layer = bf16d_off[6] + bf16d_sizes[6];
-    auto bf16d_tensor = [&](int l, int idx) -> const float* {
-        return bf16d + (size_t)l * bf16d_per_layer + bf16d_off[idx];
-    };
-    std::function<void(int)> pack_layer_weights = [&](int l) {
-        // Keep cur_layer in sync with the layer actually being packed on
-        // EVERY path — the pre-pack-once loop below only runs when
-        // use_bf16_xclbins is true; for INT8 xclbins (this model) this
-        // closure is the only place cur_layer ever gets updated, and
-        // without it every layer silently packs into layerB[0] (#1061).
-        cq.set_layer(l); co.set_layer(l); cg.set_layer(l); cd.set_layer(l);
-        if (cu_ptr) cu_ptr->set_layer(l);
-        int qr,kr,vr,unused;
-    std::function<void(int)> pack_layer_weights = [&](int l) {int qr,kr,vr,unused;
-        float*qw,*kw,*vw,*ow,*gw,*uw,*dw;
-        std::vector<float> qw_v,kw_v,vw_v,ow_v,gw_v,uw_v,dw_v;
-        int gr,ur;
-        bool bf16d_owned = false;  // issue #1074: bf16d_tensor() pointers alias an mmap, must not be free()d
-#ifdef ONEBP_SUPPORT
-        if (is_onebp) {
-            // Tensors are already correctly shaped [out_features, in_features]
-            // by construction (that's how they're stored in the 1BP tensor
-            // index) — get_tensor_f32 dequantizes Q4NX/TQ2 and hands them back
-            // as-is, no separate row-count/offset bookkeeping needed.
-            snprintf(bn,128,"blk.%d.attn_q.weight",l); onebp_model.get_tensor_f32(bn, qw_v); qw=qw_v.data();
-            snprintf(bn,128,"blk.%d.attn_k.weight",l); onebp_model.get_tensor_f32(bn, kw_v); kw=kw_v.data();
-            snprintf(bn,128,"blk.%d.attn_v.weight",l); onebp_model.get_tensor_f32(bn, vw_v); vw=vw_v.data();
-            snprintf(bn,128,"blk.%d.attn_output.weight",l); onebp_model.get_tensor_f32(bn, ow_v); ow=ow_v.data();
-            snprintf(bn,128,"blk.%d.ffn_gate.weight",l); onebp_model.get_tensor_f32(bn, gw_v); gw=gw_v.data();
-            snprintf(bn,128,"blk.%d.ffn_up.weight",l); onebp_model.get_tensor_f32(bn, uw_v); uw=uw_v.data();
-            snprintf(bn,128,"blk.%d.ffn_down.weight",l); onebp_model.get_tensor_f32(bn, dw_v); dw=dw_v.data();
-            gr = ur = GUOUT;
-        } else {
-#endif
-        if (bf16d) {
-            // Direct-BF16-source path (issue #1074) -- points straight into
-            // the mmap'd float32 blob, no dequant, no free() needed.
-            qw=const_cast<float*>(bf16d_tensor(l,0)); kw=const_cast<float*>(bf16d_tensor(l,1)); vw=const_cast<float*>(bf16d_tensor(l,2));
-            ow=const_cast<float*>(bf16d_tensor(l,3));
-            gw=const_cast<float*>(bf16d_tensor(l,4)); uw=const_cast<float*>(bf16d_tensor(l,5));
-            dw=const_cast<float*>(bf16d_tensor(l,6));
-            gr=ur=GUOUT;
-        } else {
-        qw=dequant_i8_to_float_ex(i8p(qp[l]),q_i8,H,&qr,&unused);kw=dequant_i8_to_float_ex(i8p(kp[l]),k_i8,H,&kr,&unused);vw=dequant_i8_to_float_ex(i8p(vp[l]),v_i8,H,&vr,&unused);
-        {int or2,oc2;ow=dequant_i8_to_float_ex(i8p(op[l]),o_i8,OIN,&or2,&oc2);}
-        gw=dequant_i8_to_float_ex(i8p(gp[l]),g_i8,H,&gr,&unused);uw=dequant_i8_to_float_ex(i8p(up[l]),u_i8,H,&ur,&unused);
-        {int dr2,dc2;dw=dequant_i8_to_float_ex(i8p(dp[l]),d_i8,DIN,&dr2,&dc2);}
-        bf16d_owned = true;
-        }
-#ifdef ONEBP_SUPPORT
-        }
-#endif
+    for(int l=0;l<NC;l++){int qr,kr,vr,unused;
+        float*qw=dequant_i8_to_float_ex(i8p(qp[l]),q_i8,H,&qr,&unused),*kw=dequant_i8_to_float_ex(i8p(kp[l]),k_i8,H,&kr,&unused),*vw=dequant_i8_to_float_ex(i8p(vp[l]),v_i8,H,&vr,&unused);
         int t=QOUT+KVOUT+KVOUT;std::vector<float>w((size_t)H*t);
         transpose_pack(qw,QOUT,H,w.data(),t,0); transpose_pack(kw,KVOUT,H,w.data(),t,QOUT); transpose_pack(vw,KVOUT,H,w.data(),t,QOUT+KVOUT);
-        cq.packB(w.data(),H,t,qsc[l]);
+        FLM_PACKB(cq,l,w.data(),H,t,qsc[l]);free(qw);free(kw);free(vw);
+        int or2,oc2;float*ow=dequant_i8_to_float_ex(i8p(op[l]),o_i8,OIN,&or2,&oc2);
         std::vector<float>wo((size_t)OIN*OOUT);transpose_pack(ow,OOUT,OIN,wo.data(),OOUT,0);
-        co.packB(wo.data(),OIN,OOUT,osc[l]);
+        FLM_PACKB(co,l,wo.data(),OIN,OOUT,osc[l]);free(ow);
+        int gr,ur;float*gw=dequant_i8_to_float_ex(i8p(gp[l]),g_i8,H,&gr,&unused),*uw=dequant_i8_to_float_ex(i8p(up[l]),u_i8,H,&ur,&unused);
         if(cfg.gu_split){
             std::vector<float>wg((size_t)H*gr);transpose_pack(gw,GUOUT,H,wg.data(),gr,0);
-            cg.packB(wg.data(),H,gr,gsc[l]);
+            FLM_PACKB(cg,l,wg.data(),H,gr,gsc[l]);
             std::vector<float>wu((size_t)H*ur);transpose_pack(uw,GUOUT,H,wu.data(),ur,0);
-            cu_ptr->packB(wu.data(),H,ur,usc[l]);
+            FLM_PACKB_PTR(cu_ptr,l,wu.data(),H,ur,usc[l]);
         }else{
             int t2=gr+ur;std::vector<float>w2((size_t)H*t2);
             transpose_pack(gw,GUOUT,H,w2.data(),t2,0);transpose_pack(uw,GUOUT,H,w2.data(),t2,GUOUT);
-            cg.packB(w2.data(),H,t2,gsc[l]);
-        }
+            FLM_PACKB(cg,l,w2.data(),H,t2,gsc[l]);
+        }free(gw);free(uw);
+        int dr2,dc2;float*dw=dequant_i8_to_float_ex(i8p(dp[l]),d_i8,DIN,&dr2,&dc2);
         std::vector<float>wd((size_t)DIN*DOUT);transpose_pack(dw,DOUT,DIN,wd.data(),DOUT,0);
-        cd.packB(wd.data(),DIN,DOUT,dsc[l]);
-#ifdef ONEBP_SUPPORT
-        if (!is_onebp) {
-#endif
-        if (bf16d_owned) { free(qw);free(kw);free(vw);free(ow);free(gw);free(uw);free(dw); }
-#ifdef ONEBP_SUPPORT
-        }
-#endif
-    };
+        FLM_PACKB(cd,l,wd.data(),DIN,DOUT,dsc[l]);free(dw);}
+    // Hybrid FLM: sync all weight BOs to device after packing (single DMA per type)
+    if(flm_xclbin_available){
+        hcq->sync_weights(); hco->sync_weights();
+        hcg->sync_weights(); hcd->sync_weights();
+        if(cfg.gu_split && hcu_ptr) hcu_ptr->sync_weights();
+    }
+    fprintf(stderr,"  %.0fms\n\n",std::chrono::duration<double,std::milli>(std::chrono::steady_clock::now()-tp).count());
 
-    // Pre-pack all layer weights at load time (eliminates per-layer Q4NX dequant + BFP16 pack)
-    struct PrepackedW {
-        std::vector<uint8_t> q, o, g, d, u;
-    };
-    std::vector<PrepackedW> prepacked;
-    if (use_bf16_xclbins) {
-        fprintf(stderr,"Pre-packing weights...\n");
-        auto tp=std::chrono::steady_clock::now();
-        prepacked.resize(NC);
-        for (int l = 0; l < NC; l++) {
-            pack_layer_weights(l);
-            prepacked[l].q.assign((const uint8_t*)cq.layerB[0]->map(),
-                (const uint8_t*)cq.layerB[0]->map() + cq.b_size());
-            prepacked[l].o.assign((const uint8_t*)co.layerB[0]->map(),
-                (const uint8_t*)co.layerB[0]->map() + co.b_size());
-            prepacked[l].g.assign((const uint8_t*)cg.layerB[0]->map(),
-                (const uint8_t*)cg.layerB[0]->map() + cg.b_size());
-            prepacked[l].d.assign((const uint8_t*)cd.layerB[0]->map(),
-                (const uint8_t*)cd.layerB[0]->map() + cd.b_size());
-            if (cfg.gu_split && cu_ptr) {
-                prepacked[l].u.assign((const uint8_t*)cu_ptr->layerB[0]->map(),
-                    (const uint8_t*)cu_ptr->layerB[0]->map() + cu_ptr->b_size());
-            }
-        }
-        fprintf(stderr,"  Prep: %.0fms\n",std::chrono::duration<double,std::milli>(std::chrono::steady_clock::now()-tp).count());
-        // Replace pack_layer_weights with fast memcpy path
-        pack_layer_weights = [&](int l) {
-            memcpy(cq.layerB[0]->map(),prepacked[l].q.data(),prepacked[l].q.size());
-            cq.layerB[0]->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-            memcpy(co.layerB[0]->map(),prepacked[l].o.data(),prepacked[l].o.size());
-            co.layerB[0]->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-            memcpy(cg.layerB[0]->map(),prepacked[l].g.data(),prepacked[l].g.size());
-            cg.layerB[0]->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-            memcpy(cd.layerB[0]->map(),prepacked[l].d.data(),prepacked[l].d.size());
-            cd.layerB[0]->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-            if(cfg.gu_split&&cu_ptr&&!prepacked[l].u.empty()){
-                memcpy(cu_ptr->layerB[0]->map(),prepacked[l].u.data(),prepacked[l].u.size());
-                cu_ptr->layerB[0]->sync(XCL_BO_SYNC_BO_TO_DEVICE);}
-        };
-    }
-
-    // Pre-pack all layer weights into per-layer NPU-resident BOs.
-    // pack_layer_weights writes to layerB[cur_layer] via set_layer();
-    // once loaded, weights stay resident — no per-token memcpy, dequant, or
-    // requant needed on the decode path. This applies to BOTH BF16 and INT8
-    // xclbins — INT8 weights get their per-layer scale computed once here.
-    // Previously gated on use_bf16_xclbins, which left the INT8 path doing
-    // a dequant->requant->copy cycle per token per layer (~1s/layer = 21s/tok).
-    fprintf(stderr,"Pre-packing weights into NPU-resident BOs...\n");
-    auto tp=std::chrono::steady_clock::now();
-    for (int l = 0; l < NC; l++) {
-        cq.set_layer(l); co.set_layer(l); cg.set_layer(l); cd.set_layer(l);
-        if (cu_ptr) cu_ptr->set_layer(l);
-        pack_layer_weights(l);
-    }
-    fprintf(stderr,"  Prep: %.0fms\n",std::chrono::duration<double,std::milli>(std::chrono::steady_clock::now()-tp).count());
-    // Replace pack_layer_weights with per-layer BO selection only.
-    // Weights are already resident in layerB[l] — no memcpy, no DMA sync.
-    pack_layer_weights = [&](int l) {
-        cq.set_layer(l); co.set_layer(l); cg.set_layer(l); cd.set_layer(l);
-        if (cu_ptr) cu_ptr->set_layer(l);
-    };
-    // once loaded, weights stay resident — no per-token memcpy or DMA needed.
-    if (use_bf16_xclbins) {
-        fprintf(stderr,"Pre-packing weights into NPU-resident BOs...\n");
-        auto tp=std::chrono::steady_clock::now();
-        for (int l = 0; l < NC; l++) {
-            cq.set_layer(l); co.set_layer(l); cg.set_layer(l); cd.set_layer(l);
-            if (cu_ptr) cu_ptr->set_layer(l);
-            pack_layer_weights(l);
-        }
-        fprintf(stderr,"  Prep: %.0fms\n",std::chrono::duration<double,std::milli>(std::chrono::steady_clock::now()-tp).count());
-        // Replace pack_layer_weights with per-layer BO selection only.
-        // Weights are already resident in layerB[l] — no memcpy, no DMA sync.
-        pack_layer_weights = [&](int l) {
-            cq.set_layer(l); co.set_layer(l); cg.set_layer(l); cd.set_layer(l);
-            if (cu_ptr) cu_ptr->set_layer(l);
-        };
-    }
     // RoPE
     ri(HD,cfg.rope_theta,4096);
     int kv_dwords=NKV*HD/2;
@@ -1635,17 +851,9 @@ int main(int argc,char**argv){
     // longest matching prefix, roll the KV cache back on a miss), BS is pinned
     // to 1 -> plain causal single-token greedy decode, which is correct.
     // Do not raise this without implementing verification.
-    // Override via NPU_BATCH_SIZE env var (for testing only — produces garbage).
-    int BS = 1;
-    if (const char* e = getenv("NPU_BATCH_SIZE")) {
-        int v = atoi(e);
-        if (v > 1) {
-            fprintf(stderr, "WARNING: NPU_BATCH_SIZE=%d — non-causal KV corruption, see issue #111\n", v);
-            BS = v;
-        }
-    }
+    int BS=1;
     struct KVCache{std::vector<float>k,v;int n;KVCache(int size):k(size),v(size),n(0){}};
-    int kv_size=16384*NKV*HD;
+    int kv_size=4096*NKV*HD;
     std::vector<KVCache> kv_caches;for(int i=0;i<NC;i++)kv_caches.emplace_back(kv_size);
     int qkv_n=cfg.qkv_total;
     std::vector<float> h_b(XM*H), qo_b(XM*qkv_n), at_b(XM*NH*HD), oo_b(XM*H), gt_b(XM*(cfg.gu_split?IM:2*IM)), su_b(XM*IM), dw_b(XM*H);
@@ -1657,17 +865,15 @@ int main(int argc,char**argv){
     // operations (QKV, OPROJ, GATEUP, DOWN) via this protocol. Each request
     // is header[4] (op, layer, batch, in_dim) followed by float input data.
     // Response is header[2] (0=ok, out_dim) followed by float output data.
-    static int worker_pos = 0;
     if(worker_mode){
         fprintf(stderr,"WORKER_READY\n");
         fflush(stderr);
-        fflush(stdout);
-        // Restore the real pipe onto fd 1 now that init's vendor-library
-        // stdout noise (see above) is done — the handshake write below
-        // must be the first thing the parent reads on this fd (#1059).
-        if (worker_real_stdout_fd >= 0) { dup2(worker_real_stdout_fd, 1); close(worker_real_stdout_fd); }
-        setbuf(stdout, NULL);
+        // Startup handshake: parent waits for this before sending ops (issue #365)
         write(1, "READY\n", 6);
+        setbuf(stdout, NULL);
+        clearerr(stdout);
+        write(1, "EADY\n", 5);
+        fflush(stdout);
         uint32_t hdr[4];
         while(fread(hdr,sizeof(uint32_t),4,stdin)==4){
             uint32_t op=hdr[0],layer=hdr[1],batch=hdr[2],in_dim=hdr[3];
@@ -1692,36 +898,31 @@ int main(int argc,char**argv){
             bool ok=true;
 
             try{
-                if(op==1&&cq.isReady()){ // QKV projection
-                    pack_layer_weights((int)layer);
+                if(op==1&&FLM_IS_READY(cq)){ // QKV projection
                     out_dim=cfg.qkv_total;
                     out_data.resize(batch*out_dim,0);
                     float ascale=dynamic_ascale(in_data.data(),batch*in_dim);
-                    cq.go(in_data.data(),batch,(int)in_dim,ascale,qsc[layer],out_data.data(),(int)out_dim);
-                }else if(op==2&&co.isReady()){ // O projection
-                    pack_layer_weights((int)layer);
+                    FLM_GO(cq,layer,in_data.data(),batch,(int)in_dim,ascale,qsc[layer],out_data.data(),(int)out_dim);
+                }else if(op==2&&FLM_IS_READY(co)){ // O projection
                     out_dim=H;
                     out_data.resize(batch*out_dim,0);
                     float ascale=dynamic_ascale(in_data.data(),batch*in_dim);
-                    co.go(in_data.data(),batch,(int)in_dim,ascale,osc[layer],out_data.data(),(int)out_dim);
-                }else if(op==3&&cg.isReady()){ // Gate+Up
-                    pack_layer_weights((int)layer);
+                    FLM_GO(co,layer,in_data.data(),batch,(int)in_dim,ascale,osc[layer],out_data.data(),(int)out_dim);
+                }else if(op==3&&FLM_IS_READY(cg)){ // Gate+Up
                     out_dim=cfg.gu_split?IM:(2*IM);
                     out_data.resize(batch*out_dim,0);
                     float ascale=dynamic_ascale(in_data.data(),batch*in_dim);
-                    cg.go(in_data.data(),batch,(int)in_dim,ascale,gsc[layer],out_data.data(),(int)out_dim);
-                }else if(op==4&&cfg.gu_split&&cu_ptr&&cu_ptr->isReady()){ // Up
-                    pack_layer_weights((int)layer);
+                    FLM_GO(cg,layer,in_data.data(),batch,(int)in_dim,ascale,gsc[layer],out_data.data(),(int)out_dim);
+                }else if(op==4&&cfg.gu_split&&(flm_xclbin_available ? (bool)(hcu_ptr && hcu_ptr->isReady()) : (bool)(cu_ptr && cu_ptr->isReady()))){ // Up
                     out_dim=IM;
                     out_data.resize(batch*out_dim,0);
                     float ascale=dynamic_ascale(in_data.data(),batch*in_dim);
-                    cu_ptr->go(in_data.data(),batch,(int)in_dim,ascale,usc[layer],out_data.data(),(int)out_dim);
-                }else if(op==5&&cd.isReady()){ // Down
-                    pack_layer_weights((int)layer);
+                    FLM_GO_PTR(cu_ptr,layer,in_data.data(),batch,(int)in_dim,ascale,usc[layer],out_data.data(),(int)out_dim);
+                }else if(op==5&&FLM_IS_READY(cd)){ // Down
                     out_dim=H;
                     out_data.resize(batch*out_dim,0);
                     float ascale=dynamic_ascale(in_data.data(),batch*in_dim);
-                    cd.go(in_data.data(),batch,(int)in_dim,ascale,dsc[layer],out_data.data(),(int)out_dim);
+                    FLM_GO(cd,layer,in_data.data(),batch,(int)in_dim,ascale,dsc[layer],out_data.data(),(int)out_dim);
                 }else if(op==6){ // Attention — CPU path (worker protocol doesn't carry seq_len)
                     // Worker subprocess receives individual layer ops without KV cache
                     // context. NPU attention requires the full KV cache. Use CPU fallback.
@@ -1737,325 +938,42 @@ int main(int argc,char**argv){
                     int cl = kd > 0 ? (int)(in_dim - qd - kd) / (NKV * HD) : 1;
                     if (cl < 1) cl = 1;
                     attn_omp(q_ptr, out_data.data(), cl, k_ptr, v_ptr, NH, NKV, HD, GQA);
-                }else if(op==20&&cq.isReady()){ // QKV all layers (batch, op=20)
+                }else if(op==20&&FLM_IS_READY(cq)){ // QKV all layers (batch, op=20)
                     int n_layers = NC;
                     out_dim = cfg.qkv_total;
                     out_data.resize(batch * out_dim * (size_t)n_layers, 0);
                     for (int l = 0; l < n_layers; l++) {
-                        pack_layer_weights(l);
                         float ascale = dynamic_ascale(in_data.data() + (size_t)l * batch * in_dim, batch * in_dim);
-                        cq.go( in_data.data() + (size_t)l * batch * in_dim, batch, (int)in_dim,
+                        FLM_GO(cq, l, in_data.data() + (size_t)l * batch * in_dim, batch, (int)in_dim,
                               ascale, qsc[l], out_data.data() + (size_t)l * batch * out_dim, (int)out_dim);
                     }
-                }else if(op==21&&co.isReady()){ // O all layers (batch)
+                }else if(op==21&&FLM_IS_READY(co)){ // O all layers (batch)
                     int n_layers = NC;
                     out_dim = H;
                     out_data.resize(batch * out_dim * (size_t)n_layers, 0);
                     for (int l = 0; l < n_layers; l++) {
-                        pack_layer_weights(l);
                         float ascale = dynamic_ascale(in_data.data() + (size_t)l * batch * in_dim, batch * in_dim);
-                        co.go( in_data.data() + (size_t)l * batch * in_dim, batch, (int)in_dim,
+                        FLM_GO(co, l, in_data.data() + (size_t)l * batch * in_dim, batch, (int)in_dim,
                               ascale, osc[l], out_data.data() + (size_t)l * batch * out_dim, (int)out_dim);
                     }
-                }else if(op==22&&cg.isReady()){ // Gate+Up all layers (batch)
+                }else if(op==22&&FLM_IS_READY(cg)){ // Gate+Up all layers (batch)
                     int n_layers = NC;
                     out_dim = cfg.gu_split ? IM : (2 * IM);
                     out_data.resize(batch * out_dim * (size_t)n_layers, 0);
                     for (int l = 0; l < n_layers; l++) {
-                        pack_layer_weights(l);
                         float ascale = dynamic_ascale(in_data.data() + (size_t)l * batch * in_dim, batch * in_dim);
-                        cg.go( in_data.data() + (size_t)l * batch * in_dim, batch, (int)in_dim,
+                        FLM_GO(cg, l, in_data.data() + (size_t)l * batch * in_dim, batch, (int)in_dim,
                               ascale, gsc[l], out_data.data() + (size_t)l * batch * out_dim, (int)out_dim);
                     }
-                }else if(op==23&&cd.isReady()){ // Down all layers (batch)
+                }else if(op==23&&FLM_IS_READY(cd)){ // Down all layers (batch)
                     int n_layers = NC;
                     out_dim = H;
                     out_data.resize(batch * out_dim * (size_t)n_layers, 0);
                     for (int l = 0; l < n_layers; l++) {
-                        pack_layer_weights(l);
                         float ascale = dynamic_ascale(in_data.data() + (size_t)l * batch * in_dim, batch * in_dim);
-                        cd.go( in_data.data() + (size_t)l * batch * in_dim, batch, (int)in_dim,
+                        FLM_GO(cd, l, in_data.data() + (size_t)l * batch * in_dim, batch, (int)in_dim,
                               ascale, dsc[l], out_data.data() + (size_t)l * batch * out_dim, (int)out_dim);
                     }
-                }else if(op==30){ // Fused forward: one layer, one IPC call
-                    // Bundles all 4 GEMMs + CPU ops for ONE layer into a single call.
-                    // Eliminates 4 pipe roundtrips per layer.
-                    int l = (int)layer;
-                    if(l >= NC){ ok=false; break; }
-                    out_dim = H;
-                    out_data.resize(H, 0);
-                    
-                    // Copy input
-                    memcpy(h_data.data(), in_data.data(), H * sizeof(float));
-                    
-                    // Save residual
-                    memcpy(sb_data.data(), h_data.data(), H * sizeof(float));
-                    
-                    // RMS Norm (pre-attention)
-                    rn_c(h_data.data(), in_n[l].data(), H);
-                    
-                    // QKV GEMM
-                    pack_layer_weights(l);
-                    float ascale = dynamic_ascale(h_data.data(), H);
-                    cq.go(h_data.data(), 1, H, ascale, qsc[l], qo_data.data(), qkv_n);
-                    cn(qo_data.data(), qkv_n);
-                    
-                    // Q norm + RoPE
-                    for(int hh=0; hh<NH; hh++){
-                        float* q = qo_data.data() + hh * HD;
-                        double sq = 0;
-                        for(int d=0; d<HD; d++) sq += (double)q[d] * q[d];
-                        float iq = 1.0f / sqrtf((float)(sq / HD) + EPS);
-                        const float* qn = qn_w[l].empty() ? nullptr : qn_w[l].data();
-                        for(int d=0; d<HD; d++) q[d] *= iq * (qn ? qn[d] : 1.0f);
-                        ra(q, HD, worker_pos);
-                    }
-                    // K norm + RoPE
-                    for(int kvh=0; kvh<NKV; kvh++){
-                        float* k = qo_data.data() + NH * HD + kvh * HD;
-                        double sk = 0;
-                        for(int d=0; d<HD; d++) sk += (double)k[d] * k[d];
-                        float ik = 1.0f / sqrtf((float)(sk / HD) + EPS);
-                        const float* kn = kn_w[l].empty() ? nullptr : kn_w[l].data();
-                        for(int d=0; d<HD; d++) k[d] *= ik * (kn ? kn[d] : 1.0f);
-                        ra(k, HD, worker_pos);
-                    }
-                    
-                    // Store KV
-                    int sp = kv_caches[l].n;
-                    for(int kvh=0; kvh<NKV; kvh++){
-                        memcpy(&kv_caches[l].k[(size_t)sp * NKV * HD + (size_t)kvh * HD],
-                               qo_data.data() + NH * HD + kvh * HD, HD * 4);
-                        memcpy(&kv_caches[l].v[(size_t)sp * NKV * HD + (size_t)kvh * HD],
-                               qo_data.data() + NH * HD + NKV * HD + kvh * HD, HD * 4);
-                    }
-                    kv_caches[l].n = sp + 1;
-                    int cl = kv_caches[l].n;
-                    
-                    // NPU attention (or CPU fallback)
-                    npu_attn_dispatch(qo_data.data(), at_data.data(), cl, 1, NH*HD, sp,
-                        kv_caches[l].k, kv_caches[l].v,
-                        NH, NKV, HD, GQA, rta, ca_ptrs[l].get());
-                    // CPU Attention
-                    attn_omp(qo_data.data(), at_data.data(), cl,
-                             kv_caches[l].k.data(), kv_caches[l].v.data(),
-                             NH, NKV, HD, GQA);
-                    
-                    // O projection
-                    ascale = dynamic_ascale(at_data.data(), NH * HD);
-                    co.go(at_data.data(), 1, NH*HD, ascale, osc[l], h_data.data(), H);
-                    cn(h_data.data(), H);
-                    
-                    // Residual add (post-attention)
-                    for(int i=0; i<H; i++) h_data[i] += sb_data[i];
-                    
-                    // Save residual for post-FFN
-                    memcpy(sb_data.data(), h_data.data(), H * sizeof(float));
-                    
-                    // RMS Norm (post-attention)
-                    rn_c(h_data.data(), pa_n[l].data(), H);
-                    
-                    // Gate+Up projection
-                    ascale = dynamic_ascale(h_data.data(), H);
-                    int gu_dim = cfg.gu_split ? IM : (2*IM);
-                    cg.go(h_data.data(), 1, H, ascale, gsc[l], gt_data.data(), gu_dim);
-                    cn(gt_data.data(), gu_dim);
-                    
-                    // SiLU gate (+ Up if split)
-                    if(cfg.gu_split){
-                        ascale = dynamic_ascale(h_data.data(), H);
-                        cu_ptr->go(h_data.data(), 1, H, ascale, usc[l], su_data.data(), IM);
-                        cn(su_data.data(), IM);
-                        for(int i=0; i<IM; i++)
-                            gt_data[i] = silu_f(gt_data[i]) * su_data[i];
-                    }else{
-                        for(int i=0; i<IM; i++)
-                            gt_data[i] = silu_f(gt_data[i]) * gt_data[IM + i];
-                    }
-                    
-                    // Down projection
-                    ascale = dynamic_ascale(gt_data.data(), IM);
-                    cd.go(gt_data.data(), 1, IM, ascale, dsc[l], h_data.data(), H);
-                    cn(h_data.data(), H);
-                    
-                    // Residual add (post-FFN)
-                    for(int i=0; i<H; i++) h_data[i] += sb_data[i];
-                    
-                    // Output
-                    memcpy(out_data.data(), h_data.data(), H * sizeof(float));
-                }else if(op==31){ // Fused forward: ALL layers, one IPC call
-                    // Does a complete forward pass (all 36 layers) in one shot.
-                    // Input: token embedding [H]
-                    // Output: hidden state after all layers [H]
-                    // Also updates KV cache internally.
-                    out_dim = H;
-                    out_data.resize(H, 0);
-                    memcpy(h_data.data(), in_data.data(), H * sizeof(float));
-                    
-                    for(int l=0; l<NC; l++){
-                        memcpy(sb_data.data(), h_data.data(), H * sizeof(float));
-                        rn_c(h_data.data(), in_n[l].data(), H);
-                        
-                        pack_layer_weights(l);
-                        float ascale = dynamic_ascale(h_data.data(), H);
-                        cq.go(h_data.data(), 1, H, ascale, qsc[l], qo_data.data(), qkv_n);
-                        cn(qo_data.data(), qkv_n);
-                        
-                        for(int hh=0; hh<NH; hh++){
-                            float* q = qo_data.data() + hh * HD;
-                            double sq = 0;
-                            for(int d=0; d<HD; d++) sq += (double)q[d] * q[d];
-                            float iq = 1.0f / sqrtf((float)(sq / HD) + EPS);
-                            for(int d=0; d<HD; d++) q[d] *= iq;
-                            ra(q, HD, worker_pos);
-                        }
-                        for(int kvh=0; kvh<NKV; kvh++){
-                            float* k = qo_data.data() + NH * HD + kvh * HD;
-                            double sk = 0;
-                            for(int d=0; d<HD; d++) sk += (double)k[d] * k[d];
-                            float ik = 1.0f / sqrtf((float)(sk / HD) + EPS);
-                            for(int d=0; d<HD; d++) k[d] *= ik;
-                            ra(k, HD, worker_pos);
-                        }
-                        
-                        int sp = kv_caches[l].n;
-                        for(int kvh=0; kvh<NKV; kvh++){
-                            memcpy(&kv_caches[l].k[(size_t)sp*NKV*HD+(size_t)kvh*HD],
-                                   qo_data.data()+NH*HD+kvh*HD, HD*4);
-                            memcpy(&kv_caches[l].v[(size_t)sp*NKV*HD+(size_t)kvh*HD],
-                                   qo_data.data()+NH*HD+NKV*HD+kvh*HD, HD*4);
-                        }
-                        kv_caches[l].n = sp + 1;
-                        int cl = kv_caches[l].n;
-                        
-                        // NPU attention (or CPU fallback)
-                        npu_attn_dispatch(qo_data.data(), at_data.data(), cl, 1, NH*HD, sp,
-                            kv_caches[l].k, kv_caches[l].v,
-                            NH, NKV, HD, GQA, rta, ca_ptrs[l].get());
-                        attn_omp(qo_data.data(), at_data.data(), cl,
-                                 kv_caches[l].k.data(), kv_caches[l].v.data(),
-                                 NH, NKV, HD, GQA);
-                        
-                        ascale = dynamic_ascale(at_data.data(), NH*HD);
-                        co.go(at_data.data(), 1, NH*HD, ascale, osc[l], h_data.data(), H);
-                        cn(h_data.data(), H);
-                        for(int i=0; i<H; i++) h_data[i] += sb_data[i];
-                        
-                        memcpy(sb_data.data(), h_data.data(), H*sizeof(float));
-                        rn_c(h_data.data(), pa_n[l].data(), H);
-                        
-                        ascale = dynamic_ascale(h_data.data(), H);
-                        int gu_dim = cfg.gu_split ? IM : (2*IM);
-                        cg.go(h_data.data(), 1, H, ascale, gsc[l], gt_data.data(), gu_dim);
-                        cn(gt_data.data(), gu_dim);
-                        
-                        if(cfg.gu_split){
-                            ascale = dynamic_ascale(h_data.data(), H);
-                            cu_ptr->go(h_data.data(), 1, H, ascale, usc[l], su_data.data(), IM);
-                            cn(su_data.data(), IM);
-                            for(int i=0; i<IM; i++)
-                                gt_data[i] = silu_f(gt_data[i]) * su_data[i];
-                        }else{
-                            for(int i=0; i<IM; i++)
-                                gt_data[i] = silu_f(gt_data[i]) * gt_data[IM + i];
-                        }
-                        
-                        ascale = dynamic_ascale(gt_data.data(), IM);
-                        cd.go(gt_data.data(), 1, IM, ascale, dsc[l], h_data.data(), H);
-                        cn(h_data.data(), H);
-                        for(int i=0; i<H; i++) h_data[i] += sb_data[i];
-                    }
-                    worker_pos++;
-                    memcpy(out_data.data(), h_data.data(), H * sizeof(float));
-                }else if(op==32){ // Complete forward: embed→all layers→lm_head→token
-                    // Input: token_id (int passed as first float)
-                    // Output: next_token_id (float)
-                    // Entire forward pass inside subprocess. Backend just gets the token.
-                    int input_token = (int)in_data[0];
-                    out_dim = 1;
-                    out_data.resize(1, 0);
-                    
-                    if(input_token >= 0 && (size_t)input_token * H < emb_f32.size())
-                        memcpy(h_data.data(), &emb_f32[(size_t)input_token * H], H * sizeof(float));
-                    else
-                        memset(h_data.data(), 0, H * sizeof(float));
-                    
-                    for(int l=0; l<NC; l++){
-                        memcpy(sb_data.data(), h_data.data(), H * sizeof(float));
-                        if(!in_n[l].empty()) rn_c(h_data.data(), in_n[l].data(), H);
-                        pack_layer_weights(l);
-                        float ascale = dynamic_ascale(h_data.data(), H);
-                        cq.go(h_data.data(), 1, H, ascale, qsc[l], qo_data.data(), qkv_n);
-                        cn(qo_data.data(), qkv_n);
-                        for(int hh=0; hh<NH; hh++){
-                            float* q = qo_data.data() + hh * HD;
-                            double sq=0; for(int d=0; d<HD; d++) sq+=(double)q[d]*q[d];
-                            float iq=1.0f/sqrtf((float)(sq/HD)+EPS);
-                            for(int d=0; d<HD; d++) q[d]*=iq;
-                            ra(q, HD, worker_pos);
-                        }
-                        for(int kvh=0; kvh<NKV; kvh++){
-                            float* k = qo_data.data() + NH*HD + kvh*HD;
-                            double sk=0; for(int d=0; d<HD; d++) sk+=(double)k[d]*k[d];
-                            float ik=1.0f/sqrtf((float)(sk/HD)+EPS);
-                            for(int d=0; d<HD; d++) k[d]*=ik;
-                            ra(k, HD, worker_pos);
-                        }
-                        int sp = kv_caches[l].n;
-                        for(int kvh=0; kvh<NKV; kvh++){
-                            memcpy(&kv_caches[l].k[(size_t)sp*NKV*HD+(size_t)kvh*HD], qo_data.data()+NH*HD+kvh*HD, HD*4);
-                            memcpy(&kv_caches[l].v[(size_t)sp*NKV*HD+(size_t)kvh*HD], qo_data.data()+NH*HD+NKV*HD+kvh*HD, HD*4);
-                        }
-                        kv_caches[l].n = sp+1;
-                        int cl = kv_caches[l].n;
-                        // NPU attention (or CPU fallback)
-                        npu_attn_dispatch(qo_data.data(), at_data.data(), cl, 1, NH*HD, sp,
-                            kv_caches[l].k, kv_caches[l].v,
-                            NH, NKV, HD, GQA, rta, ca_ptrs[l].get());
-                        attn_omp(qo_data.data(), at_data.data(), cl, kv_caches[l].k.data(), kv_caches[l].v.data(), NH, NKV, HD, GQA);
-                        ascale = dynamic_ascale(at_data.data(), NH*HD);
-                        co.go(at_data.data(), 1, NH*HD, ascale, osc[l], h_data.data(), H);
-                        cn(h_data.data(), H);
-                        for(int i=0; i<H; i++) h_data[i] += sb_data[i];
-                        memcpy(sb_data.data(), h_data.data(), H*sizeof(float));
-                        rn_c(h_data.data(), pa_n[l].data(), H);
-                        ascale = dynamic_ascale(h_data.data(), H);
-                        cg.go(h_data.data(), 1, H, ascale, gsc[l], gt_data.data(), cfg.gu_split?IM:(2*IM));
-                        cn(gt_data.data(), cfg.gu_split?IM:(2*IM));
-                        if(cfg.gu_split){
-                            ascale = dynamic_ascale(h_data.data(), H);
-                            cu_ptr->go(h_data.data(), 1, H, ascale, usc[l], su_data.data(), IM);
-                            cn(su_data.data(), IM);
-                            for(int i=0; i<IM; i++) gt_data[i] = silu_f(gt_data[i]) * su_data[i];
-                        }else{
-                            for(int i=0; i<IM; i++) gt_data[i] = silu_f(gt_data[i]) * gt_data[IM+i];
-                        }
-                        ascale = dynamic_ascale(gt_data.data(), IM);
-                        cd.go(gt_data.data(), 1, IM, ascale, dsc[l], h_data.data(), H);
-                        cn(h_data.data(), H);
-                        for(int i=0; i<H; i++) h_data[i] += sb_data[i];
-                    }
-                    worker_pos++;
-                    // Final norm
-                    rn_c(h_data.data(), fin_v.data(), H);
-                    // LM head: argmax over vocab.
-                    // Use lm_head_f32 if available (separate weight matrix for this
-                    // model), otherwise fall back to embedding table (tied weights).
-                    // Using emb_f32 for a model with a separate lm_head produces
-                    // wrong token IDs (different weight matrices for input embed vs
-                    // output projection).
-                    const float* lm_head_data = lm_head_f32.empty() ? emb_f32.data() : lm_head_f32.data();
-                    double max_l = -1e30; int best_t = 0;
-                    for(int n=0; n<NV; n++){
-                        double s = 0; const float* e = lm_head_data + (size_t)n*H;
-                    // LM head: argmax
-                    double max_l = -1e30; int best_t = 0;
-                    for(int n=0; n<NV; n++){
-                        double s = 0; const float* e = emb_f32.data() + (size_t)n*H;
-                        for(int k=0; k<H; k++) s += (double)h_data[k]*e[k];
-                        if(s > max_l){ max_l = s; best_t = n; }
-                    }
-                    out_data[0] = (float)best_t;
                 }else{
                     ok=false;
                 }
@@ -2114,14 +1032,15 @@ int main(int argc,char**argv){
     for(int pi=0;pi<npt;pi++)for(int i=0;i<H;i++)h_b[pi*H+i]=emb_f32[pt_vec[pi]*H+i];
     xrt::run pending_gu; bool has_pending=false;
     for(int l=0;l<NC;l++){
-        pack_layer_weights(l);
         fprintf(stderr,"  L%d",l);fflush(stderr);
         // Save pre-norm residuals
         for(int pi=0;pi<npt;pi++)for(int i=0;i<H;i++)sb_data[pi*H+i]=h_b[pi*H+i];
         for(int pi=0;pi<npt;pi++)rn_c(&h_b[pi*H],in_n[l].data(),H);
-        // Phase 1-2: QKV on NPU (synchronous go for debugging #1029)
+        // Phase 1: Launch QKV on NPU
         float qkv_ascale=dynamic_ascale(h_b.data(),npt*H);
-        cq.go(h_b.data(),npt,H,qkv_ascale,qsc[l],qo_b.data(),qkv_n);cn(qo_b.data(),npt*qkv_n);
+        auto r_qkv=FLM_LAUNCH_ASYNC(cq,l,h_b.data(),npt,H,qkv_ascale);
+        // Phase 2: Wait QKV + dequant (CPU attention runs after)
+        FLM_FINISH_ASYNC(cq,r_qkv,qo_b.data(),npt,qkv_n,qkv_ascale,qsc[l],l);cn(qo_b.data(),npt*qkv_n);
         fprintf(stderr,"q");fflush(stderr);
         float*qn=qn_w[l].data(),*kn=kn_w[l].data();
         for(int pi=0;pi<npt;pi++){
@@ -2130,62 +1049,75 @@ int main(int argc,char**argv){
             for(int kvh=0;kvh<NKV;kvh++){float*ks=&qo_b[pi*qkv_n+cfg.qkv_k_offset+kvh*HD],*vs=&qo_b[pi*qkv_n+cfg.qkv_v_offset+kvh*HD];
                 double sk=0;for(int d=0;d<HD;d++)sk+=ks[d]*ks[d];float ik=1.0f/sqrtf((float)(sk/HD)+EPS);
                 for(int d=0;d<HD;d++)ks[d]*=ik*(cfg.has_k_norm?kn[d]:1.0f);ra(ks,HD,sp+pi);
-                if ((size_t)(sp+pi+1)*NKV*HD <= (size_t)kv_caches[l].k.size()) {
-                    memcpy(&kv_caches[l].k[(sp+pi)*NKV*HD+kvh*HD],ks,HD*4);
-                    memcpy(&kv_caches[l].v[(sp+pi)*NKV*HD+kvh*HD],vs,HD*4);
-                } else {
-                    fprintf(stderr, "KV cache overflow at layer %d pos %d\n", l, sp+pi);
-                }}}
+                memcpy(&kv_caches[l].k[(sp+pi)*NKV*HD+kvh*HD],ks,HD*4);memcpy(&kv_caches[l].v[(sp+pi)*NKV*HD+kvh*HD],vs,HD*4);}}
         kv_caches[l].n=sp+npt;int cl=kv_caches[l].n;
-        // NPU attention dispatch or CPU fallback with causal mask
-        if(l < (int)ca_ptrs.size() && ca_ptrs[l] && ca_ptrs[l]->isReady()){
-            npu_attn_dispatch(qo_b.data(), at_b.data(), cl, npt, qkv_n, sp,
-                kv_caches[l].k, kv_caches[l].v,
-                NH, NKV, HD, GQA, rta, ca_ptrs[l].get());
-            fprintf(stderr,"A"); fflush(stderr);
+        // Attention: NPU or CPU fallback
+        //
+        // NPU attention uses pre-compiled KV xclbin instructions
+        // at runtime via FLM's libmha.so (MHA::generate_mha_sequence). The
+        // attn.xclbin kernel takes Q, K, V as i8 inputs and produces i16 output.
+        // K and V caches are quantized from f32 on each step.
+        //
+        // CPU attn_omp() fallback is always available.
+        if(use_npu_attn && ca_ptr && ca_ptr->isReady()){
+            // Regenerate instructions for current seq_len
+
+            if (!attn_instrs.empty()) {
+                // Compute dynamic scales for Q and K/V quantization
+                float q_ascale = dynamic_ascale(qo_b.data(), npt * NH * HD);
+                float kv_ascale = 0;
+                for (int i = 0; i < (size_t)cl * NKV * HD; i++) {
+                    float a = fabsf(kv_caches[l].k[i]);
+                    if (std::isfinite(a) && a > kv_ascale) kv_ascale = a;
+                }
+                if (kv_ascale < 1e-12f) kv_ascale = 1.0f;
+                kv_ascale = kv_ascale / 127.0f;
+
+                // Launch NPU attention kernel
+                auto r_attn = ca_ptr->launch(
+                    qo_b.data(), kv_caches[l].k.data(), kv_caches[l].v.data(),
+                    cl, npt, q_ascale, kv_ascale);
+
+                // Wait + dequantize into attention output buffer
+                ca_ptr->finish(r_attn, at_b.data(), npt, q_ascale, kv_ascale);
+                cn(at_b.data(), npt * NH * HD);
+                fprintf(stderr,"A"); fflush(stderr);
+            } else {
+                // Instr generation failed — fall back to CPU
+                #pragma omp parallel for
+                for(int pi=0;pi<npt;pi++){
+                    if (omp_get_thread_num() == 0) { fprintf(stderr,"a"); fflush(stderr); }
+                    attn_omp(&qo_b[pi*qkv_n],&at_b[pi*NH*HD],cl,kv_caches[l].k.data(),kv_caches[l].v.data(),NH,NKV,HD,GQA,sp+pi+1);
+                }
+            }
         } else {
-            // CPU attention fallback with per-position causal mask
+            // CPU attention (default fallback)
             #pragma omp parallel for
             for(int pi=0;pi<npt;pi++){
                 if (omp_get_thread_num() == 0) { fprintf(stderr,"a"); fflush(stderr); }
                 attn_omp(&qo_b[pi*qkv_n],&at_b[pi*NH*HD],cl,kv_caches[l].k.data(),kv_caches[l].v.data(),NH,NKV,HD,GQA,sp+pi+1);
             }
         }
-        // Phase 3-4: O + GU pipelined — independent inputs (at_b vs h_b)
-        // Launch O first, then quantize GU while O runs on NPU.
-        // Pattern: launch(O) → quantize(GU) → sync(GU) → wait(O) → launch(GU) → read(O) → ...
-        // Mirrors the decode loop's proven O+GU pipelining.
+        // Phase 3: Launch O + GU in parallel on NPU
         int mlp_out=cfg.gu_split?IM:2*IM;
         float o_ascale=dynamic_ascale(at_b.data(),npt*NH*HD);
         float gu_ascale=dynamic_ascale(h_b.data(),npt*H);
-        co.quantize_async(at_b.data(),npt,NH*HD,o_ascale);
-        auto r_co=co.sync_and_launch();
-        // Quantize GU while O runs — independent input (h_b, not at_b)
-        cg.quantize_async(h_b.data(),npt,H,gu_ascale);
-        cg.bA->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        cg.bC->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        cg.layerB[0]->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        // Wait for O, then launch GU while reading O back
-        co.wait_kernel(r_co);
-        auto r_cg=cg.launch();
-        co.sync_back_and_dequant(oo_b.data(),npt,H,o_ascale,osc[l]);
-        cn(oo_b.data(),npt*H);
+        auto r_o=FLM_LAUNCH_ASYNC(co,l,at_b.data(),npt,NH*HD,o_ascale);
+        auto r_gu=FLM_LAUNCH_ASYNC(cg,l,h_b.data(),npt,H,gu_ascale);
+        // Phase 4: Wait O, apply residual
+        FLM_FINISH_ASYNC(co,r_o,oo_b.data(),npt,H,o_ascale,osc[l],l);cn(oo_b.data(),npt*H);
         fprintf(stderr,"o");fflush(stderr);
-        // Apply residual + pre-FFN norm while GU runs on NPU
         for(int pi=0;pi<npt;pi++)for(int i=0;i<H;i++)h_b[pi*H+i]=sb_data[pi*H+i]+oo_b[pi*H+i];
         // Save pre-FFN residuals
         for(int pi=0;pi<npt;pi++)for(int i=0;i<H;i++)sb_data[pi*H+i]=h_b[pi*H+i];
         for(int pi=0;pi<npt;pi++)rn_c(&h_b[pi*H],pa_n[l].data(),H);
-        // Wait for GU to complete (launched before residual add)
-        cg.wait_kernel(r_cg);
-        cg.sync_back_and_dequant(gt_b.data(),npt,mlp_out,gu_ascale,gsc[l]);
-        cn(gt_b.data(),npt*mlp_out);
+        // Phase 5: Wait GU (was launched in parallel with O), SiLU, launch D
+        FLM_FINISH_ASYNC(cg,r_gu,gt_b.data(),npt,mlp_out,gu_ascale,gsc[l],l);cn(gt_b.data(),npt*mlp_out);
         fprintf(stderr,"g");fflush(stderr);
-        // SiLU gate (CPU) + optional U GEMM
-        if(cfg.gu_split){cu_ptr->go(h_b.data(),npt,H,dynamic_ascale(h_b.data(),npt*H),usc[l],su_b.data(),IM);cn(su_b.data(),npt*IM);
+        if(cfg.gu_split){FLM_GO_PTR(cu_ptr,l,h_b.data(),npt,H,dynamic_ascale(h_b.data(),npt*H),usc[l],su_b.data(),IM);cn(su_b.data(),npt*IM);
             for(int pi=0;pi<npt;pi++){for(int i=0;i<IM;i++){float gv=gt_b[pi*IM+i];if(!std::isfinite(gv))gv=0;su_b[pi*IM+i]=(gv/(1.0f+expf(-gv)))*su_b[pi*IM+i];}}}
         else{for(int pi=0;pi<npt;pi++){for(int i=0;i<IM;i++){float gv=gt_b[pi*mlp_out+i];if(!std::isfinite(gv))gv=0;su_b[pi*IM+i]=(gv/(1.0f+expf(-gv)))*gt_b[pi*mlp_out+IM+i];}}}
-        fprintf(stderr,"d");fflush(stderr);cd.go(su_b.data(),npt,IM,dynamic_ascale(su_b.data(),npt*IM),dsc[l],dw_b.data(),H);cn(dw_b.data(),npt*H);
+        fprintf(stderr,"d");fflush(stderr);FLM_GO(cd,l,su_b.data(),npt,IM,dynamic_ascale(su_b.data(),npt*IM),dsc[l],dw_b.data(),H);cn(dw_b.data(),npt*H);
         // Residual add: use saved pre-FFN values
         for(int pi=0;pi<npt;pi++)for(int i=0;i<H;i++)h_b[pi*H+i]=sb_data[pi*H+i]+dw_b[pi*H+i];
         fprintf(stderr,"\n");fflush(stderr);
@@ -2204,9 +1136,8 @@ int main(int argc,char**argv){
         auto ts_boot=std::chrono::steady_clock::now();
         float h0[H];memcpy(h0,h_data.data(),H*4);
         for(int l=0;l<NC;l++){
-            pack_layer_weights(l);
             memcpy(sb_data.data(),h0,H*4);rn_c(h0,in_n[l].data(),H);
-            cq.go(h0,1,H,dynamic_ascale(h0,H),qsc[l],qo_data.data(),qkv_n);cn(qo_data.data(),qkv_n);
+            FLM_GO(cq,l,h0,1,H,dynamic_ascale(h0,H),qsc[l],qo_data.data(),qkv_n);cn(qo_data.data(),qkv_n);
             memcpy(ko_data.data(),&qo_data[cfg.qkv_k_offset],NKV*HD*4);memcpy(vo_data.data(),&qo_data[cfg.qkv_v_offset],NKV*HD*4);
             float*qn=qn_w[l].data(),*kn=kn_w[l].data();
             for(int hh=0;hh<NH;hh++){double sq=0;for(int d=0;d<HD;d++)sq+=qo_data[hh*HD+d]*qo_data[hh*HD+d];float iq=1.0f/sqrtf((float)(sq/HD)+EPS);
@@ -2215,36 +1146,22 @@ int main(int argc,char**argv){
                 for(int d=0;d<HD;d++)ko_data[kvh*HD+d]*=ik*(cfg.has_k_norm?kn[d]:1.0f);ra(&ko_data[kvh*HD],HD,sp);
                 memcpy(&kv_caches[l].k[sp*NKV*HD+kvh*HD],&ko_data[kvh*HD],HD*4);memcpy(&kv_caches[l].v[sp*NKV*HD+kvh*HD],&vo_data[kvh*HD],HD*4);}}
             kv_caches[l].n=sp+1;int cl=kv_caches[l].n;
-            npu_attn_dispatch(qo_data.data(), at_data.data(), cl, 1, NH*HD, 0,
-                kv_caches[l].k, kv_caches[l].v,
-                NH, NKV, HD, GQA, rta, ca_ptrs[l].get());
-            if(l < (int)ca_ptrs.size() && ca_ptrs[l] && ca_ptrs[l]->isReady()) fprintf(stderr,"A");
-            if(use_npu_attn && rta.isReady()){
-                // NPU attention via runtime sequence
-                if (cl <= RT_ATTN_MAX_TK) {
-                    npu_attn_rt(rta, qo_data.data(), at_data.data(), cl,
-                        kv_caches[l].k.data(), kv_caches[l].v.data(),
-                        NH, NKV, HD, GQA, 1, NH*HD, 0);
-                    cn(at_data.data(), NH*HD);
-                    fprintf(stderr,"A");
-                } else {
-                    attn_omp(qo_data.data(),at_data.data(),cl,kv_caches[l].k.data(),kv_caches[l].v.data(),NH,NKV,HD,GQA);
-                }
-            }else if(use_npu_attn && ca_ptr && ca_ptr->isReady()){
+            if(use_npu_attn && ca_ptr && ca_ptr->isReady()){
+                // NPU attention via pre-compiled KV xclbin (fixed max_seq=4096)
                 float qs=dynamic_ascale(qo_data.data(),NH*HD);
                 float ks=0;for(int i=0;i<cl*NKV*HD;i++){float a=fabsf(kv_caches[l].k[i]);if(a>ks)ks=a;}
                 ks=ks<1e-12f?1.0f:ks/127.0f;
                 auto r=ca_ptr->launch(qo_data.data(),kv_caches[l].k.data(),kv_caches[l].v.data(),cl,1,qs,ks);
                 ca_ptr->finish(r,at_data.data(),1,qs,ks);cn(at_data.data(),NH*HD);
             }else{attn_omp(qo_data.data(),at_data.data(),cl,kv_caches[l].k.data(),kv_caches[l].v.data(),NH,NKV,HD,GQA);}
-            co.go(at_data.data(),1,NH*HD,dynamic_ascale(at_data.data(),NH*HD),osc[l],oo_data.data(),H);cn(oo_data.data(),H);for(int i=0;i<H;i++)h0[i]=sb_data[i]+oo_data[i];
+            FLM_GO(co,l,at_data.data(),1,NH*HD,dynamic_ascale(at_data.data(),NH*HD),osc[l],oo_data.data(),H);cn(oo_data.data(),H);for(int i=0;i<H;i++)h0[i]=sb_data[i]+oo_data[i];
             memcpy(sb_data.data(),h0,H*4);rn_c(h0,pa_n[l].data(),H);
             int mlp_out=cfg.gu_split?IM:2*IM;
-            cg.go(h0,1,H,dynamic_ascale(h0,H),gsc[l],gt_data.data(),mlp_out);cn(gt_data.data(),mlp_out);
-            if(cfg.gu_split){cu_ptr->go(h0,1,H,dynamic_ascale(h0,H),usc[l],su_data.data(),IM);cn(su_data.data(),IM);
+            FLM_GO(cg,l,h0,1,H,dynamic_ascale(h0,H),gsc[l],gt_data.data(),mlp_out);cn(gt_data.data(),mlp_out);
+            if(cfg.gu_split){FLM_GO_PTR(cu_ptr,l,h0,1,H,dynamic_ascale(h0,H),usc[l],su_data.data(),IM);cn(su_data.data(),IM);
                 for(int i=0;i<IM;i++){float gv=gt_data[i];if(!std::isfinite(gv))gv=0;su_data[i]=(gv/(1.0f+expf(-gv)))*su_data[i];}}
             else{for(int i=0;i<IM;i++){float gv=gt_data[i];if(!std::isfinite(gv))gv=0;su_data[i]=(gv/(1.0f+expf(-gv)))*gt_data[IM+i];}}
-            cd.go(su_data.data(),1,IM,dynamic_ascale(su_data.data(),IM),dsc[l],dwo_data.data(),H);cn(dwo_data.data(),H);for(int i=0;i<H;i++)h0[i]=sb_data[i]+dwo_data[i];
+            FLM_GO(cd,l,su_data.data(),1,IM,dynamic_ascale(su_data.data(),IM),dsc[l],dwo_data.data(),H);cn(dwo_data.data(),H);for(int i=0;i<H;i++)h0[i]=sb_data[i]+dwo_data[i];
         }
         memcpy(sb_data.data(),h0,H*4);rn_c(sb_data.data(),fin_v.data(),H);
         lm_topk_omp(sb_data.data(),lg_buf.data(),top_ids,BS,NV,H,lm_emb);
@@ -2262,18 +1179,16 @@ int main(int argc,char**argv){
         // Overlaps CPU quantize with NPU kernel execution.
         // Pattern: launch(N) → quantize(N+1) → wait(N) → dequantize(N) → sync+launch(N+1) → ...
         // co and cg are independent (different inputs) → quantize cg WHILE co runs on NPU.
-        try {
         for(int l=0;l<NC;l++){
-            pack_layer_weights(l);
             // Save pre-norm residuals before rn_c
             for(int b=0;b<batch_size;b++)for(int i=0;i<H;i++)sb_data[b*H+i]=h_b[b*H+i];
             for(int b=0;b<batch_size;b++)rn_c(&h_b[b*H],in_n[l].data(),H);
 
             // ── QKV GEMM ──
             float cq_ascale=dynamic_ascale(h_b.data(),batch_size*H);
-            cq.quantize_async(h_b.data(),batch_size,H,cq_ascale);
-            auto r_cq=cq.sync_and_launch();
-            cq.dequantize(r_cq,qo_b.data(),batch_size,qkv_n,cq_ascale,qsc[l]);
+            FLM_QUANTIZE_ASYNC(cq,h_b.data(),batch_size,H,cq_ascale);
+            auto r_cq=FLM_SYNC_AND_LAUNCH(cq,l);
+            FLM_DEQUANTIZE(cq,r_cq,qo_b.data(),batch_size,qkv_n,cq_ascale,qsc[l],l);
             cn(qo_b.data(),batch_size*qkv_n);
 
             // ── Attention + RoPE + KV cache ──
@@ -2289,40 +1204,40 @@ int main(int argc,char**argv){
                 float*ks=&qo_b[b*qkv_n+cfg.qkv_k_offset+kvh*HD],*vs=&qo_b[b*qkv_n+cfg.qkv_v_offset+kvh*HD];
                 memcpy(&kv_caches[l].k[(sp+b)*NKV*HD+kvh*HD],ks,HD*4);memcpy(&kv_caches[l].v[(sp+b)*NKV*HD+kvh*HD],vs,HD*4);}
             kv_caches[l].n=sp+batch_size;int cl=kv_caches[l].n;
-            npu_attn_dispatch(qo_b.data(), at_b.data(), cl, batch_size, qkv_n, sp,
-                kv_caches[l].k, kv_caches[l].v,
-                NH, NKV, HD, GQA, rta, ca_ptrs[l].get());
-            if(l < (int)ca_ptrs.size() && ca_ptrs[l] && ca_ptrs[l]->isReady()) fprintf(stderr,"A");
+            if(use_npu_attn && ca_ptr && ca_ptr->isReady()){
+                // NPU attention via pre-compiled KV xclbin (fixed max_seq=4096)
+                float qs=dynamic_ascale(qo_b.data(),batch_size*NH*HD);
+                float ks=0;for(int i=0;i<cl*NKV*HD;i++){float a=fabsf(kv_caches[l].k[i]);if(a>ks)ks=a;}
+                ks=ks<1e-12f?1.0f:ks/127.0f;
+                auto r=ca_ptr->launch(qo_b.data(),kv_caches[l].k.data(),kv_caches[l].v.data(),cl,batch_size,qs,ks);
+                ca_ptr->finish(r,at_b.data(),batch_size,qs,ks);cn(at_b.data(),batch_size*NH*HD);
+            }else{for(int b=0;b<batch_size;b++){attn_omp(&qo_b[b*qkv_n],&at_b[b*NH*HD],cl,kv_caches[l].k.data(),kv_caches[l].v.data(),NH,NKV,HD,GQA);}}
 
             // ── O GEMM ──
             // Launch O, then quantize GU input WHILE O runs (overlapped)
             float co_ascale=dynamic_ascale(at_b.data(),batch_size*NH*HD);
-            co.quantize_async(at_b.data(),batch_size,NH*HD,co_ascale);
-            auto r_co=co.sync_and_launch();
+            FLM_QUANTIZE_ASYNC(co,at_b.data(),batch_size,NH*HD,co_ascale);
+            auto r_co=FLM_SYNC_AND_LAUNCH(co,l);
 
             // ── GU GEMM: independent of O! Quantize GU input while O runs on NPU ──
             int mlp_out=cfg.gu_split?IM:2*IM;
             float cg_ascale=dynamic_ascale(h_b.data(),batch_size*H);
-            cg.quantize_async(h_b.data(),batch_size,H,cg_ascale);
+            FLM_QUANTIZE_ASYNC(cg,h_b.data(),batch_size,H,cg_ascale);
 
             // ── CO-GU FULLY PARALLEL ──
-            // Phase 1: Submit GU's DMA syncs WHILE O runs on NPU
-            //   sync(to_device) uses MM2S DMA channels (independent of NPU compute)
+            // Phase 1: Submit GU's DMA sync WHILE O runs on NPU
+            //   bA->sync(to_device) uses MM2S DMA channel (independent of NPU compute)
             //   This hides the sync latency behind O's NPU time.
-            //   Sync bA (activations), bC (output), layerB (weights).
-            //   bI (instruction buffer) is CACHEABLE and read-only — skip re-sync.
-            cg.bA->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-            cg.bC->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-            cg.layerB[0]->sync(XCL_BO_SYNC_BO_TO_DEVICE);
+            FLM_SYNC_A(cg,l);  // non-blocking: cg.bA sync starts, DMA runs parallel to NPU
 
             // Phase 2: Wait for O kernel completion (minimal)
-            co.wait_kernel(r_co);
+            FLM_WAIT_KERNEL(co,r_co);
 
             // Phase 3: Submit GU kernel to NPU + start co readback SIMULTANEOUSLY
             //   cg.launch() submits the kernel (queued behind O on NPU's compute)
             //   co.bC->sync uses S2MM DMA channel (independent of MM2S for cg.bA)
-            auto r_cg=cg.launch();
-            co.sync_back_and_dequant(oo_b.data(),batch_size,H,co_ascale,osc[l]);
+            auto r_cg=FLM_LAUNCH(cg,l);
+            FLM_SYNC_BACK(co,oo_b.data(),batch_size,H,co_ascale,osc[l],l);
             cn(oo_b.data(),batch_size*H);
 
             // Phase 4: Residual add + rn_c (CPU work, overlaps with cg's NPU execution)
@@ -2330,35 +1245,31 @@ int main(int argc,char**argv){
             for(int b=0;b<batch_size;b++)for(int i=0;i<H;i++)sb_data[b*H+i]=h_b[b*H+i];
             for(int b=0;b<batch_size;b++)rn_c(&h_b[b*H],pa_n[l].data(),H);
             if(cfg.gu_split){
-                cu_ptr->quantize_async(h_b.data(),batch_size,H,cg_ascale);
+                FLM_QUANTIZE_ASYNC_PTR(cu_ptr,h_b.data(),batch_size,H,cg_ascale);
             }
 
             // Phase 5: Wait for GU, read back, dequant
-            cg.wait_kernel(r_cg);
-            cg.sync_back_and_dequant(gt_b.data(),batch_size,mlp_out,cg_ascale,gsc[l]);
+            FLM_WAIT_KERNEL(cg,r_cg);
+            FLM_SYNC_BACK(cg,gt_b.data(),batch_size,mlp_out,cg_ascale,gsc[l],l);
             cn(gt_b.data(),batch_size*mlp_out);
 
             // SiLU gate + U GEMM (gu_split) or combined gate*up
             if(cfg.gu_split){
-                auto r_cu=cu_ptr->sync_and_launch();
-                cu_ptr->dequantize(r_cu,su_b.data(),batch_size,IM,cg_ascale,usc[l]);
+                auto r_cu=FLM_SYNC_AND_LAUNCH_PTR(cu_ptr,l);
+                FLM_DEQUANTIZE_PTR(cu_ptr,r_cu,su_b.data(),batch_size,IM,cg_ascale,usc[l],l);
                 cn(su_b.data(),batch_size*IM);
                 for(int b=0;b<batch_size;b++){for(int i=0;i<IM;i++){float gv=gt_b[b*IM+i];if(!std::isfinite(gv))gv=0;su_b[b*IM+i]=(gv/(1.0f+expf(-gv)))*su_b[b*IM+i];}}}
             else{for(int b=0;b<batch_size;b++){for(int i=0;i<IM;i++){float gv=gt_b[b*mlp_out+i];if(!std::isfinite(gv))gv=0;su_b[b*IM+i]=(gv/(1.0f+expf(-gv)))*gt_b[b*mlp_out+IM+i];}}}
 
             // ── D GEMM ──
             float cd_ascale=dynamic_ascale(su_b.data(),batch_size*IM);
-            cd.quantize_async(su_b.data(),batch_size,IM,cd_ascale);
-            auto r_cd=cd.sync_and_launch();
-            cd.dequantize(r_cd,dw_b.data(),batch_size,H,cd_ascale,dsc[l]);
+            FLM_QUANTIZE_ASYNC(cd,su_b.data(),batch_size,IM,cd_ascale);
+            auto r_cd=FLM_SYNC_AND_LAUNCH(cd,l);
+            FLM_DEQUANTIZE(cd,r_cd,dw_b.data(),batch_size,H,cd_ascale,dsc[l],l);
             cn(dw_b.data(),batch_size*H);
 
             // Residual add
             for(int b=0;b<batch_size;b++)for(int i=0;i<H;i++)h_b[b*H+i]=sb_data[b*H+i]+dw_b[b*H+i];
-        }
-        } catch (const std::exception& e) {
-            fprintf(stderr, "[npu_engine] layer loop failed: %s — aborting batch\n", e.what());
-            return 1;
         }
 
         // LM head on the (single, BS=1) decoded position -> greedy next token.

--- a/include/q4nx_reader.h
+++ b/include/q4nx_reader.h
@@ -42,6 +42,18 @@ struct Q4nxReader {
 
     // Read a BF16 array at offset, widened to float32, into a vector
     std::vector<float> read_floats(uint64_t offset, size_t count) const;
+
+    // Parse tensor shape [rows, cols] from the JSON header by tensor name.
+    // Returns empty vector if tensor or shape field is not found.
+    std::vector<uint64_t> get_tensor_shape(const std::string& json_header,
+                                            const std::string& tensor_name) const;
+
+    // Convenience: check that tensor_name in json_header has shape
+    // [expected_rows, expected_cols]. Returns true on match.
+    bool validate_tensor_shape(const std::string& json_header,
+                               const std::string& tensor_name,
+                               size_t expected_rows,
+                               size_t expected_cols) const;
 };
 
 // Best-effort metadata extraction for model discovery: dims from the embedding

--- a/src/q4nx_reader.cpp
+++ b/src/q4nx_reader.cpp
@@ -112,6 +112,53 @@ std::vector<float> Q4nxReader::read_floats(uint64_t offset, size_t count) const 
     return v;
 }
 
+// ── Tensor shape query ─────────────────────────────────────────────────────
+
+// Parse [rows, cols] from a JSON header string for the named tensor.
+// The JSON format is safetensors-style:
+//   {"tensor_name":{"dtype":"F32","shape":[R,C],"data_offsets":[O,E]},...}
+std::vector<uint64_t> Q4nxReader::get_tensor_shape(
+    const std::string& json_header,
+    const std::string& tensor_name) const
+{
+    std::vector<uint64_t> result;
+    // Find the tensor name key (must be a quoted JSON key)
+    auto pos = json_header.find(tensor_name);
+    if (pos == std::string::npos || pos == 0) return result;
+    if (json_header[pos - 1] != '"') {
+        // Scan forward for a proper "key" match
+        pos = json_header.find('"' + tensor_name + '"');
+        if (pos == std::string::npos) return result;
+    } else if (json_header[pos - 1] == '"') {
+        pos = pos - 1;  // back up to include the opening quote
+    }
+    // Look for "shape":[ after the tensor entry
+    // First ensure we're past the tensor name by finding the next '{'
+    auto brace = json_header.find('{', pos);
+    if (brace == std::string::npos) return result;
+    // Find "shape":[ starting from the opening brace
+    auto shape_key = json_header.find("\"shape\":[", brace);
+    if (shape_key == std::string::npos) return result;
+    auto start = shape_key + strlen("\"shape\":[");
+    uint64_t r = 0, c = 0;
+    if (sscanf(json_header.c_str() + start, "%lu,%lu", &r, &c) == 2) {
+        result.push_back(r);
+        result.push_back(c);
+    }
+    return result;
+}
+
+bool Q4nxReader::validate_tensor_shape(
+    const std::string& json_header,
+    const std::string& tensor_name,
+    size_t expected_rows,
+    size_t expected_cols) const
+{
+    auto shape = get_tensor_shape(json_header, tensor_name);
+    if (shape.size() != 2) return false;
+    return shape[0] == expected_rows && shape[1] == expected_cols;
+}
+
 // ── read_q4nx_metadata ─────────────────────────────────────────────────────
 
 bool read_q4nx_metadata(const std::string& path, ModelConfig& cfg) {


### PR DESCRIPTION
### **User description**
Closes #1073, Closes #1074


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Per-group INT8 quantization for NPU GEMM

- lm_head.weight shape validation with fallback to tied embeddings

- Added tensor shape query API to Q4NX reader


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Q4NX model file"] --> B["lm_head.weight shape check"]
  B -- "shape mismatch" --> C["Fallback to tied embeddings"]
  B -- "shape valid" --> D["Dequantize lm_head"]
  E["NPU GEMM"] --> F["Per-group INT8 quantization"]
  F --> G["Group scales stored per 32 elements"]
  G --> H["Effective Bscale = average of group scales"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>npu_engine_i8.cpp</strong><dd><code>Per-group INT8 quantization and lm_head validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/npu_engine_i8.cpp

<ul><li>Added per-group INT8 quantization in <code>packB()</code>: K divided into groups of <br>32, each with its own scale<br> <li> Updated <code>go()</code> to compute effective Bscale as average of per-group <br>scales<br> <li> Added <code>init_with_generator()</code> for dynamic instruction generation<br> <li> Added <code>jshape()</code> to parse tensor shape from JSON header<br> <li> Added lm_head.weight shape validation: falls back to tied embeddings <br>if shape mismatches</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1113/files#diff-f65877d1e690cf5d2a19acb35b4ce8ccf157e72d9995b51ffb72e72337b61e71">+37/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>q4nx_reader.cpp</strong><dd><code>Tensor shape query API for Q4NX reader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/q4nx_reader.cpp

<ul><li>Added <code>get_tensor_shape()</code> to parse [rows, cols] from JSON header for a <br>named tensor<br> <li> Added <code>validate_tensor_shape()</code> convenience function to check expected <br>dimensions</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1113/files#diff-1ab49a79619a58bc0cb98da4959e7fdd4191cf1a92dccf7e94b776079c79624f">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>q4nx_reader.h</strong><dd><code>Header declarations for shape query API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/q4nx_reader.h

- Declared `get_tensor_shape()` and `validate_tensor_shape()` methods


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1113/files#diff-e92562c014e1b4f8de7b0b0c736b8c2455ee37c585d47039e8d1aaa741a9217d">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

