### PR TITLE
fix: remaining audit findings — 19 issues (#1262, #1264-#1275, #1277, #1279-#1285)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -947,7 +947,8 @@ if(EXISTS "${FLM_BINARY}")
         COMMAND cd ${FLM_SOURCE_DIR} && cmake --build build -j8
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         COMMENT "Updating FLM submodule to latest + rebuilding"
-        BYPRODUCTS ${FLM_BINARY}
+        # no BYPRODUCTS: build_flm already declares ${FLM_BINARY}, and a
+        # second rule for the same output breaks the Ninja generator (issue #1284)
     )
     add_dependencies(unified_server update_flm)
 else()
@@ -1225,8 +1226,10 @@ if(TARGET npu_engine_hybrid)
         ${CMAKE_SOURCE_DIR}/engine/npu
         ${CMAKE_SOURCE_DIR}/include
         ${CMAKE_SOURCE_DIR})
+    // -ffast-math implies -ffinite-math-only and compiles the std::isfinite
+    // NaN/Inf masks out (issue #1277) — keep them alive.
     target_compile_options(npu_engine_hybrid PRIVATE
-        -O3 -march=native -ffast-math -std=c++23 -fopenmp)
+        -O3 -march=native -std=c++23 -fopenmp)
     target_link_libraries(npu_engine_hybrid PRIVATE xrt_coreutil uuid rt pthread)
     target_link_options(npu_engine_hybrid PRIVATE
         -L${THEROCK_SDK_BASE}/lib -lamdhip64 -Wl,-rpath,${THEROCK_SDK_BASE}/lib -fopenmp)

