### PR TITLE
ci(smoke): prevent pkill self-match in vision_server cleanup

### DIFF
--- a/.github/workflows/end-to-end-smoke.yml
+++ b/.github/workflows/end-to-end-smoke.yml
@@ -52,7 +52,7 @@ jobs:
           sudo systemctl stop 1bit-systems.service || true
           # Also kill stray manual servers (vision_server etc.) that can
           # squat on 8099 and answer health checks with the wrong schema.
-          pkill -f "vision_server.*8099" || true
+          pkill -f "[v]ision_server.*8099" || true
           sleep 2
 
       - name: Start server


### PR DESCRIPTION
### **User description**
The `pkill -f "vision_server.*8099"` pattern matches its own invoking shell when the step runs via `bash -c`, which can kill the runner mid-job. `[v]ision_server` bracket trick excludes the pattern string itself.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix pkill self-match in smoke CI cleanup

- Use bracket trick to avoid killing runner


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pkill pattern"] -- "bracket trick" --> B["avoids self-match"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>end-to-end-smoke.yml</strong><dd><code>Fix pkill self-match in smoke cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/end-to-end-smoke.yml

<ul><li>Changed pkill pattern from "vision_server.*8099" to <br>"[v]ision_server.*8099"<br> <li> Prevents the pattern from matching its own invoking shell<br> <li> Ensures cleanup step doesn't kill the CI runner mid-job</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1253/files#diff-ce7583116dfeff04a5365187d78ae67293490e66e36673d3233b26e96f97023c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

