### PR TITLE
ci(smoke): vision_server health/model-load check (#1257)

### DIFF
--- a/.github/workflows/end-to-end-smoke.yml
+++ b/.github/workflows/end-to-end-smoke.yml
@@ -54,6 +54,9 @@ jobs:
           # Also kill stray manual servers (vision_server etc.) that can
           # squat on 8099 and answer health checks with the wrong schema.
           pkill -f "[v]ision_server.*8099" || true
+          # -9 fallback: a wedged instance can survive SIGTERM and squat on 8099
+          # with the wrong health schema (issue #1257 incident class).
+          pkill -9 -f "[v]ision_server.*8099" || true
           sleep 2
 
       - name: Start server

--- a/.github/workflows/end-to-end-smoke.yml
+++ b/.github/workflows/end-to-end-smoke.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           source env.sh
           cmake -B build -G Ninja
-          cmake --build build --target unified_server -j$(nproc)
+          cmake --build build --target unified_server vision_server -j$(nproc)
 
       - name: Download test model
         # Model files are git-ignored (symlinked to HF cache locally).
@@ -162,9 +162,49 @@ jobs:
           print('Tokens:', d['usage'].get('completion_tokens'))
           "
 
+      - name: Test vision_server health (issue #1257)
+        # vision_server had zero CI coverage; a stray instance once squatted on
+        # 8099 answering health checks with the wrong schema (PR #1248 run).
+        # Models are gitignored (present on the self-hosted runner); skip
+        # gracefully elsewhere.
+        run: |
+          MM="models/Mage-VL-4B.1bp"
+          VIT="models/Mage-ViT.1bp"
+          if [ ! -f "$MM" ] || [ ! -f "$VIT" ]; then
+            echo "SKIP: vision models not present ($MM / $VIT)"
+            exit 0
+          fi
+          # Free the GPU for the VL stack.
+          pkill -f "unified_server.*8099" 2>/dev/null || true
+          sleep 2
+          ./build/vision_server --port 8099 --mmproj "$VIT" --model "$MM" \
+            &>/tmp/smoke_vision_server.log &
+          echo "pid=$!"
+          for i in $(seq 1 60); do
+            sleep 2
+            if curl -sf http://127.0.0.1:8099/v1/health >/dev/null 2>&1; then
+              echo "vision_server ready after $((i*2))s"
+              break
+            fi
+          done
+          curl -sf http://127.0.0.1:8099/v1/health | python3 -c "
+          import json,sys; d=json.load(sys.stdin)
+          assert d['status'] == 'ok', 'health check failed'
+          assert 'VL' in d.get('service',''), 'wrong service schema'
+          assert d.get('model') and d.get('mmproj'), 'missing model/mmproj'
+          assert d.get('port') == 8099, 'wrong port'
+          print('OK: vision_server health endpoint')
+          "
+          curl -sf http://127.0.0.1:8099/v1/models | python3 -c "
+          import json,sys; d=json.load(sys.stdin)
+          assert 'data' in d and len(d['data']) > 0, 'no models listed'
+          print('OK: vision_server models endpoint:', d['data'][0].get('id'))
+          "
+          pkill -f "vision_server.*8099" 2>/dev/null || true
       - name: Cleanup
         if: always()
         run: |
           pkill -f "unified_server.*8099" 2>/dev/null || true
+          pkill -f "[v]ision_server.*8099" 2>/dev/null || true
           rm -f /tmp/unified_server.lock
           sudo systemctl start 1bit-systems.service || true


### PR DESCRIPTION
### **User description**
Closes the CI-coverage gap from #1257 (point 1).

## What

- **Build** step now also builds `vision_server`
- New **"Test vision_server health"** step after the unified_server tests:
  - kills unified_server on 8099 to free the GPU
  - starts `vision_server --port 8099` with the gitignored Mage-VL models (present on the self-hosted runner; **skips gracefully** elsewhere)
  - asserts the `/v1/health` schema (`status/service/model/mmproj/port`) and `/v1/models`
  - kills the instance; **Cleanup** also now pkills stray `[v]ision_server.*8099` (the exact incident class from #1248's run) before restarting the production service

## Verified

Locally on the runner box: vision_server ready in 16s, both endpoint assertions pass.

Not addressed here (per issue, design decision): whether `/v1/health` should share one schema with unified_server — deliberately left alone.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds CI smoke test for vision_server health/model-load

- Builds vision_server alongside unified_server in workflow

- Asserts /v1/health and /v1/models schemas with graceful skip

- Cleans up stray vision_server processes to prevent port conflicts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build unified_server + vision_server"] --> B["Run unified_server tests"]
  B --> C["Start vision_server on port 8099"]
  C --> D["Check /v1/health schema"]
  C --> E["Check /v1/models endpoint"]
  D --> F["Kill vision_server"]
  E --> F
  F --> G["Cleanup stray processes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>end-to-end-smoke.yml</strong><dd><code>Add vision_server smoke test and cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/end-to-end-smoke.yml

<ul><li>Build step now compiles vision_server target<br> <li> Added new test step for vision_server health and models endpoints<br> <li> Includes graceful skip if vision models are absent<br> <li> Enhanced cleanup to kill stray vision_server processes</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1301/files#diff-ce7583116dfeff04a5365187d78ae67293490e66e36673d3233b26e96f97023c">+41/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

