### PR TITLE
fix(vision_server): clamp tokenizer encode/decode counts to buffer size

### DIFF
--- a/tools/vision_server.cpp
+++ b/tools/vision_server.cpp
@@ -277,11 +277,14 @@ static std::string extract_text(const json& content) {
 // ── Tokenizer helpers: .htok (merge-BPE) when loaded, else GGUF greedy ──
 static std::vector<int> encode_text(SimpleTokenizer& st, const std::string& text) {
     if (g_htok) {
+        // Buffer is 2x text + 16: BPE output can never exceed 1 token/byte.
         std::vector<int> ids(text.size() * 2 + 16);
         size_t n = 0;
         rcpp_tokenizer_encode(g_htok, text.data(), text.size(), 1,
                               ids.data(), ids.size(), &n);
-        ids.resize(n);
+        // rcpp reports the TRUE count even when the buffer is too small —
+        // clamp so resize() never materializes unwritten elements.
+        ids.resize(std::min(n, ids.size()));
         return ids;
     }
     return st.encode(text);
@@ -292,7 +295,9 @@ static std::string decode_text(SimpleTokenizer& st, const std::vector<int>& ids)
         char buf[65536];
         size_t l = 0;
         rcpp_tokenizer_decode(g_htok, ids.data(), ids.size(), buf, sizeof(buf), &l);
-        return std::string(buf, l);
+        // l is the TRUE byte count and may exceed the buffer — clamp before
+        // constructing the string to avoid an out-of-bounds read.
+        return std::string(buf, std::min(l, sizeof(buf)));
     }
     return st.decode(ids);
 }


### PR DESCRIPTION
### **User description**
Addresses the PR #1248 automated review: rcpp_tokenizer_encode/decode report the TRUE count even when the buffer is too small. ids.resize(n) materialized unwritten elements and std::string(buf, l) read past a 64KB stack buffer. Both now clamp.


___

### **PR Type**
Bug fix


___

### **Description**
- Clamp tokenizer encode/decode counts to buffer size

- Prevent out-of-bounds reads and unwritten element materialization

- Fixes issues found in PR #1248 automated review


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["rcpp_tokenizer_encode"] --> B["Clamp count"]
  B --> C["ids.resize"]
  D["rcpp_tokenizer_decode"] --> E["Clamp length"]
  E --> F["std::string"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vision_server.cpp</strong><dd><code>Clamp tokenizer buffer counts to prevent overruns</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vision_server.cpp

<ul><li>Clamp encode count to buffer size before resize<br> <li> Clamp decode length to buffer size before string construction<br> <li> Add comments explaining buffer size rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1249/files#diff-3a1fcd28fd2c11a8b6aa52603e7d2a62fd6568b80605db85ae53aeac0d641701">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

