### PR TITLE
fix(build): main doesn't build — CMake '//' comment syntax + ZAYA_B_MAX scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1226,8 +1226,8 @@ if(TARGET npu_engine_hybrid)
         ${CMAKE_SOURCE_DIR}/engine/npu
         ${CMAKE_SOURCE_DIR}/include
         ${CMAKE_SOURCE_DIR})
-    // -ffast-math implies -ffinite-math-only and compiles the std::isfinite
-    // NaN/Inf masks out (issue #1277) — keep them alive.
+    # -ffast-math implies -ffinite-math-only and compiles the std::isfinite
+    # NaN/Inf masks out (issue #1277) — keep them alive.
     target_compile_options(npu_engine_hybrid PRIVATE
         -O3 -march=native -std=c++23 -fopenmp)
     target_link_libraries(npu_engine_hybrid PRIVATE xrt_coreutil uuid rt pthread)

--- a/src/zaya_engine.cpp
+++ b/src/zaya_engine.cpp
@@ -21,6 +21,7 @@
 // ── Runtime config (set by zaya_init from model header) ──
 static constexpr float RMD_EPS=1e-5f;
 static constexpr int BLK=256;
+static constexpr size_t ZAYA_B_MAX = 8;  // batch cap for zaya_forward_batch (also sizes d_hs/d_lm_vocab)
 static thread_local ZayaConfig eng;  // populated by zaya_init from ZayaConfig parameter
 
 // Page gather kernel: copies page-allocated KV slots into a contiguous


### PR DESCRIPTION
## Why

`main` doesn't build — two breakages, both introduced by #1288 (90a33642):

1. `CMakeLists.txt:1229` — audit-fix comment for #1277 written C-style (`//`) instead of CMake-style (`#`): `cmake -B build` fails with `Parse error. Expected a command name, got unquoted argument with text "//".` Every smoke-test run since has died at Build in ~6s, including the run on #1255's own merge — the workflow self-trigger added in #1255 never got a green run.
2. `src/zaya_engine.cpp` — the #1264 fix declared `constexpr size_t ZAYA_B_MAX = 8` as a **function-local** constant inside `zaya_create`, but `zaya_forward_batch` uses it too → `use of undeclared identifier 'ZAYA_B_MAX'` (confirmed on run 30674035591 once configure passed). Moved to file scope next to `BLK`.

## Fixes

- 2-line comment syntax change (`//` → `#`) in CMakeLists.txt
- `ZAYA_B_MAX` hoisted to file scope (1 line)

Verified locally: `cmake -B build -G Ninja` configures clean, `cmake --build build --target unified_server` links (42/42).