### PR TITLE
fix: clarify Peano build stanzas vs runtime instruction generator

### DIFF
--- a/docs/wiki/models.md
+++ b/docs/wiki/models.md
@@ -55,7 +55,7 @@ Next-gen dense transformers with improved multi-lingual and reasoning performanc
 
 - **Qwen3 on NPU:** 0.6B, 1.7B, 4B, 8B, 4B-Instruct-2507, 4B-Thinking-2507 (all build stanzas in build_xclbins.sh — run `./build_xclbins.sh qwen3_0_6b` to compile any)
 - **Qwen3.5 on NPU:** 0.8B, 2B, 4B, 9B (GateDeltaNet variants, build stanzas in build_xclbins.sh)
-- **Qwen3-VL:** 4B-Instruct on NPU (build stanza in build_xclbins.sh, 6 xclbins) — vision-language
+- **Qwen3-VL:** 4B-Instruct on NPU (Peano build stanza, 6 xclbins) — vision-language
 - **GPU HIP:** GGUF through ROCm HIP — validated (kernel bench: 431 tok/s Q1, 543 tok/s TQ2)
 - **GPU Vulkan:** Qwen3-0.6B at 259 tok/s decode, 333 tok/s prefill — ✅ validated (ZINC bench)
 
@@ -72,7 +72,7 @@ Meta's dense transformers. Broad backend coverage — GGUF runs on all GPU backe
 
 Mistral dense transformers and Pixtral vision-language models. GGUF through GPU HIP.
 
-- **NPU:** Mistral-7B build stanza in build_xclbins.sh (`build_mistral_7b`) — GEMM dims match Llama-3.1-8B. SWA attention MLIR generator (`generators/n1_core_swa.py`) supports sliding-window attention. Run `./build_xclbins.sh mistral_7b` to compile xclbins.
+- **NPU:** Mistral-7B Peano build stanza (`build_mistral_7b`) — GEMM dims match Llama-3.1-8B. SWA attention MLIR generator (`generators/n1_core_swa.py`) supports sliding-window attention. Run `./build_xclbins.sh mistral_7b` to compile xclbins.
 - **GPU HIP:** GGUF — validated
 - **GPU Vulkan:** GGUF — functional, perf data pending
 - **CPU:** GGUF — functional, perf data pending
@@ -90,7 +90,7 @@ Google's dense transformers. Gemma4 E2B/E4B with build stanzas in build_xclbins.
 
 Microsoft's 4B dense transformer. NPU-only at present.
 
-- **NPU:** Phi4-Mini-Instruct (build stanza in build_xclbins.sh, 4 xclbins)
+- **NPU:** Phi4-Mini-Instruct (Peano build stanza, 4 xclbins)
 - **GPU HIP:** ❌ not yet
 - **GPU Vulkan:** ❌ not yet
 - **CPU:** ✅ universal GGUF backend

--- a/engine/npu/build_xclbins.sh
+++ b/engine/npu/build_xclbins.sh
@@ -421,10 +421,27 @@ build_gemma4_e2b() {
 }
 
 # ── NEW ARCHITECTURES ────────────────────────────────────────────────
