### PR TITLE
feat(vision): Qwen3 chat template + 1BP v2 index + converter header fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,8 @@ jobs:
               test_ternary_gemm_smallm test_sherry_gemv test_bonsai_gemv \
               test_zaya_moe_gemv test_cca_attn test_wmma_i8_gemv \
               test_bonsai_e2e test_sherry_e2e test_block_scaled_ternary \
-              onebitd onebit onebit_bin unified_router ppl_generic gguf_to_onebp
+              onebitd onebit onebit_bin unified_router ppl_generic gguf_to_onebp \
+              vision_server vl_logit_check
           else
             echo "ROCm not available on this runner — reference checks only."
             if [ -f tests/test_medusa_skeleton.cpp ]; then

--- a/include/onebp_loader.h
+++ b/include/onebp_loader.h
@@ -11,6 +11,7 @@ struct OnebpTensor {
     std::vector<uint32_t> dims;
     uint64_t offset;
     uint64_t bytes;
+    uint32_t quant = 0;   // v2: per-tensor quant (0 = use header quant)
 };
 
 struct OnebpModel {

--- a/src/backend.h
+++ b/src/backend.h
@@ -60,6 +60,11 @@ struct Backend {
     /// Returns the predicted token ID, -1 on error.
     virtual int generate(int token_id) = 0;
 
+    /// Logits of the most recent forward/generate step (vocab floats), or
+    /// nullptr if the backend doesn't retain them. Used for sampling and
+    /// logit-level validation.
+    virtual const float* last_logits() { return nullptr; }
+
     /// Clean up resources.
     virtual void destroy() = 0;
 

--- a/src/backend_generic.cpp
+++ b/src/backend_generic.cpp
@@ -669,6 +669,10 @@ struct GenericBackend : Backend {
         return forward(token_id);
     }
 
+    const float* last_logits() override {
+        return initialized ? logits_buf.data() : nullptr;
+    }
+
     bool forward(int token_id, float* hidden_out) override {
         int tok = forward(token_id);
         if (hidden_out) *hidden_out = 0.0f;

--- a/src/onebp_model.cpp
+++ b/src/onebp_model.cpp
@@ -72,6 +72,15 @@ bool OnebpModel::load(const char* path) {
         }
         memcpy(&t.offset, data + pos, 8); pos += 8;
         memcpy(&t.bytes, data + pos, 8); pos += 8;
+        // v2 (ONEBP_VERSION 2): per-entry quant field (mixed-quant files).
+        // v1 readers must skip it or every entry after the first desyncs.
+        if (header.version >= 2) {
+            if (pos + 4 > file_size) {
+                fprintf(stderr, "1BP: truncated at per-tensor quant at entry %u/%u\n", i, header.tensor_count);
+                return false;
+            }
+            memcpy(&t.quant, data + pos, 4); pos += 4;
+        }
         tensors.push_back(t);
     }
 

--- a/tools/gguf_to_onebp.cpp
+++ b/tools/gguf_to_onebp.cpp
@@ -221,6 +221,30 @@ int main(int argc, char** argv) {
 
     // Try explicit vocab_size; fall back to token_embd.weight rows or tokens array.
     gu("vocab_size", hdr.vocab_size);
+
+    // Context length, RoPE, BOS/EOS — previously never written (headers
+    // shipped max_seq_len=0 and rope_theta=0, breaking KV-cache sizing in
+    // every loader and RoPE in the generic backend).
+    {
+        std::string arch = reader.architecture();
+        uint32_t ctx = 0;
+        if (!reader.get_u32(arch + ".context_length", ctx))
+            reader.get_u32("context_length", ctx);
+        hdr.max_seq_len = ctx ? (int)ctx : 131072;
+        float rope = 0.0f;
+        if (!reader.get_f32(arch + ".rope.freq_base", rope))
+            reader.get_f32("rope.freq_base", rope);
+        hdr.rope_theta_f = (uint32_t)((rope > 0.0f ? rope : 10000.0f) * 1000.0f);
+        uint32_t bos = 0, eos = 0;
+        if (!reader.get_u32(arch + ".bos_token_id", bos))
+            if (!reader.get_u32("bos_token_id", bos))
+                reader.get_u32("tokenizer.ggml.bos_token_id", bos);
+        if (!reader.get_u32(arch + ".eos_token_id", eos))
+            if (!reader.get_u32("eos_token_id", eos))
+                reader.get_u32("tokenizer.ggml.eos_token_id", eos);
+        hdr.bos_token_id = bos;
+        hdr.eos_token_id = eos;
+    }
     if (!hdr.vocab_size) {
         // Some GGUF files omit vocab_size — infer from token_embd.weight shape.
         // GGUF ne[] convention: shape[0] = embedding_length (hidden), shape[1] =

--- a/tools/vision_server.cpp
+++ b/tools/vision_server.cpp
@@ -59,6 +59,15 @@ static const int VL_VISION_START = 151652;
 static const int VL_VISION_END   = 151653;
 static const int VL_EOS_ID       = 151645; // Qwen2 <|im_end|>
 
+// Qwen3/Mage-VL chat template (applied when the .htok tokenizer is loaded,
+// i.e. the special tokens exist in vocab) — matches chat_template.jinja:
+//   <|im_start|>system\nYou are a helpful assistant.<|im_end|>\n
+//   <|im_start|>user\n<|vision_start|>...<|vision_end|>{text}<|im_end|>\n
+//   <|im_start|>assistant\n
+static const char* VL_TMPL_SYS       = "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n";
+static const char* VL_TMPL_USER_OPEN = "<|im_start|>user\n";
+static const char* VL_TMPL_ASSIST    = "<|im_end|>\n<|im_start|>assistant\n";
+
 // ── Globals ──
 static std::atomic<bool> keep_running{true};
 static int g_port = 8089;
@@ -491,6 +500,16 @@ int main(int argc, char** argv) {
         //    Real ViT forward: pixels -> mage_vit_forward (patch embed + 28
         //    transformer layers + 2x2 merger + projector) -> text-hidden
         //    embeddings, one forward_embed per token.
+        //    With the Qwen3 template the vision block sits inside the user
+        //    turn: <|im_start|>user\n <vision_start> embeds <vision_end> \n{text}
+        std::vector<int> prompt_ids;
+        int next = -1;
+        if (g_htok) {
+            // system + user-turn opener before the vision block (or the text
+            // when there are no images)
+            auto open = encode_text(tokenizer, std::string(VL_TMPL_SYS) + VL_TMPL_USER_OPEN);
+            for (int t : open) be->generate(t);
+        }
         for (auto& vr : images) {
             be->generate(VL_VISION_START);
             std::vector<float> embs = mage_vit_forward(
@@ -530,21 +549,37 @@ int main(int argc, char** argv) {
             be->generate(VL_VISION_END);
         }
 
-        // 2. Tokenize and feed text prompt
-        auto prompt_ids = encode_text(tokenizer, text_prompt);
+        // 2. Tokenize and feed text prompt (template close for htok models)
+        if (g_htok) text_prompt += VL_TMPL_ASSIST;
+        prompt_ids = encode_text(tokenizer, text_prompt);
         if (prompt_ids.empty()) prompt_ids = {tokenizer.bos_id};
 
         fprintf(stderr, "Prompt: '%s' -> %zu tokens\n", text_prompt.c_str(), prompt_ids.size());
-        for (size_t i = 0; i < prompt_ids.size(); i++)
-            be->generate(prompt_ids[i]);
+        for (size_t i = 0; i < prompt_ids.size(); i++) {
+            int r = be->generate(prompt_ids[i]);
+            if (r >= 0) next = r;   // keep the last prediction for step 3
+        }
 
-        // 3. Generate response
+        // 3. Generate response. `next` already holds the prediction after the
+        //    last prompt token (kept from step 2) — it is the first output token.
         std::vector<int> output_tokens;
-        for (int i = 0; i < max_tokens; i++) {
-            int next = be->generate(output_tokens.empty() ? prompt_ids.back() : output_tokens.back());
-            if (next < 0) break;
+        if (next >= 0) {
             output_tokens.push_back(next);
-            if (next == eos_id_of(tokenizer)) break;
+            for (int i = 0; i < max_tokens - 1; i++) {
+                int nxt = be->generate(next);
+                if (nxt < 0) break;
+                next = nxt;
+                output_tokens.push_back(nxt);
+                if (nxt == eos_id_of(tokenizer)) break;
+            }
+        } else {
+            // No prediction from the prompt feed — degenerate fallback.
+            for (int i = 0; i < max_tokens; i++) {
+                int nxt = be->generate(prompt_ids.back());
+                if (nxt < 0) break;
+                output_tokens.push_back(nxt);
+                if (nxt == eos_id_of(tokenizer)) break;
+            }
         }
 
         // ── Build response ──

--- a/tools/vl_logit_check.cpp
+++ b/tools/vl_logit_check.cpp
@@ -8,11 +8,19 @@
 // Usage:
 //   vl_logit_check <model.1bp> <tokenizer.htok> <prompt> <logits.bin> <ids.txt>
 #include "backend.h"
-#include "onebp_loader.h"
+#include "onebp_format.h"
 #include "rocm_cpp/tokenizer.h"
 #include <cstdio>
 #include <string>
 #include <vector>
+
+static bool read_header(const char* path, OnebpHeader& h) {
+    FILE* f = fopen(path, "rb");
+    if (!f) return false;
+    bool ok = fread(&h, sizeof(h), 1, f) == 1;
+    fclose(f);
+    return ok && h.valid();
+}
 
 int main(int argc, char** argv) {
     if (argc < 6) {
@@ -24,9 +32,11 @@ int main(int argc, char** argv) {
     const char* prompt = argv[3];
 
     // ── Config from the 1BP header (same as vision_server) ──
-    OnebpModel mdl;
-    if (!mdl.load(model_path)) return 1;
-    const auto& h = mdl.header;
+    OnebpHeader h;
+    if (!read_header(model_path, h)) {
+        fprintf(stderr, "FAIL: header\n");
+        return 1;
+    }
     ModelConfig cfg;
     cfg.hidden = cfg.hidden_size = h.hidden_size;
     cfg.n_layers = cfg.num_layers = h.num_layers;
@@ -64,7 +74,7 @@ int main(int argc, char** argv) {
         return 1;
     }
     be->reset();
-    fprintf(stderr, "prompt: %zu tokens\n", ids.size());
+    fprintf(stderr, "prompt: %zu tokens, initialized=%d\n", ids.size(), (int)be->initialized);
     for (size_t i = 0; i < ids.size(); i++) {
         int r = be->generate(ids[i]);
         if (r < 0) fprintf(stderr, "WARN: token %d rejected\n", ids[i]);


### PR DESCRIPTION
### **User description**
Three independent fixes completing the VL work:

1. vision_server: Qwen3/Mage-VL chat template (matches chat_template.jinja) — fixes immediate-EOS responses, enables instruction following ("What color is the central square?" → "white"). Also fixes a pre-existing double-feed of the last prompt token.

2. 1BP v2 index support in src/onebp_model.cpp — the v1 reader did not consume the per-tensor quant field written for version-2 files, desyncing every entry after the first (the "ndim=1862270976" corruption in regenerated files like Qwen3-0.6B).

3. gguf_to_onebp never wrote max_seq_len/rope_theta/bos/eos — headers shipped zeros, breaking KV sizing and RoPE in every consumer. Now reads arch.context_length / arch.rope.freq_base / tokenizer.ggml bos-eos.

Also: Backend::last_logits() lands on main (vl_logit_check depends on it — #1254 shipped an unbuildable tool because CI builds a fixed target list; vision_server + vl_logit_check are now in the CI list).

Validated: Qwen3-8B.Q4_K_M.gguf → Qwen3-8B.1bp (Q4NX) loads and predicts "The capital of France is" → " Paris" (coherent top-5).


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds logit-level validation tool comparing 1BP Q4NX vs BF16

- Implements C++ harness and Python reference for decoder checks

- Integrates validation into CMake build system

- Reports cosine similarity and top-5 token overlap metrics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["1BP Q4NX model"] --> B["vl_logit_check.cpp"]
  B --> C["logits.bin + ids.txt"]
  C --> D["vl_logit_check_ref.py"]
  E["BF16 reference"] --> D
  D --> F["Comparison metrics"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>backend_generic.cpp</strong><dd><code>Add last_logits() method to GenericBackend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1260/files#diff-82c4d3084e1369da4c917a8935387c33afa514e729d6753dd0bb508a05a8da0e">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vision_server.cpp</strong><dd><code>Add Qwen3 chat template and fix token feed</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1260/files#diff-3a1fcd28fd2c11a8b6aa52603e7d2a62fd6568b80605db85ae53aeac0d641701">+44/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>onebp_loader.h</strong><dd><code>Add quant field to OnebpTensor struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1260/files#diff-1e034ae80a15995ad468d9b639295f124e7394d0d4c1d35232a9fd085ad3b180">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backend.h</strong><dd><code>Add virtual last_logits() to Backend interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1260/files#diff-d6dfe5f4bb211599238aa0f67296b9303e79e68ee577f4a092f1b58656edfad8">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>onebp_model.cpp</strong><dd><code>Support v2 per-tensor quant field in loader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1260/files#diff-842b881bed98882493a4264c0f757817052d6d451adbfa44e1792c3bfc30fe91">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gguf_to_onebp.cpp</strong><dd><code>Write context length, RoPE, BOS/EOS headers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1260/files#diff-65a50d4807400176fcc66f07cc83b9bae115eafd6c17b40d095b0b6e1e557488">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>vl_logit_check.cpp</strong><dd><code>Add C++ logit dump harness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1260/files#diff-58e71dc7b20e1cd12ef24f8e3e9985767b60c646fa0ac347129e023b551cc0b1">+15/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ci.yml</strong><dd><code>Add vision_server and vl_logit_check to CI build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1260/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

