### PR TITLE
feat(vision): Mage-VL text model + tokenizer — full VL inference end-to-end

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1065,7 +1065,7 @@ target_link_libraries(vision_qwen2vl_poc PRIVATE backend_manager vl_image dl)
 # OpenAI-compatible /v1/chat/completions with image_url support.
 # Auto-detects GPU (HIP) and falls back to CPU for image preprocessing.
 # Requires a VL-capable text model + mmproj GGUF file.
-add_executable(vision_server tools/vision_server.cpp)
+add_executable(vision_server tools/vision_server.cpp src/tokenizer.cpp)
 target_include_directories(vision_server PRIVATE src/ include/ engine/npu/src)
 target_compile_options(vision_server PRIVATE -O3 -Wall -Wno-unused-result -std=c++23)
 target_link_libraries(vision_server PRIVATE

--- a/tools/hf_to_onebp.py
+++ b/tools/hf_to_onebp.py
@@ -363,12 +363,15 @@ def detect_architecture(config, tensors):
 def build_header(config, tensors, arch_str, quant_type, tile_rows=32, tile_cols=256, group_size=32):
     """Build a 1BP header from config and architecture info."""
     hdr = bytearray(256)
+    # Layout must match OnebpHeader (include/onebp_format.h) exactly:
+    # magic@0 version@4 arch@8 quant@12 scale_type@16 hidden@20 ...
     struct.pack_into("<I", hdr, 0, ONEBP_MAGIC)
     struct.pack_into("<I", hdr, 4, ONEBP_VERSION)
 
     arch_enum = ARCH_MAP.get(arch_str, ONEBP_DENSE)
     struct.pack_into("<I", hdr, 8, arch_enum)
     struct.pack_into("<I", hdr, 12, QUANT_MAP.get(quant_type, ONEBP_Q4NX))
+    struct.pack_into("<I", hdr, 16, 0)  # scale_type
 
     # Read dimensions from config with fallbacks
     hs = config.get("hidden_size", config.get("d_model", 0))
@@ -405,33 +408,34 @@ def build_header(config, tensors, arch_str, quant_type, tile_rows=32, tile_cols=
                         break
                 break
 
-    struct.pack_into("<i", hdr, 16, hs)
-    struct.pack_into("<i", hdr, 20, nl)
-    struct.pack_into("<i", hdr, 24, nh if nh > 0 else 1)
-    struct.pack_into("<i", hdr, 28, nkv if nkv > 0 else nh)
-    struct.pack_into("<i", hdr, 32, hd if hd > 0 else (hs // nh if nh > 0 else 128))
-    struct.pack_into("<i", hdr, 36, im)
-    struct.pack_into("<i", hdr, 40, vs)
-    struct.pack_into("<i", hdr, 44, msl)
-    struct.pack_into("<I", hdr, 48, tile_rows)
-    struct.pack_into("<I", hdr, 52, tile_cols)
-    struct.pack_into("<I", hdr, 56, group_size)
+    struct.pack_into("<i", hdr, 20, hs)
+    struct.pack_into("<i", hdr, 24, nl)
+    struct.pack_into("<i", hdr, 28, nh if nh > 0 else 1)
+    struct.pack_into("<i", hdr, 32, nkv if nkv > 0 else nh)
+    struct.pack_into("<i", hdr, 36, hd if hd > 0 else (hs // nh if nh > 0 else 128))
+    struct.pack_into("<i", hdr, 40, im)
+    struct.pack_into("<i", hdr, 44, vs)
+    struct.pack_into("<i", hdr, 48, msl)
+    struct.pack_into("<I", hdr, 52, tile_rows)
+    struct.pack_into("<I", hdr, 56, tile_cols)
+    struct.pack_into("<I", hdr, 60, group_size)
 
     # Quantization flags
     has_q = 1 if config.get("q_norm", config.get("has_q_norm", False)) else 0
     has_k = 1 if config.get("k_norm", config.get("has_k_norm", False)) else 0
     has_bias = 1 if config.get("bias", config.get("has_bias", False)) else 0
-    struct.pack_into("<I", hdr, 60, has_q)
-    struct.pack_into("<I", hdr, 64, has_k)
-    struct.pack_into("<I", hdr, 68, has_bias)
+    struct.pack_into("<I", hdr, 64, has_q)
+    struct.pack_into("<I", hdr, 68, has_k)
+    struct.pack_into("<I", hdr, 72, has_bias)
 
     # RoPE theta (stored as fixed-point * 1000)
     rope_theta = config.get("rope_theta", config.get("rope.theta", 10000.0))
-    struct.pack_into("<I", hdr, 72, int(rope_theta * 1000))
+    struct.pack_into("<I", hdr, 76, int(rope_theta * 1000))
 
     # Token IDs
-    struct.pack_into("<i", hdr, 76, config.get("bos_token_id", 1))
-    struct.pack_into("<i", hdr, 80, config.get("eos_token_id", 2))
+    struct.pack_into("<i", hdr, 80, config.get("bos_token_id", 1))
+    struct.pack_into("<i", hdr, 84, config.get("eos_token_id", 2))
+    # tensor_count@88 is patched in convert() after the index is built
 
     # ─── Architecture-specific fields ───────────────────────────
     if arch_str in ("kimi_k3", "moonlight", "kimi_vl"):
@@ -441,25 +445,24 @@ def build_header(config, tensors, arch_str, quant_type, tile_rows=32, tile_cols=
         n_ff_exp = config.get("intermediate_size", im)
         n_ff_shexp = config.get("shared_expert_intermediate_size", n_ff_exp)
 
-        struct.pack_into("<I", hdr, 84, n_exp)
-        struct.pack_into("<I", hdr, 88, n_used)
-        struct.pack_into("<I", hdr, 92, n_ff_exp)
-        struct.pack_into("<I", hdr, 96, n_ff_shexp)
+        struct.pack_into("<I", hdr, 92, n_exp)
+        struct.pack_into("<I", hdr, 96, n_used)
+        struct.pack_into("<I", hdr, 100, n_ff_exp)
+        struct.pack_into("<I", hdr, 104, n_ff_shexp)
 
-        # K3 specific: KDA config
+        # K3 specific: KDA config in reserved[0..2] (offset 148)
         if arch_str == "kimi_k3":
             n_kda = config.get("num_kda_layers", 69)
             n_mla = config.get("num_mla_layers", 24)
             kda_dim = config.get("kda_latent_dim", 3584)
-            struct.pack_into("<i", hdr, 100, n_kda)     # reserved[0]
-            struct.pack_into("<i", hdr, 104, n_mla)     # reserved[1]
-            # KDA/VL specific in reserved fields
-            struct.pack_into("<i", hdr, 108, kda_dim)   # reserved[2]
+            struct.pack_into("<i", hdr, 148, n_kda)     # reserved[0]
+            struct.pack_into("<i", hdr, 152, n_mla)     # reserved[1]
+            struct.pack_into("<i", hdr, 156, kda_dim)   # reserved[2]
 
-    # Vision config
+    # Vision config in reserved[3]
     if arch_str == "kimi_vl":
         v_hs = config.get("vision_hidden_size", 1024)
-        struct.pack_into("<i", hdr, 112, v_hs)
+        struct.pack_into("<i", hdr, 160, v_hs)
 
     # Model tag
     tag = config.get("_name_or_path", config.get("model_type", arch_str))
@@ -609,9 +612,9 @@ def convert(input_path, output_path, arch_str=None, quant_str="Q4NX", verbose=Tr
 
         print(f"  Index written, tensor_count={len(tensor_entries)}")
 
-        # Update tensor count in header
+        # Update tensor count in header (offset 88 = OnebpHeader::tensor_count)
         hdr_updated = bytearray(hdr)
-        struct.pack_into("<I", hdr_updated, 84, len(tensor_entries))
+        struct.pack_into("<I", hdr_updated, 88, len(tensor_entries))
 
         # Write quantized tile data
         quant_start = time.time()

--- a/tools/qwen3_to_onebp.py
+++ b/tools/qwen3_to_onebp.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""qwen3_to_onebp.py — convert a Qwen3-family HF text model to 1BP (Q4NX).
+
+Mirrors the loader expectations of GenericBackend::load_1bp
+(src/backend_generic.cpp) and the NPU engine loader:
+  - 2-D tensors: Q4NX tiles (32x256, gs=32, bf16 scales), stored exactly as
+    the HF safetensors layout ([out, in] row-major — no transposes)
+  - 1-D tensors (norms, Qwen3 per-head QK-norm): raw F32, ndim=1
+  - names: blk.N.attn_q/attn_k/attn_v/attn_output/ffn_gate/ffn_up/ffn_down,
+    blk.N.attn_norm/ffn_norm, blk.N.attn_q_norm/attn_k_norm,
+    token_embd.weight, output_norm.weight, output.weight
+  - header: arch=ONEBP_DEEPSEEK2(20) like the original Mage-VL conversion,
+    has_q_norm/has_k_norm=1, rope_theta in fixed point, bos/eos/tensor_count
+
+Handles the Mage-VL nesting (model.language_model.*) and plain Qwen3
+(model.*). Usage:
+  python3 qwen3_to_onebp.py /path/to/checkpoint models/out.1bp
+"""
+import argparse, glob, json, os, struct, sys, time
+import numpy as np
+
+ONEBP_MAGIC = 0x00504231
+ONEBP_Q4NX = 0
+ONEBP_DEEPSEEK2 = 20  # Qwen3-style with QK-norm (matches original Mage-VL file)
+
+TR, TC = 32, 256  # tile_rows, tile_cols
+GS = 32
+
+
+def f32b(v):
+    """float32 -> upper 16 bits (BF16 for Q4NX scales)."""
+    return np.float32(v).view(np.uint32) >> 16
+
+
+def quant_tile_q4nx(data):
+    """One Q4NX tile: bf16 scales/zps + packed 4-bit, layout matches the
+    engine loader's dequant_tile (scales, zps, then low-nibble=even cols)."""
+    r, c = data.shape
+    grps = TC // GS
+    padded = np.zeros((TR, TC), dtype=np.float32)
+    padded[:r, :c] = data
+    grouped = padded.reshape(TR, grps, GS)
+    mn = grouped.min(axis=2)
+    mx = grouped.max(axis=2)
+    rng = mx - mn
+    flat = rng < 1e-10
+    scale = np.where(flat, 1.0, rng / 15.0).astype(np.float32)
+    zp = np.where(flat, 0.0, mn).astype(np.float32)
+    inv = 1.0 / scale
+    qi = np.clip(np.round((grouped - zp[:, :, None]) * inv[:, :, None]), 0, 15).astype(np.uint8)
+    qi = qi.reshape(TR, TC)
+    pk = (qi[:, 1::2] << 4) | qi[:, 0::2]
+    return f32b(scale).astype(np.uint16).tobytes() + \
+           f32b(zp).astype(np.uint16).tobytes() + pk.tobytes()
+
+
+def load_shard_tensors(paths):
+    tensors = {}
+    for fn in paths:
+        with open(fn, 'rb') as f:
+            n = struct.unpack('<Q', f.read(8))[0]
+            hdr = json.loads(f.read(n))
+            data = f.read()
+        for name, e in hdr.items():
+            if name == '__metadata__':
+                continue
+            o0, o1 = e['data_offsets']
+            raw = data[o0:o1]
+            if e['dtype'] == 'BF16':
+                u16 = np.frombuffer(raw, dtype='<u2').reshape(e['shape'])
+                arr = (u16.astype(np.uint32) << 16).view(np.float32)
+            elif e['dtype'] == 'F32':
+                arr = np.frombuffer(raw, dtype='<f4').reshape(e['shape']).copy()
+            elif e['dtype'] == 'F16':
+                arr = np.frombuffer(raw, dtype='<f2').reshape(e['shape']).astype(np.float32)
+            else:
+                raise ValueError(f'unhandled dtype {e["dtype"]} for {name}')
+            tensors[name] = arr
+    return tensors
+
+
+def map_name(hf_name):
+    """HF Qwen3 / Mage-VL text tensor name -> 1BP canonical name (or None)."""
+    n = hf_name
+    if n.startswith('model.language_model.'):
+        n = n[len('model.language_model.'):]
+    if n.startswith('model.visual.') or n.startswith('visual.'):
+        return None
+    if n.startswith('layers.'):
+        n = n[len('layers.'):]
+        parts = n.split('.', 1)
+        blk = f'blk.{parts[0]}.'
+        rest = parts[1]
+        table = {
+            'input_layernorm.weight': 'attn_norm.weight',
+            'post_attention_layernorm.weight': 'ffn_norm.weight',
+            'self_attn.q_proj.weight': 'attn_q.weight',
+            'self_attn.q_norm.weight': 'attn_q_norm.weight',
+            'self_attn.k_proj.weight': 'attn_k.weight',
+            'self_attn.k_norm.weight': 'attn_k_norm.weight',
+            'self_attn.v_proj.weight': 'attn_v.weight',
+            'self_attn.o_proj.weight': 'attn_output.weight',
+            'mlp.gate_proj.weight': 'ffn_gate.weight',
+            'mlp.up_proj.weight': 'ffn_up.weight',
+            'mlp.down_proj.weight': 'ffn_down.weight',
+        }
+        if rest not in table:
+            return None
+        return blk + table[rest]
+    if n == 'embed_tokens.weight':
+        return 'token_embd.weight'
+    if n == 'norm.weight':
+        return 'output_norm.weight'
+    if n == 'lm_head.weight':
+        return 'output.weight'
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('input', help='checkpoint dir with model-*.safetensors')
+    ap.add_argument('out')
+    ap.add_argument('--arch', type=int, default=ONEBP_DEEPSEEK2)
+    args = ap.parse_args()
+
+    paths = sorted(glob.glob(os.path.join(args.input, 'model-*.safetensors')))
+    if not paths:
+        print(f'error: no model-*.safetensors in {args.input}', file=sys.stderr)
+        sys.exit(1)
+    t0 = time.time()
+    print(f'loading {len(paths)} shards...')
+    t = load_shard_tensors(paths)
+    print(f'loaded {len(t)} tensors in {time.time()-t0:.0f}s')
+
+    cfg = json.load(open(os.path.join(args.input, 'config.json')))
+    tc = cfg.get('text_config') or {}
+    cfg = {**cfg, **tc}
+    H = cfg['hidden_size']; L = cfg['num_hidden_layers']
+    NH = cfg['num_attention_heads']; NKV = cfg.get('num_key_value_heads', NH)
+    HD = cfg.get('head_dim', H // NH)
+    FF = cfg['intermediate_size']
+    V = cfg['vocab_size']
+    max_seq = cfg.get('max_position_embeddings', 131072)
+    rope = float(cfg.get('rope_theta', 1000000.0))
+    bos = cfg.get('bos_token_id', 0); eos = cfg.get('eos_token_id', 0)
+
+    # ── Collect mapped tensors ──
+    entries = []  # (name, ndim, dims, data)
+    for name, arr in t.items():
+        m = map_name(name)
+        if not m:
+            continue
+        entries.append((m, arr))
+    entries.sort(key=lambda e: e[0])
+    if not entries:
+        print('error: no text-model tensors mapped', file=sys.stderr)
+        sys.exit(1)
+    have = {n for n, _ in entries}
+    expect = {'token_embd.weight', 'output_norm.weight', 'output.weight',
+              'blk.0.attn_q.weight', 'blk.0.attn_q_norm.weight',
+              'blk.0.ffn_gate.weight'}
+    for e in sorted(expect - have):
+        print(f'  WARN missing {e}')
+
+    # ── Header (256 B, layout per include/onebp_format.h) ──
+    hdr = struct.pack('<5I', ONEBP_MAGIC, 1, args.arch, ONEBP_Q4NX, 0)
+    hdr += struct.pack('<8i', H, L, NH, NKV, HD, FF, V, max_seq)
+    hdr += struct.pack('<10I', TR, TC, GS, 1, 1, 0, int(rope * 1000), bos, eos,
+                       len(entries))
+    hdr += struct.pack('<14I', *([0] * 14))
+    hdr += struct.pack('<6I', *([0] * 6))  # reserved[0..5]
+    hdr += b'\x00' * (192 - len(hdr))
+    tag = os.path.basename(args.out).encode()[:63]
+    hdr += tag + b'\x00' * (64 - len(tag))
+    assert len(hdr) == 256
+
+    # ── Index + data ──
+    idx = b''
+    off = 0
+    total = 0
+    sizes2 = []
+    for name, arr in entries:
+        nd = arr.ndim
+        dims = list(arr.shape)
+        if nd == 1:
+            sz = dims[0] * 4
+        else:
+            rows, cols = dims
+            ntr = (rows + TR - 1) // TR
+            ntc = (cols + TC - 1) // TC
+            sz = ntr * ntc * (TR * (TC // GS) * 4 + TR * TC // 2)
+        sizes2.append(sz)
+        nb = name.encode()
+        idx += struct.pack('<I', len(nb)) + nb + b'\x00'
+        idx += struct.pack('<I', nd) + struct.pack(f'<{nd}I', *dims)
+        idx += struct.pack('<2Q', off, sz)
+        off += sz
+    with open(args.out, 'wb') as f:
+        f.write(hdr)
+        f.write(idx)
+        # second pass: quantized data
+        for (name, arr), sz in zip(entries, sizes2):
+            if arr.ndim == 1:
+                f.write(np.ascontiguousarray(arr, dtype='<f4').tobytes())
+            else:
+                rows, cols = arr.shape
+                for r0 in range(0, rows, TR):
+                    for c0 in range(0, cols, TC):
+                        f.write(quant_tile_q4nx(arr[r0:r0+TR, c0:c0+TC]))
+            total += sz
+    print(f'wrote {args.out}: {len(entries)} tensors, {total/1e6:.0f} MB '
+          f'({time.time()-t0:.0f}s)')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/tokenizer_json_to_htok.py
+++ b/tools/tokenizer_json_to_htok.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""tokenizer_json_to_htok.py — convert HF tokenizer.json to .htok v2.
+
+Writes the binary format read by rcpp_tokenizer_load (src/tokenizer.cpp):
+  "HTOK" u32 version(2) u32 vocab_size u32 num_merges u32 bos u32 eos
+  vocab[].: u16 len + bytes            (id = position; empty bytes = unused id)
+  merges[]: u32 a u32 b u32 merged     (rank = insertion order)
+  u32 num_special + u32 special_ids[]
+
+Usage:
+  python3 tokenizer_json_to_htok.py tokenizer.json out.htok
+"""
+import argparse, json, struct, sys
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('tokenizer_json')
+    ap.add_argument('out')
+    args = ap.parse_args()
+
+    t = json.load(open(args.tokenizer_json))
+    m = t['model']
+    vocab = m['vocab']                      # str -> id
+    merges = m['merges']                    # ["a b", ...]
+    added = {a['content']: a['id'] for a in t.get('added_tokens', [])}
+
+    id_to_str = {}
+    for s, i in vocab.items():
+        id_to_str[i] = s
+    for s, i in added.items():
+        id_to_str[i] = s
+    if not id_to_str:
+        print('error: empty vocab', file=sys.stderr)
+        sys.exit(1)
+
+    vocab_size = max(id_to_str) + 1
+    # Empty ids beyond the tokenizer's own range (e.g. Qwen3 reserves 293
+    # slots past its 22 declared specials) get empty strings — the loader
+    # skips them for encode but keeps id numbering aligned with the model.
+    out = [id_to_str.get(i, '') for i in range(vocab_size)]
+    assert len(out) == vocab_size
+
+    def id_of(s):
+        i = vocab.get(s)
+        if i is None:
+            i = added.get(s)
+        if i is None:
+            print(f'error: merge component {s!r} not in vocab', file=sys.stderr)
+            sys.exit(1)
+        return i
+
+    merge_triples = []
+    for ent in merges:
+        if isinstance(ent, list):
+            a, b = ent[0], ent[1]
+        else:
+            a, b = ent.split()
+        merged = a + b
+        merge_triples.append((id_of(a), id_of(b), id_of(merged)))
+
+    bos = vocab.get('<|endoftext|>')
+    if bos is None:
+        bos = added.get('<|endoftext|>', 0)
+    eos = vocab.get('<|im_end|>')
+    if eos is None:
+        eos = added.get('<|im_end|>', bos or 0)
+
+    special_ids = sorted(added.values())
+
+    with open(args.out, 'wb') as f:
+        f.write(b'HTOK')
+        f.write(struct.pack('<5I', 2, vocab_size, len(merge_triples), bos, eos))
+        for s in out:
+            b = s.encode('utf-8')
+            if len(b) > 65535:
+                print(f'error: token too long ({len(b)} B): {s[:40]!r}',
+                      file=sys.stderr)
+                sys.exit(1)
+            f.write(struct.pack('<H', len(b)))
+            f.write(b)
+        for a, b, merged in merge_triples:
+            f.write(struct.pack('<3I', a, b, merged))
+        f.write(struct.pack('<I', len(special_ids)))
+        for sid in special_ids:
+            f.write(struct.pack('<I', sid))
+    print(f'wrote {args.out}: vocab={vocab_size} merges={len(merge_triples)} '
+          f'specials={len(special_ids)} bos={bos} eos={eos}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/vision_server.cpp
+++ b/tools/vision_server.cpp
@@ -34,6 +34,7 @@
 #include "vision_encoder.h"
 #include "vl_processor.h"
 #include "onebp_loader.h"
+#include "rocm_cpp/tokenizer.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -63,6 +64,8 @@ static std::atomic<bool> keep_running{true};
 static int g_port = 8089;
 static std::string g_mmproj_path;
 static std::string g_model_path;
+static std::string g_tokenizer_path;
+static rcpp_tokenizer_t* g_htok = nullptr;
 
 static void handle_sigint(int) { keep_running = false; }
 
@@ -271,24 +274,53 @@ static std::string extract_text(const json& content) {
 }
 #endif
 
+// ── Tokenizer helpers: .htok (merge-BPE) when loaded, else GGUF greedy ──
+static std::vector<int> encode_text(SimpleTokenizer& st, const std::string& text) {
+    if (g_htok) {
+        std::vector<int> ids(text.size() * 2 + 16);
+        size_t n = 0;
+        rcpp_tokenizer_encode(g_htok, text.data(), text.size(), 1,
+                              ids.data(), ids.size(), &n);
+        ids.resize(n);
+        return ids;
+    }
+    return st.encode(text);
+}
+
+static std::string decode_text(SimpleTokenizer& st, const std::vector<int>& ids) {
+    if (g_htok) {
+        char buf[65536];
+        size_t l = 0;
+        rcpp_tokenizer_decode(g_htok, ids.data(), ids.size(), buf, sizeof(buf), &l);
+        return std::string(buf, l);
+    }
+    return st.decode(ids);
+}
+
+static int eos_id_of(SimpleTokenizer& st) {
+    return g_htok ? rcpp_tokenizer_eos_id(g_htok) : st.eos_id;
+}
+
 // ── Main ──
 int main(int argc, char** argv) {
     signal(SIGINT, handle_sigint);
     signal(SIGTERM, handle_sigint);
 
     static struct option long_opts[] = {
-        {"port",    required_argument, nullptr, 'p'},
-        {"mmproj",  required_argument, nullptr, 'm'},
-        {"model",   required_argument, nullptr, 'M'},
+        {"port",      required_argument, nullptr, 'p'},
+        {"mmproj",    required_argument, nullptr, 'm'},
+        {"model",     required_argument, nullptr, 'M'},
+        {"tokenizer", required_argument, nullptr, 't'},
         {nullptr, 0, nullptr, 0}
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "p:m:M:", long_opts, nullptr)) != -1) {
+    while ((opt = getopt_long(argc, argv, "p:m:M:t:", long_opts, nullptr)) != -1) {
         switch (opt) {
             case 'p': g_port = atoi(optarg); break;
             case 'm': g_mmproj_path = optarg; break;
             case 'M': g_model_path = optarg; break;
+            case 't': g_tokenizer_path = optarg; break;
         }
     }
 
@@ -298,8 +330,20 @@ int main(int argc, char** argv) {
     }
 
     // ── Load tokenizer ──
+    // .htok (Qwen3/Mage-VL BPE via rcpp_tokenizer) takes precedence over the
+    // GGUF-embedded vocab fallback.
+    if (g_tokenizer_path.size() >= 5 &&
+        g_tokenizer_path.substr(g_tokenizer_path.size() - 5) == ".htok") {
+        if (rcpp_tokenizer_load(g_tokenizer_path.c_str(), &g_htok) == 0 && g_htok)
+            fprintf(stderr, "Loaded htok tokenizer %s (BOS=%d EOS=%d)\n",
+                    g_tokenizer_path.c_str(), rcpp_tokenizer_bos_id(g_htok),
+                    rcpp_tokenizer_eos_id(g_htok));
+        else
+            fprintf(stderr, "WARNING: failed to load htok %s — falling back\n",
+                    g_tokenizer_path.c_str());
+    }
     SimpleTokenizer tokenizer;
-    if (!tokenizer.load(g_model_path)) {
+    if (!g_htok && !tokenizer.load(g_model_path)) {
         fprintf(stderr, "WARNING: could not load tokenizer from %s\n", g_model_path.c_str());
     }
 
@@ -482,7 +526,7 @@ int main(int argc, char** argv) {
         }
 
         // 2. Tokenize and feed text prompt
-        auto prompt_ids = tokenizer.encode(text_prompt);
+        auto prompt_ids = encode_text(tokenizer, text_prompt);
         if (prompt_ids.empty()) prompt_ids = {tokenizer.bos_id};
 
         fprintf(stderr, "Prompt: '%s' -> %zu tokens\n", text_prompt.c_str(), prompt_ids.size());
@@ -495,7 +539,7 @@ int main(int argc, char** argv) {
             int next = be->generate(output_tokens.empty() ? prompt_ids.back() : output_tokens.back());
             if (next < 0) break;
             output_tokens.push_back(next);
-            if (next == tokenizer.eos_id) break;
+            if (next == eos_id_of(tokenizer)) break;
         }
 
         // ── Build response ──
@@ -509,7 +553,7 @@ int main(int argc, char** argv) {
         choice["index"] = 0;
         json message;
         message["role"] = "assistant";
-        message["content"] = tokenizer.decode(output_tokens);
+        message["content"] = decode_text(tokenizer, output_tokens);
         choice["message"] = message;
         choice["finish_reason"] = "stop";
 


### PR DESCRIPTION
### **User description**
Mage-VL runs fully end-to-end: Mage-ViT tower + Qwen3-4B text decoder + Qwen3 BPE tokenizer. First grounded response on the test image: \"A colorful cube with a white square in the center.\"

- tools/qwen3_to_onebp.py — HF Qwen3-family safetensors → 1BP Q4NX (blk.N.* names, 32x256 tiles, raw-F32 1-D norms, QK-norm flags). 4B params → 2.76 GB.
- tools/tokenizer_json_to_htok.py — tokenizer.json → .htok v2 for rcpp_tokenizer.
- vision_server --tokenizer flag (.htok merge-BPE with GGUF fallback).
- fix(tools/hf_to_onebp.py) — header was shifted 4 bytes vs OnebpHeader (scale_type missing, all fields misaligned, tensor_count written into eos slot, kimi fields in wrong slots); output was unloadable by any C++ consumer. Now matches the struct.

Models (gitignored): models/Mage-VL-4B.1bp regenerated (old file corrupt), models/Mage-VL.htok.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Adds Qwen3/Mage-VL text model conversion and tokenizer support

- Fixes 1BP header layout misalignment in hf_to_onebp.py

- Integrates .htok tokenizer into vision_server with fallback

- Enables full end-to-end VL inference with Qwen3 BPE tokenizer


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HF Qwen3 safetensors"] --> B["qwen3_to_onebp.py"]
  B --> C["1BP Q4NX model"]
  D["tokenizer.json"] --> E["tokenizer_json_to_htok.py"]
  E --> F[".htok tokenizer"]
  C --> G["vision_server"]
  F --> G
  G --> H["VL inference response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vision_server.cpp</strong><dd><code>Integrate .htok tokenizer into vision server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vision_server.cpp

<ul><li>Added --tokenizer flag and .htok loading via rcpp_tokenizer<br> <li> Added encode_text/decode_text/eos_id_of helpers with fallback<br> <li> Integrated tokenizer into prompt encoding and response decoding</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1248/files#diff-3a1fcd28fd2c11a8b6aa52603e7d2a62fd6568b80605db85ae53aeac0d641701">+52/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>qwen3_to_onebp.py</strong><dd><code>Add Qwen3 to 1BP converter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/qwen3_to_onebp.py

<ul><li>New script to convert Qwen3-family HF models to 1BP Q4NX<br> <li> Maps language model tensors to canonical 1BP names<br> <li> Handles QK-norm, tiling, and header construction</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1248/files#diff-4b125ffa2804833565663419a31ce283c74e6b2cf25447bc1c4505c95ce2da26">+216/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tokenizer_json_to_htok.py</strong><dd><code>Add tokenizer JSON to htok converter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/tokenizer_json_to_htok.py

<ul><li>New script to convert HF tokenizer.json to .htok v2<br> <li> Writes vocab, merges, specials, and BOS/EOS IDs<br> <li> Handles added tokens and empty slots</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1248/files#diff-d63e82f46e8f570e807cf9c544a19f440d2a31374d1d3d26fb8c3ef2dd3abd07">+92/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hf_to_onebp.py</strong><dd><code>Fix 1BP header field alignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/hf_to_onebp.py

<ul><li>Fixed header layout to match OnebpHeader struct exactly<br> <li> Added missing scale_type field at offset 16<br> <li> Shifted all subsequent fields by 4 bytes<br> <li> Corrected tensor_count offset to 88</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1248/files#diff-27e9e7ed5f19bac86809cf64809c1c7fcbe6469600be92ec80d87be41cad4ae0">+33/-30</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Link tokenizer into vision server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CMakeLists.txt

- Added src/tokenizer.cpp to vision_server build


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1248/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

