### PR TITLE
fix: audit findings #1261 #1266 #1281 — stack smash, embed OOB, .htok caps

### DIFF
--- a/src/backend_cpu.cpp
+++ b/src/backend_cpu.cpp
@@ -764,7 +764,12 @@ struct CPUBackend : Backend {
     }
 
     bool forward(int token_id, float* hidden_out) override {
-        // Embed
+        // Embed — validate against the embedding table (issue #1266:
+        // /v1/completions accepted arbitrary client token ids).
+        if (token_id < 0 || token_id >= cfg.vocab_size) {
+            fprintf(stderr, "[cpu] token_id %d out of range [0,%d)\n", token_id, cfg.vocab_size);
+            return false;
+        }
         for (int i = 0; i < H; i++)
             hs[i] = (embed[token_id * (size_t)H + i] + ibias[i]) * iscale[i];
 

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -183,6 +183,17 @@ rcpp_tokenizer_load(const char* path, rcpp_tokenizer_t** out)
     f.read(reinterpret_cast<char*>(&bos), 4);
     f.read(reinterpret_cast<char*>(&eos), 4);
 
+    // Sizes come straight from the file — cap them so a crafted .htok cannot
+    // force unbounded allocations or OOB id_to_bytes indexing (issue #1281).
+    constexpr uint32_t MAX_HTOK_VOCAB = 1u << 20;    // 1M tokens
+    constexpr uint32_t MAX_HTOK_MERGES = 1u << 22;   // 4M merges
+    if (vocab_size == 0 || vocab_size > MAX_HTOK_VOCAB ||
+        num_merges > MAX_HTOK_MERGES) {
+        fprintf(stderr, "[tokenizer] implausible .htok sizes: vocab=%u merges=%u\n",
+                vocab_size, num_merges);
+        return RCPP_INVALID_ARG;
+    }
+
     auto t = new rcpp_tokenizer();
     t->bos_id = (int32_t)bos;
     t->eos_id = (int32_t)eos;
@@ -210,6 +221,11 @@ rcpp_tokenizer_load(const char* path, rcpp_tokenizer_t** out)
         f.read(reinterpret_cast<char*>(&b), 4);
         f.read(reinterpret_cast<char*>(&merged), 4);
         if (!f) { fprintf(stderr, "[tokenizer] short read at merge %u\n", i); return RCPP_INVALID_ARG; }
+        if (a >= vocab_size || b >= vocab_size || merged >= vocab_size) {
+            fprintf(stderr, "[tokenizer] merge %u references id outside vocab\n", i);
+            delete t;
+            return RCPP_INVALID_ARG;
+        }
         t->merges.emplace(MergeKey{(int32_t)a, (int32_t)b},
                           std::make_pair((int32_t)merged, (int32_t)i));
     }
@@ -221,6 +237,11 @@ rcpp_tokenizer_load(const char* path, rcpp_tokenizer_t** out)
         for (uint32_t i = 0; i < num_special; ++i) {
             uint32_t sid = 0;
             f.read(reinterpret_cast<char*>(&sid), 4);
+            if (sid >= vocab_size) {
+                fprintf(stderr, "[tokenizer] special id %u outside vocab\n", sid);
+                delete t;
+                return RCPP_INVALID_ARG;
+            }
             t->special_ids.push_back((int32_t)sid);
         }
     }

--- a/tools/token_router.cpp
+++ b/tools/token_router.cpp
@@ -999,20 +999,26 @@ int main(int argc, char** argv) {
         auto bp = req.find("\r\n\r\n");
         std::string body = (bp == std::string::npos) ? "" : req.substr(bp+4);
 
-        // Parse Content-Length for body
+        // Parse Content-Length for body. The extra read is capped to the room
+        // left in buf — an attacker-controlled Content-Length used to smash
+        // the stack (issue #1261); a missing header terminator is rejected.
         std::string cl_header = "Content-Length: ";
         auto clp = req.find(cl_header);
-        if (clp != std::string::npos) {
+        if (bp != std::string::npos && clp != std::string::npos) {
             auto cl_end = req.find("\r\n", clp);
             if (cl_end != std::string::npos) {
                 int body_len = atoi(req.substr(clp + cl_header.size(), cl_end - clp - cl_header.size()).c_str());
+                size_t head = bp + 4;
+                int cap = (int)(sizeof(buf) - head);
+                if (body_len < 0) body_len = 0;
+                if (body_len > cap) body_len = cap;
                 if ((int)body.size() < body_len) {
                     // Read remaining body
                     int remaining = body_len - (int)body.size();
-                    int more = (int)read(cl, buf + bp + 4, remaining);
+                    int more = (int)read(cl, buf + head, remaining);
                     if (more > 0) {
-                        buf[bp + 4 + more] = 0;
-                        body = std::string(buf + bp + 4);
+                        buf[head + more] = 0;
+                        body = std::string(buf + head);
                     }
                 }
             }


### PR DESCRIPTION
- #1261 CRITICAL: token_router remote stack smash via attacker-controlled Content-Length — body read now capped to buffer room, terminator required.
- #1266 HIGH: backend_cpu 1BP path unvalidated embed index (unauth OOB read via /v1/completions tokens) — validated against cfg.vocab_size.
- #1281 MED: .htok loader caps vocab/merges (1M/4M), validates merge pairs and special ids < vocab_size. Negative test: crafted file with out-of-range special id rejected at load; Mage-VL.htok still loads and encodes.