### PR TITLE
fix(#1257): align vision_server health schema + add systemd unit

### DIFF
--- a/.github/workflows/end-to-end-smoke.yml
+++ b/.github/workflows/end-to-end-smoke.yml
@@ -196,6 +196,8 @@ jobs:
           assert 'VL' in d.get('service',''), 'wrong service schema'
           assert d.get('model') and d.get('mmproj'), 'missing model/mmproj'
           assert d.get('port') == 8099, 'wrong port'
+          assert d.get('version','').startswith('vision-server-'), 'missing/odd version'
+          assert d.get('uptime',''), 'missing uptime'
           print('OK: vision_server health endpoint')
           "
           curl -sf http://127.0.0.1:8099/v1/models | python3 -c "

--- a/packaging/services/vision-server.service
+++ b/packaging/services/vision-server.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=1bit-systems Vision-Language Inference Server
+Documentation=https://1bit.systems
+After=network.target
+
+[Service]
+Type=simple
+User=1bit
+Group=render
+ExecStart=/opt/1bit-systems/build/vision_server \
+    --port 8099 \
+    --model /opt/1bit-systems/models/Mage-VL-4B.1bp \
+    --mmproj /opt/1bit-systems/models/Mage-ViT.1bp \
+    --tokenizer /opt/1bit-systems/models/qwen3-vl.htok
+Restart=on-failure
+RestartSec=10
+Environment=OMP_NUM_THREADS=16
+DeviceAllow=/dev/accel/accel0 rw
+DeviceAllow=/dev/dri/renderD128 rw
+SupplementaryGroups=render
+
+# Sandboxing
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=false
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+CapabilityBoundingSet=
+# ReadWritePaths needed for ProtectSystem=strict
+ReadWritePaths=/opt/1bit-systems/build
+ReadWritePaths=/opt/1bit-systems/models
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/vision_server.cpp
+++ b/tools/vision_server.cpp
@@ -78,6 +78,7 @@ static std::string g_mmproj_path;
 static std::string g_model_path;
 static std::string g_tokenizer_path;
 static rcpp_tokenizer_t* g_htok = nullptr;
+static time_t g_start_time = 0;
 
 static void handle_sigint(int) { keep_running = false; }
 
@@ -367,6 +368,8 @@ int main(int argc, char** argv) {
         }
     }
 
+    g_start_time = time(nullptr);
+
     if (g_mmproj_path.empty() || g_model_path.empty()) {
         fprintf(stderr, "Usage: %s --mmproj <mmproj.gguf> --model <text.gguf> [--port 8089]\n", argv[0]);
         return 1;
@@ -462,9 +465,11 @@ int main(int argc, char** argv) {
         json j;
         j["status"] = "ok";
         j["service"] = "1bit-systems VL inference server";
+        j["version"] = "vision-server-1.0";
         j["model"] = g_model_path;
         j["mmproj"] = g_mmproj_path;
         j["port"] = g_port;
+        j["uptime"] = std::to_string(g_start_time) + "s";
         res.set_content(j.dump(2), "application/json");
     });
 


### PR DESCRIPTION
### **User description**
Closes remaining points of #1257 (CI coverage already done in #1301).

## What

- **Health schema alignment**: Added `version` ("vision-server-1.0") and `uptime` (server start timestamp) fields to vision_server `/v1/health`, matching the fields unified_server already returns
- **Systemd unit**: New `packaging/services/vision-server.service` with sandboxing (ProtectSystem=strict, NoNewPrivileges, device ACLs for NPU/GPU)
- **CI assertions**: Smoke test now validates `version` and `uptime` fields

## Remaining open issues

- **#1247** (wave32 hardcoded): Deferred LOW priority per audit — 35+ files, ~100+ hardcoded constants. Explicitly marked as deferred in the audit findings.
- **#1243** (legacy 1BP catalog re-conversion): Requires running `gguf_to_onebp` on source GGUF models and PPL-validating each output. Data-processing task, not a code fix.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Align vision_server health schema with unified_server

- Add systemd unit for vision_server with sandboxing

- Update CI smoke test assertions for new health fields

- Track server start time for uptime reporting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["vision_server.cpp"] -- "add version/uptime" --> B["/v1/health"]
  C["vision-server.service"] -- "systemd unit" --> D["vision_server"]
  E["smoke test"] -- "assert new fields" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vision_server.cpp</strong><dd><code>Add version and uptime to health endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/vision_server.cpp

<ul><li>Added <code>g_start_time</code> static variable initialized at startup<br> <li> Added <code>version</code> field ("vision-server-1.0") to <code>/v1/health</code> response<br> <li> Added <code>uptime</code> field (server start timestamp) to <code>/v1/health</code> response</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1303/files#diff-3a1fcd28fd2c11a8b6aa52603e7d2a62fd6568b80605db85ae53aeac0d641701">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>end-to-end-smoke.yml</strong><dd><code>Extend smoke test health assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/end-to-end-smoke.yml

<ul><li>Added assertions for <code>version</code> field starting with "vision-server-"<br> <li> Added assertion for non-empty <code>uptime</code> field in health check</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1303/files#diff-ce7583116dfeff04a5365187d78ae67293490e66e36673d3233b26e96f97023c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vision-server.service</strong><dd><code>Add systemd unit for vision server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packaging/services/vision-server.service

<ul><li>New systemd unit file for vision_server service<br> <li> Includes sandboxing (ProtectSystem=strict, NoNewPrivileges, etc.)<br> <li> Configures device access for NPU/GPU and supplementary groups</ul>


</details>


  </td>
  <td><a href="https://github.com/bong-water-water-bong/1bit-systems/pull/1303/files#diff-a7962c07ab38a7a51804bfc7cdcec8e093f385ccc84c0719c7db79d9c96498db">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

