### PR TITLE
ci(smoke): kill stray vision_server before starting unified_server on 8099

### DIFF
--- a/.github/workflows/end-to-end-smoke.yml
+++ b/.github/workflows/end-to-end-smoke.yml
@@ -50,6 +50,9 @@ jobs:
         # unconditionally in Cleanup below.
         run: |
           sudo systemctl stop 1bit-systems.service || true
+          # Also kill stray manual servers (vision_server etc.) that can
+          # squat on 8099 and answer health checks with the wrong schema.
+          pkill -f "vision_server.*8099" || true
           sleep 2
 
       - name: Start server


### PR DESCRIPTION
### **User description**
Fixes CI smoke-test failures (e.g. PR #1248 run 30666803652): a manually-started vision_server left bound to 8099 answers the workflow's health checks with a different schema (no `generation_timeout_ms`/backends), so the health assertion fails. This pkill clears strays alongside the existing production-service stop.


___

### **PR Type**
Bug fix


___

### **Description**
- Kill stray vision_server before starting unified_server

- Prevents CI health check schema mismatch on port 8099

- Adds pkill command alongside existing service stop


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI workflow"] --> B["Stop 1bit-systems.service"]
  B --> C["pkill vision_server on 8099"]
  C --> D["Start unified_server"]
  D --> E["Health check passes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>end-to-end-smoke.yml</strong><dd><code>Add pkill for stray vision_server in CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/end-to-end-smoke.yml

<ul><li>Added pkill command to kill stray vision_server processes on port 8099<br> <li> Placed after systemctl stop to clear manual servers before starting <br>unified_server<br> <li> Uses <code>|| true</code> to avoid failing if no process matches</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1250/files#diff-ce7583116dfeff04a5365187d78ae67293490e66e36673d3233b26e96f97023c">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