--- a/engine/npu/src/dequant_q4nx.cpp
+++ b/engine/npu/src/dequant_q4nx.cpp
@@ -88,10 +88,14 @@ extern "C" float* dequant_i8_to_float_ex(const uint8_t* data, int i8_rows, int i
                 if (!std::isfinite(zp) || std::fabs(zp) > 100.0f) zp = 0.0f;
 
                 uint8_t byte_val = lane_data[col * 8 + byte_idx];
-                int8_t val;
-                if (nibble_sel == 0) val = (int8_t)(byte_val & 0x0F);
-                else                 val = (int8_t)((byte_val >> 4) & 0x0F);
-                if (val >= 8) val -= 16;
+                // UNSIGNED asymmetric Q4NX — the zero-point is carried in the
+                // per-group `zeros` array; the old `val >= 8 -> val -= 16`
+                // signed reinterpretation decoded the same bytes differently
+                // from onebp_loader's round-trip-verified decoder and the
+                // cpu_q4nx_loader (issue #1268).
+                uint8_t val;
+                if (nibble_sel == 0) val = (byte_val & 0x0F);
+                else                 val = ((byte_val >> 4) & 0x0F);
 
                 out[(tile_row * TILE_ROWS + lr) * (*out_cols) +
                     (tile_col * TILE_COLS + col)] = (float)val * scale + zp;

--- a/engine/npu/src/fused_engine.cpp
+++ b/engine/npu/src/fused_engine.cpp
@@ -275,6 +275,17 @@ public:
     void chunked_dma(npu_sequence& seq, uint32_t elem_sz, uint32_t arg,
                      uint32_t rows, uint32_t cols, uint64_t ddr_off,
                      int bd_id, bool issue_token = false) {
+        // The DMA descriptor carries a 32-bit DDR offset (issue #1285): for
+        // models whose per-layer weight offsets exceed 4 GiB the cast below
+        // wrapped and loaded wrong tiles silently. Refuse loudly instead.
+        uint64_t last_off = ddr_off + (uint64_t)(cols - 1) * rows * elem_sz;
+        if (last_off > 0xFFFFFFFFull) {
+            fprintf(stderr, "[fused] DDR offset %llu exceeds 32-bit DMA "
+                            "descriptor — fused path cannot load >4 GiB "
+                            "weights (issue #1285)\n",
+                    (unsigned long long)last_off);
+            exit(1);
+        }
         for (uint32_t c = 0; c < cols; c += TILE_N) {
             uint32_t chunk = std::min(TILE_N, cols - c);
             uint32_t bd = bd_id;

--- a/engine/npu/src/npu_engine_fused.cpp
+++ b/engine/npu/src/npu_engine_fused.cpp
@@ -702,7 +702,9 @@ int main(int argc, char** argv) {
             std::vector<__half> W_f16((size_t)NV * H);
             for (int n = 0; n < NV; n++)
                 for (int k = 0; k < H; k++)
-                    W_f16[(size_t)n * H + k] = __float2half(embed_f32[(size_t)k * NV + n]);
+                    // embed is row-major [NV][H] — the old k*NV+n stride transposed
+                    // against the wrong axis (issue #1270: garbage logits)
+                    W_f16[(size_t)n * H + k] = __float2half(embed_f32[(size_t)n * H + k]);
             hipMemcpy(d_W, W_f16.data(), wsz, hipMemcpyHostToDevice);
             return true;
         }

--- a/engine/npu/src/npu_engine_fused.hip
+++ b/engine/npu/src/npu_engine_fused.hip
@@ -722,7 +722,9 @@ int main(int argc, char** argv) {
             std::vector<__half> W_f16((size_t)NV * H);
             for (int n = 0; n < NV; n++)
                 for (int k = 0; k < H; k++)
-                    W_f16[(size_t)n * H + k] = __float2half(embed_f32[(size_t)k * NV + n]);
+                    // embed is row-major [NV][H] — the old k*NV+n stride transposed
+                    // against the wrong axis (issue #1270: garbage logits)
+                    W_f16[(size_t)n * H + k] = __float2half(embed_f32[(size_t)n * H + k]);
             hipMemcpy(d_W, W_f16.data(), wsz, hipMemcpyHostToDevice);
             return true;
         }

--- a/engine/npu/src/npu_engine_overlap.cpp
+++ b/engine/npu/src/npu_engine_overlap.cpp
@@ -733,7 +733,9 @@ int main(int argc, char** argv) {
             std::vector<__half> W_f16((size_t)NV * H);
             for (int n = 0; n < NV; n++)
                 for (int k = 0; k < H; k++)
-                    W_f16[(size_t)n * H + k] = __float2half(embed_f32[(size_t)k * NV + n]);
+                    // embed is row-major [NV][H] — the old k*NV+n stride transposed
+                    // against the wrong axis (issue #1270: garbage logits)
+                    W_f16[(size_t)n * H + k] = __float2half(embed_f32[(size_t)n * H + k]);
             hipMemcpy(d_W, W_f16.data(), wsz, hipMemcpyHostToDevice);
             return true;
         }

--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -1004,7 +1004,10 @@ int main(int argc,char**argv){
                 }else if(op==6){ // Attention — CPU path (worker protocol doesn't carry seq_len)
                     // Worker subprocess receives individual layer ops without KV cache
                     // context. NPU attention requires the full KV cache. Use CPU fallback.
-                    int qd = cfg.xclbin_qkv_k / 4;  // approximate: NH*HD
+                    // Q width is NH*HD, not xclbin_qkv_k/4 (issue #1269: the
+                    // old value sized the output 8x too small — heap OOB write
+                    // — and read K from inside Q).
+                    int qd = NH * HD;
                     out_dim = qd;
                     out_data.resize(batch*out_dim,0);
                     // in_data layout: [Q:QD, K:KD, V:KD]
@@ -1131,6 +1134,11 @@ int main(int argc,char**argv){
                                     ks[d] *= ik * (cfg.has_k_norm ? kn[d] : 1.0f);
                                 ra(ks, HD, fuse_pos);
                                 float* vs = &fqo[qkv_v_off + kvh * HD];
+                                // fuse KV capacity is 4096 positions (issue #1267)
+                                if (fuse_pos >= 4096) {
+                                    fprintf(stderr, "[npu] fuse KV overflow (pos=%d) — restarting context\n", fuse_pos);
+                                    fuse_pos = 0;
+                                }
                                 memcpy(&fuse_kv[l].k[(size_t)fuse_pos * NKV * HD + (size_t)kvh * HD], ks, HD * 4);
                                 memcpy(&fuse_kv[l].v[(size_t)fuse_pos * NKV * HD + (size_t)kvh * HD], vs, HD * 4);
                             }
@@ -1440,6 +1448,12 @@ int main(int argc,char**argv){
                 for(int kvh=0;kvh<NKV;kvh++){float*ks=&qo_b[b*qkv_n+cfg.qkv_k_offset+kvh*HD],*vs=&qo_b[b*qkv_n+cfg.qkv_v_offset+kvh*HD];
                     double sk=0;for(int d=0;d<HD;d++)sk+=ks[d]*ks[d];float ik=1.0f/sqrtf((float)(sk/HD)+EPS);
                     for(int d=0;d<HD;d++)ks[d]*=ik*(cfg.has_k_norm?kn[d]:1.0f);ra(ks,HD,sp+b);}
+            }
+            // KV capacity is 4096 positions (issue #1267) — restart the
+            // context instead of writing OOB once exhausted.
+            if (sp + batch_size > 4096) {
+                fprintf(stderr, "[npu] KV overflow at layer %d (sp=%d) — restarting context\n", l, sp);
+                sp = 0;
             }
             for(int b=0;b<batch_size;b++)for(int kvh=0;kvh<NKV;kvh++){
                 float*ks=&qo_b[b*qkv_n+cfg.qkv_k_offset+kvh*HD],*vs=&qo_b[b*qkv_n+cfg.qkv_v_offset+kvh*HD];

--- a/kernels/fp8_wmma_gemv.hip
+++ b/kernels/fp8_wmma_gemv.hip
@@ -69,15 +69,15 @@ __launch_bounds__(32) __global__ void fp8_wmma_gemv_kernel(
                 }
             }
         }
-        // Activation tile broadcast from x_fp8 (same for all output rows)
-        fp8x16_t x_tile;
-        int x_base = tile_base * 16;
-        if (lane == 0)
-            for (int i = 0; i < 16; i++) x_tile[i] = x_fp8[x_base + i];
-        for (int i = 0; i < 16; i++) x_tile[i] = __shfl(x_tile[i], 0);
-        __syncthreads();
-
         for (int t = 0; t < n_tiles; t++) {
+            // Activation tile must be reloaded per K-tile: x[t*16:(t+1)*16],
+            // not the first tile (issue #1273 — reusing x[0:16] for every K
+            // tile silently corrupted any model with hidden size > 16).
+            fp8x16_t x_tile;
+            int x_base = (tile_base + t) * 16;
+            if (lane == 0)
+                for (int i = 0; i < 16; i++) x_tile[i] = x_fp8[x_base + i];
+            for (int i = 0; i < 16; i++) x_tile[i] = __shfl(x_tile[i], 0);
             fp8x16_t W_frag;
             for (int i = 0; i < 16; i++)
                 W_frag[i] = W_lds[lane * FP8_TILES_PER_BATCH * 16 + t * 16 + i];

--- a/kernels/fused_norm_gemv.hip
+++ b/kernels/fused_norm_gemv.hip
@@ -46,7 +46,8 @@ __global__ void fused_norm_q4k_gemv(
     // ── Step 2: Q4_K packed GEMV ──
     float8_t acc = {};
     for (int b = 0; b < nb; b++) {
-        const uint8_t* blk = W + ((size_t)(blockIdx.x * 64) * nb + b) * 144;
+                // warp*16 row offset (issue #1274)
+        const uint8_t* blk = W + (((size_t)(blockIdx.x * 64) + (size_t)warp * 16) * nb + b) * 144;
         float d = (float)*(const __fp16*)blk;
         float dm = (float)*(const __fp16*)(blk + 2);
         uint8_t sc[12];

--- a/kernels/q4k_gemv.hip
+++ b/kernels/q4k_gemv.hip
@@ -62,7 +62,9 @@ __global__ void q4k_gemv_wmma(
     float8_t acc = {};
 
     for (int b = 0; b < nb; b++) {
-        const uint8_t* blk = W + ((size_t)(blockIdx.x * 64) * nb + b) * 144;
+        // warp*16 row offset — all 4 warps used to read warp 0's weights
+        // (issue #1274), so every row of the block got dot(x, W[row0]).
+        const uint8_t* blk = W + (((size_t)(blockIdx.x * 64) + (size_t)warp * 16) * nb + b) * 144;
 
         // Read header: all lanes get d, dm, scales (broadcast from lane 0)
         float d, dm; uint8_t sc[12];

--- a/kernels/zaya_moe_ternary_gemv.hip
+++ b/kernels/zaya_moe_ternary_gemv.hip
@@ -111,15 +111,18 @@ __global__ void zaya_moe_ternary_gemv_kernel(
     __shared__ int8_t x_shared[LDS_TILE_I8];
 
     for (int kw = 0; kw < experts_per_wave; ++kw) {
+        // Validity is WAVE-uniform (same token + slot for every lane), so mask
+        // the work instead of break/continue: a data-dependent early exit
+        // skipped __syncthreads() for some waves and deadlocked the block
+        // (issue #1262).
         const int expert_slot = wave * experts_per_wave + kw;
-        if (expert_slot >= top_k) break;
-
-        const int expert_idx = expert_indices[(size_t)token * top_k + expert_slot];
-        const float router_wt = expert_weights[(size_t)token * top_k + expert_slot];
-        // Guard: ignore invalid expert indices
-        if (expert_idx < 0 || expert_idx >= num_experts) continue;
-
-        const float per_expert_scale = expert_scales[expert_idx];
+        const bool slot_ok = expert_slot < top_k;
+        const int expert_idx = slot_ok
+            ? expert_indices[(size_t)token * top_k + expert_slot] : -1;
+        const float router_wt = slot_ok
+            ? expert_weights[(size_t)token * top_k + expert_slot] : 0.0f;
+        const bool expert_ok = slot_ok && expert_idx >= 0 && expert_idx < num_experts;
+        const float per_expert_scale = expert_ok ? expert_scales[expert_idx] : 0.0f;
 
         int32_t acc = 0;
 
@@ -156,6 +159,7 @@ __global__ void zaya_moe_ternary_gemv_kernel(
             }
             __syncthreads();
 
+            if (!expert_ok) continue;  // wave-uniform skip — barrier above already ran
             const int tile_macrogroups = LDS_TILE_I8 / WEIGHTS_PER_MACROGROUP;  // 128
             const int tile_mg_start   = k_base / WEIGHTS_PER_MACROGROUP;
 
@@ -200,20 +204,22 @@ __global__ void zaya_moe_ternary_gemv_kernel(
             }
         }
 
-        // Warp reduction
-        #pragma unroll
-        for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
-            acc += __shfl_xor_sync(0xffffffffULL, acc, offset);
-        }
+        if (expert_ok) {
+            // Warp reduction
+            #pragma unroll
+            for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+                acc += __shfl_xor_sync(0xffffffffULL, acc, offset);
+            }
 
-        if (lane == 0) {
-            // Apply activation scale, per-expert scale, and router weight
-            // Clamp to FP16 range to prevent NaN propagation through RMSNorm
-            constexpr float FP16_MAX = 65504.0f;
-            float out = (float)acc * x_scale * per_expert_scale * router_wt;
-            out = fminf(fmaxf(out, -FP16_MAX), FP16_MAX);
-            // Write to y_f16[token][expert_idx]
-            y_f16[(size_t)token * num_experts + expert_idx] = __float2half(out);
+            if (lane == 0) {
+                // Apply activation scale, per-expert scale, and router weight
+                // Clamp to FP16 range to prevent NaN propagation through RMSNorm
+                constexpr float FP16_MAX = 65504.0f;
+                float out = (float)acc * x_scale * per_expert_scale * router_wt;
+                out = fminf(fmaxf(out, -FP16_MAX), FP16_MAX);
+                // Write to y_f16[token][expert_idx]
+                y_f16[(size_t)token * num_experts + expert_idx] = __float2half(out);
+            }
         }
     }
 }

--- a/kernels/zaya_moe_wmma_batched.hip
+++ b/kernels/zaya_moe_wmma_batched.hip
@@ -130,8 +130,11 @@ __global__ void wmma_gemv_single(
     // of a row_major fragment. Each warp lane contributes one input value
     // from the vector, and we use __shfl to broadcast it.
     //
-    // A quicker approach: use LDS to stage the input, then broadcast.
-    __shared__ __half s_in[WMMA_N]; // 16 input values (one 16-wide slice)
+    // 16×16 LDS staging: all 16 rows hold the same in[k:k+16] slice so a
+    // row_major fragment load is valid. The old 16-half s_in made
+    // load_matrix_sync read a 16×16 fragment out of a 16-element buffer
+    // (issue #1265: OOB shared read + garbage fragments past K=16).
+    __shared__ __half s_in_tile[WMMA_M][WMMA_N];
     int tx = threadIdx.x;
 
     fragment<matrix_a, WMMA_M, WMMA_N, WMMA_K, half, row_major> frag_a;
@@ -142,21 +145,17 @@ __global__ void wmma_gemv_single(
             // Load weights — same as batched version
             load_matrix_sync(frag_a, &wt[m_base * (size_t)K + k], K);
 
-            // For single-token GEMV, we load the input as B=16 where
-            // rows 1..15 are copies of row 0. Since the input vector
-            // is K elements, we load in[k:k+16] and broadcast.
-            //
-            // We load frag_b as row_major 16×16 from a shared memory
-            // staging area where all 16 rows contain in[k:k+16].
+            // Stage in[k:k+16] into row 0, broadcast to all 16 rows, then
+            // load a valid row_major 16×16 fragment.
             if (tx < WMMA_N && (k + tx) < K) {
-                s_in[tx] = in[k + tx];
+                s_in_tile[0][tx] = in[k + tx];
             }
             __syncthreads();
-            // s_in now has in[k:k+15]. Fill all 16 rows by loading
-            // from s_in with stride 0 (same 16 values repeated).
-            // rocWMMA doesn't support stride=0, so we load into LDS
-            // as 16 contiguous rows.
-            load_matrix_sync(frag_b, s_in, WMMA_N); // row_major, 16×16 from 16-element "stride"
+            for (int r = 0; r < WMMA_M; r++) {
+                if (tx < WMMA_N) s_in_tile[r][tx] = s_in_tile[0][tx];
+            }
+            __syncthreads();
+            load_matrix_sync(frag_b, &s_in_tile[0][0], WMMA_N);
 
             mma_sync(acc, frag_a, frag_b, acc);
         }

--- a/src/backend_fused.cpp
+++ b/src/backend_fused.cpp
@@ -410,6 +410,12 @@ struct FusedBackend : Backend {
     // forward — PURE GPU LOOP
     // ══════════════════════════════════════
     bool forward(int token_id, float* hidden_out) override {
+        // KV cache holds max_seq positions; the store kernel never compares
+        // (issue #1267) — refuse instead of writing OOB.
+        if (pos >= max_seq) {
+            fprintf(stderr, "[fused] KV overflow: pos=%d >= max_seq=%d\n", pos, max_seq);
+            return false;
+        }
         const int H_ = H, NH_ = NH, NKV_ = NKV, HD_ = this->HD_, IM_ = IM, NC_ = NC;
 
         // Embedding → GPU

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -215,6 +215,11 @@ struct Hip1bpBackend : Backend {
 
     bool forward(int token_id,float* hidden_out)override{
         if(!gpu_ok)return false;
+        // KV cache holds max_seq positions (issue #1267)
+        if (pos >= max_seq) {
+            fprintf(stderr, "[hip_1bp] KV overflow: pos=%d >= max_seq=%d\n", pos, max_seq);
+            return false;
+        }
         int H_=H,NH_=NH,NKV_=NKV,HD_=HD,IM_=IM,NC_=NC;
         int block=256;
 

--- a/src/backend_laguna.cpp
+++ b/src/backend_laguna.cpp
@@ -523,6 +523,11 @@ struct LagunaBackend : Backend {
     }
 
     int forward(int token) {
+        // grow_cache_if_needed caps at MAX_KV_POS (issue #1267)
+        if (pos >= MAX_KV_POS) {
+            fprintf(stderr, "[laguna] KV overflow: pos=%d >= MAX_KV_POS=%d\n", pos, MAX_KV_POS);
+            return -1;
+        }
         grow_cache_if_needed();
 
         // Embedding lookup

--- a/src/backend_manager.cpp
+++ b/src/backend_manager.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <algorithm>
 #include <thread>
+#include <future>
 #include <chrono>
 #ifndef _WIN32
 #include <unistd.h>
@@ -455,20 +456,21 @@ bool BackendManager::init_in_order(const ModelConfig& cfg, const std::string& we
         }
         info.instance = std::shared_ptr<Backend>(raw);
 
-        // Timeout guard: if a backend takes >10s to init (e.g. CPU scanning
+        // Timeout guard: if a backend takes >6s to init (e.g. CPU scanning
         // missing weights), skip it so higher-tier backends like NPU FLM get
-        // a chance. Run init in a detached thread with a deadline.
+        // a chance. std::async + wait_for — the old std::thread joinable()
+        // poll joined on the first iteration (joinable() is true right after
+        // construction), so the deadline was dead code and a hung init blocked
+        // the manager forever; its by-ref captures would UAF after detach
+        // (issue #1282). By-value captures keep the backend alive on timeout.
+        auto init_fut = std::async(std::launch::async, [info, cfg, weights_dir]() {
+            return info.instance->init(cfg, weights_dir);
+        });
         bool init_ok = false;
-        std::thread init_thread([&]() { init_ok = info.instance->init(cfg, weights_dir); });
-        auto init_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(6);
-        while (std::chrono::steady_clock::now() < init_deadline) {
-            if (init_thread.joinable()) { init_thread.join(); break; }
-            usleep(10000); // 10ms poll
-        }
-        if (init_thread.joinable()) {
-            // Timed out — detach and skip
-            init_thread.detach();
-            printf("  → ⏱️  init timed out (>10s) — skipping\n");
+        if (init_fut.wait_for(std::chrono::seconds(6)) == std::future_status::ready) {
+            init_ok = init_fut.get();
+        } else {
+            printf("  → ⏱️  init timed out (>6s) — skipping\n");
             destroy_instance(info);
             continue;
         }

--- a/src/gguf_reader.cpp
+++ b/src/gguf_reader.cpp
@@ -523,7 +523,16 @@ bool GgufReader::open(const std::string& path) {
         if (fread(&ti.dtype, 4, 1, f_) != 1) { fclose(f_); f_ = nullptr; return false; }
         uint64_t rel_offset; if (fread(&rel_offset, 8, 1, f_) != 1) { fclose(f_); f_ = nullptr; return false; }
         ti.numel = 1;
-        for (auto s : ti.shape) ti.numel *= (s ? s : 1);
+        for (auto s : ti.shape) {
+            // Saturating multiply (issue #1280): dims are up to 2^24 and
+            // ndim up to 16 — an unchecked chain can wrap to a small numel
+            // that slips past the MAX_TENSOR_ELEMENTS cap below.
+            if (s > 0 && ti.numel > (uint64_t)-1 / (uint64_t)s) {
+                ti.numel = (uint64_t)-1;  // saturate; caps reject it downstream
+                break;
+            }
+            ti.numel *= (s ? s : 1);
+        }
         ti.abs_offset = rel_offset; // fixed up to absolute after the loop
         tensor_order_.push_back(name);
         tensors_[name] = ti; // abs_offset placeholder for now

--- a/src/q4nx_reader.cpp
+++ b/src/q4nx_reader.cpp
@@ -102,7 +102,9 @@ std::vector<float> Q4nxReader::read_floats(uint64_t offset, size_t count) const 
     static constexpr size_t MAX_FLOATS = 256ULL * 1024 * 1024; // 256M elems = 512 MiB BF16
     if (count > MAX_FLOATS) return v;
     uint64_t byte_len = (uint64_t)count * 2;
-    if (offset + byte_len > size) return v;
+    // Check offset > size BEFORE the sum — offset + byte_len wraps for
+    // offsets near 2^64 and let the guard pass (issue #1283).
+    if (offset > size || byte_len > size - offset) return v;
     v.resize(count);
     const uint16_t* bf16 = (const uint16_t*)(data + offset);
     for (size_t i = 0; i < count; i++) {

--- a/src/zaya_engine.cpp
+++ b/src/zaya_engine.cpp
@@ -257,12 +257,16 @@ ZayaState* zaya_init(const char* weights_dir, const ZayaConfig* cfg) {
         return true;
     };
     #define ALLOC_OR_FAIL(s, alloc_fn, ptr, n) do { if (!alloc_fn(ptr, n)) { zaya_destroy(s); return nullptr; } } while(0)
-    ALLOC_OR_FAIL(s, alloc_f16, s->d_hs, eng.h);
-    ALLOC_OR_FAIL(s, alloc_f16, s->d_ao, eng.h);
+    // Batch path (zaya_forward_batch) writes per-token slices d_hs + b*eng.h
+    // and d_lm_vocab + b*eng.vocab for up to B_MAX tokens — size for B_MAX,
+    // not one (issue #1264: OOB GPU writes for any B >= 2).
+    constexpr size_t ZAYA_B_MAX = 8;
+    ALLOC_OR_FAIL(s, alloc_f16, s->d_hs, eng.h * ZAYA_B_MAX);
+    ALLOC_OR_FAIL(s, alloc_f16, s->d_ao, eng.h * ZAYA_B_MAX);
     ALLOC_OR_FAIL(s, alloc_f16, s->d_tmp, std::max(eng.h, 2*eng.n_ff));
     ALLOC_OR_FAIL(s, alloc_f16, s->d_fnw, eng.h);
     ALLOC_OR_FAIL(s, alloc_f16, s->d_lm_out, 4096);
-    ALLOC_OR_FAIL(s, alloc_f16, s->d_lm_vocab, eng.vocab);
+    ALLOC_OR_FAIL(s, alloc_f16, s->d_lm_vocab, eng.vocab * ZAYA_B_MAX);
     // d_argmax_idx, d_sorted_ids, d_expert_counts, d_expert_offsets are
     // declared as int* (and used as int by kernels) but allocated via
     // alloc_f32 since hipMalloc works in bytes and both int/float are 4 B.
@@ -670,9 +674,17 @@ void zaya_forward_batch(ZayaState* s, const int* token_ids, float* logits_out, i
     }
 
     // ── Embedding lookup for all B tokens ──
+    if (B < 1 || B > (int)ZAYA_B_MAX) {
+        fprintf(stderr, "[zaya] batch B=%d out of range [1,%zu]\n", B, ZAYA_B_MAX);
+        return;
+    }
     std::vector<__half> hh(B * eng.h);
     for (int b = 0; b < B; b++) {
         int tid = token_ids[b];
+        if (tid < 0 || tid >= eng.vocab) {
+            fprintf(stderr, "[zaya] token id %d out of range [0,%d)\n", tid, eng.vocab);
+            return;
+        }
         for (int i = 0; i < eng.h; i++) {
             float raw = s->embed[tid * (size_t)eng.h + i];
             hh[b * (size_t)eng.h + i] = __float2half((raw + s->ibias[i]) * s->iscale[i]);

--- a/tools/jarvis/billing.cpp
+++ b/tools/jarvis/billing.cpp
@@ -87,8 +87,10 @@ static std::string hmac_sha256_hex(const std::string& key, const std::string& ms
 static bool verify_stripe_signature(const std::string& payload, const std::string& sig_header) {
     const char* secret = getenv("STRIPE_WEBHOOK_SECRET");
     if (!secret || !*secret) {
-        // No secret configured — accept all webhooks (dev mode)
-        return true;
+        // Fail closed (issue #1279): without a secret every webhook would
+        // rewrite customer tier state. Dev mode must set the secret too.
+        fprintf(stderr, "[billing] STRIPE_WEBHOOK_SECRET not set — refusing webhook\n");
+        return false;
     }
 
     if (sig_header.empty()) return false;
@@ -115,6 +117,18 @@ static bool verify_stripe_signature(const std::string& payload, const std::strin
     } while (comma != std::string::npos);
 
     if (timestamp.empty() || expected_sig.empty()) return false;
+
+    // Replay protection: Stripe mandates rejecting timestamps older than
+    // ~5 minutes (issue #1279).
+    errno = 0;
+    char* end = nullptr;
+    long long ts = strtoll(timestamp.c_str(), &end, 10);
+    if (errno != 0 || !end || *end != '\0') return false;
+    long long now = (long long)time(nullptr);
+    if (ts < now - 300 || ts > now + 300) {
+        fprintf(stderr, "[billing] webhook timestamp %lld outside 5-min window\n", ts);
+        return false;
+    }
 
     // Build the signed payload string: "<timestamp>.<payload>"
     std::string signed_payload = timestamp + "." + payload;

--- a/tools/jarvis_server.cpp
+++ b/tools/jarvis_server.cpp
@@ -512,6 +512,18 @@ static json handle_chat(const json& body) {
 }
 
 // ── main ───────────────────────────────────────────────────────────────
+// The vendored httplib has no has_file()/get_file_value() — multipart
+// files live in req.form.files (multimap name -> FormData).
+static bool has_file(const httplib::Request& req, const std::string& name) {
+    return req.is_multipart_form_data() &&
+           req.form.files.find(name) != req.form.files.end();
+}
+static httplib::FormData get_file_value(const httplib::Request& req,
+                                        const std::string& name) {
+    auto it = req.form.files.find(name);
+    return it == req.form.files.end() ? httplib::FormData{} : it->second;
+}
+
 int main(int argc, char** argv) {
     bool no_beacon = false;
     for (int i = 1; i < argc; i++) {
@@ -544,7 +556,7 @@ int main(int argc, char** argv) {
             return httplib::Server::HandlerResponse::Handled;
         }
 
-        // Public endpoints: no auth required
+// Public endpoints: no auth required
         std::string path = req.path;
         bool public_path = (path == "/" || path == "/chat" ||
             path == "/health" || path == "/live" ||
@@ -556,13 +568,21 @@ int main(int argc, char** argv) {
             return httplib::Server::HandlerResponse::Unhandled;
         }
 
-        // Auth-protected paths:
+        // Auth-protected paths: default-deny — everything not explicitly
+        // public requires a key (issue #1272: /v1/knowledge, /v1/persona,
+        // /v1/agent/plan and /api/chat fell through as "Unhandled" and ran
+        // unauthenticated).
         bool protected_path = (path.rfind("/v1/chat", 0) == 0 ||
             path.rfind("/v1/audio/", 0) == 0 ||
             path.rfind("/v1/voice/", 0) == 0 ||
             path.rfind("/v1/api-key", 0) == 0 ||
             path == "/v1/usage" ||
-            path.rfind("/v1/billing/", 0) == 0);
+            path.rfind("/v1/billing/", 0) == 0 ||
+            path.rfind("/v1/knowledge", 0) == 0 ||
+            path.rfind("/v1/persona", 0) == 0 ||
+            path.rfind("/v1/agent", 0) == 0 ||
+            path == "/api/chat" ||
+            path == "/dashboard");
 
         if (protected_path) {
             auto auth_it = req.headers.find("Authorization");
@@ -708,8 +728,8 @@ int main(int argc, char** argv) {
 
     svr.Post("/v1/knowledge/upload", [&](const httplib::Request& req, httplib::Response& res) {
         std::string filename, content;
-        if (req.has_file("file") || req.has_file("filename")) {
-            const auto& file = req.has_file("file") ? req.get_file_value("file") : req.get_file_value("filename");
+        if (has_file(req, "file") || has_file(req, "filename")) {
+            const auto& file = has_file(req, "file") ? get_file_value(req, "file") : get_file_value(req, "filename");
             filename = file.filename;
             content = file.content;
         } else {
@@ -791,8 +811,8 @@ int main(int argc, char** argv) {
 
     svr.Post("/v1/audio/transcriptions", [&](const httplib::Request& req, httplib::Response& res) {
         std::string audio_bytes;
-        if (req.has_file("file")) audio_bytes = req.get_file_value("file").content;
-        else if (req.has_file("audio")) audio_bytes = req.get_file_value("audio").content;
+        if (has_file(req, "file")) audio_bytes = get_file_value(req, "file").content;
+        else if (has_file(req, "audio")) audio_bytes = get_file_value(req, "audio").content;
 
         if (audio_bytes.empty()) {
             res.status = 400;
@@ -871,8 +891,8 @@ int main(int argc, char** argv) {
     svr.Post("/v1/audio/chat", [&](const httplib::Request& req, httplib::Response& res) {
         // ── Extract audio ─────────────────────────────────────────
         std::string audio_bytes;
-        if (req.has_file("file")) audio_bytes = req.get_file_value("file").content;
-        else if (req.has_file("audio")) audio_bytes = req.get_file_value("audio").content;
+        if (has_file(req, "file")) audio_bytes = get_file_value(req, "file").content;
+        else if (has_file(req, "audio")) audio_bytes = get_file_value(req, "audio").content;
 
         if (audio_bytes.empty()) {
             json body;

--- a/tools/token_router.cpp
+++ b/tools/token_router.cpp
@@ -85,6 +85,9 @@ static std::string json_str(const std::string& j, const std::string& k);
 
 // ── NPU Engine Subprocess ──
 struct NpuEngine {
+    // Engine pipes are shared by all request threads — serialize access
+    // (issue #1275: concurrent infer() interleaved NPU request/response).
+    std::mutex mu;
     pid_t pid = 0;
     int stdin_fd = -1;
     int stdout_fd = -1;
@@ -158,6 +161,7 @@ struct NpuEngine {
     // Send tokens to NPU engine, get back generated tokens + logprobs
     // Returns empty on failure
     std::string infer(const std::vector<int>& prompt_tokens, int max_new) {
+        std::lock_guard<std::mutex> lock(mu);
         if (!ready) return "";
 
         // Build request JSON
@@ -214,6 +218,8 @@ struct NpuEngine {
 
 // ── GPU Engine (zaya_server HTTP subprocess) ──
 struct GpuEngine {
+    // libcurl easy handles are not thread-safe — serialize (issue #1275)
+    std::mutex mu;
     pid_t pid = 0;
     int port = 13307;
     bool ready = false;
@@ -289,6 +295,7 @@ struct GpuEngine {
 
     // Send tokens to zaya_server, get back JSON response
     std::string infer(const std::vector<int>& tokens, int n_predict) {
+        std::lock_guard<std::mutex> lock(mu);
         if (!ready || !curl) return "";
 
         // Build request JSON: {"tokens":[...],"n_predict":N}
@@ -339,6 +346,7 @@ struct GpuEngine {
     //   On accept: gpu_token matches first draft token; tokens = gpu-generated continuation
     //   On reject: gpu_token is the GPU's preferred token; replacement_tokens = GPU continuation
     std::string verify(const std::vector<int>& context, const std::vector<int>& draft_tokens) {
+        std::lock_guard<std::mutex> lock(mu);
         if (!ready || draft_tokens.empty()) {
             return "{\"accept\":false,\"gpu_token\":0,\"replacement_tokens\":[]}";
         }

--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -302,8 +302,10 @@ static json generate_completion(BackendManager& mgr,
                                  const std::string& user_message = "") {
     json result;
 
-    // Select fixed backend if specified (overrides strategy routing)
+    // Select fixed backend if specified (overrides strategy routing).
+    // Mutates mgr state read by /v1/health + /v1/models under g_config_mutex (issue #1271).
     if (backend_id != "auto" && backend_id != "") {
+        std::lock_guard<std::mutex> cfg_lock(g_config_mutex);
         mgr.select_backend(backend_id);
     }
 
@@ -315,6 +317,9 @@ static json generate_completion(BackendManager& mgr,
         TokenContext init_ctx{-1, 0.0, -1.0, 0,
                              prompt_tokens.size(), (size_t)max_tokens,
                              user_message};
+        // route() reads strategy state that /v1/strategy/select mutates under
+        // g_strategy_mutex — same lock here (issue #1271).
+        std::lock_guard<std::mutex> strat_lock(g_strategy_mutex);
         auto decision = strategy_engine->route(init_ctx);
         active_backend_id = decision.backend;
         if (!decision.draft_backend.empty()) {
@@ -405,6 +410,8 @@ static json generate_completion(BackendManager& mgr,
             TokenContext ctx{last_token, last_lp, last_entropy,
                             (size_t)i, prompt_tokens.size(), (size_t)max_tokens,
                             user_message};
+            // issue #1271: strategy state is mutated under g_strategy_mutex
+            std::lock_guard<std::mutex> strat_lock(g_strategy_mutex);
             auto decision = strategy_engine->route(ctx);
 
             // Select the decided backend
@@ -878,7 +885,13 @@ int main(int argc, char** argv) {
     g_tokenizer.load_from_gguf(cfg.model_path);
     BackendRoute route = select_backend_route(cfg);
     printf("  Router: %s\n", route.reason.c_str());
-    bool inited = mgr.init(cfg, g_weights_dir, route.backend_ids_in_order);
+    // mgr state is read by /v1/health + /v1/models under g_config_mutex —
+    // mutate under the same lock (issue #1271).
+    bool inited;
+    {
+        std::lock_guard<std::mutex> cfg_lock(g_config_mutex);
+        inited = mgr.init(cfg, g_weights_dir, route.backend_ids_in_order);
+    }
     if (inited) {
         // Select active backend from the route's ordered list (not global
         // priority order), so the backend that matches the model format is


### PR DESCRIPTION
### **User description**
All 19 remaining audit findings fixed. Host code compiled with g++, kernels with hipcc (gfx1151); on-hardware validation pending (GPU/NPU down post-reboot).

Kernel correctness: #1262 wave-divergent barrier deadlock (uniform masking), #1264 batch buffers ×8 + token bounds, #1265 16×16 LDS staging, #1268 signed nibble decode removed (3 decoders now agree on unsigned), #1269 op==6 qd=NH*HD, #1270 LM-head transpose ×3, #1273 fp8 x-tile reload, #1274 warp row offset ×2, #1267 KV position caps ×5 backends (context restart).

Server/host: #1271 lock topology (strategy/config mutex parity), #1272 jarvis default-deny auth (+ fixed pre-existing has_file() breakage — jarvis never compiled in CI), #1275 per-engine mutexes, #1277 -ffast-math dropped, #1279 stripe fail-closed + replay window, #1280 saturating numel, #1282 std::async timeout, #1283 bounds reorder, #1284 CMake BYPRODUCTS, #1285 >4GiB DMA refuse.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix 19 audit findings across kernels, host, and server

- Correct kernel bugs: deadlock, OOB, transposes, and tile reloads

- Harden server auth, webhook verification, and resource bounds

- Add saturating numel, DMA limits, and KV position caps


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Audit Findings] --> B[Kernel Fixes]
  A --> C[Host Fixes]
  A --> D[Server Fixes]
  B --> B1[Deadlock, OOB, Transpose]
  C --> C1[Bounds, Mutex, Timeout]
  D --> D1[Auth, Webhook, Replay]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>dequant_q4nx.cpp</strong><dd><code>Remove signed nibble decode for unsigned Q4NX</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-167e72e29afa5b8071129772dd74ca48711ff82f88aaa242030639200098f331">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>npu_engine_fused.cpp</strong><dd><code>Fix embedding transpose in fused engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-3207eb5532162c6816963281a766bdf2f2ca4aa6008ffc1b84dd4781105301c3">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>npu_engine_overlap.cpp</strong><dd><code>Fix embedding transpose in overlap engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-5d30b6fe3d5ae02dd92ef83a3ae8444cb027c9a588d97c9e87940fe632285e37">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>npu_engine_universal.cpp</strong><dd><code>Fix attention dims and add KV caps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-63677a636d5ff19712cf034cc1e2c15a96b194137caee54d8bd6883b0b76a10b">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backend_manager.cpp</strong><dd><code>Fix init timeout with std::async</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-f2ed10bacc975dc1c4ed35af9a62ab967874cf0273695b07cceb6059ed53a1cf">+14/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>gguf_reader.cpp</strong><dd><code>Add saturating numel multiply</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-472fa7a111b054f3abe9c1430eb5d7d00bf8361c210434125e48f7fa1f0b1773">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>q4nx_reader.cpp</strong><dd><code>Fix offset overflow check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-1ab49a79619a58bc0cb98da4959e7fdd4191cf1a92dccf7e94b776079c79624f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zaya_engine.cpp</strong><dd><code>Fix batch buffers and token bounds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-0b81ac9c4a9187f1efc799ba81a001c4494a21bead7786931cb4714515b884ea">+15/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>jarvis_server.cpp</strong><dd><code>Fix file handling and default-deny auth</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-7b1e2d203e21efac45ca8e9b9745856529d5a59dec4643f79df5dcef24581145">+29/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>npu_engine_fused.hip</strong><dd><code>Fix embedding transpose in fused hip</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-6b59d8e8fa620b219868cb27c69fd6f5fb5f1417f42e6705e52da2a02d6506d2">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fp8_wmma_gemv.hip</strong><dd><code>Reload activation tile per K-tile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-ee6d878eb46b09e10016ac1b5941d6cd79e4a429bcdddbbfeb0dde2e8755430e">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fused_norm_gemv.hip</strong><dd><code>Add warp row offset in fused norm</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-0ccb521e64058b0710781caf4a5ddc06383ae47bed6b35c159dd56b0b9b391e1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>q4k_gemv.hip</strong><dd><code>Add warp row offset in q4k gemv</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-952a709da1d9c353715a4ed9d91813d89a8496bea04f20d8c8090f6b828b335a">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zaya_moe_ternary_gemv.hip</strong><dd><code>Fix wave-divergent barrier deadlock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-7680ffa2c4ff8c05f9646fb638db988d58633dbc2fec1e26919b27326cc876c5">+27/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>zaya_moe_wmma_batched.hip</strong><dd><code>Fix 16x16 LDS staging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-0de2ec3544badc5f2bcaf7ea2e0c03b64b5b9759a008ddcba1b532152f6ec214">+13/-14</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>fused_engine.cpp</strong><dd><code>Add 32-bit DMA offset overflow check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-0633466722a7f9efc55225c82c49498a49992d52d87ce2da334277617e2b8663">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backend_fused.cpp</strong><dd><code>Add KV overflow check in fused backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-7c92f1f525d2aad11e434c364f206f2af82f8b1984c0535866b4f8e9fa211e4f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backend_hip_1bp.cpp</strong><dd><code>Add KV overflow check in hip_1bp backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-c4812ee96d278d2d2b452760b359c0521f1a016dce68e46c6668555b33eec182">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backend_laguna.cpp</strong><dd><code>Add KV overflow check in laguna backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-76238f4aa0ecc4bcf540c2276683714f4dc373b96d18b528436586ff81b23f1f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Security</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>billing.cpp</strong><dd><code>Fail closed and add replay protection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-a5178f54763b1016b0d5999e0a9ace3038e8cfa5011dbdf3739b70a5ea49860e">+16/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>token_router.cpp</strong><dd><code>Add per-engine mutexes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-7909d4507240156c4bbbc89850cdad19caad28c9f8875e1ff9b1623f9088688c">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>unified_server.cpp</strong><dd><code>Add mutex locks for strategy and config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-108a4e5ad06a8667d81e8da41605283a4dff15e0519645becad615fded67977c">+15/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CMakeLists.txt</strong><dd><code>Fix BYPRODUCTS and remove fast-math</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1288/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

