### PR TITLE
fix: MoE FFN scratch buffer overflow + aliasing in forward_embed

### DIFF
--- a/src/backend_generic.cpp
+++ b/src/backend_generic.cpp
@@ -63,7 +63,7 @@ struct GenericBackend : Backend {
     std::vector<float> scratch_x, scratch_x2, scratch_q, scratch_k, scratch_v;
     std::vector<float> scratch_scores, scratch_att, scratch_gate_up, scratch_silu_buf;
     std::vector<float> scratch_moe_router_probs, scratch_moe_ffn_acc;
-    std::vector<float> scratch_moe_gate, scratch_moe_up, scratch_moe_down;
+    std::vector<float> scratch_moe_gate, scratch_moe_up, scratch_moe_silu, scratch_moe_down;
     std::vector<int> scratch_moe_idx;  // expert index for partial_sort
     std::vector<float> rope_freqs;     // precomputed RoPE frequencies (1/theta^(2i/rot_dim))
     float inv_sqrt_hd_ = 0.0f;         // cached 1/sqrt(head_dim)
@@ -228,7 +228,7 @@ struct GenericBackend : Backend {
         if (cfg.n_experts > 0) {
             scratch_moe_router_probs.resize(cfg.n_experts);
             scratch_moe_ffn_acc.resize(H);
-            scratch_moe_gate.resize(FF); scratch_moe_up.resize(FF); scratch_moe_down.resize(H);
+            scratch_moe_gate.resize(FF); scratch_moe_up.resize(FF); scratch_moe_silu.resize(FF); scratch_moe_down.resize(H);
             scratch_moe_idx.resize(cfg.n_experts);
         }
         scratch_allocated_ = true;
@@ -971,7 +971,7 @@ struct GenericBackend : Backend {
                 memset(ffn_acc, 0, H * sizeof(float));
                 float* gate_buf = scratch_moe_gate.data();
                 float* up_buf = scratch_moe_up.data();
-                float* moe_silu = scratch_moe_down.data();  // reused: scratch_moe_down holds silu output then down output
+                float* moe_silu = scratch_moe_silu.data();  // FF-sized; must NOT alias down_buf (H-sized)
                 float* down_buf = scratch_moe_down.data();
                 for (int t = 0; t < NEU; t++) {
                     int e = idx[t];


### PR DESCRIPTION
### **User description**
Fixes #1342 (CRITICAL, roadmap item).

`scratch_moe_down` was sized `H` (hidden_size) but reused for both the SiLU output (`FF` elements) and the down-projection output (`H` elements):

1. **Heap overflow** — `ffn_activate()` writes `FF` elements into an `H`-sized buffer. Any MoE config with `intermediate_size > hidden_size` (the common case, e.g. Mixtral-8x7B H=4096/FF=14336) overflows on every FFN pass of every token.
2. **In-place aliasing** — `down_buf` and `moe_silu` were the same pointer, so `matmul(out=down_buf, in=moe_silu)` reads input elements already overwritten by concurrent OpenMP row writes — wrong down-projection on every MoE token, independent of (1).

Fix: dedicated `FF`-sized `scratch_moe_silu` buffer, distinct from the `H`-sized `scratch_moe_down`. 3-line change, verified with `g++ -std=c++20 -fsyntax-only` against the repo include tree.

Worth a Mixtral/Qwen2-MoE smoke test on the generic CPU backend before merge (no MoE model available in this environment to run one).


___

### **PR Type**
Bug fix


___

### **Description**
- Fix MoE FFN scratch buffer heap overflow

- Resolve in-place aliasing in down-projection matmul

- Add dedicated FF-sized scratch_moe_silu buffer

- Prevent corruption of every MoE token


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["scratch_moe_down (H-sized)"] -- "was reused for SiLU output" --> B["Heap overflow when FF > H"]
  C["down_buf == moe_silu"] -- "aliased pointers" --> D["Corrupted matmul output"]
  E["New scratch_moe_silu (FF-sized)"] -- "separate buffer" --> F["Correct SiLU output"]
  G["down_buf (H-sized)"] -- "no aliasing" --> H["Correct down-projection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_generic.cpp</strong><dd><code>Add dedicated MoE SiLU scratch buffer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_generic.cpp

<ul><li>Added <code>scratch_moe_silu</code> vector to scratch buffer declarations<br> <li> Resized <code>scratch_moe_silu</code> to <code>FF</code> in <code>init()</code> for MoE configs<br> <li> Changed <code>moe_silu</code> pointer to use new <code>scratch_moe_silu</code> instead of <br><code>scratch_moe_down</code><br> <li> Prevents heap overflow and eliminates in-place aliasing in matmul</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1389/files#diff-82c4d3084e1369da4c917a8935387c33afa514e729d6753dd0bb508a05a8da0e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

