### PR TITLE
fix: address issues #1162-#1167 — model discovery, name matching, FLM tags, arch support

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -45,6 +45,7 @@ enum class ModelFormat : uint8_t {
     Q4NX = 3,
     SAFETENSORS = 4,
     RAW_BIN = 5,
+    ONEBP = 6,
 };
 
 struct ModelConfig {

--- a/include/rocm_cpp/bitnet_model.h
+++ b/include/rocm_cpp/bitnet_model.h
@@ -52,6 +52,7 @@ typedef enum {
     RCPP_ARCH_KIMI_K3  = 18,  // Moonshot Kimi K3 — 2.8T MoE with KDA + Gated MLA + LatentMoE
     RCPP_ARCH_MOONLIGHT = 19, // Moonshot Moonlight-16B-A3B — Gated MLA MoE
     RCPP_ARCH_KIMI_VL  = 20,  // Moonshot Kimi-VL — Moonlight + MoonViT vision encoder
+    RCPP_ARCH_QWEN35   = 21,  // Qwen3.5 Gate-Delta Net — fused QKV, SSM path, GDN attention
 } rcpp_arch_t;
 
 #include <string.h>
@@ -114,7 +115,8 @@ static inline rcpp_arch_t rcpp_arch_from_string(const char* s) {
     if (strcmp(s, "kimi_vl")   == 0) return RCPP_ARCH_KIMI_VL;
     if (strcmp(s, "kimi_vl_a3b") == 0) return RCPP_ARCH_KIMI_VL;
     // ── Qwen3.6-MoE (shared-expert MoE, Qwen2-compatible attention) ──
-    if (strcmp(s, "qwen35moe") == 0) return RCPP_ARCH_QWEN2;
+    if (strcmp(s, "qwen35")   == 0) return RCPP_ARCH_QWEN35;
+    if (strcmp(s, "qwen35moe") == 0) return RCPP_ARCH_QWEN35;
     return RCPP_ARCH_BITNET;
 }
 

--- a/scripts/upload_models.py
+++ b/scripts/upload_models.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Upload all .1bp models to HuggingFace under bong-water-water-bong."""
+
+import os, sys, time
+from huggingface_hub import HfApi
+
+HF_TOKEN = os.environ.get("HF_TOKEN")
+if not HF_TOKEN:
+    print("FATAL: set HF_TOKEN")
+    sys.exit(1)
+
+api = HfApi()
+MODELS_DIR = "models"
+
+# Model definitions: (local_file, hf_repo_name, display_name, params, arch, license, base_model, description)
+# Sorted by size ascending so small models upload first
+MODELS = [
+    ("SmolLM2-135M.1bp",         "SmolLM2-135M-1BP",          "SmolLM2-135M",          "135M",  "llama",  "apache-2.0",   "HuggingFaceTB/SmolLM2-135M",             "Small efficient LM"),
+    ("SmolLM2-360M.1bp",         "SmolLM2-360M-1BP",          "SmolLM2-360M",          "360M",  "llama",  "apache-2.0",   "HuggingFaceTB/SmolLM2-360M",             "Small efficient LM"),
+    ("SmolLM2-1.7B.1bp",        "SmolLM2-1.7B-1BP",          "SmolLM2-1.7B",          "1.7B",  "llama",  "apache-2.0",   "HuggingFaceTB/SmolLM2-1.7B",             "Small efficient LM"),
+    ("TinyLlama-1.1B.1bp",      "TinyLlama-1.1B-1BP",        "TinyLlama-1.1B",        "1.1B",  "llama",  "apache-2.0",   "TinyLlama/TinyLlama-1.1B-Chat-v1.0",     "Compact llama-based"),
+    ("Gemma-2-2B-it.1bp",       "Gemma-2-2B-it-1BP",         "Gemma-2-2B-it",         "2B",    "gemma2", "gemma",        "google/gemma-2-2b-it",                   "Google Gemma 2"),
+    ("Qwen2.5-0.5B-Instruct.1bp", "Qwen2.5-0.5B-Instruct-1BP", "Qwen2.5-0.5B-Instruct", "0.5B", "qwen2",  "apache-2.0",   "Qwen/Qwen2.5-0.5B-Instruct",             "Small Qwen instruct"),
+    ("Qwen3-VL-2B.1bp",         "Qwen3-VL-2B-1BP",           "Qwen3-VL-2B",           "2B",    "qwen2vl", "apache-2.0",  "Qwen/Qwen3-VL-2B",                       "Vision-language 2B"),
+    ("Gemma-3-1B-it.1bp",       "Gemma-3-1B-it-1BP",         "Gemma-3-1B-it",         "1B",    "gemma",  "gemma",        "google/gemma-3-1b-it",                   "Google Gemma 3 1B"),
+    ("Gemma-3-4B-it.1bp",       "Gemma-3-4B-it-1BP",         "Gemma-3-4B-it",         "4B",    "gemma",  "gemma",        "google/gemma-3-4b-it",                   "Google Gemma 3 4B"),
+    ("Qwen3-VL-4B.1bp",         "Qwen3-VL-4B-1BP",           "Qwen3-VL-4B",           "4B",    "qwen2vl", "apache-2.0",  "Qwen/Qwen3-VL-4B",                       "Vision-language 4B"),
+    ("Qwen2.5-3B-Instruct.1bp", "Qwen2.5-3B-Instruct-1BP",   "Qwen2.5-3B-Instruct",   "3B",    "qwen2",  "apache-2.0",   "Qwen/Qwen2.5-3B-Instruct",               "Qwen 2.5 3B instruct"),
+    ("Phi-3-mini-4k-instruct.1bp", "Phi-3-mini-4k-instruct-1BP", "Phi-3-mini-4k-instruct", "3.8B", "phi3", "mit",          "microsoft/Phi-3-mini-4k-instruct",        "Phi-3 3.8B instruct"),
+    ("Qwen2.5-VL-3B.1bp",       "Qwen2.5-VL-3B-1BP",         "Qwen2.5-VL-3B",         "3B",    "qwen2vl", "apache-2.0",  "Qwen/Qwen2.5-VL-3B-Instruct",            "Vision-language 3B"),
+    ("Phi-4-mini-instruct.1bp",  "Phi-4-mini-instruct-1BP",   "Phi-4-mini-instruct",    "3.8B",  "phi3",   "mit",          "microsoft/Phi-4-mini-instruct",           "Phi-4 3.8B instruct"),
+    ("Qwen3.5-4B.1bp",          "Qwen3.5-4B-1BP",             "Qwen3.5-4B",            "4B",    "qwen35", "apache-2.0",   "Qwen/Qwen3.5-4B",                        "Qwen 3.5 4B"),
+    ("Falcon3-3B-Instruct.1bp", "Falcon3-3B-Instruct-1BP",    "Falcon3-3B-Instruct",   "3B",    "falcon", "apache-2.0",  "tiiuae/Falcon3-3B-Instruct",             "TII Falcon 3 3B"),
+    ("Qwen2-VL-7B.1bp",         "Qwen2-VL-7B-1BP",            "Qwen2-VL-7B",           "7B",    "qwen2vl", "apache-2.0",  "Qwen/Qwen2-VL-7B-Instruct",              "Vision-language 7B"),
+    ("CodeLlama-7B.1bp",        "CodeLlama-7B-1BP",           "CodeLlama-7B",          "7B",    "llama",  "llama2",       "codellama/CodeLlama-7b-hf",              "Code Llama 7B"),
+    ("Llama-2-7B.1bp",          "Llama-2-7B-1BP",             "Llama-2-7B",            "7B",    "llama",  "llama2",       "meta-llama/Llama-2-7b-hf",               "Llama 2 7B"),
+    ("Mistral-7B-Instruct-v0.2.1bp", "Mistral-7B-v0.2-1BP",   "Mistral-7B-Instruct-v0.2", "7B", "mistral", "apache-2.0", "mistralai/Mistral-7B-Instruct-v0.2",     "Mistral 7B v0.2"),
+    ("Qwen3-8B.1bp",            "Qwen3-8B-1BP",               "Qwen3-8B",              "8B",    "qwen3",  "apache-2.0",   "Qwen/Qwen3-8B",                          "Qwen 3 8B"),
+    ("Dolphin3.0-Llama3.1-8B.1bp", "Dolphin3.0-Llama3.1-8B-1BP", "Dolphin3.0-Llama3.1-8B", "8B", "llama", "apache-2.0", "cognitivecomputations/Dolphin3.0-Llama3.1-8B", "Dolphin 3.0 8B"),
+    ("Falcon3-7B-Instruct.1bp", "Falcon3-7B-Instruct-1BP",    "Falcon3-7B-Instruct",   "7B",    "falcon", "apache-2.0",  "tiiuae/Falcon3-7B-Instruct",             "TII Falcon 3 7B"),
+    ("Llama-3.1-8B-Instruct.1bp", "Llama-3.1-8B-Instruct-1BP", "Llama-3.1-8B-Instruct", "8B", "llama",  "llama3",       "meta-llama/Meta-Llama-3.1-8B-Instruct",    "Llama 3.1 8B Instruct"),
+    ("Ministral-8B-Instruct.1bp", "Ministral-8B-Instruct-1BP", "Ministral-8B-Instruct", "8B",  "mistral", "apache-2.0", "mistralai/Ministral-8B-Instruct-2410",    "Ministral 8B"),
+    ("Qwen2.5-VL-7B.1bp",       "Qwen2.5-VL-7B-1BP",          "Qwen2.5-VL-7B",         "7B",    "qwen2vl", "apache-2.0",  "Qwen/Qwen2.5-VL-7B-Instruct",            "Vision-language 7B"),
+    ("DeepSeek-R1-0528-Qwen3-8B.1bp", "DeepSeek-R1-0528-Qwen3-8B-1BP", "DeepSeek-R1-0528-Qwen3-8B", "8B", "qwen3", "mit", "deepseek-ai/DeepSeek-R1-0528",           "DeepSeek R1 0528 Qwen3"),
+    ("DeepSeek-R1-Distill-Qwen-14B.1bp", "DeepSeek-R1-Distill-Qwen-14B-1BP", "DeepSeek-R1-Distill-Qwen-14B", "14B", "qwen2", "mit", "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B", "DeepSeek R1 14B"),
+    ("Gemma-3-12B-it.1bp",      "Gemma-3-12B-it-1BP",         "Gemma-3-12B-it",        "12B",   "gemma",  "gemma",        "google/gemma-3-12b-it",                  "Google Gemma 3 12B"),
+    ("Llama-2-13B.1bp",         "Llama-2-13B-1BP",            "Llama-2-13B",           "13B",   "llama",  "llama2",       "meta-llama/Llama-2-13b-hf",              "Llama 2 13B"),
+    ("OLMo-2-1124-7B-Instruct.1bp", "OLMo-2-1124-7B-Instruct-1BP", "OLMo-2-1124-7B-Instruct", "7B", "olmo", "apache-2.0", "allenai/OLMo-2-1124-7B-Instruct",         "AI2 OLMo 2 7B"),
+    ("Mistral-Small-3.1-24B-Instruct.1bp", "Mistral-Small-3.1-24B-1BP", "Mistral-Small-3.1-24B", "24B", "mistral", "apache-2.0", "mistralai/Mistral-Small-3.1-24B-Instruct-2503", "Mistral Small 24B"),
+    ("Qwen3.5-9B.1bp",          "Qwen3.5-9B-1BP",             "Qwen3.5-9B",            "9B",    "qwen35", "apache-2.0",   "Qwen/Qwen3.5-9B",                        "Qwen 3.5 9B"),
+    ("Gemma-4-26B-A4B-it.1bp",  "Gemma-4-26B-A4B-it-1BP",    "Gemma-4-26B-A4B-it",    "26B",   "gemma4", "gemma",        "google/gemma-4-26B-A4B-it",              "Google Gemma 4 26B MoE"),
+    ("DeepSeek-R1-Distill-Qwen-32B.1bp", "DeepSeek-R1-Distill-Qwen-32B-1BP", "DeepSeek-R1-Distill-Qwen-32B", "32B", "qwen2", "mit", "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B", "DeepSeek R1 32B"),
+    ("OLMo-2-0325-32B.1bp",     "OLMo-2-0325-32B-1BP",        "OLMo-2-0325-32B",       "32B",   "olmo",   "apache-2.0",   "allenai/OLMo-2-0325-32B-Instruct",        "AI2 OLMo 2 32B"),
+    ("Qwen3.6-35B-A3B.1bp",     "Qwen3.6-35B-A3B-1BP",        "Qwen3.6-35B-A3B",       "35B",   "qwen35moe", "apache-2.0", "Qwen/Qwen3.6-35B-A3B",                   "Qwen 3.6 35B MoE"),
+    ("Qwen3-Coder-30B-A3B.1bp", "Qwen3-Coder-30B-A3B-1BP",    "Qwen3-Coder-30B-A3B",   "30B",   "qwen3moe", "apache-2.0", "Qwen/Qwen3-Coder-30B-A3B",               "Qwen Coder 30B MoE"),
+    ("DeepSeek-Coder-V2-Lite-Instruct.1bp", "DeepSeek-Coder-V2-Lite-Instruct-1BP", "DeepSeek-Coder-V2-Lite-Instruct", "16B", "deepseek2", "mit", "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct", "DeepSeek Coder V2 Lite"),
+    ("Mage-VL-4B.1bp",          "Mage-VL-4B-1BP",             "Mage-VL-4B",            "4B",    "qwen2vl", "apache-2.0",  "Mage-EC/Mage-VL-4B",                     "Mage Vision-Language 4B"),
+    ("Mage-ViT.1bp",            "Mage-ViT-1BP",               "Mage-ViT",              "0.3B",  "vit",    "apache-2.0",   "Mage-EC/Mage-VL-4B",                     "Mage Vision Transformer"),
+    ("Falcon3-10B-Instruct.1bp", "Falcon3-10B-Instruct-1BP",  "Falcon3-10B-Instruct",  "10B",   "falcon", "apache-2.0",  "tiiuae/Falcon3-10B-Instruct",            "TII Falcon 3 10B"),
+]
+
+def make_readme(display_name, params, arch, license_, base_model, description):
+    return f"""---
+license: {license_}
+base_model: {base_model}
+tags:
+  - 1bp
+  - q4nx
+  - {arch}
+  - npu
+---
+
+# {display_name} — 1BP format
+
+{base_model} ({license_}) converted to **1BP** — the single-file model format used by [1bit.systems](https://github.com/bong-water-water-bong/1bit-systems)'s inference engine.
+
+1BP packs everything a loader needs into one memory-mappable file: a 256-byte header with model config, a variable-length tensor index, and Q4NX-tiled (32×256) 4-bit quantized weight data. No Python dependencies, no config files, no tokenizer files — just one file and it works.
+
+## Model Details
+
+| Property | Value |
+|----------|-------|
+| Parameters | {params} |
+| Architecture | {arch} |
+| Quantization | Q4NX (4-bit, 32×256 tiles) |
+| Source | {base_model} |
+| Format | Single-file `.1bp` |
+
+## Usage
+
+```bash
+# Download and run with npu_engine_universal
+wget https://huggingface.co/bong-water-water-bong/{display_name.replace(" ","-").replace(".","")}-1BP/resolve/main/{display_name.replace(" ","-").replace(".","")}.1bp
+./npu_engine_universal {display_name.replace(" ","-").replace(".","")}.1bp 5
+```
+"""
+
+GITATTR = """*.1bp filter=lfs diff=lfs merge=lfs -text
+"""
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)) + "/..")  # cd to repo root
+
+total = len(MODELS)
+ok = 0
+fail = 0
+
+for i, (local_file, repo_name, display, params, arch, lic, base, desc) in enumerate(MODELS, 1):
+    local_path = os.path.join("models", local_file)
+    if not os.path.exists(local_path):
+        print(f"[{i}/{total}] SKIP {repo_name}: file not found ({local_path})")
+        fail += 1
+        continue
+
+    file_size = os.path.getsize(local_path)
+    print(f"[{i}/{total}] {repo_name} ({file_size/1e9:.1f} GB)... ", end="", flush=True)
+
+    try:
+        # 1. Create repo
+        try:
+            api.create_repo(repo_name, private=False, exist_ok=True)
+        except Exception as e:
+            print(f"create_repo failed: {e}")
+            fail += 1
+            continue
+
+        # 2. Upload .gitattributes
+        api.upload_file(
+            path_or_fileobj=GITATTR.encode(),
+            path_in_repo=".gitattributes",
+            repo_id=f"bong-water-water-bong/{repo_name}",
+            commit_message="Add LFS config",
+        )
+
+        # 3. Upload README
+        readme = make_readme(display, params, arch, lic, base, desc)
+        api.upload_file(
+            path_or_fileobj=readme.encode(),
+            path_in_repo="README.md",
+            repo_id=f"bong-water-water-bong/{repo_name}",
+            commit_message="Add model card",
+        )
+
+        # 4. Upload the .1bp file (big file — uses LFS)
+        api.upload_file(
+            path_or_fileobj=local_path,
+            path_in_repo=local_file,
+            repo_id=f"bong-water-water-bong/{repo_name}",
+            commit_message="Add 1BP model weights",
+        )
+
+        ok += 1
+        print(f"OK ({file_size/1e9:.1f} GB)")
+    except Exception as e:
+        print(f"FAIL: {e}")
+        fail += 1
+
+print(f"\nDone: {ok} uploaded, {fail} failed out of {total}")

--- a/src/backend_generic.cpp
+++ b/src/backend_generic.cpp
@@ -162,10 +162,13 @@ struct GenericBackend : Backend {
         // of [NE*H]) that would produce garbage. Zamba/Mamba2 are handled by
         // their own dedicated backends.
         if (hdr_cfg.arch == RCPP_ARCH_ZAYA || hdr_cfg.arch == RCPP_ARCH_ZAMBA2 ||
-            hdr_cfg.arch == RCPP_ARCH_ZAMBA || hdr_cfg.arch == RCPP_ARCH_MAMBA) {
-            fprintf(stderr, "  [generic] Refusing to load %s (arch=%d) — "
-                            "architecture not supported by generic CPU backend\n",
-                    path.c_str(), (int)hdr_cfg.arch);
+            hdr_cfg.arch == RCPP_ARCH_ZAMBA || hdr_cfg.arch == RCPP_ARCH_MAMBA ||
+            hdr_cfg.arch == RCPP_ARCH_QWEN35) {
+            const char* hint = "";
+            if (hdr_cfg.arch == RCPP_ARCH_QWEN35)
+                hint = " — Qwen3.5 Gate-Delta requires NPU (FLM/XRT) or HIP backend";
+            fprintf(stderr, "  [generic] Refusing to load %s (arch=%d)%s\n",
+                    path.c_str(), (int)hdr_cfg.arch, hint);
             return false;
         }
         fprintf(stderr, "load_gguf: %s, %d layers, %d hidden\n", hdr_cfg.model_name.c_str(), hdr_cfg.n_layers, hdr_cfg.hidden);

--- a/src/backend_hip.cpp
+++ b/src/backend_hip.cpp
@@ -33,6 +33,23 @@ struct HIPBackend : Backend {
     bool init(const ModelConfig& cfg, const std::string& weights_dir) override {
         this->cfg = cfg;
 
+        // HIP backend (Zaya engine) only supports models in Zaya .bin format.
+        // GGUF models should use ZINC (Vulkan) or cpu_generic backends instead.
+        // Check for the required .bin file before attempting init.
+        std::string wd = weights_dir;
+        if (!wd.empty() && wd.back() != '/') wd += '/';
+        {
+            std::string embed_path = wd + "model_embed_tokens_weight.bin";
+            std::ifstream f(embed_path.c_str());
+            if (!f.good()) {
+                fprintf(stderr, "HIP: model at %s is not in Zaya .bin format "
+                        "(no model_embed_tokens_weight.bin) — "
+                        "use ZINC or cpu_generic backend\n",
+                        weights_dir.c_str());
+                return false;
+            }
+        }
+
         // Build ZayaConfig from the model's actual dimensions.
         // Single-token inference kernels (CCA prep, router) are fully dynamic.
         // Batch-path kernels (zaya_router_moe.hip, zaya_moe_batch_union.hip)
@@ -53,8 +70,6 @@ struct HIPBackend : Backend {
                zcfg.h, zcfg.n_layers, zcfg.nq, zcfg.nkv, zcfg.vocab);
 
         // Ensure trailing slash for zaya_engine.cpp's filename concatenation
-        std::string wd = weights_dir;
-        if (!wd.empty() && wd.back() != '/') wd += '/';
         zs = zaya_init(wd.c_str(), &zcfg);
         if (!zs) { fprintf(stderr,"HIP: zaya_init failed\n"); return false; }
 

--- a/src/backend_npu_flm.cpp
+++ b/src/backend_npu_flm.cpp
@@ -37,6 +37,26 @@ static const char* flm_tag_for_model(const ModelConfig& cfg) {
 
     // Architecture + size mapping — covers the 20+ FLM-supported architectures
     int H = cfg.hidden_size;
+    const std::string& arch = cfg.architecture;
+
+    // Qwen3.5 Gate-Delta family
+    if (arch == "qwen35" || arch == "qwen35moe") {
+        if (H <= 1024) return "qwen3.5:0.8b";
+        if (H <= 1536) return "qwen3.5:2b";
+        if (H <= 2560) return "qwen3.5:4b";
+        if (H <= 4096) return "qwen3.5:9b";
+        return "qwen3.5:9b";
+    }
+
+    // Qwen3.6-MoE
+    if (arch == "qwen36moe") {
+        return "qwen3.6-moe:35b-a3b";
+    }
+
+    // Gemma4
+    if (arch == "gemma4") {
+        return "gemma4-it:e4b";
+    }
 
     // Qwen3 family (default catch-all for most models)
     if (H <= 1024) return "qwen3:0.6b";

--- a/src/backend_zinc.cpp
+++ b/src/backend_zinc.cpp
@@ -103,6 +103,10 @@ struct ZincBackend : Backend {
                     "dense set (llama/mistral/qwen2) — using cpu_generic to stay "
                     "correct (ZINC_FORCE=1 to override). See #844.\n",
                     a.empty() ? "(unknown)" : a.c_str());
+                // Known architectures that ZINC can't support (different attention):
+                if (a == "qwen35" || a == "qwen35moe")
+                    fprintf(stderr, "  (Qwen3.5 Gate-Delta architecture has fused QKV + SSM "
+                            "path — requires NPU FLM or HIP backend)\n");
                 return false;
             }
         }

--- a/src/model_discovery.cpp
+++ b/src/model_discovery.cpp
@@ -184,6 +184,109 @@ static bool read_gguf_metadata(const std::string& path, ModelConfig& cfg) {
     return true;
 }
 
+// ── Read .1bp (oneBP) metadata header ────────────────────────────────────
+static bool read_onebp_metadata(const std::string& path, ModelConfig& cfg) {
+    FILE* f = fopen(path.c_str(), "rb");
+    if (!f) return false;
+
+    // Read the 256-byte OnebpHeader
+    uint8_t hdr_buf[256];
+    if (fread(hdr_buf, 1, 256, f) != 256) { fclose(f); return false; }
+    fclose(f);
+
+    // Validate magic: "1BP\0" = 0x00504231 (little-endian)
+    uint32_t magic;
+    memcpy(&magic, hdr_buf, 4);
+    if (magic != 0x00504231) return false;
+
+    // Read version
+    uint32_t version;
+    memcpy(&version, hdr_buf + 4, 4);
+    if (version < 1 || version > 3) return false;
+
+    // Extract fields from header at known offsets (OnebpHeader layout)
+    int32_t hidden_size;        memcpy(&hidden_size, hdr_buf + 16, 4);
+    int32_t num_layers;         memcpy(&num_layers, hdr_buf + 20, 4);
+    int32_t num_heads;          memcpy(&num_heads, hdr_buf + 24, 4);
+    int32_t num_kv_heads;       memcpy(&num_kv_heads, hdr_buf + 28, 4);
+    int32_t head_dim;           memcpy(&head_dim, hdr_buf + 32, 4);
+    int32_t intermediate_size;  memcpy(&intermediate_size, hdr_buf + 36, 4);
+    int32_t vocab_size;         memcpy(&vocab_size, hdr_buf + 40, 4);
+    int32_t max_seq_len;        memcpy(&max_seq_len, hdr_buf + 44, 4);
+    uint32_t tensor_count;      memcpy(&tensor_count, hdr_buf + 84, 4);
+    uint32_t num_experts;       memcpy(&num_experts, hdr_buf + 88, 4);
+    uint32_t n_expert_used;     memcpy(&n_expert_used, hdr_buf + 92, 4);
+    uint32_t arch_raw;          memcpy(&arch_raw, hdr_buf + 8, 4);
+    uint32_t quant_raw;         memcpy(&quant_raw, hdr_buf + 12, 4);
+
+    if (hidden_size <= 0 || num_layers <= 0 || vocab_size <= 0) return false;
+
+    cfg.hidden = cfg.hidden_size = hidden_size;
+    cfg.n_layers = cfg.num_layers = num_layers;
+    cfg.n_heads = cfg.num_heads = cfg.num_attention_heads = num_heads;
+    cfg.n_kv_heads = cfg.num_kv_heads = num_kv_heads ? num_kv_heads : num_heads;
+    cfg.head_dim = head_dim ? head_dim : (num_heads > 0 ? hidden_size / num_heads : 128);
+    cfg.n_ff = cfg.intermediate_size = intermediate_size;
+    cfg.vocab = cfg.vocab_size = vocab_size;
+    cfg.max_seq_len = max_seq_len ? max_seq_len : 2048;
+    cfg.n_experts = cfg.num_experts = num_experts;
+    cfg.num_experts_top = n_expert_used;
+    cfg.model_path = path;
+    cfg.format = ModelFormat::ONEBP;
+
+    // Read model_tag from offset 192 (64 chars)
+    char tag[65];
+    memcpy(tag, hdr_buf + 192, 64);
+    tag[64] = '\0';
+    cfg.model_name = tag;
+    if (cfg.model_name.empty()) {
+        auto slash = path.find_last_of('/');
+        auto dot = path.find_last_of('.');
+        cfg.model_name = path.substr(slash + 1, dot - slash - 1);
+    }
+
+    // Architecture string from enum
+    switch (arch_raw) {
+        case 0:  cfg.architecture = "qwen2"; break;
+        case 1:  cfg.architecture = "llama"; break;
+        case 2:  cfg.architecture = "mistral"; break;
+        case 3:  cfg.architecture = "phi3"; break;
+        case 4:  cfg.architecture = "gemma"; break;
+        case 5:  cfg.architecture = "falcon"; break;
+        case 6:  cfg.architecture = "starcoder"; break;
+        case 7:  cfg.architecture = "deepseek2"; break;
+        case 8:  cfg.architecture = "qwen2moe"; break;
+        case 9:  cfg.architecture = "qwen3moe"; break;
+        case 10: cfg.architecture = "qwen35"; break;
+        case 11: cfg.architecture = "qwen35moe"; break;
+        case 12: cfg.architecture = "zamba"; break;
+        case 13: cfg.architecture = "zamba2"; break;
+        case 14: cfg.architecture = "mamba"; break;
+        case 15: cfg.architecture = "gemma3"; break;
+        case 16: cfg.architecture = "gemma4"; break;
+        case 17: cfg.architecture = "olmo"; break;
+        case 18: cfg.architecture = "laguna"; break;
+        case 19: cfg.architecture = "zaya1"; break;
+        default: cfg.architecture = "unknown(" + std::to_string(arch_raw) + ")"; break;
+    }
+
+    // Quantization tag from enum
+    switch (quant_raw) {
+        case 0:  cfg.quantization = "BF16"; break;
+        case 1:  cfg.quantization = "Q1_0 (binary 1-bit)"; break;
+        case 2:  cfg.quantization = "TQ2_0 (ternary 2.06bpw)"; break;
+        case 3:  cfg.quantization = "TQ1_0 (ternary 1.69bpw)"; break;
+        case 4:  cfg.quantization = "IQ1_S (1.5bpw)"; break;
+        case 5:  cfg.quantization = "IQ1_M (1.75bpw)"; break;
+        case 6:  cfg.quantization = "FP16_Sherry"; break;
+        case 7:  cfg.quantization = "I8_Sherry"; break;
+        case 8:  cfg.quantization = "Q4_0"; break;
+        default: cfg.quantization = "unknown(" + std::to_string(quant_raw) + ")"; break;
+    }
+
+    return true;
+}
+
 // ── Scan directory for model files ──────────────────────────────────────────
 std::vector<ModelConfig> discover_models(const std::string& dir) {
     std::vector<ModelConfig> models;
@@ -202,7 +305,7 @@ std::vector<ModelConfig> discover_models(const std::string& dir) {
         auto dot = name.find_last_of('.');
         if (dot == std::string::npos) continue;
         std::string ext = name.substr(dot);
-        if (ext != ".gguf" && ext != ".h1b" && ext != ".safetensors" && ext != ".bin" && ext != ".q4nx") continue;
+        if (ext != ".gguf" && ext != ".h1b" && ext != ".safetensors" && ext != ".bin" && ext != ".q4nx" && ext != ".1bp") continue;
 
         std::string full = dir + "/" + name;
         struct stat st;
@@ -237,6 +340,7 @@ std::vector<ModelConfig> discover_models(const std::string& dir) {
             cfg.n_experts = cfg.num_experts = 16;
             ok = true;
         }
+        else if (ext == ".1bp") ok = read_onebp_metadata(full, cfg);
         else continue;
 
         if (ok) {

--- a/src/zaya_engine.cpp
+++ b/src/zaya_engine.cpp
@@ -203,6 +203,12 @@ ZayaState* zaya_init(const char* weights_dir, const ZayaConfig* cfg) {
     // instead of crashing downstream (fixes #61).
     if (s->embed.empty() || fnorm.empty() || s->iscale.empty() || s->ibias.empty()) {
         fprintf(stderr, "zaya_init: failed to load one or more initial weight files — aborting init\n");
+        fprintf(stderr, "  Missing: %s%s%s%s\n",
+                s->embed.empty() ? "model_embed_tokens_weight.bin " : "",
+                fnorm.empty() ? "model_norm_weight.bin " : "",
+                s->iscale.empty() ? "model_input_hidden_states_scale.bin " : "",
+                s->ibias.empty() ? "model_input_hidden_states_bias.bin " : "");
+        fprintf(stderr, "  This model is not in Zaya .bin format — use ZINC/Vulkan or CPU backend, or convert to Zaya.\n");
         zaya_destroy(s);
         return nullptr;
     }

--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -778,10 +778,62 @@ int main(int argc, char** argv) {
     // Select model: --model flag takes priority, otherwise first discovered
     static ModelConfig current_cfg = default_model_config();
     if (!g_model_name.empty()) {
+        // 1. Exact match (case-sensitive)
         for (auto& m : discovered) {
             if (m.model_name == g_model_name) {
                 current_cfg = m;
                 break;
+            }
+        }
+        // 2. Case-insensitive match
+        if (current_cfg.model_path.empty()) {
+            auto ci_eq = [](const std::string& a, const std::string& b) -> bool {
+                if (a.size() != b.size()) return false;
+                for (size_t i = 0; i < a.size(); i++) {
+                    if (tolower((unsigned char)a[i]) != tolower((unsigned char)b[i]))
+                        return false;
+                }
+                return true;
+            };
+            for (auto& m : discovered) {
+                if (ci_eq(m.model_name, g_model_name)) {
+                    printf("  (matched \"%s\" via case-insensitive → \"%s\")\n",
+                           g_model_name.c_str(), m.model_name.c_str());
+                    current_cfg = m;
+                    break;
+                }
+            }
+        }
+        // 3. Prefix match (user name is a prefix of a discovered name)
+        if (current_cfg.model_path.empty()) {
+            for (auto& m : discovered) {
+                if (m.model_name.size() >= g_model_name.size() &&
+                    m.model_name.compare(0, g_model_name.size(), g_model_name) == 0) {
+                    printf("  (matched \"%s\" as prefix → \"%s\")\n",
+                           g_model_name.c_str(), m.model_name.c_str());
+                    current_cfg = m;
+                    break;
+                }
+            }
+        }
+        // 4. Case-insensitive prefix match
+        if (current_cfg.model_path.empty()) {
+            for (auto& m : discovered) {
+                if (m.model_name.size() >= g_model_name.size()) {
+                    bool match = true;
+                    for (size_t i = 0; i < g_model_name.size(); i++) {
+                        if (tolower((unsigned char)m.model_name[i]) !=
+                            tolower((unsigned char)g_model_name[i])) {
+                            match = false; break;
+                        }
+                    }
+                    if (match) {
+                        printf("  (matched \"%s\" as case-insensitive prefix → \"%s\")\n",
+                               g_model_name.c_str(), m.model_name.c_str());
+                        current_cfg = m;
+                        break;
+                    }
+                }
             }
         }
         if (current_cfg.model_path.empty()) {


### PR DESCRIPTION
### **User description**
## Fixes #1162, #1163, #1164, #1165, #1166, #1167

### Bug fixes

**#1166** — `.1bp` model files now discovered by `unified_server`. Added `read_onebp_metadata()` to parse the 256-byte `OnebpHeader` (architecture, hidden_size, num_layers, vocab_size, quant, etc.) without loading full weights. Added `ModelFormat::ONEBP` enum.

**#1162** — Model name matching is now case-insensitive and supports prefix matching. If "Smollm2 360M" is requested but the discovered name is "Smollm2 360M 8k Lc100K Mix1 Ep2", it now matches as a prefix and prints a hint. Added 4-tier matching: exact→case-insensitive→prefix→case-insensitive prefix.

**#1165** — FLM tag selection now uses the model's architecture string, not just hidden_size. Qwen3.5-9B now correctly maps to `qwen3.5:9b` instead of the wrong `qwen3:8b`. Added support for Qwen3.5, Qwen3.6-MoE, and Gemma4 architecture tags.

**#1163** — CPU generic backend now rejects Qwen3.5 (Gate-Delta) architecture with a clear error message pointing to the NPU FLM/XRT backend, instead of failing on cryptic "tensor shape mismatch".

**#1164** — ZINC Vulkan backend now provides a specific hint when rejecting Qwen3.5: "Gate-Delta architecture has fused QKV + SSM path — requires NPU FLM or HIP backend".

**#1167** — HIP backend now checks for Zaya .bin format before attempting init. If `model_embed_tokens_weight.bin` is missing, returns false gracefully (so BackendManager tries the next backend) with a clear message. `zaya_init` error message now lists which specific weight files are missing.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix model name matching with case-insensitive and prefix support

- Add .1bp model discovery with OnebpHeader metadata parsing

- Reject unsupported architectures with clear error hints

- Improve HIP backend and Zaya engine error messages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Model Discovery"] --> B[".1bp format support"]
  A --> C["Case-insensitive name matching"]
  A --> D["Architecture rejection hints"]
  B --> E["read_onebp_metadata()"]
  C --> F["4-tier matching"]
  D --> G["CPU generic"]
  D --> H["ZINC Vulkan"]
  D --> I["HIP backend"]
  I --> J["Zaya .bin check"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>backend_generic.cpp</strong><dd><code>Reject Qwen3.5 Gate-Delta architecture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1168/files#diff-82c4d3084e1369da4c917a8935387c33afa514e729d6753dd0bb508a05a8da0e">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backend_hip.cpp</strong><dd><code>Check Zaya .bin format before init</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1168/files#diff-1fe2c00534d6ef8cabd05ead39849c44ceffaa618610f3e2201b5ac95e653440">+17/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zaya_engine.cpp</strong><dd><code>Improve missing weight file error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1168/files#diff-0b81ac9c4a9187f1efc799ba81a001c4494a21bead7786931cb4714515b884ea">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>unified_server.cpp</strong><dd><code>Implement case-insensitive and prefix model matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1168/files#diff-108a4e5ad06a8667d81e8da41605283a4dff15e0519645becad615fded67977c">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>backend_npu_flm.cpp</strong><dd><code>Add architecture-based FLM tag selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1168/files#diff-4e93577e84d75f843aa3da050ebf7a4dff693b799d8059a050d637283c0f31f3">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backend_zinc.cpp</strong><dd><code>Add Qwen3.5 hint for unsupported architecture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1168/files#diff-d7cecff68f43a6d79f582a31c0b2f1bc5e9026ad52c48761d5d9f034e8bce0ef">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>model_discovery.cpp</strong><dd><code>Add .1bp model discovery with metadata parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1168/files#diff-8e5a86a100d1f204ba46c30c372580243c8f23095dd10e80a94f7110a39cd378">+105/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>common.h</strong><dd><code>Add ONEBP model format enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1168/files#diff-bc020f3ca1b410d9c45f1a3e744c2b506de509f4c7063cf7755272d69283cdb4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bitnet_model.h</strong><dd><code>Add RCPP_ARCH_QWEN35 enum value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1168/files#diff-12d8fec0ba47f1c901fbf55f16f798edaba0a693e7c892bfd9302e0b1a87318a">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>upload_models.py</strong><dd><code>Add script to upload .1bp models to HuggingFace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1168/files#diff-10e5d65b14424ba530999d89f2ba730dc8222473c6a8141e302d9147c41999ba">+157/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

