### PR TITLE
fix: install libxrt-dev in Release workflow for fused NPU backend

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,11 @@ jobs:
           apt-get install -y -qq git cmake ninja-build build-essential \
             libvulkan-dev uuid-dev python3-pip python3-venv
 
+          # XRT (Xilinx Runtime) for NPU fused engine compilation.
+          # backend_fused.cpp/backend_fused_npu.cpp need xrt headers at compile time.
+          apt-get install -y -qq libxrt-dev 2>/dev/null || \
+            echo "::warning::libxrt-dev not available — fused NPU backends stubbed"
+
           # Install TheRock nightly ROCm SDK (AMD's C++ toolchain for Strix Halo)
           # This replaces the system ROCm at /opt/rocm with TheRock 7.15.0a
           # at /opt/rocm-therock. CMakeLists.txt auto-detects /opt/rocm-therock

--- a/engine/npu/src/gemm_npu_instructions.cpp
+++ b/engine/npu/src/gemm_npu_instructions.cpp
@@ -312,3 +312,28 @@ void mha_generate_sequence(
 
     seq->cmds2seq();
 }
+
+// ── Compatibility wrapper: split A/B offset variant ──
+// Called by HybridFlmCtx (npu_engine_hybrid_flm.h).
+// The unified gemm_generate_sequence uses a single weight offset.
+// This wrapper adapts the split-offset call to the unified API.
+void gemm_generate_sequence_i8_split(
+    npu_sequence*           seq,
+    uint32_t                M,
+    uint32_t                K,
+    uint32_t                N,
+    uint32_t                a_ddr_offset,
+    uint32_t                b_base_offset,
+    bool                    add_bias,
+    int                     activation,
+    uint32_t                bias_offset,
+    uint32_t                output_offset
+) {
+    // Unified function computes B = weight_offset + K*M + ...
+    // Caller wants A at a_ddr_offset, B at b_base_offset.
+    // Adjust weight_offset so B lands where caller expects.
+    uint32_t layer_b_offset = b_base_offset - (a_ddr_offset + K * M);
+    gemm_generate_sequence(seq, M, K, N,
+        a_ddr_offset + layer_b_offset,
+        add_bias, activation, bias_offset, output_offset);
+}


### PR DESCRIPTION
### **User description**
The Release workflow (rocm/dev-ubuntu-24.04:7.2.4-complete container) fails with:
```
fatal error: 'xrt/xrt_bo.h' file not found
fatal error: 'xrt/xrt_device.h' file not found
```

PR #1195 added backend_fused.cpp/backend_fused_npu.cpp to unified_server
sources, which include XRT headers via engine/fusion/zero_copy/npu_gemm_kernel.h.
The build container needs libxrt-dev to compile these files.

libxrt-dev is available in Ubuntu 24.04 universe ($ apt-cache show libxrt-dev).


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add compatibility wrapper for gemm_generate_sequence_i8_split

- Install libxrt-dev in Release workflow for NPU backend


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NPU Build Fixes"] --> B["gemm_generate_sequence_i8_split wrapper"]
  A --> C["Install libxrt-dev in Release workflow"]
  B --> D["Adapts split-offset calls to unified API"]
  C --> E["Provides XRT headers for fused NPU compilation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gemm_npu_instructions.cpp</strong><dd><code>Add split-offset wrapper for NPU compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/gemm_npu_instructions.cpp

<ul><li>Added compatibility wrapper <code>gemm_generate_sequence_i8_split</code> for <br>HybridFlmCtx<br> <li> Adapts split A/B offset calls to unified <code>gemm_generate_sequence</code> API</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1224/files#diff-51e80bf040ae6e8bcfc5150d87255ccb63b73e3432e5ddd3c553dac2cc9293e8">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Install XRT headers for fused NPU backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Added <code>libxrt-dev</code> installation for Xilinx Runtime headers<br> <li> Includes fallback warning if package unavailable</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1224/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

