### PR TITLE
fix: audit findings #1263 #1276 #1278 — heap OOB, vision_server race, SSRF

### DIFF
--- a/src/backend_generic.cpp
+++ b/src/backend_generic.cpp
@@ -725,7 +725,10 @@ struct GenericBackend : Backend {
         float eps = cfg.rms_norm_eps, theta = cfg.rope_theta;
         int rot_dim = cfg.head_dim;  // full RoPE by default
 
-        std::vector<float> x(H), x2(H), q(NH*HD), k(NKV*HD), v(NKV*HD), scores(HD);
+        // scores indexed by past position (t <= pos) — must hold max_seq_len,
+        // not HD (issue #1263: heap OOB for prompts > head_dim tokens).
+        std::vector<float> x(H), x2(H), q(NH*HD), k(NKV*HD), v(NKV*HD);
+        std::vector<float> scores((size_t)cfg.max_seq_len > (size_t)HD ? (size_t)cfg.max_seq_len : (size_t)HD);
         std::vector<float> att(NH*HD);
         std::vector<float> gate_up(FF*2);
 

--- a/src/vl_processor.cpp
+++ b/src/vl_processor.cpp
@@ -15,6 +15,9 @@
 #include "vl_processor.h"
 
 #include <cstdio>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <cstring>
 #include <cstdlib>
 #include <cstring>
 #include <cmath>
@@ -92,18 +95,55 @@ std::vector<unsigned char> vl_download_image(const std::string& url, int timeout
         size_t host_end = url.find('/', host_start);
         if (host_end == std::string::npos) host_end = url.find(':', host_start);
         std::string host = url.substr(host_start, host_end - host_start);
-        // Block loopback, link-local, private ranges by hostname
-        if (host == "localhost" || host == "127.0.0.1" || host == "::1" ||
-            host.find("10.") == 0 || host.find("172.16.") == 0 ||
-            host.find("172.17.") == 0 || host.find("172.18.") == 0 ||
-            host.find("172.19.") == 0 || host.find("172.20.") == 0 ||
-            host.find("172.21.") == 0 || host.find("172.22.") == 0 ||
-            host.find("172.23.") == 0 || host.find("172.24.") == 0 ||
-            host.find("172.25.") == 0 || host.find("172.26.") == 0 ||
-            host.find("172.27.") == 0 || host.find("172.28.") == 0 ||
-            host.find("172.29.") == 0 || host.find("172.30.") == 0 ||
-            host.find("172.31.") == 0 || host.find("192.168.") == 0 ||
-            host.find("169.254.") == 0 || host.find("0.0.0.0") == 0) {
+        // Strip the port (and IPv6 brackets) so getaddrinfo sees a bare host.
+        if (!host.empty() && host[0] == '[') {
+            auto br = host.find(']');
+            host = (br == std::string::npos) ? host : host.substr(1, br - 1);
+        } else {
+            auto colon = host.find(':');
+            if (colon != std::string::npos) host = host.substr(0, colon);
+        }
+        // SSRF guard (issue #1278): resolve and reject private/loopback/link-
+        // local ADDRESSES. Literal hostname prefix matching was bypassable
+        // (127.0.0.1.nip.io, hex/octal literals, userinfo tricks).
+        bool blocked = false;
+        struct addrinfo hints{}, * res = nullptr;
+        hints.ai_family = AF_UNSPEC;
+        hints.ai_socktype = SOCK_STREAM;
+        if (getaddrinfo(host.c_str(), nullptr, &hints, &res) == 0) {
+            for (auto* ai = res; ai; ai = ai->ai_next) {
+                void* addr = nullptr;
+                if (ai->ai_family == AF_INET)
+                    addr = &((struct sockaddr_in*)ai->ai_addr)->sin_addr;
+                else if (ai->ai_family == AF_INET6)
+                    addr = &((struct sockaddr_in6*)ai->ai_addr)->sin6_addr;
+                if (!addr) continue;
+                char ip[INET6_ADDRSTRLEN] = {};
+                inet_ntop(ai->ai_family, addr, ip, sizeof(ip));
+                // inet_pton on the numeric form; classify by prefix
+                unsigned char b[16] = {};
+                if (ai->ai_family == AF_INET) {
+                    b[0] = ((struct sockaddr_in*)ai->ai_addr)->sin_addr.s_addr & 0xFF;
+                    b[1] = (((struct sockaddr_in*)ai->ai_addr)->sin_addr.s_addr >> 8) & 0xFF;
+                }
+                bool priv = false;
+                if (ai->ai_family == AF_INET) {
+                    priv = b[0] == 127 || b[0] == 10 || (b[0] == 172 && b[1] >= 16 && b[1] <= 31) ||
+                           (b[0] == 192 && b[1] == 168) || (b[0] == 169 && b[1] == 254) || b[0] == 0;
+                } else {
+                    const unsigned char* s6 = (const unsigned char*)addr;
+                    priv = s6[0] == 0xFE && (s6[1] & 0xC0) == 0x80;  // link-local fe80::/10
+                    bool loop = true;
+                    for (int i = 0; i < 15; i++) if (s6[i] != 0) loop = false;
+                    if (loop && s6[15] == 1) priv = true;  // ::1
+                }
+                if (priv) { blocked = true; break; }
+            }
+            freeaddrinfo(res);
+        } else {
+            blocked = true;  // unresolvable — refuse rather than let curl guess
+        }
+        if (blocked) {
             fprintf(stderr, "[vl] ERROR: blocked internal/private host: '%s'\n", host.c_str());
             return {};
         }

--- a/tools/vision_server.cpp
+++ b/tools/vision_server.cpp
@@ -43,6 +43,7 @@
 #include <vector>
 #include <thread>
 #include <atomic>
+#include <mutex>
 #include <signal.h>
 #include <getopt.h>
 
@@ -70,6 +71,7 @@ static const char* VL_TMPL_ASSIST    = "<|im_end|>\n<|im_start|>assistant\n";
 
 // ── Globals ──
 static std::atomic<bool> keep_running{true};
+static std::mutex g_inference_mutex;  // serialize backend access (httplib thread pool, issue #1276)
 static int g_port = 8089;
 static std::string g_mmproj_path;
 static std::string g_model_path;
@@ -449,6 +451,7 @@ int main(int argc, char** argv) {
 
     // ── POST /v1/chat/completions ──
     svr.Post("/v1/chat/completions", [&](const httplib::Request& req, httplib::Response& res) {
+        std::lock_guard<std::mutex> infer_lock(g_inference_mutex);
         json body;
         try {
             body = json::parse(req.body);


### PR DESCRIPTION
### **User description**
Three verified audit findings, all in the vision_server / generic-backend stack:

- #1263 HIGH — backend_generic CPU attention sized `scores` to head_dim but indexed by past position; prompts >128 tokens wrote past the heap. Verified with a 202-token prompt before/after.
- #1276 HIGH — vision_server shared one Backend* across httplib's thread pool with no lock; the handler now runs under g_inference_mutex.
- #1278 MED — vl_download_image SSRF guard was hostname prefix matching (bypassable: nip.io, decimal literals, userinfo); now resolves and rejects private/loopback/link-local addresses, fails closed on unresolved hosts. Verified all bypass forms blocked, external fetch still works.


___

### **PR Type**
Bug fix, Security, Enhancement


___

### **Description**
- Fix heap OOB in generic backend attention scores sizing

- Add mutex to serialize vision_server backend access

- Harden SSRF guard with address resolution and blocking

- Fail closed on unresolvable hosts in image downloads


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["backend_generic.cpp"] -- "scores sized to max_seq_len" --> B["Fix heap OOB"]
  C["vision_server.cpp"] -- "add g_inference_mutex" --> D["Serialize backend access"]
  E["vl_processor.cpp"] -- "resolve & block private IPs" --> F["Harden SSRF guard"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_generic.cpp</strong><dd><code>Fix scores vector size for attention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_generic.cpp

<ul><li>Resize scores vector to max_seq_len instead of head_dim<br> <li> Prevent heap out-of-bounds writes for long prompts<br> <li> Add comment explaining the fix for issue #1263</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1286/files#diff-82c4d3084e1369da4c917a8935387c33afa514e729d6753dd0bb508a05a8da0e">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vision_server.cpp</strong><dd><code>Add mutex for backend concurrency safety</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vision_server.cpp

<ul><li>Add global mutex to serialize backend access<br> <li> Wrap chat completions handler with lock_guard<br> <li> Prevent concurrent KV-cache corruption from thread pool</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1286/files#diff-3a1fcd28fd2c11a8b6aa52603e7d2a62fd6568b80605db85ae53aeac0d641701">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Security</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vl_processor.cpp</strong><dd><code>Harden SSRF guard with address resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/vl_processor.cpp

<ul><li>Replace hostname prefix matching with getaddrinfo resolution<br> <li> Block private, loopback, and link-local addresses (IPv4/IPv6)<br> <li> Fail closed on unresolvable hosts to prevent SSRF<br> <li> Strip port and IPv6 brackets before resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1286/files#diff-3484432b29f80613463d57b77d83429e6a3ceb01a290bb5906890faa8bfad3b0">+52/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

