### PR TITLE
ci(smoke): trigger on workflow changes; ignore zig-cache/AppImage

### DIFF
--- a/.github/workflows/end-to-end-smoke.yml
+++ b/.github/workflows/end-to-end-smoke.yml
@@ -10,6 +10,7 @@ on:
       - "src/zamba2_engine*"
       - "src/gguf_*.cpp"
       - "CMakeLists.txt"
+      - ".github/workflows/*"
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,8 @@ build-npu/
 engine/npu/build-npu/
 build/*.ninja*
 .workspace/
+
+# Build caches / packaged artifacts (never commit; they balloon .git)
+.zig-cache/
+**/.zig-cache/
+*.AppImage


### PR DESCRIPTION
### **User description**
1. Smoke test now runs when its own workflow changes (added .github/workflows/* to the path filter) — so #1250/#1253-style fixes verify themselves.\n2. .gitignore: .zig-cache/ + *.AppImage. .git was 13GB: 7.6GB was orphaned tmp_pack garbage from repacking once-committed zig-cache artifacts; now 2.0GB after cleanup. These patterns prevent recurrence.


___

### **PR Type**
Enhancement


___

### **Description**
- Trigger smoke test on workflow changes

- Add .github/workflows/* to path filter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR changes"] --> B["workflow file changed?"]
  B -- "yes" --> C["Run smoke test"]
  B -- "no" --> D["Skip smoke test"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>end-to-end-smoke.yml</strong><dd><code>Add workflow path trigger for smoke test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/end-to-end-smoke.yml

<ul><li>Added <code>.github/workflows/*</code> to the pull_request paths filter<br> <li> Ensures smoke test runs when workflow files change<br> <li> Enables self-verification of workflow fixes</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1255/files#diff-ce7583116dfeff04a5365187d78ae67293490e66e36673d3233b26e96f97023c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

