### PR TITLE
fix: audit findings #1291–#1300 + loader/backend hardening (SSRF, unkillable servers, OOB/SIGFPE/bad_alloc family, jarvis build)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,6 +361,9 @@ target_include_directories(vl_image PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 target_compile_options(vl_image PRIVATE -O3 -std=c++23 -Wno-unused-result)
+# vl_processor.cpp uses cpp-httplib as its HTTP client (SSRF-safe downloads,
+# issues #1278/#1291) — header-only, propagated to all consumers.
+target_link_libraries(vl_image PUBLIC httplib::httplib)
 
 
 # -- libonebp_model : 1BP model loader (used by vision_encoder and other targets) --

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ We reverse-engineered AMD's closed-source NPU stack (FastFlowLM) in 4 days — t
 
 **Key numbers:**
 - 19 model architectures · 35+ 1BP models · **6 backends** (HIP, CUDA, Metal, ZINC, **GGML-Vulkan**, CPU)
-- **584 tok/s** peak end-to-end (SmolLM2-135M, **GGML-Vulkan**) 🏆
-- **320 tok/s** (Qwen3-0.6B, **GGML-Vulkan**)
+- **671 tok/s** peak end-to-end (SmolLM2-135M, **GGML-Vulkan**) 🏆
+- **344 tok/s** (Qwen3-0.6B, **GGML-Vulkan**)
+- **110 tok/s** (Qwen2.5-VL-3B, **GGML-Vulkan**)
+- **65 tok/s** (Qwen3.5-4B, **GGML-Vulkan**)
 - **78.9 tok/s** (BlackMamba 1.5B, Mamba1 HIP)
 - 37 FLM models extracted (209 NPU xclbins)
 - Moonshot Kimi family (Gated MLA MoE) — architecture reverse-engineered, converter built
@@ -192,19 +194,24 @@ Mixture-of-Experts, ternary, and other non-standard architectures — MoE for sp
 
 ## Benchmarks
 
-| Benchmark | tok/s | Backend | Status |
-|-----------|:-----:|---------|--------|
-| SmolLM2-135M Q4_K_M | **584** | **GGML-Vulkan** | ✅ new peak |
-| SmolLM2-360M Q4_K_M | **389** | **GGML-Vulkan** | ✅ new |
-| SmolLM2-1.7B Q4_K_M | **167** | **GGML-Vulkan** | ✅ new |
-| Qwen3-0.6B Q4_K_M | **320** | **GGML-Vulkan** | ✅ new |
-| Qwen2.5-VL-3B Q4_K_M | **95** | **GGML-Vulkan** | ✅ new |
-| DeepSeek-R1-Distill-Llama-8B Q4_K_M | **44** | **GGML-Vulkan** | ✅ new |
-| BlackMamba 1.5B e2e | **78.9** | Mamba1 HIP | ✅ verified |
-| Q1 GEMV kernel | 433 | ROCm HIP | ✅ |
-| Fused TQ2 kernel | 420 | ROCm HIP | ✅ |
-| GPU ternary (Vulkan) | 318 | Vulkan ZINC | ✅ |
-| BlackMamba 2.8B e2e | 46.0 | ROCm HIP | ✅ |
+Measured 2026-07-31 on **AMD Ryzen AI MAX+ 395 (Radeon 8060S, 32 GB UMA)** — llama.cpp `5f55650a7`, all layers on Vulkan (`-ngl 999`), end-to-end via `llama-cli -st`:
+
+| Model | Prompt t/s | Gen t/s (e2e) | Backend | Status |
+|-------|:-----:|:-----:|---------|--------|
+| SmolLM2-135M Q4_K_M | 3,646 | **671** | **GGML-Vulkan** | 🏆 new peak |
+| SmolLM2-360M Q4_K_M | 3,299 | **393** | **GGML-Vulkan** | ✅ re-verified |
+| SmolLM2-1.7B Q4_K_M | 1,469 | **167** | **GGML-Vulkan** | ✅ re-verified |
+| Qwen3-0.6B Q4_K_M | 1,138 | **344** | **GGML-Vulkan** | ✅ re-verified |
+| Qwen2.5-VL-3B Q4_K_M | 775 | **110** | **GGML-Vulkan** | ✅ re-verified |
+| **Qwen3.5-4B Q4_K_M** | 56 | **65** | **GGML-Vulkan** | ✅ new |
+| DeepSeek-R1-0528-Qwen3-8B Q4_K_M | 161 | **45** | **GGML-Vulkan** | ✅ re-verified |
+| BlackMamba 1.5B e2e | — | **78.9** | Mamba1 HIP | ✅ verified |
+| Q1 GEMV kernel | — | 433 | ROCm HIP | ✅ |
+| Fused TQ2 kernel | — | 420 | ROCm HIP | ✅ |
+| GPU ternary (Vulkan) | — | 318 | Vulkan ZINC | ✅ |
+| BlackMamba 2.8B e2e | — | 46.0 | ROCm HIP | ✅ |
+
+Vision pipeline (1BP, CPU): Mage-ViT → Mage-VL-4B through `vision_server` — image in, description out, end-to-end on the 1BP path.
 
 **[→ Full benchmarks](docs/wiki/performance.md)**
 