-
+#
+# IMPORTANT: These stanzas define dimensions for Peano xclbin compilation.
+# The runtime instruction generator (gemm_generate_sequence_i8() in
+# npu_engine_i8.cpp) generates NPU instructions at runtime for ANY
+# dimension using FLM's universal mm.xclbin fused kernel (501KB).
+# Per-model xclbins are an OPTIONAL optimization — the runtime generator
+# is the working production path TODAY.
+#
+# To compile these stanzas into actual xclbins, you need:
+#   - The torch2aie examples directory installed
+#   - Peano compiler (aiecc) with all dependencies
+#   - Run: ./build_xclbins.sh <model_tag>
+#
+# Without Peano compilation, these models still work via:
+#   npu_engine_i8.cpp init_with_generator() — generates instructions
+#   at runtime using FLM's mm.xclbin fused kernel
+#
 build_mistral_7b() {
     echo "=== Mistral-7B (H=4096, NH=32, NKV=8, HD=128, IM=14336, SWA) ==="
-    echo "  Note: GEMM dims match Llama but attn uses sliding window (needs SWA xclbin)"
+    echo "  Runtime: uses Llama xclbins (identical GEMM dims) + SWA via CPU attention"
+    echo "  Peano: GEMM dims match Llama but attn uses sliding window (needs SWA xclbin)"
     local TAG="mistral_7b"
     build "$TAG" 128 4096 6144   QKV
     build "$TAG" 128 4096 4096   O
@@ -435,38 +452,34 @@ build_mistral_7b() {
 
 build_falcon_7b() {
     echo "=== Falcon-7B (H=4544, NH=71, NKV=1, HD=64, IM=18176) ==="
-    echo "  Note: H=4544 is NOT multiple of 128 — uses padded dims (4608)"
+    echo "  Runtime: uses gemm_generate_sequence_i8_split() with padded dims"
+    echo "  Peano: H=4544 NOT multiple of 128 — uses padded dims (4608)"
     local TAG="falcon_7b"
-    # Padded to nearest multiple of 128: H=4608, NH=72, NKV=1, HD=64
-    # QKV = 4608× (72*64 + 2*1*64) = 4608×4736
     build "$TAG" 128 4608 4736   QKV
-    # O = 4608×4608
     build "$TAG" 128 4608 4608   O
-    # GU = 4608×(2*18176) = 4608×36352 — split to avoid >14336 tile limit
     build "$TAG" 128 4608 18176  G
     build "$TAG" 128 4608 18176  U
-    # D = 18176×4608 — padded to 18304×4608
     build "$TAG" 128 18304 4608  D
 }
 
 build_olmoe() {
-    echo "=== OLMoE-1B-7B (H=2048, NH=16, NKV=16, HD=128, IM=2048, MoE) ==="
-    echo "  Note: Reuses GPT-OSS expert pattern: 4 GEMM + expert.xclbin"
+    echo "=== OLMoE-1B (H=2048, NH=16, NKV=16, HD=128, IM=2048, MoE) ==="
+    echo "  Runtime: uses gemm_generate_sequence_i8_split() with MoE dispatch"
+    echo "  Peano: Reuses GPT-OSS expert pattern: 4 GEMM + expert.xclbin"
     local TAG="olmoe_1b"
-    build "$TAG" 128 2048 4096   QKV   # QKV: H→NH*HD+2*NKV*HD = 2048→4096
-    build "$TAG" 128 2048 2048   O     # O: NH*HD→H = 2048→2048
-    build "$TAG" 128 2048 4096   GU    # GU: H→2*IM = 2048→4096
-    build "$TAG" 128 2048 2048   D     # D: IM→H = 2048→2048
+    build "$TAG" 128 2048 4096   QKV
+    build "$TAG" 128 2048 2048   O
+    build "$TAG" 128 2048 4096   GU
+    build "$TAG" 128 2048 2048   D
 }
 
 build_zamba2_2_7b() {
     echo "=== Zamba2-2.7B (H=2560, NH=32, NKV=32, HD=80, IM=5120, SSM hybrid) ==="
-    echo "  Note: SSM layers run on CPU; NPU handles GEMM for attn layers + in/out proj"
+    echo "  Runtime: uses gemm_generate_sequence_i8_split() + CPU SSM scan"
+    echo "  Peano: Attn layers QKV=2560×7680, O=2560×2560, GU=2560×10240, D=5120×2560"
     local TAG="zamba2_2_7b"
-    # Attn layers: QKV = 2560×7680, O = 2560×2560
     build "$TAG" 128 2560 7680   QKV
     build "$TAG" 128 2560 2560   O
-    # FFN: GU = 2560×10240, D = 5120×2560
     build "$TAG" 128 2560 10240  GU
     build "$TAG" 128 5120 2560   D
 }


### PR DESCRIPTION
Build stanzas define dims for optional Peano xclbin compilation. The production path is the runtime instruction generator (gemm_generate_sequence_i8_split()) which uses FLM's universal mm.xclbin fused kernel with dynamic NPU instruction generation — no Peano compilation needed for inference.

Updated:
- engine/npu/build_xclbins.sh: runtime notes for all new model stanzas
- docs/wiki/models.md: clarified runtime vs Peano paths