### PR TITLE
fix: audit findings #1256 + #1259 — checked hipError_t, smoke-test assertion

### DIFF
--- a/.github/workflows/end-to-end-smoke.yml
+++ b/.github/workflows/end-to-end-smoke.yml
@@ -98,7 +98,7 @@ jobs:
           import json,sys; d=json.load(sys.stdin)
           assert d['status'] == 'ok', 'health check failed'
           assert d.get('model'), 'no model'
-          assert d.get('generation_timeout_ms') == 10000, 'wrong timeout'
+          assert d.get('generation_timeout_ms', 0) > 0, 'wrong timeout'
           print('OK: health endpoint')
           "
 

--- a/kernels/vitallm_sparse_kv.hip
+++ b/kernels/vitallm_sparse_kv.hip
@@ -109,10 +109,14 @@ extern "C" int vitallm_sparse_attention(
     // Returns number of KV entries selected (K or seq_len if K >= seq_len)
     if (top_k >= seq_len) return seq_len;  // no filtering needed
     
-    // Allocate temp buffers
-    float* scores; int* indices;
-    hipMallocAsync(&scores, seq_len * 4, (hipStream_t)stream);
-    hipMallocAsync(&indices, top_k * 4, (hipStream_t)stream);
+    // Allocate temp buffers — check returns (issue #1256: on OOM the
+    // downstream kernel would write through null/garbage pointers).
+    float* scores = nullptr; int* indices = nullptr;
+    if (hipMallocAsync(&scores, seq_len * 4, (hipStream_t)stream) != hipSuccess ||
+        hipMallocAsync(&indices, top_k * 4, (hipStream_t)stream) != hipSuccess) {
+        fprintf(stderr, "[vitallm] hipMallocAsync failed (seq_len=%d top_k=%d)\n", seq_len, top_k);
+        return -1;
+    }
     
     // Compute surrogate scores (simplified: launch one block per head)
     // ...

--- a/src/laguna_gemv.hip
+++ b/src/laguna_gemv.hip
@@ -60,8 +60,12 @@ extern "C" void launch_q4nx_gemv(const float* x, const uint8_t* w, float* y,
 #ifndef __HIP_DEVICE_COMPILE__
 extern "C" int test_q4nx_gemv_hip() {
     float x_h[32]; for(int i=0;i<32;i++) x_h[i]=(i==4)?1.0f:0.0f;
-    float *x_d,*y_d; uint8_t*w_d;
-    hipMalloc(&x_d,32*4); hipMalloc(&y_d,256*4); hipMalloc(&w_d,TB);
+    float *x_d=nullptr,*y_d=nullptr; uint8_t*w_d=nullptr;
+    if (hipMalloc(&x_d,32*4) != hipSuccess || hipMalloc(&y_d,256*4) != hipSuccess ||
+        hipMalloc(&w_d,TB) != hipSuccess) {
+        fprintf(stderr, "[laguna] test hipMalloc failed\n");
+        return 1;
+    }
     uint8_t th[TB]; memset(th,0,TB);
     for(int r=0;r<TR;r++){for(int g=0;g<NG;g++){((uint16_t*)(th+r*RB))[g]=0x3F80;}
         uint8_t*pk=th+r*RB+NG*4;for(int i=0;i<256;i++){int bi=i/2;if(i&1)pk[bi]|=(1<<4);else pk[bi]|=1;}}


### PR DESCRIPTION
### **User description**
- #1256: vitallm_sparse_kv hipMallocAsync and laguna_gemv hipMalloc returns now checked — GPU OOM was silently corrupting downstream kernels.
- #1259: smoke test asserts generation_timeout_ms > 0 instead of the hardcoded ==10000 coupling to the workflow flag.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Check hipError_t returns in vitallm_sparse_kv and laguna_gemv

- Replace hardcoded smoke-test timeout assertion with > 0 check

- Prevent silent GPU OOM corruption with clear error propagation

- Decouple smoke test from workflow CLI flag value


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["vitallm_sparse_kv.hip"] -- "check hipMallocAsync" --> B["Return -1 on failure"]
  C["laguna_gemv.hip"] -- "check hipMalloc" --> D["Return 1 on failure"]
  E["end-to-end-smoke.yml"] -- "assert timeout > 0" --> F["Decoupled from flag"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>end-to-end-smoke.yml</strong><dd><code>Decouple smoke-test timeout assertion from hardcoded value</code></dd></summary>
<hr>

.github/workflows/end-to-end-smoke.yml

<ul><li>Changed assertion from <code>== 10000</code> to <code>> 0</code> for <code>generation_timeout_ms</code><br> <li> Uses default value 0 to handle missing field<br> <li> Removes coupling to workflow CLI flag value</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1289/files#diff-ce7583116dfeff04a5365187d78ae67293490e66e36673d3233b26e96f97023c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vitallm_sparse_kv.hip</strong><dd><code>Check hipMallocAsync returns in sparse KV kernel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernels/vitallm_sparse_kv.hip

<ul><li>Added null initialization for scores and indices pointers<br> <li> Check hipMallocAsync return values for both allocations<br> <li> On failure, print error and return -1 instead of proceeding<br> <li> Prevents downstream kernel writes through null/garbage pointers</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1289/files#diff-204af426239df1b3b46a7574f58f1a3e96f86a71372ca921ee924f557cf17176">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>laguna_gemv.hip</strong><dd><code>Check hipMalloc returns in GEMV test path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/laguna_gemv.hip

<ul><li>Added null initialization for x_d, y_d, and w_d pointers<br> <li> Check hipMalloc return values for all three allocations<br> <li> On failure, print error and return 1 instead of proceeding<br> <li> Prevents silent corruption in GEMV test path</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1289/files#diff-95a8ae2d6538475d63cb0f375dff1c56a73c24b2b89a943b24c3be08c27415af">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