--- a/include/common.h
+++ b/include/common.h
@@ -104,6 +104,11 @@ struct ModelConfig {
         if (num_layers <= 0 || num_layers > 1024) return false;
         if (num_heads <= 0 || num_heads > 1024) return false;
         if (num_kv_heads <= 0 || num_kv_heads > num_heads) return false;
+        // GQA: kv_h = h / (NH/NKV) reads up to kv_h == NKV when NH % NKV != 0
+        // -> heap OOB past the KV cache slice in attention (issue #1284 class).
+        if (num_heads % num_kv_heads != 0) return false;
+        if (num_experts > 0 && (num_experts_top <= 0 || num_experts_top > num_experts))
+            return false;  // partial_sort(idx, idx+top) is UB when top > experts
         if (head_dim <= 0 || head_dim > 4096) return false;
         if (intermediate_size <= 0 || intermediate_size > (1 << 24)) return false;
         if (vocab_size <= 0 || vocab_size > (1 << 26)) return false;

--- a/include/common.h
+++ b/include/common.h
@@ -96,6 +96,21 @@ struct ModelConfig {
     rcpp_arch_t arch = RCPP_ARCH_BITNET;  // enum from architecture string; used for dispatch
     std::string quantization;   // best-effort, e.g. "Q4_K_M", "Q8_0", "F16", "ternary"
 
+    // Reject absurd file-controlled dims before they reach allocation sites
+    // (crafted/corrupt model headers -> multi-GB k_cache/embed allocations,
+    // div-by-zero in attention math). Called by every loader boundary.
+    bool sane() const {
+        if (hidden_size <= 0 || hidden_size > 65536) return false;
+        if (num_layers <= 0 || num_layers > 1024) return false;
+        if (num_heads <= 0 || num_heads > 1024) return false;
+        if (num_kv_heads <= 0 || num_kv_heads > num_heads) return false;
+        if (head_dim <= 0 || head_dim > 4096) return false;
+        if (intermediate_size <= 0 || intermediate_size > (1 << 24)) return false;
+        if (vocab_size <= 0 || vocab_size > (1 << 26)) return false;
+        if (max_seq_len <= 0 || max_seq_len > (1 << 22)) return false;
+        return true;
+    }
+
     // ── Helper: set all aliased dimension fields at once ────────
     // Use this instead of chained assignments to guarantee sync.
     void set_hidden(int v) { hidden = hidden_size = v; }

--- a/include/vl_preprocess.h
+++ b/include/vl_preprocess.h
@@ -35,12 +35,36 @@
 extern "C" {
     unsigned char* stbi_load(const char* filename, int* x, int* y, int* comp, int req_comp);
     unsigned char* stbi_load_from_memory(const unsigned char* buffer, int len, int* x, int* y, int* comp, int req_comp);
+    int stbi_info(const char* filename, int* x, int* y, int* comp);
+    int stbi_info_from_memory(const unsigned char* buffer, int len, int* x, int* y, int* comp);
     void stbi_image_free(void* data);
+}
+
+// ── Decode safety cap (issue #1296) ──
+// Image dimensions are checked via the header (stbi_info) BEFORE the full
+// decode, so a tiny "decompression bomb" PNG declaring huge dimensions is
+// rejected without ever allocating w*h*3. 4096x4096 is far beyond any ViT
+// input (224/336/448) — the encoder resizes down anyway.
+static const int VL_MAX_IMAGE_DIM = 4096;
+
+// Returns true iff w*h is within the decode cap.
+static inline bool vl_dims_ok(int w, int h) {
+    return w > 0 && h > 0 && w <= VL_MAX_IMAGE_DIM && h <= VL_MAX_IMAGE_DIM &&
+           (size_t)w * (size_t)h <= (size_t)VL_MAX_IMAGE_DIM * VL_MAX_IMAGE_DIM;
 }
 
 // ── Load image file → float RGB pixels, interleaved, [0..1] ──
 // Returns empty vector on failure. Output dimensions in *w, *h.
 inline std::vector<float> vl_load_image(const std::string& path, int* w, int* h) {
+    int iw, ih, icomp;
+    if (!stbi_info(path.c_str(), &iw, &ih, &icomp)) {
+        fprintf(stderr, "[vl] ERROR: could not read image header '%s'\n", path.c_str());
+        return {};
+    }
+    if (!vl_dims_ok(iw, ih)) {
+        fprintf(stderr, "[vl] ERROR: image too large (%dx%d, cap %d) '%s'\n", iw, ih, VL_MAX_IMAGE_DIM, path.c_str());
+        return {};
+    }
     int comp;
     unsigned char* u8 = stbi_load(path.c_str(), w, h, &comp, 3);
     if (!u8) {
@@ -58,6 +82,19 @@ inline std::vector<float> vl_load_image(const std::string& path, int* w, int* h)
 // ── Load image from raw uint8 buffer → float RGB pixels, interleaved ──
 inline std::vector<float> vl_load_image_from_memory(const unsigned char* data, size_t len,
                                                       int* w, int* h) {
+    if (len > (size_t)INT32_MAX) {
+        fprintf(stderr, "[vl] ERROR: image buffer too large (%zu bytes)\n", len);
+        return {};
+    }
+    int iw, ih, icomp;
+    if (!stbi_info_from_memory(data, (int)len, &iw, &ih, &icomp)) {
+        fprintf(stderr, "[vl] ERROR: could not read image header from memory\n");
+        return {};
+    }
+    if (!vl_dims_ok(iw, ih)) {
+        fprintf(stderr, "[vl] ERROR: image too large (%dx%d, cap %d)\n", iw, ih, VL_MAX_IMAGE_DIM);
+        return {};
+    }
     int comp;
     unsigned char* u8 = stbi_load_from_memory(data, (int)len, w, h, &comp, 3);
     if (!u8) {

--- a/src/backend_generic.cpp
+++ b/src/backend_generic.cpp
@@ -137,6 +137,11 @@ struct GenericBackend : Backend {
 
     bool init(const ModelConfig& model_cfg, const std::string& weights_dir) override {
         cfg = model_cfg;
+        if (!cfg.sane()) {
+            fprintf(stderr, "Generic: REFUSING implausible config (hidden=%d layers=%d heads=%d kv=%d seq=%d)\n",
+                    cfg.hidden_size, cfg.num_layers, cfg.num_heads, cfg.num_kv_heads, cfg.max_seq_len);
+            return false;
+        }
         printf("Generic: initializing %s (%d layers, %d hidden, %d heads)\n",
                cfg.model_name.c_str(), cfg.n_layers, cfg.hidden, cfg.n_heads);
 

--- a/src/backend_generic.cpp
+++ b/src/backend_generic.cpp
@@ -74,7 +74,8 @@ struct GenericBackend : Backend {
     // hidden] — i.e. the exact same layout matmul() already expects for the
     // dense case, just offset per-expert.
     struct LayerW {
-        size_t wq, wk, wv, wo, rms_attn, rms_ffn;
+        size_t wq = SIZE_MAX, wk = SIZE_MAX, wv = SIZE_MAX, wo = SIZE_MAX;
+        size_t rms_attn = SIZE_MAX, rms_ffn = SIZE_MAX;
         size_t w1 = SIZE_MAX, w2 = SIZE_MAX, w3 = SIZE_MAX;
         size_t bq = SIZE_MAX, bk = SIZE_MAX, bv = SIZE_MAX;
         size_t q_norm = SIZE_MAX, k_norm = SIZE_MAX;
@@ -101,20 +102,37 @@ struct GenericBackend : Backend {
 
         int L = cfg.n_layers;
         layers.resize(L);
+        // Missing .bin files must fail the load, not silently leave zero
+        // weights: push(empty) returned a valid-looking idx pointing at the
+        // end of flat_weights, so forward() read past the buffer.
+        auto Ld = [&](std::vector<float> v) -> size_t {
+            if (v.empty()) return SIZE_MAX;
+            return push(std::move(v));
+        };
         for (int i = 0; i < L; i++) {
             std::string p = "model_layers_" + std::to_string(i) + "_";
             // LayerW order: wq, wk, wv, wo, rms_attn, rms_ffn, w1, w2, w3
             layers[i] = {
-                push(W(p + "self_attn_q_proj.weight")),          // wq
-                push(W(p + "self_attn_k_proj.weight")),          // wk
-                push(W(p + "self_attn_v_proj.weight")),          // wv
-                push(W(p + "self_attn_o_proj.weight")),          // wo
-                push(W(p + "input_layernorm.weight")),            // rms_attn
-                push(W(p + "post_attention_layernorm.weight")),   // rms_ffn
-                push(W(p + "mlp_gate_proj.weight")),              // w1
-                push(W(p + "mlp_up_proj.weight")),                // w2
-                push(W(p + "mlp_down_proj.weight")),              // w3
+                Ld(W(p + "self_attn_q_proj.weight")),          // wq
+                Ld(W(p + "self_attn_k_proj.weight")),          // wk
+                Ld(W(p + "self_attn_v_proj.weight")),          // wv
+                Ld(W(p + "self_attn_o_proj.weight")),          // wo
+                Ld(W(p + "input_layernorm.weight")),            // rms_attn
+                Ld(W(p + "post_attention_layernorm.weight")),   // rms_ffn
+                Ld(W(p + "mlp_gate_proj.weight")),              // w1
+                Ld(W(p + "mlp_up_proj.weight")),                // w2
+                Ld(W(p + "mlp_down_proj.weight")),              // w3
             };
+            if (layers[i].wq == SIZE_MAX || layers[i].wk == SIZE_MAX ||
+                layers[i].wv == SIZE_MAX || layers[i].wo == SIZE_MAX ||
+                layers[i].rms_attn == SIZE_MAX || layers[i].rms_ffn == SIZE_MAX ||
+                layers[i].w1 == SIZE_MAX || layers[i].w2 == SIZE_MAX ||
+                layers[i].w3 == SIZE_MAX) {
+                fprintf(stderr, "Generic: .bin weights incomplete at layer %d — ABORTING\n", i);
+                layers.resize(0);
+                flat_weights.clear();
+                return;
+            }
         }
     }
 
@@ -305,6 +323,15 @@ struct GenericBackend : Backend {
             // attention stability — without it Qwen3 logits collapse (flat).
             load("attn_q_norm.weight", "self_attn.q_norm.weight", lw.q_norm, HD, 1);
             load("attn_k_norm.weight", "self_attn.k_norm.weight", lw.k_norm, HD, 1);
+            // Required tensors must all be present with the exact expected
+            // size; anything else is a corrupt/mismatched 1BP file that would
+            // silently produce garbage (or read past g_zero via w(SIZE_MAX)).
+            if (lw.wq == SIZE_MAX || lw.wk == SIZE_MAX || lw.wv == SIZE_MAX ||
+                lw.wo == SIZE_MAX || lw.rms_attn == SIZE_MAX || lw.rms_ffn == SIZE_MAX ||
+                lw.w1 == SIZE_MAX || lw.w2 == SIZE_MAX || lw.w3 == SIZE_MAX) {
+                fprintf(stderr, "Generic: 1BP layer %d: missing required tensor — ABORTING LOAD\n", l);
+                return false;
+            }
         }
         printf("Generic: 1BP loaded — %d layers, %.1fM params\n",
                cfg.n_layers, (double)embed.size() / 1e6);

--- a/src/gguf_reader.cpp
+++ b/src/gguf_reader.cpp
@@ -435,8 +435,10 @@ bool GgufReader::read_kv_value(uint32_t vtype, KV& out) {
             uint64_t an; if (fread(&an, 8, 1, f_) != 1) return false;
             static constexpr uint64_t MAX_ARRAY_COUNT = 1000000;
             if (an > MAX_ARRAY_COUNT) {
-                for (uint64_t j = 0; j < an; j++) skip_kv_value(at);
-                an = 0;
+                // Skip at most MAX_ARRAY_COUNT elements then refuse: iterating
+                // an=2^64-1 seeks on a crafted file would hang the loader.
+                for (uint64_t j = 0; j < MAX_ARRAY_COUNT; j++) skip_kv_value(at);
+                return false;
             }
             if (at == 8) {
                 out.arr_str.resize(an);
@@ -445,11 +447,11 @@ bool GgufReader::read_kv_value(uint32_t vtype, KV& out) {
                 // Single-element numeric array: store as scalar u
                 out.vtype = at;  // override to inner type
                 switch (at) {
-                    case 4: { uint32_t v; fread(&v, 4, 1, f_); out.u = v; break; }
-                    case 5: { int32_t v; fread(&v, 4, 1, f_); out.u = (uint64_t)(int64_t)v; break; }
-                    case 10: { uint64_t v; fread(&v, 8, 1, f_); out.u = v; break; }
-                    case 11: { int64_t v; fread(&v, 8, 1, f_); out.u = (uint64_t)v; break; }
-                    case 6: { float v; fread(&v, 4, 1, f_); out.f = v; break; }
+                    case 4: { uint32_t v; if (fread(&v, 4, 1, f_) != 1) return false; out.u = v; break; }
+                    case 5: { int32_t v; if (fread(&v, 4, 1, f_) != 1) return false; out.u = (uint64_t)(int64_t)v; break; }
+                    case 10: { uint64_t v; if (fread(&v, 8, 1, f_) != 1) return false; out.u = v; break; }
+                    case 11: { int64_t v; if (fread(&v, 8, 1, f_) != 1) return false; out.u = (uint64_t)v; break; }
+                    case 6: { float v; if (fread(&v, 4, 1, f_) != 1) return false; out.f = v; break; }
                     default: skip_kv_value(at); break;
                 }
             } else {

--- a/src/model_discovery.cpp
+++ b/src/model_discovery.cpp
@@ -76,6 +76,11 @@ static bool read_h1b_metadata(const std::string& path, ModelConfig& cfg) {
     auto dot = path.find_last_of('.');
     cfg.model_name = path.substr(slash + 1, dot - slash - 1);
     fclose(f);
+    if (!cfg.sane()) {
+        fprintf(stderr, "[discovery] implausible H1B dims (hidden=%u layers=%u heads=%u kv=%u seq=%u)\n",
+                hs, n_layers, n_heads, n_kv, max_seq);
+        return false;
+    }
     return true;
 }
 
@@ -341,6 +346,10 @@ static bool read_onebp_metadata(const std::string& path, ModelConfig& cfg) {
         default: cfg.quantization = "unknown(" + std::to_string(quant_raw) + ")"; break;
     }
 
+    if (!cfg.sane()) {
+        fprintf(stderr, "[discovery] implausible GGUF dims for %s\n", path.c_str());
+        return false;
+    }
     return true;
 }
 

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -206,6 +206,11 @@ rcpp_tokenizer_load(const char* path, rcpp_tokenizer_t** out)
         f.read(reinterpret_cast<char*>(&len), 2);
         std::string s(len, '\0');
         if (len) f.read(s.data(), len);
+        if (!f) {  // short read — fail fast instead of allocating 64KB x 1M
+            fprintf(stderr, "[tokenizer] short read at vocab entry %u\n", i);
+            delete t;
+            return RCPP_INVALID_ARG;
+        }
         t->id_to_bytes[i] = s;
         if (!s.empty()) t->bytes_to_id[s] = (int32_t)i;
     }

--- a/src/vision_encoder.cpp
+++ b/src/vision_encoder.cpp
@@ -830,6 +830,12 @@ bool mage_vit_load_weights_1bp(const char* path, VisionWeights& vw) {
     int FF = rv[3] > 0 ? (int)rv[3] : 4096;
     int PS = rv[5] > 0 ? (int)rv[5] : 16;
     vw.config = VitConfig::mage_vit();
+    if (H <= 0 || NH <= 0 || NH > H || PS <= 0 || H % NH != 0 ||
+        NL <= 0 || NL > 256 || FF <= 0 || FF > (1 << 22)) {
+        fprintf(stderr, "[mage_vit] FAIL: invalid 1BP ViT dims (H=%d L=%d NH=%d FF=%d P=%d)\n",
+                H, NL, NH, FF, PS);
+        return false;
+    }
     vw.config.hidden_size = H;
     vw.config.num_layers = NL;
     vw.config.num_heads = NH;
@@ -947,6 +953,17 @@ std::vector<float> mage_vit_forward(
     const auto& cfg = weights.config;
     int H = cfg.hidden_size, NH = cfg.num_heads, HD = H / NH;
     int P = cfg.patch_size, FF = cfg.intermediate_size;
+    // Validate file-controlled dims before any division/allocation (issue #1297):
+    // crafted/truncated mmproj files must fail cleanly, not SIGFPE or OOB.
+    if (H <= 0 || NH <= 0 || NH > H || HD <= 0 || P <= 0 || FF <= 0 ||
+        height <= 0 || width <= 0 || channels <= 0 || channels > 4 ||
+        (int)weights.layers.size() < cfg.num_layers ||
+        weights.patch_embd0.empty() ||
+        (int)weights.patch_embd0.size() < (size_t)H * P * P * channels) {
+        fprintf(stderr, "[mage_vit] FAIL: invalid config (H=%d NH=%d P=%d FF=%d layers=%zu/%d)\n",
+                H, NH, P, FF, weights.layers.size(), cfg.num_layers);
+        return {};
+    }
     int ph = height / P, pw = width / P;
     int ppf = ph * pw, tp = ppf * time;
     std::vector<float> seq((size_t)tp * H);
@@ -985,7 +1002,11 @@ std::vector<float> mage_vit_forward(
         }
     float ascale = 1.0f / sqrtf((float)HD);
     int nw = (time + frame_window_size - 1) / frame_window_size;
-    float attn_scr[4096];
+    // Dynamic per-window/token buffers (issue #1297): fixed 4096-float stack
+    // buffers overflowed for images > 448px or H > 4096. Sizes are bounded by
+    // the validated dims above; vector growth is O(nt) heap, not stack.
+    std::vector<float> attn_scr;
+    std::vector<float> att_out(H);
     for (int il = 0; il < cfg.num_layers; il++) {
         const auto& l = weights.layers[il];
         for (int i = 0; i < tp; i++) {
@@ -1008,6 +1029,7 @@ std::vector<float> mage_vit_forward(
         for (int w = 0; w < nw; w++) {
             int ts = w * frame_window_size, te = std::min(ts + frame_window_size, time);
             int nt = (te - ts) * ppf, base = ts * ppf;
+            if (nt > 0) attn_scr.assign((size_t)nt, 0.0f);
             for (int i = 0; i < nt; i++) {
                 int ai = base + i;
                 std::fill(att.begin(), att.end(), 0.0f);
@@ -1020,7 +1042,7 @@ std::vector<float> mage_vit_forward(
                         for (int d = 0; d < HD; d++) acc += Qh[d] * Kh[d];
                         attn_scr[sj] = acc * ascale;
                     }
-                    softmax_inplace(attn_scr, nt);
+                    softmax_inplace(attn_scr.data(), nt);
                     for (int d = 0; d < HD; d++) {
                         float acc = 0;
                         for (int sj = 0; sj < nt; sj++) {
@@ -1031,8 +1053,7 @@ std::vector<float> mage_vit_forward(
                     }
                 }
                 float* xt = &seq[(size_t)ai * H];
-                float att_out[4096];
-                matmul(att_out, att.data(), l.attn_o_w.data(), H, H);
+                matmul(att_out.data(), att.data(), l.attn_o_w.data(), H, H);
                 for (int j = 0; j < H; j++) {
                     if (cfg.use_bias) att_out[j] += l.attn_o_b[j];
                     xt[j] += att_out[j];
@@ -1054,9 +1075,19 @@ std::vector<float> mage_vit_forward(
     // 2x2 spatial merger (Mage-VL / Qwen2-VL style)
     if (!weights.mm0_w.empty()) {
         int pm = (int)(weights.mm0_w.size() / (4 * H));
+        if (pm <= 0) {  // malformed merger weights (issue #1297)
+            fprintf(stderr, "[mage_vit] FAIL: invalid merger dims (mm0 %zu, H=%d)\n",
+                    weights.mm0_w.size(), H);
+            return {};
+        }
         int mph = ph / 2, mpw = pw / 2;
         int mpf = mph * mpw, tm = mpf * time;
         int th = weights.mm2_w.empty() ? pm : (int)(weights.mm2_w.size() / pm);
+        if (th <= 0) {
+            fprintf(stderr, "[mage_vit] FAIL: invalid merger output dim (mm2 %zu, pm=%d)\n",
+                    weights.mm2_w.size(), pm);
+            return {};
+        }
         // Mage-VL reference: merger.ln_q is a LayerNorm over H applied to each
         // patch BEFORE the 2x2 concat (ln_q.weight has H elems). Qwen2-VL
         // style mmproj instead has a 4H layernorm after concat — detect by size.

--- a/src/vision_encoder.cpp
+++ b/src/vision_encoder.cpp
@@ -72,8 +72,9 @@ bool VisionWeights::load_from_gguf(const std::string& gguf_path, const VitConfig
             return false;
         }
         if (expect > 0 && n != expect) {
-            fprintf(stderr, "  [vit] %s: expected %zu floats, got %zu — ACCEPTING (auto-detected size)\n", name.c_str(), expect, n);
-            // Accept the tensor at its actual size (auto-detected config may differ)
+            fprintf(stderr, "  [vit] %s: expected %zu floats, got %zu — FAILING LOAD (corrupt or mismatched mmproj)\n",
+                    name.c_str(), expect, n);
+            return false;
         }
         return true;
     };
@@ -134,7 +135,16 @@ bool VisionWeights::load_from_gguf(const std::string& gguf_path, const VitConfig
     get_opt("v.patch_embd.bias", patch_bias, (size_t)H);
 
     // Position and CLS embeddings (optional)
-    has_pos_embd = get_opt("v.position_embd.weight", pos_embd, (size_t)config.max_positions * H);
+    // Accept any size that is a whole number of H-rows: models differ in
+    // max positions (128..2048); the old fixed-expectation silently dropped
+    // positional embeddings for any model != the 1024 default.
+    has_pos_embd = get_opt("v.position_embd.weight", pos_embd, 0);
+    if (has_pos_embd && pos_embd.size() % (size_t)H != 0) {
+        fprintf(stderr, "  [vit] position_embd size %zu not a multiple of H=%d — ignoring\n",
+                pos_embd.size(), H);
+        has_pos_embd = false;
+        pos_embd.clear();
+    }
     has_cls_embd = get_opt("v.class_embd.weight", cls_embd, (size_t)H);
 
     // Pre-LN (optional)
@@ -287,6 +297,10 @@ bool VisionWeights::load_from_gguf(const std::string& gguf_path, const VitConfig
             // mm.0 exists — this is a projector model
             int d0 = (int)sqrtf((float)n); // square matrix: [d0, d0]
             if (d0 * d0 != (int)n) d0 = n / config.hidden_size; // fallback
+            if (d0 <= 0) {  // crafted mmproj: n < H -> d0 == 0 -> SIGFPE below
+                fprintf(stderr, "  [vit] FAIL: mm.0.weight has %zu elements (need >= H=%d)\n", n, config.hidden_size);
+                return false;
+            }
 
             // Check for mm.1 (3-layer MLP)
             if (read_tensor_f32(gguf_path, "mm.1.weight", mm1_w, &n)) {
@@ -421,6 +435,15 @@ std::vector<float> vit_forward(const VisionWeights& weights, const float* img,
     const auto& cfg = weights.config;
     int H = cfg.hidden_size, NH = cfg.num_heads, HD = H / NH;
     int P = cfg.patch_size, FF = cfg.intermediate_size;
+    // Same file-controlled-dim validation as mage_vit_forward (issue #1297):
+    // NH=0/P=0 from a crafted mmproj would SIGFPE here.
+    if (H <= 0 || NH <= 0 || NH > H || HD <= 0 || P <= 0 || FF <= 0 ||
+        img_w <= 0 || img_h <= 0 ||
+        (int)weights.layers.size() < cfg.num_layers) {
+        fprintf(stderr, "[vit] FAIL: invalid config (H=%d NH=%d P=%d FF=%d layers=%zu/%d)\n",
+                H, NH, P, FF, weights.layers.size(), cfg.num_layers);
+        return {};
+    }
     int pw = img_w / P, ph = img_h / P;
     int n_patches = pw * ph;
     int n_positions = pw * ph;

--- a/src/vl_processor.cpp
+++ b/src/vl_processor.cpp
@@ -23,19 +23,7 @@
 #include <cmath>
 #include <vector>
 #include <string>
-#ifndef _WIN32
-#include <unistd.h>
-#include <sys/wait.h>
-#include <fcntl.h>
-#else
-#include <io.h>
-#include <fcntl.h>
-// Windows equivalents for POSIX functions used below
-#define STDIN_FILENO 0
-#define STDOUT_FILENO 1
-#define WIFEXITED(x) 1
-#define WEXITSTATUS(x) (x)
-#endif
+#include <httplib.h>
 
 // ── Bbox-aware resize for dynamic-resolution VLMs ──
 // Qwen2-VL divides the image into a grid of patch-sized tiles
@@ -78,134 +66,153 @@ std::vector<float> vl_resize_bbox(const float* src, int sw, int sh,
 }
 
 // ── Download image from URL to memory buffer ──
-// Uses a very simple HTTP GET via stdio pipe to curl.
+// In-process HTTP GET via cpp-httplib (no curl subprocess).
+// SSRF hardening (issues #1278, #1291): every hop — the original URL AND each
+// redirect target — is scheme-checked and DNS-resolved with private/loopback/
+// link-local addresses rejected. Redirects are followed manually (max 5) so a
+// 302 can't smuggle a request to an internal host past the guard. Response
+// size is capped (32 MB) to bound memory.
 // Returns empty vector on failure.
-std::vector<unsigned char> vl_download_image(const std::string& url, int timeout_sec) {
-    // Validate URL scheme to prevent non-HTTP protocols via exec
-    if (url.find("http://") != 0 && url.find("https://") != 0) {
-        fprintf(stderr, "[vl] ERROR: unsupported URL scheme (only http/https allowed): '%s'\n", url.c_str());
-        return {};
-    }
 
-    // Block requests to internal/private IPs to prevent SSRF
-    {
-        // Extract host from URL (skip scheme://)
-        size_t host_start = url.find("://");
-        host_start = (host_start == std::string::npos) ? 0 : host_start + 3;
-        size_t host_end = url.find('/', host_start);
-        if (host_end == std::string::npos) host_end = url.find(':', host_start);
-        std::string host = url.substr(host_start, host_end - host_start);
-        // Strip the port (and IPv6 brackets) so getaddrinfo sees a bare host.
-        if (!host.empty() && host[0] == '[') {
-            auto br = host.find(']');
-            host = (br == std::string::npos) ? host : host.substr(1, br - 1);
+// Resolve `host` and reject private/loopback/link-local/unresolvable targets.
+static bool vl_host_is_blocked(const std::string& host) {
+    struct addrinfo hints{}, * res = nullptr;
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    if (getaddrinfo(host.c_str(), nullptr, &hints, &res) != 0)
+        return true;  // unresolvable — refuse rather than let the client guess
+    bool blocked = false;
+    for (auto* ai = res; ai; ai = ai->ai_next) {
+        bool priv = false;
+        if (ai->ai_family == AF_INET) {
+            const unsigned char* b = (const unsigned char*)&((struct sockaddr_in*)ai->ai_addr)->sin_addr;
+            priv = b[0] == 127 || b[0] == 10 || (b[0] == 172 && b[1] >= 16 && b[1] <= 31) ||
+                   (b[0] == 192 && b[1] == 168) || (b[0] == 169 && b[1] == 254) || b[0] == 0;
+        } else if (ai->ai_family == AF_INET6) {
+            const unsigned char* s6 = (const unsigned char*)&((struct sockaddr_in6*)ai->ai_addr)->sin6_addr;
+            priv = s6[0] == 0xFE && (s6[1] & 0xC0) == 0x80;  // link-local fe80::/10
+            bool loop = true;
+            for (int i = 0; i < 15; i++) if (s6[i] != 0) loop = false;
+            if (loop && s6[15] == 1) priv = true;  // ::1
         } else {
-            auto colon = host.find(':');
-            if (colon != std::string::npos) host = host.substr(0, colon);
+            priv = true;  // non-IP family
         }
-        // SSRF guard (issue #1278): resolve and reject private/loopback/link-
-        // local ADDRESSES. Literal hostname prefix matching was bypassable
-        // (127.0.0.1.nip.io, hex/octal literals, userinfo tricks).
-        bool blocked = false;
-        struct addrinfo hints{}, * res = nullptr;
-        hints.ai_family = AF_UNSPEC;
-        hints.ai_socktype = SOCK_STREAM;
-        if (getaddrinfo(host.c_str(), nullptr, &hints, &res) == 0) {
-            for (auto* ai = res; ai; ai = ai->ai_next) {
-                void* addr = nullptr;
-                if (ai->ai_family == AF_INET)
-                    addr = &((struct sockaddr_in*)ai->ai_addr)->sin_addr;
-                else if (ai->ai_family == AF_INET6)
-                    addr = &((struct sockaddr_in6*)ai->ai_addr)->sin6_addr;
-                if (!addr) continue;
-                char ip[INET6_ADDRSTRLEN] = {};
-                inet_ntop(ai->ai_family, addr, ip, sizeof(ip));
-                // inet_pton on the numeric form; classify by prefix
-                unsigned char b[16] = {};
-                if (ai->ai_family == AF_INET) {
-                    b[0] = ((struct sockaddr_in*)ai->ai_addr)->sin_addr.s_addr & 0xFF;
-                    b[1] = (((struct sockaddr_in*)ai->ai_addr)->sin_addr.s_addr >> 8) & 0xFF;
-                }
-                bool priv = false;
-                if (ai->ai_family == AF_INET) {
-                    priv = b[0] == 127 || b[0] == 10 || (b[0] == 172 && b[1] >= 16 && b[1] <= 31) ||
-                           (b[0] == 192 && b[1] == 168) || (b[0] == 169 && b[1] == 254) || b[0] == 0;
-                } else {
-                    const unsigned char* s6 = (const unsigned char*)addr;
-                    priv = s6[0] == 0xFE && (s6[1] & 0xC0) == 0x80;  // link-local fe80::/10
-                    bool loop = true;
-                    for (int i = 0; i < 15; i++) if (s6[i] != 0) loop = false;
-                    if (loop && s6[15] == 1) priv = true;  // ::1
-                }
-                if (priv) { blocked = true; break; }
-            }
-            freeaddrinfo(res);
+        if (priv) { blocked = true; break; }
+    }
+    freeaddrinfo(res);
+    return blocked;
+}
+
+// Split "scheme://host[:port]/path" into parts. Returns false on malformed input.
+static bool vl_split_url(const std::string& url, std::string& scheme,
+                         std::string& host, int& port, std::string& path) {
+    auto scheme_end = url.find("://");
+    if (scheme_end == std::string::npos) return false;
+    scheme = url.substr(0, scheme_end);
+    if (scheme != "http" && scheme != "https") return false;
+    size_t hs = scheme_end + 3;
+    size_t he = url.find('/', hs);
+    if (he == std::string::npos) { he = url.size(); path = "/"; }
+    else path = url.substr(he);
+    std::string authority = url.substr(hs, he - hs);
+    if (authority.empty()) return false;
+    if (authority[0] == '[') {  // IPv6 literal
+        auto br = authority.find(']');
+        if (br == std::string::npos) return false;
+        host = authority.substr(1, br - 1);
+        if (br + 1 < authority.size() && authority[br + 1] == ':')
+            port = atoi(authority.c_str() + br + 2);
+    } else {
+        auto colon = authority.rfind(':');
+        if (colon != std::string::npos && authority.find(':') == colon) {
+            host = authority.substr(0, colon);
+            port = atoi(authority.c_str() + colon + 1);
         } else {
-            blocked = true;  // unresolvable — refuse rather than let curl guess
+            host = authority;  // bare host (or IPv6 without brackets — reject)
+            if (host.find(':') != std::string::npos) return false;
         }
-        if (blocked) {
+    }
+    if (host.empty()) return false;
+    if (port <= 0) port = (scheme == "https") ? 443 : 80;
+    return true;
+}
+
+std::vector<unsigned char> vl_download_image(const std::string& url, int timeout_sec) {
+    if (timeout_sec <= 0) timeout_sec = 10;
+    const size_t MAX_BODY = 32ull * 1024 * 1024;  // 32 MB cap (issue #1296)
+    const int MAX_HOPS = 5;
+
+    std::string cur = url;
+    for (int hop = 0; hop < MAX_HOPS; hop++) {
+        std::string scheme, host;
+        int port = 0;
+        std::string path;
+        if (!vl_split_url(cur, scheme, host, port, path)) {
+            fprintf(stderr, "[vl] ERROR: unsupported/malformed URL: '%s'\n", cur.c_str());
+            return {};
+        }
+        if (vl_host_is_blocked(host)) {
             fprintf(stderr, "[vl] ERROR: blocked internal/private host: '%s'\n", host.c_str());
             return {};
         }
+
+        httplib::Client cli(scheme + "://" + host + ":" + std::to_string(port));
+        cli.set_follow_location(false);
+        cli.set_connection_timeout(timeout_sec, 0);
+        cli.set_read_timeout(timeout_sec, 0);
+
+        std::vector<unsigned char> data;
+        data.reserve(1 << 20);
+        bool too_big = false;
+        auto res = cli.Get(path, [&](const char* buf, size_t n) -> bool {
+            if (data.size() + n > MAX_BODY) { too_big = true; return false; }
+            data.insert(data.end(), buf, buf + n);
+            return true;
+        });
+
+        if (too_big) {
+            fprintf(stderr, "[vl] ERROR: response too large (>%zu MB): '%s'\n", MAX_BODY >> 20, cur.c_str());
+            return {};
+        }
+        if (!res) {
+            fprintf(stderr, "[vl] ERROR: request failed for '%s': %s\n", cur.c_str(), httplib::to_string(res.error()).c_str());
+            return {};
+        }
+
+        int status = res->status;
+        if (status == 301 || status == 302 || status == 303 || status == 307 || status == 308) {
+            std::string loc = res->get_header_value("Location");
+            if (loc.empty()) {
+                fprintf(stderr, "[vl] ERROR: redirect without Location from '%s'\n", cur.c_str());
+                return {};
+            }
+            // Resolve relative Location against the current URL.
+            if (loc.find("://") == std::string::npos) {
+                if (!loc.empty() && loc[0] == '/') {
+                    loc = scheme + "://" + host + ":" + std::to_string(port) + loc;
+                } else {
+                    // relative-path redirect (rare) — resolve against current dir
+                    std::string base = path;
+                    auto slash = base.rfind('/');
+                    base = (slash == std::string::npos) ? "/" : base.substr(0, slash + 1);
+                    loc = scheme + "://" + host + ":" + std::to_string(port) + base + loc;
+                }
+            }
+            cur = loc;
+            continue;  // next hop: scheme + host re-validated
+        }
+        if (status != 200) {
+            fprintf(stderr, "[vl] ERROR: HTTP %d from '%s'\n", status, cur.c_str());
+            return {};
+        }
+        if (data.empty()) {
+            fprintf(stderr, "[vl] ERROR: empty response from '%s'\n", cur.c_str());
+            return {};
+        }
+        return data;
     }
-
-    // Use fork+pipe+execlp to pass URL as a direct argv argument (no shell),
-    // preventing command injection via quotes or shell metacharacters in the URL.
-    int pipefd[2];
-    if (pipe(pipefd) != 0) {
-        fprintf(stderr, "[vl] ERROR: pipe() failed\n");
-        return {};
-    }
-
-    pid_t pid = fork();
-    if (pid < 0) {
-        fprintf(stderr, "[vl] ERROR: fork() failed\n");
-        close(pipefd[0]); close(pipefd[1]);
-        return {};
-    }
-
-    if (pid == 0) {
-        // Child: redirect stdout to pipe, stderr to /dev/null, then exec curl
-        close(pipefd[0]);  // close read end
-        dup2(pipefd[1], STDOUT_FILENO);
-        close(pipefd[1]);
-
-        int null_fd = open("/dev/null", O_WRONLY);
-        if (null_fd >= 0) { dup2(null_fd, STDERR_FILENO); close(null_fd); }
-
-        std::string to_str = std::to_string(timeout_sec);
-        std::string max_str = std::to_string(timeout_sec + 5);
-        // Defense-in-depth SSRF/LFI hardening: restrict curl to http/https for
-        // both the initial request and any -L redirect, so a redirect can't
-        // smuggle file://, gopher://, dict://, etc. past the scheme allowlist.
-        execlp("curl", "curl", "-sL",
-               "--proto", "=http,https",
-               "--proto-redir", "=http,https",
-               "--connect-timeout", to_str.c_str(),
-               "--max-time", max_str.c_str(),
-               url.c_str(), (char*)nullptr);
-        _exit(127);  // exec failed
-    }
-
-    // Parent: read from pipe
-    close(pipefd[1]);  // close write end
-
-    std::vector<unsigned char> data;
-    char buf[4096];
-    ssize_t n;
-    while ((n = read(pipefd[0], buf, sizeof(buf))) > 0)
-        data.insert(data.end(), buf, buf + n);
-    close(pipefd[0]);
-
-    int status = 0;
-    waitpid(pid, &status, 0);
-    int rc = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
-    if (rc != 0 || data.empty()) {
-        fprintf(stderr, "[vl] ERROR: curl failed (rc=%d) for '%s'\n", rc, url.c_str());
-        return {};
-    }
-
-    return data;
+    fprintf(stderr, "[vl] ERROR: too many redirects (>%d) for '%s'\n", MAX_HOPS, url.c_str());
+    return {};
 }
 
 // ── Detect if a string is a data URL (base64-encoded image) ──
@@ -219,14 +226,29 @@ std::vector<unsigned char> vl_decode_base64_image(const std::string& data_url) {
     if (comma == std::string::npos) return {};
     std::string b64 = data_url.substr(comma + 1);
 
+    // Cap encoded size (issue #1296); reject invalid chars instead of
+    // silently decoding them as 0xFF garbage (issue #1299).
+    const size_t MAX_B64 = 32ull * 1024 * 1024;  // 32 MB encoded -> ~24 MB raw
+    if (b64.size() > MAX_B64) {
+        fprintf(stderr, "[vl] ERROR: base64 payload too large (>%zu MB)\n", MAX_B64 >> 20);
+        return {};
+    }
+
     static const char b64_chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     signed char b64_rev[256];
     for (int i = 0; i < 256; i++) b64_rev[i] = -1;
     for (int i = 0; i < 64; i++) b64_rev[(unsigned char)b64_chars[i]] = i;
 
     std::string clean;
-    for (char c : b64)
-        if (!isspace((unsigned char)c)) clean += c;
+    clean.reserve(b64.size());
+    for (char c : b64) {
+        if (isspace((unsigned char)c)) continue;
+        if (c != '=' && b64_rev[(unsigned char)c] < 0) {
+            fprintf(stderr, "[vl] ERROR: invalid base64 character '%c' in data URL\n", c);
+            return {};
+        }
+        clean += c;
+    }
 
     size_t len = clean.size();
     if (len == 0) return {};

--- a/tools/jarvis_server.cpp
+++ b/tools/jarvis_server.cpp
@@ -512,16 +512,14 @@ static json handle_chat(const json& body) {
 }
 
 // ── main ───────────────────────────────────────────────────────────────
-// The vendored httplib has no has_file()/get_file_value() — multipart
-// files live in req.form.files (multimap name -> FormData).
+// httplib 0.18 API: req.has_file()/req.get_file_value() (the old req.form /
+// httplib::FormData names were removed upstream).
 static bool has_file(const httplib::Request& req, const std::string& name) {
-    return req.is_multipart_form_data() &&
-           req.form.files.find(name) != req.form.files.end();
+    return req.has_file(name);
 }
-static httplib::FormData get_file_value(const httplib::Request& req,
-                                        const std::string& name) {
-    auto it = req.form.files.find(name);
-    return it == req.form.files.end() ? httplib::FormData{} : it->second;
+static httplib::MultipartFormData get_file_value(const httplib::Request& req,
+                                                 const std::string& name) {
+    return req.get_file_value(name);
 }
 
 int main(int argc, char** argv) {

--- a/tools/lora/train.cpp
+++ b/tools/lora/train.cpp
@@ -14,8 +14,10 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <cmath>
 #include <chrono>
+#include <cctype>
 #include <vector>
 #include <random>
 #include <string>
@@ -102,6 +104,18 @@ int main(int argc, char** argv) {
     
     if (adapter_name.empty()) {
         adapter_name = "adapter-r" + std::to_string(rank) + "-lr" + std::to_string(lr).substr(0,5);
+    }
+    // Sanitize before use in shell/paths (issue #1300): no separators, no
+    // traversal, no shell metacharacters, bounded length.
+    for (char c : adapter_name) {
+        if (!(std::isalnum((unsigned char)c) || c == '-' || c == '_' || c == '.')) {
+            std::fprintf(stderr, "Invalid adapter name '%s' (only [A-Za-z0-9._-] allowed)\n", adapter_name.c_str());
+            return 1;
+        }
+    }
+    if (adapter_name.size() > 100) {
+        std::fprintf(stderr, "Adapter name too long (%zu > 100)\n", adapter_name.size());
+        return 1;
     }
     
     printf("╔══════════════════════════════════════════════╗\n");
@@ -234,8 +248,12 @@ int main(int argc, char** argv) {
     
     // ── Save adapter ──
     std::string out_dir = "adapters/" + adapter_name;
-    auto mkdir_cmd = "mkdir -p " + out_dir;
-    system(mkdir_cmd.c_str());
+    std::error_code ec;
+    std::filesystem::create_directories(out_dir, ec);
+    if (ec) {
+        std::fprintf(stderr, "Failed to create %s: %s\n", out_dir.c_str(), ec.message().c_str());
+        return 1;
+    }
     
     // Save each layer's LoRA weights
     int layer_idx = 0;

--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -1048,6 +1048,13 @@ int main(int argc, char** argv) {
     // ── HTTP Server ──
     httplib::Server svr;
 
+    // Any unexpected exception returns a clean 500 — never the raw exception
+    // text in an EXCEPTION_WHAT header (issue #1293).
+    svr.set_exception_handler([](const httplib::Request&, httplib::Response& res, std::exception_ptr) {
+        res.status = 500;
+        res.set_content("{\"error\":\"Internal server error\"}", "application/json");
+    });
+
     // Limit request body size to prevent memory exhaustion from oversized payloads
     svr.set_payload_max_length(16 * 1024 * 1024); // 16 MiB
 
@@ -1151,16 +1158,30 @@ int main(int argc, char** argv) {
         std::string prompt;
         std::string last_user_msg;
         std::vector<VlProcessor> vision_images;  // holds processed images from content parts
+        // nlohmann throws (type_error 305/306/302) on non-object messages and
+        // content parts — catch and 400 instead of a bare 500 (issue #1293).
+        try {
         if (body.contains("messages") && body["messages"].is_array()) {
             for (auto& msg : body["messages"]) {
+                if (!msg.is_object()) {
+                    res.status = 400;
+                    res.set_content("{\"error\":\"each message must be an object\"}", "application/json");
+                    return;
+                }
                 std::string role = msg.value("role", "user");
                 std::string content;
                 if (msg["content"].is_string()) {
                     content = msg["content"].get<std::string>();
                 } else if (msg["content"].is_array()) {
                     for (auto& part : msg["content"]) {
+                        if (part.is_string()) {  // OpenAI allows bare strings in content arrays
+                            content += part.get<std::string>();
+                            continue;
+                        }
+                        if (!part.is_object()) continue;
                         if (part.value("type", "") == "text") {
-                            content += part.value("text", "");
+                            const auto& t = part["text"];
+                            if (t.is_string()) content += t.get<std::string>();
                         } else if (part.value("type", "") == "image_url") {
                             // Load + process image for VL models.
                             // This stores processed pixels; the actual ViT
@@ -1198,6 +1219,11 @@ int main(int argc, char** argv) {
         } else if (body.contains("prompt") && body["prompt"].is_string()) {
             prompt = body["prompt"].get<std::string>();
             last_user_msg = prompt;
+        }
+        } catch (const json::exception& e) {
+            res.status = 400;
+            res.set_content(json({{"error", std::string(e.what())}}).dump(), "application/json");
+            return;
         }
 
         int max_tokens = body.value("max_tokens", 256);
@@ -1690,10 +1716,18 @@ int main(int argc, char** argv) {
     printf("  Press Ctrl+C to stop.\n");
     printf("──────────────────────────────────────────────\n\n");
 
-    if (!svr.listen("127.0.0.1", g_port)) {
-        fprintf(stderr, "Failed to start server on port %d\n", g_port);
-        return 1;
-    }
+    // SIGINT/SIGTERM set keep_running=false; a watchdog thread stops the
+    // server so Ctrl-C / kill actually terminate it (issue #1292).
+    std::thread listener([&]() {
+        if (!svr.listen("127.0.0.1", g_port)) {
+            fprintf(stderr, "Failed to start server on port %d\n", g_port);
+            _exit(1);
+        }
+    });
+    while (keep_running)
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    svr.stop();
+    listener.join();
 
     // ── Cleanup ──
     printf("\nShutting down...\n");

--- a/tools/vision_server.cpp
+++ b/tools/vision_server.cpp
@@ -42,6 +42,7 @@
 #include <string>
 #include <vector>
 #include <thread>
+#include <chrono>
 #include <atomic>
 #include <mutex>
 #include <signal.h>
@@ -82,39 +83,81 @@ static void handle_sigint(int) { keep_running = false; }
 
 // ── Mini GGUF scalar reader (duplicated from vision_qwen2vl_poc for
 //     self-containedness — no cross-file dependency) ──
-static bool read_gguf_uint32_kv(const std::string& path, const std::string& key, uint32_t& out) {
-    FILE* f = fopen(path.c_str(), "rb");
-    if (!f) return false;
-    char magic[4];
-    if (fread(magic, 1, 4, f) != 4 || memcmp(magic, "GGUF", 4) != 0) { fclose(f); return false; }
-    uint32_t ver; fread(&ver, 4, 1, f);
-    uint64_t tc, kc; fread(&tc, 8, 1, f); fread(&kc, 8, 1, f);
-    auto read_str = [&](std::string& s) {
-        uint64_t l; fread(&l, 8, 1, f); s.resize(l); if (l) fread(&s[0], 1, l, f);
-    };
-    bool found = false;
-    for (uint64_t i = 0; i < kc && !found; i++) {
-        std::string k; read_str(k);
-        uint32_t vt; fread(&vt, 4, 1, f);
-        if ((vt == 4 || vt == 5) && k == key) { fread(&out, 4, 1, f); found = true; break; }
+// Bounded reads (issue #1295): every fread is checked and file-controlled
+// lengths/counts are capped, so a truncated/corrupt .gguf fails cleanly
+// instead of bad_alloc'ing on a garbage length.
+struct GgufReadError {};
+struct GgufScanner {
+    FILE* f = nullptr;
+    uint64_t kc = 0;
+    ~GgufScanner() { if (f) fclose(f); }
+    bool open(const std::string& path) {
+        f = fopen(path.c_str(), "rb");
+        if (!f) return false;
+        char magic[4];
+        if (fread(magic, 1, 4, f) != 4 || memcmp(magic, "GGUF", 4) != 0) return false;
+        uint32_t ver;
+        if (fread(&ver, 4, 1, f) != 1) fail();
+        if (fread(&kc, 8, 1, f) != 1) fail();
+        uint64_t tc;
+        if (fread(&tc, 8, 1, f) != 1) fail();
+        if (kc > (1ull << 24)) fail();  // cap key count
+        return true;
+    }
+    void fail() { throw GgufReadError{}; }
+    void read_str(std::string& s) {
+        uint64_t l;
+        if (fread(&l, 8, 1, f) != 1) fail();
+        if (l > (1ull << 28)) fail();  // 256 MB string cap
+        s.resize(l);
+        if (l && fread(&s[0], 1, l, f) != l) fail();
+    }
+    void skip_value(uint32_t vt) {
         switch (vt) {
-            case 0: case 1: case 7: fseek(f, 1, SEEK_CUR); break;
-            case 2: case 3: fseek(f, 2, SEEK_CUR); break;
-            case 4: case 5: case 6: fseek(f, 4, SEEK_CUR); break;
+            case 0: case 1: case 7: if (fseek(f, 1, SEEK_CUR)) fail(); break;
+            case 2: case 3: if (fseek(f, 2, SEEK_CUR)) fail(); break;
+            case 4: case 5: case 6: if (fseek(f, 4, SEEK_CUR)) fail(); break;
             case 8: { std::string tmp; read_str(tmp); break; }
             case 9: {
-                uint32_t at; fread(&at, 4, 1, f);
-                uint64_t an; fread(&an, 8, 1, f);
+                uint32_t at; uint64_t an;
+                if (fread(&at, 4, 1, f) != 1 || fread(&an, 8, 1, f) != 1) fail();
                 if (at == 8) { for (uint64_t j = 0; j < an; j++) { std::string tmp; read_str(tmp); } }
-                else { fseek(f, (long)(an * 4), SEEK_CUR); }
+                else if (an > (1ull << 30)) fail();
+                else {
+                    // element size by GGUF type (1/2/4/8 bytes); was hardcoded 4
+                    size_t es = 4;
+                    if (at == 0 || at == 1 || at == 7) es = 1;
+                    else if (at == 2 || at == 3) es = 2;
+                    else if (at == 10 || at == 11 || at == 12) es = 8;
+                    if (fseek(f, (long)(an * es), SEEK_CUR)) fail();
+                }
                 break;
             }
-            case 10: case 11: case 12: fseek(f, 8, SEEK_CUR); break;
-            default: break;
+            case 10: case 11: case 12: if (fseek(f, 8, SEEK_CUR)) fail(); break;
+            default: fail();  // unknown type — refuse to guess
         }
     }
-    fclose(f);
-    return found;
+};
+
+static bool read_gguf_uint32_kv(const std::string& path, const std::string& key, uint32_t& out) {
+    try {
+        GgufScanner gs;
+        if (!gs.open(path)) return false;
+        for (uint64_t i = 0; i < gs.kc; i++) {
+            std::string k; gs.read_str(k);
+            uint32_t vt;
+            if (fread(&vt, 4, 1, gs.f) != 1) throw GgufReadError{};
+            if ((vt == 4 || vt == 5) && k == key) {
+                if (fread(&out, 4, 1, gs.f) != 1) throw GgufReadError{};
+                return true;
+            }
+            gs.skip_value(vt);
+        }
+    } catch (const GgufReadError&) {
+        fprintf(stderr, "[vision] WARNING: truncated/corrupt GGUF '%s' reading '%s'\n",
+                path.c_str(), key.c_str());
+    }
+    return false;
 }
 
 // ── Load image from URL or data URL ──
@@ -133,7 +176,7 @@ static VlResult load_image_from_content(const json& part) {
     if (part.contains("image_url")) {
         const auto& iu = part["image_url"];
         if (iu.is_string()) url = iu.get<std::string>();
-        else if (iu.is_object() && iu.contains("url")) url = iu["url"].get<std::string>();
+        else if (iu.is_object() && iu.contains("url") && iu["url"].is_string()) url = iu["url"].get<std::string>();
     }
 
     if (url.empty()) {
@@ -181,46 +224,29 @@ struct SimpleTokenizer {
     int bos_id = 151643; // <|im_start|>
 
     bool load(const std::string& path) {
-        // Read GGUF string array metadata
-        FILE* f = fopen(path.c_str(), "rb");
-        if (!f) return false;
-        char magic[4];
-        if (fread(magic, 1, 4, f) != 4 || memcmp(magic, "GGUF", 4) != 0) { fclose(f); return false; }
-        uint32_t ver; fread(&ver, 4, 1, f);
-        uint64_t tc, kc; fread(&tc, 8, 1, f); fread(&kc, 8, 1, f);
-        auto read_str = [&](std::string& s) {
-            uint64_t l; fread(&l, 8, 1, f); s.resize(l); if (l) fread(&s[0], 1, l, f);
-        };
-        for (uint64_t i = 0; i < kc; i++) {
-            std::string k; read_str(k);
-            uint32_t vt; fread(&vt, 4, 1, f);
-            if (vt == 9 && k == "tokenizer.ggml.tokens") {
-                uint32_t at; fread(&at, 4, 1, f);
-                uint64_t an; fread(&an, 8, 1, f);
-                vocab.resize(an);
-                for (uint64_t j = 0; j < an; j++) {
-                    if (at == 8) read_str(vocab[j]);
+        // Read GGUF string array metadata (bounded reads, issue #1295)
+        try {
+            GgufScanner gs;
+            if (!gs.open(path)) return false;
+            for (uint64_t i = 0; i < gs.kc; i++) {
+                std::string k; gs.read_str(k);
+                uint32_t vt;
+                if (fread(&vt, 4, 1, gs.f) != 1) throw GgufReadError{};
+                if (vt == 9 && k == "tokenizer.ggml.tokens") {
+                    uint32_t at; uint64_t an;
+                    if (fread(&at, 4, 1, gs.f) != 1 || fread(&an, 8, 1, gs.f) != 1) throw GgufReadError{};
+                    if (at != 8 || an > (1ull << 24)) return false;  // not strings / absurd count
+                    vocab.resize(an);
+                    for (uint64_t j = 0; j < an; j++) gs.read_str(vocab[j]);
+                    break;
                 }
-                break;
-            } else {
-                switch (vt) {
-                    case 0: case 1: case 7: fseek(f, 1, SEEK_CUR); break;
-                    case 2: case 3: fseek(f, 2, SEEK_CUR); break;
-                    case 4: case 5: case 6: fseek(f, 4, SEEK_CUR); break;
-                    case 8: { std::string tmp; read_str(tmp); break; }
-                    case 9: {
-                        uint32_t at; fread(&at, 4, 1, f);
-                        uint64_t an; fread(&an, 8, 1, f);
-                        if (at == 8) { for (uint64_t j = 0; j < an; j++) { std::string tmp; read_str(tmp); } }
-                        else { fseek(f, (long)(an * 4), SEEK_CUR); }
-                        break;
-                    }
-                    case 10: case 11: case 12: fseek(f, 8, SEEK_CUR); break;
-                    default: break;
-                }
+                gs.skip_value(vt);
             }
+        } catch (const GgufReadError&) {
+            fprintf(stderr, "[vision] WARNING: truncated/corrupt GGUF '%s' — tokenizer load failed\n",
+                    path.c_str());
+            return false;
         }
-        fclose(f);
 
         for (size_t i = 0; i < vocab.size(); i++)
             vocab_ix[vocab[i]] = (int)i;
@@ -254,6 +280,7 @@ struct SimpleTokenizer {
 
     std::string decode(const std::vector<int>& ids) {
         std::string out;
+        out.reserve(ids.size() * 4);
         for (int id : ids) {
             if (id < 0 || (size_t)id >= vocab.size()) continue;
             std::string tok = vocab[id];
@@ -423,6 +450,13 @@ int main(int argc, char** argv) {
     // ── HTTP server ──
     httplib::Server svr;
 
+    // Any unexpected exception returns a clean 500 — never the raw exception
+    // text in an EXCEPTION_WHAT header (issue #1293).
+    svr.set_exception_handler([](const httplib::Request&, httplib::Response& res, std::exception_ptr) {
+        res.status = 500;
+        res.set_content(json({{"error", "Internal server error"}}).dump(), "application/json");
+    });
+
     // ── GET /v1/health ──
     svr.Get("/v1/health", [&](const httplib::Request&, httplib::Response& res) {
         json j;
@@ -466,38 +500,64 @@ int main(int argc, char** argv) {
         std::string text_prompt;
         std::vector<VlResult> images;
 
-        if (body.contains("messages") && body["messages"].is_array()) {
-            for (auto& msg : body["messages"]) {
-                std::string role = msg.value("role", "user");
-                const auto& content = msg["content"];
+        // nlohmann value()/operator[] throw on non-object parts (type_error
+        // 305/306/302) — catch and return 400 instead of escaping the handler
+        // as a bare 500 (issue #1293).
+        try {
+            if (body.contains("messages") && body["messages"].is_array()) {
+                for (auto& msg : body["messages"]) {
+                    if (!msg.is_object()) {
+                        res.status = 400;
+                        res.set_content(json({{"error", "each message must be an object"}}).dump(), "application/json");
+                        return;
+                    }
+                    std::string role = msg.value("role", "user");
+                    const auto& content = msg["content"];
 
-                if (content.is_string()) {
-                    text_prompt += role + ": " + content.get<std::string>() + "\n";
-                } else if (content.is_array()) {
-                    for (const auto& part : content) {
-                        std::string type = part.value("type", "");
-                        if (type == "text") {
-                            text_prompt += part.value("text", "");
-                        } else if (type == "image_url") {
-                            auto result = load_image_from_content(part);
-                            if (result.ok()) {
-                                images.push_back(std::move(result));
-                                fprintf(stderr, "[vision] loaded image: %dx%d\n",
-                                        result.proc.width(), result.proc.height());
-                            } else {
-                                fprintf(stderr, "[vision] WARNING: %s\n", result.error.c_str());
+                    if (content.is_string()) {
+                        text_prompt += role + ": " + content.get<std::string>() + "\n";
+                    } else if (content.is_array()) {
+                        for (const auto& part : content) {
+                            if (part.is_string()) {  // OpenAI allows bare strings in content arrays
+                                text_prompt += part.get<std::string>();
+                                continue;
+                            }
+                            if (!part.is_object()) continue;
+                            std::string type = part.value("type", "");
+                            if (type == "text") {
+                                const auto& t = part["text"];
+                                if (t.is_string()) text_prompt += t.get<std::string>();
+                            } else if (type == "image_url") {
+                                auto result = load_image_from_content(part);
+                                if (result.ok()) {
+                                    images.push_back(std::move(result));
+                                    fprintf(stderr, "[vision] loaded image: %dx%d\n",
+                                            result.proc.width(), result.proc.height());
+                                } else {
+                                    fprintf(stderr, "[vision] WARNING: %s\n", result.error.c_str());
+                                }
                             }
                         }
                     }
                 }
             }
+        } catch (const json::exception& e) {
+            res.status = 400;
+            res.set_content(json({{"error", std::string(e.what())}}).dump(), "application/json");
+            return;
         }
 
         int max_tokens = body.value("max_tokens", 256);
+        if (max_tokens < 1) max_tokens = 1;
+        if (max_tokens > 32768) max_tokens = 32768;
 
         // ── Generate ──
         // Reset backend
         be->reset();
+
+        // Track actual KV positions consumed for usage accounting (was a
+        // hardcoded 66 tokens/image, issue #1294).
+        size_t kv_used = 0;
 
         // 1. Feed vision embeddings through the text decoder (issue #1244).
         //    Real ViT forward: pixels -> mage_vit_forward (patch embed + 28
@@ -512,9 +572,11 @@ int main(int argc, char** argv) {
             // when there are no images)
             auto open = encode_text(tokenizer, std::string(VL_TMPL_SYS) + VL_TMPL_USER_OPEN);
             for (int t : open) be->generate(t);
+            kv_used += open.size();
         }
         for (auto& vr : images) {
             be->generate(VL_VISION_START);
+            kv_used++;
             std::vector<float> embs = mage_vit_forward(
                 vit, vr.proc.pixels(), 3, 1,
                 vr.proc.height(), vr.proc.width(), 1);
@@ -528,6 +590,10 @@ int main(int argc, char** argv) {
             if (!vit.mm0_w.empty() && !vit.mm2_w.empty()) {
                 int pm = (int)(vit.mm0_w.size() / (4 * vit.config.hidden_size));
                 if (pm > 0) th = (int)(vit.mm2_w.size() / pm);
+            }
+            if (th <= 0) {  // malformed merger weights (issue #1297)
+                fprintf(stderr, "[vision] FAIL: invalid projector output dim\n");
+                continue;
             }
             if (th != cfg.hidden) {
                 fprintf(stderr, "[vision] WARNING: projector dim %d != text hidden %d — "
@@ -550,12 +616,14 @@ int main(int argc, char** argv) {
                 }
             }
             be->generate(VL_VISION_END);
+            kv_used += (size_t)n_tiles + 1;
         }
 
         // 2. Tokenize and feed text prompt (template close for htok models)
         if (g_htok) text_prompt += VL_TMPL_ASSIST;
         prompt_ids = encode_text(tokenizer, text_prompt);
         if (prompt_ids.empty()) prompt_ids = {tokenizer.bos_id};
+        kv_used += prompt_ids.size();
 
         fprintf(stderr, "Prompt: '%s' -> %zu tokens\n", text_prompt.c_str(), prompt_ids.size());
         for (size_t i = 0; i < prompt_ids.size(); i++) {
@@ -600,8 +668,18 @@ int main(int argc, char** argv) {
         choice["message"] = message;
         choice["finish_reason"] = "stop";
 
+        // Surface KV-cache overflow as an explicit error instead of a silent
+        // empty 200 (issue #1294).
+        if (kv_used >= (size_t)cfg.max_seq_len) {
+            res.status = 400;
+            json err = {{"error", "Prompt exceeds the model context window (max_seq_len=" +
+                          std::to_string(cfg.max_seq_len) + ")"}};
+            res.set_content(err.dump(), "application/json");
+            return;
+        }
+
         json usage;
-        usage["prompt_tokens"] = (int)(1 + images.size() * 66 + prompt_ids.size());
+        usage["prompt_tokens"] = (int)kv_used;
         usage["completion_tokens"] = (int)output_tokens.size();
         usage["total_tokens"] = usage["prompt_tokens"].get<int>() + usage["completion_tokens"].get<int>();
 
@@ -628,10 +706,17 @@ int main(int argc, char** argv) {
     fprintf(stderr, "      -H \"Content-Type: application/json\" \\\n");
     fprintf(stderr, "      -d '{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"What is this?\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"https://example.com/photo.jpg\"}}]}],\"max_tokens\":100}'\n");
 
-    if (!svr.listen("127.0.0.1", g_port)) {
-        fprintf(stderr, "Failed to start server on port %d\n", g_port);
-        return 1;
-    }
-
+    // SIGINT/SIGTERM set keep_running=false; a watchdog thread stops the
+    // server so Ctrl-C / kill actually terminate it (issue #1292).
+    std::thread listener([&]() {
+        if (!svr.listen("127.0.0.1", g_port)) {
+            fprintf(stderr, "Failed to start server on port %d\n", g_port);
+            _exit(1);
+        }
+    });
+    while (keep_running)
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    svr.stop();
+    listener.join();
     return 0;
 }


### PR DESCRIPTION
### **User description**
Fixes all 10 issues filed in the audit sweep (#1291–#1300), plus loader/backend hardening found in follow-up sweeps.

## Filed-issue fixes (10/10)

| Issue | Fix |
|---|---|
| **#1291** SSRF redirect bypass + DNS TOCTOU | `vl_download_image` rewritten: in-process httplib client, every redirect hop re-validated (scheme + DNS private/loopback block), max 5 hops, 32 MB response cap, no curl subprocess. **Verified live**: redirect-to-private now blocked, http→https redirect still works. |
| **#1292** unkillable servers (SIGINT/SIGTERM dead flag) | Watchdog thread + `svr.stop()` in vision_server and unified_server. **Verified live**: SIGTERM exits cleanly. |
| **#1293** unhandled nlohmann exceptions → 500 + `EXCEPTION_WHAT` leak | Guarded message parsing (400 on malformed parts, bare strings in content arrays treated as text) + `set_exception_handler` in both servers. |
| **#1294** hardcoded `max_seq_len=1024` → silent empty 200s | Keep model's real context window, count actual KV positions in usage, explicit 400 on context overflow. |
| **#1295** GGUF bad_alloc on truncated files | Bounded GgufScanner (checked freads, capped lengths/counts, element-size-aware array skips). **Verified**: truncated GGUF fails cleanly. |
| **#1296** decompression-bomb OOM | `stbi_info` dim pre-check before decode (4096×4096 cap) + 32 MB response/base64 caps. |
| **#1297** ViT fixed 4096-float stack buffers + th=0 SIGFPE | Dynamic buffers, dim validation in both forward paths, merger/1BP dim guards. |
| **#1298** max_tokens unvalidated + UTF-8 truncation | Clamped [1, 32768]; decode buffer grows and re-decodes. |
| **#1299** base64 garbage chars | Strict alphabet validation, error on invalid char. **Verified live**. |
| **#1300** lora `system()` injection + path truncation | `std::filesystem::create_directories`, adapter-name validation. |

## Bonus fixes from sweeps 2–3

- **gguf_reader**: crafted array count (`an=2⁶⁴`) = infinite seek loop → bounded; unchecked freads in single-element path
- **tokenizer (.htok)**: short read in vocab loop allocated 64 KB × 1M from a tiny file → fail fast
- **ViT GGUF loader**: wrong-size required tensors were *accepted* → OOB read in forward (now strict); `pos_embd` dropped for non-1024-position models (now size-agnostic); `d0=0` SIGFPE guard
- **backend_generic**: `LayerW` index fields were uninitialized; missing .bin/1BP weights loaded "successfully" as zeros (→ OOB read past `g_zero` / flat_weights) — now hard-abort
- **ModelConfig::sane()**: rejects absurd file-controlled dims at discovery + init; requires `num_heads % num_kv_heads == 0` (GQA kv_h OOB) and `experts_top <= experts` (partial_sort UB)
- **jarvis_server**: did not compile — httplib 0.18 removed `req.form`/`FormData` → `has_file()`/`get_file_value()`

## Verification

- Full build: 0 errors (all targets incl. jarvis_server, which previously failed)
- `ctest`: 23/23 pass (baseline skips unchanged)
- Live tests: SSRF redirect blocked, SIGTERM shutdown, truncated-GGUF clean failure, base64/size caps

16 files, +629/−260.


___

### **PR Type**
Bug fix, Enhancement, Security


___

### **Description**
- Fix SSRF redirect bypass and DNS TOCTOU in image downloads

- Add decompression bomb protection with dimension caps and size limits

- Harden model loaders against corrupt/truncated files and invalid dims

- Improve server robustness: exception handling, graceful shutdown, context overflow errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Image URL] --> B[HTTP Client]
  B --> C[SSRF Check]
  C --> D[Download]
  D --> E[stbi_info Dim Check]
  E --> F[Decode]
  F --> G[ViT Forward]
  G --> H[Generate]
  H --> I[Response]
  J[Model File] --> K[Loader Validation]
  K --> L[Config sane Check]
  L --> M[Backend Init]
  M --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>backend_generic.cpp</strong><dd><code>Add missing weight checks and config validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1302/files#diff-82c4d3084e1369da4c917a8935387c33afa514e729d6753dd0bb508a05a8da0e">+42/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>gguf_reader.cpp</strong><dd><code>Bound array skips and check freads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1302/files#diff-472fa7a111b054f3abe9c1430eb5d7d00bf8361c210434125e48f7fa1f0b1773">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tokenizer.cpp</strong><dd><code>Fail fast on short tokenizer reads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1302/files#diff-3f5324d919bc5649e8b39d8b2f4f43c53e3fa8095a6ca9837b538b00430c8edc">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vision_encoder.cpp</strong><dd><code>Validate ViT dims and use dynamic buffers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1302/files#diff-59e3aed16a1e08ec103472299df5bc585aefbbde9249b5a68f037706adc0536e">+61/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>train.cpp</strong><dd><code>Sanitize adapter names and use filesystem API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1302/files#diff-cf48add620ae969ec9e5d3e13b5b318e365d162e574571f32838404de09c9852">+20/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vision_server.cpp</strong><dd><code>Fix context overflow, add exception handling, graceful shutdown</code></dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1302/files#diff-3a1fcd28fd2c11a8b6aa52603e7d2a62fd6568b80605db85ae53aeac0d641701">+174/-89</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>model_discovery.cpp</strong><dd><code>Validate model dimensions before loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1302/files#diff-8e5a86a100d1f204ba46c30c372580243c8f23095dd10e80a94f7110a39cd378">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>jarvis_server.cpp</strong><dd><code>Update httplib multipart API usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1302/files#diff-7b1e2d203e21efac45ca8e9b9745856529d5a59dec4643f79df5dcef24581145">+6/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>unified_server.cpp</strong><dd><code>Add exception handler and graceful shutdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1302/files#diff-108a4e5ad06a8667d81e8da41605283a4dff15e0519645becad615fded67977c">+39/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>common.h</strong><dd><code>Add ModelConfig sanity validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1302/files#diff-bc020f3ca1b410d9c45f1a3e744c2b506de509f4c7063cf7755272d69283cdb4">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Security</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>vl_processor.cpp</strong><dd><code>Replace curl with httplib, add SSRF and size caps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1302/files#diff-3484432b29f80613463d57b77d83429e6a3ceb01a290bb5906890faa8bfad3b0">+151/-129</a></td>

</tr>

<tr>
  <td><strong>vl_preprocess.h</strong><dd><code>Add image dimension pre-checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1302/files#diff-81c2037230940d328f32a2888e79261d1598347c1a29526e90c1b43597a91212">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CMakeLists.txt</strong><dd><code>Link httplib to vl_image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1302/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

