### PR TITLE
feat(validation): logit-level check of 1BP Q4NX decoder vs BF16 reference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1066,6 +1066,12 @@ target_link_libraries(vision_qwen2vl_poc PRIVATE backend_manager vl_image dl)
 # Auto-detects GPU (HIP) and falls back to CPU for image preprocessing.
 # Requires a VL-capable text model + mmproj GGUF file.
 add_executable(vision_server tools/vision_server.cpp src/tokenizer.cpp)
+
+# -- vl_logit_check : logit-level 1BP-vs-BF16 decoder validation -----------
+add_executable(vl_logit_check tools/vl_logit_check.cpp src/tokenizer.cpp)
+target_include_directories(vl_logit_check PRIVATE src/ include/ engine/npu/src)
+target_compile_options(vl_logit_check PRIVATE -O3 -Wall -Wno-unused-result -std=c++23)
+target_link_libraries(vl_logit_check PRIVATE backend_manager onebp_model dl)
 target_include_directories(vision_server PRIVATE src/ include/ engine/npu/src)
 target_compile_options(vision_server PRIVATE -O3 -Wall -Wno-unused-result -std=c++23)
 target_link_libraries(vision_server PRIVATE

--- a/tools/vl_logit_check.cpp
+++ b/tools/vl_logit_check.cpp
@@ -1,0 +1,89 @@
+// vl_logit_check.cpp — logit-level validation of a 1BP text model against
+// the BF16 reference (tools/vl_logit_check_ref.py).
+//
+// Feeds a prompt through the same GenericBackend path vision_server uses,
+// dumps the next-token logits, and (in ref mode) the token ids. The python
+// side replays the identical ids through torch and compares.
+//
+// Usage:
+//   vl_logit_check <model.1bp> <tokenizer.htok> <prompt> <logits.bin> <ids.txt>
+#include "backend.h"
+#include "onebp_loader.h"
+#include "rocm_cpp/tokenizer.h"
+#include <cstdio>
+#include <string>
+#include <vector>
+
+int main(int argc, char** argv) {
+    if (argc < 6) {
+        fprintf(stderr, "usage: %s <model.1bp> <tok.htok> <prompt> <logits.bin> <ids.txt>\n", argv[0]);
+        return 1;
+    }
+    const char* model_path = argv[1];
+    const char* tok_path = argv[2];
+    const char* prompt = argv[3];
+
+    // ── Config from the 1BP header (same as vision_server) ──
+    OnebpModel mdl;
+    if (!mdl.load(model_path)) return 1;
+    const auto& h = mdl.header;
+    ModelConfig cfg;
+    cfg.hidden = cfg.hidden_size = h.hidden_size;
+    cfg.n_layers = cfg.num_layers = h.num_layers;
+    cfg.n_heads = cfg.num_heads = cfg.num_attention_heads = h.num_attention_heads;
+    cfg.n_kv_heads = cfg.num_kv_heads = h.num_kv_heads ? h.num_kv_heads : h.num_attention_heads;
+    cfg.head_dim = h.head_dim ? h.head_dim : 128;
+    cfg.n_ff = cfg.intermediate_size = h.intermediate_size;
+    cfg.vocab = cfg.vocab_size = h.vocab_size;
+    cfg.max_seq_len = h.max_seq_len;
+    cfg.eos_token_id = h.eos_token_id;
+    cfg.rope_theta = h.rope_theta();
+    cfg.rms_norm_eps = 1e-6f;
+    cfg.model_path = model_path;
+    cfg.format = ModelFormat::ONEBP;
+    fprintf(stderr, "cfg: H=%d L=%d NH=%d NKV=%d HD=%d FF=%d V=%d rope=%.0f\n",
+            cfg.hidden, cfg.n_layers, cfg.n_heads, cfg.n_kv_heads,
+            cfg.head_dim, cfg.n_ff, cfg.vocab, cfg.rope_theta);
+
+    // ── Tokenizer ──
+    rcpp_tokenizer_t* tok = nullptr;
+    if (rcpp_tokenizer_load(tok_path, &tok) != 0 || !tok) {
+        fprintf(stderr, "FAIL: tokenizer load\n");
+        return 1;
+    }
+    std::vector<int> ids(prompt ? strlen(prompt) * 2 + 16 : 64);
+    size_t n = 0;
+    rcpp_tokenizer_encode(tok, prompt, prompt ? strlen(prompt) : 0, 1,
+                          ids.data(), ids.size(), &n);
+    ids.resize(std::min(n, ids.size()));
+
+    // ── Backend ──
+    Backend* be = create_generic_backend();
+    if (!be->init(cfg, model_path)) {
+        fprintf(stderr, "FAIL: backend init\n");
+        return 1;
+    }
+    be->reset();
+    fprintf(stderr, "prompt: %zu tokens\n", ids.size());
+    for (size_t i = 0; i < ids.size(); i++) {
+        int r = be->generate(ids[i]);
+        if (r < 0) fprintf(stderr, "WARN: token %d rejected\n", ids[i]);
+    }
+    const float* logits = be->last_logits();
+    if (!logits) { fprintf(stderr, "FAIL: no logits\n"); return 1; }
+
+    // ── Dump ──
+    FILE* f = fopen(argv[4], "wb");
+    if (!f) return 1;
+    fwrite(logits, sizeof(float), (size_t)cfg.vocab, f);
+    fclose(f);
+    f = fopen(argv[5], "w");
+    if (!f) return 1;
+    for (size_t i = 0; i < ids.size(); i++) fprintf(f, "%d\n", ids[i]);
+    fclose(f);
+    int argmax = 0;
+    for (int i = 1; i < cfg.vocab; i++)
+        if (logits[i] > logits[argmax]) argmax = i;
+    fprintf(stderr, "dumped logits (%d floats), argmax=%d\n", cfg.vocab, argmax);
+    return 0;
+}

--- a/tools/vl_logit_check_ref.py
+++ b/tools/vl_logit_check_ref.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""vl_logit_check_ref.py — compare 1BP Q4NX decoder logits vs BF16 reference.
+
+Replays the token ids the C++ harness used (tools/vl_logit_check.cpp) through
+the checkpoint's own Qwen3 text model in torch and compares next-token logits:
+cosine, top-5 overlap, argmax agreement. Exit 0 = match.
+
+Usage:
+  vl_logit_check <model.1bp> <tok.htok> <prompt> <logits.bin> <ids.txt>
+  vl_logit_check_ref.py <ckpt_dir> <logits.bin> <ids.txt>
+"""
+import argparse, json, struct, sys
+import numpy as np
+import torch
+
+CKPT = '/home/bcloud/checkpoints/Mage-VL'
+
+
+def load_shard_tensors(fns):
+    out = {}
+    for fn in fns:
+        with open(fn, 'rb') as f:
+            n = struct.unpack('<Q', f.read(8))[0]
+            hdr = json.loads(f.read(n))
+            data = f.read()
+        for name, e in hdr.items():
+            if name == '__metadata__':
+                continue
+            o0, o1 = e['data_offsets']
+            raw = data[o0:o1]
+            if e['dtype'] == 'BF16':
+                u16 = np.frombuffer(raw, dtype='<u2').reshape(e['shape'])
+                arr = (u16.astype(np.uint32) << 16).view(np.float32)
+            elif e['dtype'] == 'F32':
+                arr = np.frombuffer(raw, dtype='<f4').reshape(e['shape']).copy()
+            else:
+                raise ValueError(e['dtype'])
+            out[name] = arr
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--ckpt', default=CKPT)
+    ap.add_argument('logits_bin')
+    ap.add_argument('ids_txt')
+    args = ap.parse_args()
+
+    cpp_logits = np.fromfile(args.logits_bin, dtype='<f4')
+    ids = [int(x) for x in open(args.ids_txt)]
+
+    sys.path.insert(0, args.ckpt)
+    import modeling_mage_vl as mm
+    cfg = json.load(open(f'{args.ckpt}/config.json'))
+    tcfg = mm.MageVLConfig(**cfg).text_config
+
+    from transformers import Qwen3Config, Qwen3ForCausalLM
+    qcfg = Qwen3Config(
+        vocab_size=tcfg.vocab_size,
+        hidden_size=tcfg.hidden_size,
+        intermediate_size=tcfg.intermediate_size,
+        num_hidden_layers=tcfg.num_hidden_layers,
+        num_attention_heads=tcfg.num_attention_heads,
+        num_key_value_heads=tcfg.num_key_value_heads,
+        head_dim=tcfg.head_dim,
+        max_position_embeddings=tcfg.max_position_embeddings,
+        rope_theta=1e6,
+        rms_norm_eps=tcfg.rms_norm_eps,
+        attention_bias=False,
+        tie_word_embeddings=False,
+    )
+    model = Qwen3ForCausalLM(qcfg)
+
+    sd = load_shard_tensors([f'{args.ckpt}/model-00001-of-00002.safetensors',
+                             f'{args.ckpt}/model-00002-of-00002.safetensors'])
+    state = {}
+    for k, v in sd.items():
+        if k == 'lm_head.weight':
+            state[k] = torch.tensor(v)
+        elif k.startswith('model.language_model.'):
+            state['model.' + k[len('model.language_model.'):]] = torch.tensor(v)
+    model.load_state_dict(state, strict=True)
+    model.eval()
+
+    with torch.no_grad():
+        out = model(torch.tensor([ids]))
+        ref_logits = out.logits[0, -1].numpy()
+
+    print(f'cpp: {cpp_logits.shape}  torch: {ref_logits.shape} '
+          f'(prompt {len(ids)} tokens)')
+    # normalize for cosine (logit scales may differ from temperature)
+    a = cpp_logits - cpp_logits.mean()
+    b = ref_logits - ref_logits.mean()
+    cos = float(np.sum(a * b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+    print(f'logit cosine (mean-centered): {cos:.6f}')
+    scale = np.linalg.norm(ref_logits) / np.linalg.norm(cpp_logits)
+    print(f'scale ref/cpp: {scale:.4f}')
+    top5_cpp = np.argsort(cpp_logits)[-5:][::-1]
+    top5_ref = np.argsort(ref_logits)[-5:][::-1]
+    print('top5 cpp: ', top5_cpp.tolist())
+    print('top5 ref: ', top5_ref.tolist())
+    overlap = len(set(top5_cpp) & set(top5_ref))
+    argmax_match = top5_cpp[0] == top5_ref[0]
+    print(f'top5 overlap: {overlap}/5, argmax match: {argmax_match}')
+    ok = cos > 0.95 and argmax_match
+    print('MATCH' if ok else 'MISMATCH')
+    return 0 if ok else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
### **User description**
Closes the gap from PR #1248 feedback (item 1): quantitative decoder validation.

vl_logit_check replays a prompt through the exact GenericBackend path vision_server uses (1BP Q4NX) and dumps next-token logits; vl_logit_check_ref.py replays the same token ids through the checkpoint's own Qwen3-4B in torch.

Results (Mage-VL-4B, Q4NX vs BF16):
- "The capital of France is" — cosine 0.969 (mean-centered), top-5 4/5, argmax match
- "The largest planet in the solar system is" — top-5 5/5, argmax match, scale 1.008

Also adds Backend::last_logits() (retained logits buffer; useful for sampling later).


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds logit-level validation tool comparing 1BP Q4NX vs BF16

- Implements C++ harness and Python reference for decoder checks

- Integrates validation into CMake build system

- Reports cosine similarity and top-5 token overlap metrics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["1BP Q4NX model"] --> B["vl_logit_check.cpp"]
  B --> C["logits.bin + ids.txt"]
  C --> D["vl_logit_check_ref.py"]
  E["BF16 reference"] --> D
  D --> F["Comparison metrics"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vl_logit_check.cpp</strong><dd><code>Add C++ logit dump harness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vl_logit_check.cpp

<ul><li>Loads 1BP model and tokenizer, encodes prompt<br> <li> Runs backend generation and dumps logits and token ids<br> <li> Configures model from header fields</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1254/files#diff-58e71dc7b20e1cd12ef24f8e3e9985767b60c646fa0ac347129e023b551cc0b1">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vl_logit_check_ref.py</strong><dd><code>Add Python reference comparison script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vl_logit_check_ref.py

<ul><li>Loads BF16 reference model from safetensors<br> <li> Replays token ids and computes logits<br> <li> Compares cosine, top-5 overlap, argmax match</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1254/files#diff-6c9a6489cc5215ae6b869e4ef29819fd4e9b2ce70b98e887086938594be6ef96">+111/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Add validation tool to build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CMakeLists.txt

<ul><li>Adds vl_logit_check executable target<br> <li> Links backend_manager, onebp_model, and dl libraries</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1254/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

