### PR TITLE
fix: restore files cut by ponytail purge (#1325) that were still needed

### DIFF
--- a/engine/npu/kernel/README.md
+++ b/engine/npu/kernel/README.md
@@ -1,0 +1,95 @@
+# NPU AIE Kernels — Qwen3-0.6B Support
+
+## Overview
+
+The NPU engine uses 5 AIE (AI Engine) kernels compiled for the XDNA 2 array on
+Strix Halo. Each kernel runs on the AIE compute tiles and processes one layer
+of the transformer decode pipeline.
+
+## Kernel Pipeline
+
+```
+                    ┌──────────────────────────┐
+                    │  qwen3_decode_kernels     │
+                    │  (main16 Q4NX GEMM)       │
+                    │  QKV, O, G, U, D proj    │
+                    └──────┬───────────┬────────┘
+                           │           │
+                    ┌──────▼──┐  ┌─────▼──────────┐
+                    │postproc │  │  full_vector    │
+                    │_qkv     │  │  _station       │
+                    │RoPE +   │  │  residual add   │
+                    │KV cache │  │  + RMSNorm      │
+                    └────┬────┘  └───────┬─────────┘
+                         │              │
+                    ┌────▼────┐   ┌──────▼─────────┐
+                    │edge_attn│   │   swiglu        │
+                    │QK softmax│  │   SiLU(Gate*Up) │
+                    │×V accum │   │   + Down proj   │
+                    └─────────┘   └────────────────┘
+```
+
+## Model Dimension Constants
+
+### Qwen3-0.6B (defined in `qwen3_constants_06b.h`)
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| H         | 1024  | Hidden size |
+| NH        | 16    | Num Q heads |
+| NKV       | 8     | Num K/V heads |
+| HD        | 128   | Head dimension |
+| IM        | 3072  | Intermediate size (FFN) |
+| NV        | 151936| Vocab size |
+| NC        | 28    | Num layers |
+| AW        | 4     | Attention workers (32-tile grid: 4 cols × 2 rows) |
+| WQH       | 4     | Q heads per worker = NH/AW |
+
+### Key differences from 8B
+| Parameter | 0.6B | 8B | Reason |
+|-----------|------|----|--------|
+| kQBodyRecords | 4 | 8 | Q output = NH×HD = 2048, 2048/512 = 4 |
+| kOBodyRecords | 2 | 8 | O output = H = 1024, 1024/512 = 2 |
+| kKvBodyRecords | 2 | 2 | K/V output = NKV×HD = 1024, same |
+| kUpGateReplays | 12 | 48 | IM=3072, 6 blocks each for UP+GATE |
+| kDownBodyRecords | 2 | 8 | Down output = H = 1024 |
+| kQChunksPerRecord | 4 | 16 | Chunk size = 256, Q in dim = 1024 |
+| kOChunksPerRecord | 8 | 16 | O in dim = 2048 (NH×HD) |
+| kDownChunksPerRecord | 12 | 48 | Down in dim = 3072 (IM) |
+| kHeads (edge_attn) | 4 | 8 | WQH=NH/AW=16/4=4 |
+
+## Kernel Source Files
+
+| Kernel | Source | Status | Notes |
+|--------|--------|--------|-------|
+| main16 Q4NX GEMM | `qwen3_decode_kernels_06b.cc` | ✅ Done | Includes `qwen3_constants_06b.h` |
+| Edge attention | `edge_attention.cc` | ✅ Done | Switchable via `MODEL_QWEN3_8B` / default=0.6B |
+| Post-process QKV | `postprocess_qkv_06b.cc` | ✅ Done | RoPE + KV cache prep. Q=2048, K=V=1024 |
+| Full vector station | `full_vector_station_06b.cc` | ✅ Done | Residual add + RMSNorm, H=1024 |
+| SwiGLU | `swiglu_06b.cc` | ✅ Done | IM-independent LUT-based |
+
+## Building
+
+Kernels require AMD's AIE compiler toolchain (xchesscc/aiecc):
+
+```bash
+# Set up the MLIR/AIE toolchain
+export TORCH2AIE_ROOT=/path/to/torch2aie
+
+# Build all 5 kernels
+bash engine/npu/kernel/build_06b_kernels.sh
+```
+
+For the full fused-layer xclbin, see the MLIR generator at:
+`~/torch2aie/examples/qwen3-decode-layer/cases/`
+
+## MLIR Generation for 0.6B
+
+The fused xclbin is generated from an MLIR design produced by
+`full_layer_engine_generate.py`. To generate a 0.6B design:
+
+1. Create `qwen3_06b_decode_layer_runner` (copied from `qwen3_8b` case)
+2. Override constants to use `qwen3_constants_06b.h` values
+3. Adjust `WEIGHT_PATCH_BD_IDS` for 5 spans instead of 8 (see docs/MLIR-GENERATOR-BLOCKER.md)
+4. Update `link_with` paths to `*_06b.o` kernel objects
+
+See `docs/MLIR-GENERATOR-BLOCKER.md` for the full blocker analysis.

--- a/engine/npu/kernel/build_06b_kernels.sh
+++ b/engine/npu/kernel/build_06b_kernels.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# build_06b_kernels.sh — Compile Qwen3-0.6B NPU AIE kernels
+# Uses AMD AIE compiler toolchain (aiecc/xchesscc) from torch2aie.
+#
+# Prerequisites:
+#   TORCH2AIE_ROOT=/home/bcloud/torch2aie  (or set env)
+#   source $TORCH2AIE_ROOT/setup_env.sh    (sets PATH, LD_LIBRARY_PATH)
+set -euo pipefail
+
+TORCH2AIE_ROOT="${TORCH2AIE_ROOT:-${HOME}/torch2aie}"
+SRCDIR="$(cd "$(dirname "$0")" && pwd)"
+BUILDDIR="${SRCDIR}/../build"
+KERNELDIR="${SRCDIR}"
+OUTDIR="${BUILDDIR}/qwen3_0_6b_kernels"
+mkdir -p "$OUTDIR"
+
+# Toolchain paths
+AIETOOLS="${TORCH2AIE_ROOT}/toolchain/aietools"
+MLIR_AIE="${TORCH2AIE_ROOT}/toolchain/mlir_aie"
+XCHESSCC="${AIETOOLS}/bin/xchesscc_wrapper"
+
+# Include paths for AIE kernel compilation
+INCLUDES=(
+  -I"${KERNELDIR}"
+  -I"${AIETOOLS}/include"
+  -I"${MLIR_AIE}/include"
+  -I"${MLIR_AIE}/include/aie_kernels"
+  -I"${MLIR_AIE}/include/aie_kernels/aie2p"
+)
+
+echo "=== Building Qwen3-0.6B NPU AIE kernels ==="
+echo "Output: ${OUTDIR}"
+echo ""
+
+compile_kernel() {
+    local src="$1"
+    local out="$2"
+    local extra_defs="${3:-}"
+    echo "  Compiling: $(basename "$src") -> $(basename "$out")"
+    $XCHESSCC aie2p \
+        ${extra_defs} \
+        "${INCLUDES[@]}" \
+        -c "$src" \
+        -o "$out"
+}
+
+# 1. main16 Q4NX GEMM/dequant kernel (06b variant)
+compile_kernel \
+    "${KERNELDIR}/qwen3_decode_kernels_06b.cc" \
+    "${OUTDIR}/qwen3_decode_kernels_06b.o"
+
+# 2. Edge attention kernel (06b: kHeads=4 per worker)
+compile_kernel \
+    "${KERNELDIR}/edge_attention.cc" \
+    "${OUTDIR}/edge_attention_06b.o" \
+    "-DMODEL_QWEN3_0_6B"
+
+# 3. Post-process QKV (shared source, uses qwen3_constants_06b.h)
+#    Q=2048bf16 output (NH×HD=16×128) from 1024bf16 input (H)
+#    K=V=1024bf16 output (NKV×HD=8×128) from 1024bf16 input (H)
+compile_kernel \
+    "${KERNELDIR}/postprocess_qkv_06b.cc" \
+    "${OUTDIR}/postprocess_qkv_06b.o"
+
+# 4. Full vector station (residual add + RMSNorm, H=1024)
+compile_kernel \
+    "${KERNELDIR}/full_vector_station_06b.cc" \
+    "${OUTDIR}/full_vector_station_06b.o"
+
+# 5. SwiGLU (IM-independent, same for all models)
+compile_kernel \
+    "${KERNELDIR}/swiglu_06b.cc" \
+    "${OUTDIR}/swiglu_06b.o"
+
+echo ""
+echo "=== All 5 kernels compiled successfully ==="
+ls -lh "${OUTDIR}/"*.o

--- a/engine/npu/kernel/edge_attention.cc
+++ b/engine/npu/kernel/edge_attention.cc
@@ -1,0 +1,356 @@
+#include <aie_api/aie.hpp>
+#include <adf/intrinsics.h>
+#include <stdint.h>
+
+namespace {
+
+// Model selection: define MODEL_QWEN3_8B or MODEL_QWEN3_0_6B before including.
+// Default: Qwen3-0.6B (4 heads per attention worker, WQH = NH/AW = 16/4 = 4)
+#ifdef MODEL_QWEN3_8B
+  constexpr int32_t kHeads = 8;       // NH=32, AW=4, WQH=32/4=8
+  constexpr int32_t kContext = 16;
+  constexpr int32_t kHeadDim = 128;
+  constexpr int32_t kGqaRatio = 4;     // NH/NKV = 32/8
+  constexpr int32_t kWeightDwords = 64;
+  constexpr int32_t kVecLanes = 32;
+#else
+  // Qwen3-0.6B default
+  constexpr int32_t kHeads = 4;        // NH=16, AW=4, WQH=16/4=4
+  constexpr int32_t kContext = 16;
+  constexpr int32_t kHeadDim = 128;
+  constexpr int32_t kGqaRatio = 2;     // NH/NKV = 16/8
+  constexpr int32_t kWeightDwords = 32;
+  constexpr int32_t kVecLanes = 32;
+#endif
+
+constexpr int32_t kAccumLanes = kHeads * kHeadDim;
+constexpr int32_t kStateDwords = kHeads * 2;
+constexpr float kRsqrtHeadDim = 0.0883883476f;
+
+using VecBf16 = aie::vector<bfloat16, kVecLanes>;
+using VecF32 = aie::vector<float, kVecLanes>;
+using AccF32 = aie::accum<accfloat, kVecLanes>;
+
+#ifdef QWEN3_ENABLE_EDGE_ATTENTION_CYCLE_PROFILE
+constexpr int32_t kEdgeProfileMarker = 0x41545450;
+static uint64_t g_init_cycles = 0;
+static uint64_t g_carrier_cycles = 0;
+static uint64_t g_accum_cycles = 0;
+static uint64_t g_finish_cycles = 0;
+static int32_t g_carrier_calls = 0;
+static int32_t g_accum_calls = 0;
+
+__attribute__((always_inline)) static inline uint64_t current_cycles() {
+    return ::aie::tile::current().cycles();
+}
+
+__attribute__((always_inline)) static inline void store_u64_words(
+    int32_t *words,
+    int32_t index,
+    uint64_t value
+) {
+    words[index] = static_cast<int32_t>(value & 0xffffffffULL);
+    words[index + 1] = static_cast<int32_t>(value >> 32);
+}
+
+static void reset_profile() {
+    g_init_cycles = 0;
+    g_carrier_cycles = 0;
+    g_accum_cycles = 0;
+    g_finish_cycles = 0;
+    g_carrier_calls = 0;
+    g_accum_calls = 0;
+}
+
+static void emit_profile_summary(int32_t *output) {
+    output[0] = kEdgeProfileMarker;
+    store_u64_words(output, 1, g_init_cycles);
+    store_u64_words(output, 3, g_carrier_cycles);
+    store_u64_words(output, 5, g_accum_cycles);
+    store_u64_words(output, 7, g_finish_cycles);
+    output[9] = g_carrier_calls;
+    output[10] = g_accum_calls;
+}
+#endif
+
+static bfloat16 bf16_lane(int32_t *payload, int32_t lane) {
+    bfloat16 *values = reinterpret_cast<bfloat16 *>(payload);
+    return values[lane];
+}
+
+static bfloat16 *as_bf16(int32_t *payload) {
+    return reinterpret_cast<bfloat16 *>(payload);
+}
+
+static float *as_f32(int32_t *payload) {
+    return reinterpret_cast<float *>(payload);
+}
+
+static int32_t floor_i32(float value) {
+    const int32_t truncated = static_cast<int32_t>(value);
+    return static_cast<float>(truncated) > value ? truncated - 1 : truncated;
+}
+
+static float pow2_i32(int32_t exponent) {
+    if (exponent < -126) {
+        return 0.0f;
+    }
+    if (exponent > 127) {
+        exponent = 127;
+    }
+    union {
+        uint32_t u;
+        float f;
+    } bits;
+    bits.u = static_cast<uint32_t>(exponent + 127) << 23;
+    return bits.f;
+}
+
+static float fast_exp(float value) {
+    if (value <= -20.0f) {
+        return 0.0f;
+    }
+    if (value >= 0.0f) {
+        return 1.0f;
+    }
+    constexpr float inv_ln2 = 1.4426950409f;
+    constexpr float ln2 = 0.6931471806f;
+    const int32_t exponent = floor_i32(value * inv_ln2);
+    const float reduced = value - static_cast<float>(exponent) * ln2;
+    const float r2 = reduced * reduced;
+    const float r3 = r2 * reduced;
+    const float r4 = r3 * reduced;
+    const float polynomial = 1.0f + reduced + 0.5f * r2 + 0.16666667f * r3 + 0.04166667f * r4;
+    return pow2_i32(exponent) * polynomial;
+}
+
+static float attention_score_bf16(
+    int32_t *q_window,
+    int32_t *k_window,
+    int32_t q_head,
+    int32_t token
+) {
+    const int32_t kv_head = q_head / kGqaRatio;
+    const int32_t q_base = q_head * kHeadDim;
+    const int32_t k_base = kv_head * kContext * kHeadDim + token * kHeadDim;
+    bfloat16 *__restrict q_values = as_bf16(q_window);
+    bfloat16 *__restrict k_values = as_bf16(k_window);
+    AccF32 acc = aie::zeros<accfloat, kVecLanes>();
+    for (int32_t dim = 0; dim < kHeadDim; dim += kVecLanes)
+        chess_prepare_for_pipelining chess_loop_range(4, 4) {
+        VecBf16 q_vec = aie::load_v<kVecLanes>(q_values + q_base + dim);
+        VecBf16 k_vec = aie::load_v<kVecLanes>(k_values + k_base + dim);
+        acc = aie::mac(acc, q_vec, k_vec);
+    }
+    return aie::reduce_add(acc.template to_vector<float>()) * kRsqrtHeadDim;
+}
+
+static void accum_v_block_for_head(
+    bfloat16 *__restrict v_values,
+    bfloat16 *__restrict weights,
+    float *__restrict accum_values,
+    int32_t q_head,
+    float old_scale,
+    float block_scale
+) {
+    const int32_t kv_head = q_head / kGqaRatio;
+    const int32_t q_base = q_head * kHeadDim;
+    const int32_t v_base = kv_head * kContext * kHeadDim;
+    VecF32 old_scale_vec = aie::broadcast<float, kVecLanes>(old_scale);
+    VecF32 block_scale_vec = aie::broadcast<float, kVecLanes>(block_scale);
+    for (int32_t dim = 0; dim < kHeadDim; dim += kVecLanes)
+        chess_prepare_for_pipelining chess_loop_range(4, 4) {
+        AccF32 block_acc = aie::zeros<accfloat, kVecLanes>();
+        for (int32_t token = 0; token < kContext; token++)
+            chess_prepare_for_pipelining chess_loop_range(kContext, kContext) {
+            VecBf16 weight_vec =
+                aie::broadcast<bfloat16, kVecLanes>(weights[q_head * kContext + token]);
+            VecBf16 v_vec =
+                aie::load_v<kVecLanes>(v_values + v_base + token * kHeadDim + dim);
+            block_acc = aie::mac(block_acc, v_vec, weight_vec);
+        }
+        VecF32 old_vec = aie::load_v<kVecLanes>(accum_values + q_base + dim);
+        AccF32 old_scaled = aie::mul(old_vec, old_scale_vec);
+        AccF32 block_scaled = aie::mul(block_acc.template to_vector<float>(), block_scale_vec);
+        old_scaled = aie::add(old_scaled, block_scaled);
+        aie::store_v(accum_values + q_base + dim, old_scaled.template to_vector<float>());
+    }
+}
+
+} // namespace
+
+extern "C" {
+
+void qwen3_attention_bf16_make_carrier_masked(
+    int32_t *q_window,
+    int32_t *k_window,
+    int32_t *carrier,
+    int32_t window,
+    int32_t block,
+    int32_t blocks,
+    int32_t tail_tokens,
+    int32_t q_dwords,
+    int32_t k_dwords,
+    int32_t carrier_dwords
+) {
+#ifdef QWEN3_ENABLE_EDGE_ATTENTION_CYCLE_PROFILE
+    const uint64_t start = current_cycles();
+#endif
+    const int32_t valid_tokens = block + 1 == blocks ? tail_tokens : kContext;
+    bfloat16 *weights = reinterpret_cast<bfloat16 *>(carrier);
+    float *scalars = as_f32(carrier + kWeightDwords);
+    for (int32_t q_head = 0; q_head < kHeads; q_head++) {
+        float scores[kContext];
+        float running_max = attention_score_bf16(q_window, k_window, q_head, 0);
+        scores[0] = running_max;
+        for (int32_t token = 1; token < valid_tokens; token++) {
+            scores[token] = attention_score_bf16(q_window, k_window, q_head, token);
+            if (scores[token] > running_max) {
+                running_max = scores[token];
+            }
+        }
+
+        float weight_sum = 0.0f;
+        for (int32_t token = 0; token < kContext; token++) {
+            float weight = 0.0f;
+            if (token < valid_tokens) {
+                weight = fast_exp(scores[token] - running_max);
+                weight_sum += weight;
+            }
+            weights[q_head * kContext + token] = static_cast<bfloat16>(weight);
+        }
+
+        scalars[q_head * 2] = running_max;
+        scalars[q_head * 2 + 1] = weight_sum;
+    }
+
+    (void)window;
+    (void)q_dwords;
+    (void)k_dwords;
+    (void)carrier_dwords;
+#ifdef QWEN3_ENABLE_EDGE_ATTENTION_CYCLE_PROFILE
+    g_carrier_cycles += current_cycles() - start;
+    g_carrier_calls += 1;
+#endif
+}
+
+void qwen3_attention_bf16_init_accum(
+    int32_t *accum,
+    int32_t *state,
+    int32_t accum_lanes,
+    int32_t state_dwords
+) {
+#ifdef QWEN3_ENABLE_EDGE_ATTENTION_CYCLE_PROFILE
+    reset_profile();
+    const uint64_t start = current_cycles();
+#endif
+    float *accum_values = as_f32(accum);
+    float *state_values = as_f32(state);
+    VecF32 zero_vec = aie::zeros<float, kVecLanes>();
+    for (int32_t idx = 0; idx < kAccumLanes; idx += kVecLanes)
+        chess_prepare_for_pipelining chess_loop_range(32, 32) {
+        aie::store_v(accum_values + idx, zero_vec);
+    }
+    aie::vector<float, kStateDwords> zero_state = aie::zeros<float, kStateDwords>();
+    aie::store_v(state_values, zero_state);
+
+    (void)accum_lanes;
+    (void)state_dwords;
+#ifdef QWEN3_ENABLE_EDGE_ATTENTION_CYCLE_PROFILE
+    g_init_cycles = current_cycles() - start;
+#endif
+}
+
+void qwen3_attention_bf16_accum_block(
+    int32_t *v_window,
+    int32_t *carrier,
+    int32_t *accum,
+    int32_t *state,
+    int32_t block,
+    int32_t v_dwords,
+    int32_t carrier_dwords,
+    int32_t accum_lanes,
+    int32_t state_dwords
+) {
+#ifdef QWEN3_ENABLE_EDGE_ATTENTION_CYCLE_PROFILE
+    const uint64_t start = current_cycles();
+#endif
+    bfloat16 *weights = reinterpret_cast<bfloat16 *>(carrier);
+    float *scalars = as_f32(carrier + kWeightDwords);
+    float *accum_values = as_f32(accum);
+    float *state_values = as_f32(state);
+    bfloat16 *v_values = as_bf16(v_window);
+
+    for (int32_t q_head = 0; q_head < kHeads; q_head++) {
+        const float block_max = scalars[q_head * 2];
+        const float block_sum = scalars[q_head * 2 + 1];
+        if (block_sum == 0.0f) {
+            continue;
+        }
+        const float old_max = state_values[q_head * 2];
+        const float old_sum = state_values[q_head * 2 + 1];
+        float new_max = block_max;
+        float old_scale = 0.0f;
+        float block_scale = 1.0f;
+        if (old_sum != 0.0f) {
+            new_max = old_max > block_max ? old_max : block_max;
+            old_scale = fast_exp(old_max - new_max);
+            block_scale = fast_exp(block_max - new_max);
+        }
+
+        accum_v_block_for_head(v_values, weights, accum_values, q_head, old_scale, block_scale);
+
+        state_values[q_head * 2] = new_max;
+        state_values[q_head * 2 + 1] = old_sum * old_scale + block_sum * block_scale;
+    }
+
+    (void)block;
+    (void)v_dwords;
+    (void)carrier_dwords;
+    (void)accum_lanes;
+    (void)state_dwords;
+#ifdef QWEN3_ENABLE_EDGE_ATTENTION_CYCLE_PROFILE
+    g_accum_cycles += current_cycles() - start;
+    g_accum_calls += 1;
+#endif
+}
+
+void qwen3_attention_bf16_finish_accum(
+    int32_t *accum,
+    int32_t *state,
+    int32_t *output,
+    int32_t output_dwords,
+    int32_t accum_lanes,
+    int32_t state_dwords
+) {
+#ifdef QWEN3_ENABLE_EDGE_ATTENTION_CYCLE_PROFILE
+    const uint64_t start = current_cycles();
+#endif
+    ::aie::set_rounding(aie::rounding_mode::conv_even);
+    float *accum_values = as_f32(accum);
+    float *state_values = as_f32(state);
+    bfloat16 *payload = reinterpret_cast<bfloat16 *>(output);
+    for (int32_t idx = 0; idx < output_dwords * 2; idx++) {
+        payload[idx] = static_cast<bfloat16>(0.0f);
+    }
+    for (int32_t q_head = 0; q_head < kHeads; q_head++) {
+        const float weight_sum = state_values[q_head * 2 + 1];
+        const VecF32 inv_sum_vec = aie::broadcast<float, kVecLanes>(1.0f / weight_sum);
+        for (int32_t dim = 0; dim < kHeadDim; dim += kVecLanes)
+            chess_prepare_for_pipelining chess_loop_range(4, 4) {
+            const int32_t lane = q_head * kHeadDim + dim;
+            VecF32 accum_vec = aie::load_v<kVecLanes>(accum_values + lane);
+            AccF32 scaled = aie::mul(accum_vec, inv_sum_vec);
+            aie::store_v(payload + lane, scaled.template to_vector<bfloat16>());
+        }
+    }
+
+    (void)accum_lanes;
+    (void)state_dwords;
+#ifdef QWEN3_ENABLE_EDGE_ATTENTION_CYCLE_PROFILE
+    g_finish_cycles = current_cycles() - start;
+    emit_profile_summary(output);
+#endif
+}
+
+} // extern "C"

--- a/engine/npu/kernel/edge_attention_06b_compact.cc
+++ b/engine/npu/kernel/edge_attention_06b_compact.cc
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// edge_attention_06b_compact.cc — L2-optimized attention kernel for Qwen3-0.6B
+//
+// Fixes "Resource allocation blocked (L2 48KB limit)" by reducing per-tile
+// buffer footprint:
+//   1. kContext=8 (half-block), attention done in 2 passes → K/V window halved
+//   2. kHeads=4 (WQH=NH/AW=16/4=4)
+//   3. No cycle profiling (saves ~1KB of .data LUT constants)
+//
+// L2 budget per tile:
+//   Q window: 4 × 128 × 2 = 1,024 B
+//   K window: 2 × 8 × 128 × 2 = 4,096 B  (was 8,192 with kContext=16)
+//   V window: same = 4,096 B             (was 8,192)
+//   Carrier: 4 × 8 × 2 + 4 × 2 × 4 = 64 + 32 = 96 B
+//   Accum: 4 × 128 × 4 = 2,048 B
+//   State: 4 × 2 × 4 = 32 B
+//   Scratch/scores[8]: 32 B
+//   MLIR DMA descriptors + locks: ~4 KB
+//   Total: ~15 KB ✓ (within 48 KB)
+
+#include <aie_api/aie.hpp>
+#include <adf/intrinsics.h>
+#include <stdint.h>
+
+namespace {
+
+constexpr int32_t kHeads = 4;          // WQH = NH/AW = 16/4
+constexpr int32_t kContext = 8;        // Half-block (2 passes for full 16)
+constexpr int32_t kHeadDim = 128;
+constexpr int32_t kGqaRatio = 2;      // NH/NKV = 16/8
+constexpr int32_t kWeightDwords = 32; // kHeads * kContext * 2 + kHeads * 2 = 72 → round up
+constexpr int32_t kVecLanes = 32;
+constexpr int32_t kAccumLanes = kHeads * kHeadDim;
+constexpr int32_t kStateDwords = kHeads * 2;
+constexpr float kRsqrtHeadDim = 0.0883883476f;
+
+using VecBf16 = aie::vector<bfloat16, kVecLanes>;
+using VecF32 = aie::vector<float, kVecLanes>;
+using AccF32 = aie::accum<accfloat, kVecLanes>;
+
+static bfloat16 *as_bf16(int32_t *payload) {
+    return reinterpret_cast<bfloat16 *>(payload);
+}
+
+static float *as_f32(int32_t *payload) {
+    return reinterpret_cast<float *>(payload);
+}
+
+// Fast exp approximation for negative inputs in range [-20, 0]
+static float fast_exp(float value) {
+    if (value <= -20.0f) return 0.0f;
+    if (value >= 0.0f) return 1.0f;
+    constexpr float inv_ln2 = 1.4426950409f;
+    constexpr float ln2 = 0.6931471806f;
+    int32_t exponent;
+    float reduced = __builtin_frexpf(value * inv_ln2, &exponent);
+    // frexp gives mantissa in [0.5, 1.0), but we want floor
+    // Use the polynomial on the fractional part
+    reduced = value - (float)exponent * ln2;
+    float r2 = reduced * reduced;
+    float r3 = r2 * reduced;
+    float r4 = r3 * reduced;
+    float poly = 1.0f + reduced + 0.5f * r2 + 0.16666667f * r3 + 0.04166667f * r4;
+    union { uint32_t u; float f; } bits;
+    bits.u = (uint32_t)(exponent + 127) << 23;
+    return bits.f * poly;
+}
+
+static float attention_score_bf16(
+    int32_t *q_window,
+    int32_t *k_window,
+    int32_t q_head,
+    int32_t token
+) {
+    const int32_t kv_head = q_head / kGqaRatio;
+    const int32_t q_base = q_head * kHeadDim;
+    const int32_t k_base = kv_head * kContext * kHeadDim + token * kHeadDim;
+    bfloat16 *__restrict q_values = as_bf16(q_window);
+    bfloat16 *__restrict k_values = as_bf16(k_window);
+    AccF32 acc = aie::zeros<accfloat, kVecLanes>();
+    for (int32_t dim = 0; dim < kHeadDim; dim += kVecLanes)
+        chess_prepare_for_pipelining chess_loop_range(4, 4) {
+        VecBf16 q_vec = aie::load_v<kVecLanes>(q_values + q_base + dim);
+        VecBf16 k_vec = aie::load_v<kVecLanes>(k_values + k_base + dim);
+        acc = aie::mac(acc, q_vec, k_vec);
+    }
+    return aie::reduce_add(acc.template to_vector<float>()) * kRsqrtHeadDim;
+}
+
+static void accum_v_block_for_head(
+    bfloat16 *__restrict v_values,
+    bfloat16 *__restrict weights,
+    float *__restrict accum_values,
+    int32_t q_head,
+    float old_scale,
+    float block_scale
+) {
+    const int32_t kv_head = q_head / kGqaRatio;
+    const int32_t q_base = q_head * kHeadDim;
+    const int32_t v_base = kv_head * kContext * kHeadDim;
+    VecF32 old_scale_vec = aie::broadcast<float, kVecLanes>(old_scale);
+    VecF32 block_scale_vec = aie::broadcast<float, kVecLanes>(block_scale);
+    for (int32_t dim = 0; dim < kHeadDim; dim += kVecLanes)
+        chess_prepare_for_pipelining chess_loop_range(4, 4) {
+        AccF32 block_acc = aie::zeros<accfloat, kVecLanes>();
+        for (int32_t token = 0; token < kContext; token++)
+            chess_prepare_for_pipelining chess_loop_range(kContext, kContext) {
+            VecBf16 weight_vec =
+                aie::broadcast<bfloat16, kVecLanes>(weights[q_head * kContext + token]);
+            VecBf16 v_vec =
+                aie::load_v<kVecLanes>(v_values + v_base + token * kHeadDim + dim);
+            block_acc = aie::mac(block_acc, v_vec, weight_vec);
+        }
+        VecF32 old_vec = aie::load_v<kVecLanes>(accum_values + q_base + dim);
+        AccF32 old_scaled = aie::mul(old_vec, old_scale_vec);
+        AccF32 block_scaled = aie::mul(block_acc.template to_vector<float>(), block_scale_vec);
+        old_scaled = aie::add(old_scaled, block_scaled);
+        aie::store_v(accum_values + q_base + dim, old_scaled.template to_vector<float>());
+    }
+}
+
+} // namespace
+
+extern "C" {
+
+void qwen3_attention_bf16_make_carrier_masked(
+    int32_t *q_window, int32_t *k_window, int32_t *carrier, int32_t window,
+    int32_t block, int32_t blocks, int32_t tail_tokens, int32_t q_dwords,
+    int32_t k_dwords, int32_t carrier_dwords) {
+    const int32_t valid_tokens = block + 1 == blocks ? tail_tokens : kContext;
+    bfloat16 *weights = reinterpret_cast<bfloat16 *>(carrier);
+    float *scalars = as_f32(carrier + kWeightDwords);
+    for (int32_t q_head = 0; q_head < kHeads; q_head++) {
+        float scores[kContext];
+        float running_max = attention_score_bf16(q_window, k_window, q_head, 0);
+        scores[0] = running_max;
+        for (int32_t token = 1; token < valid_tokens; token++) {
+            scores[token] = attention_score_bf16(q_window, k_window, q_head, token);
+            if (scores[token] > running_max) running_max = scores[token];
+        }
+        float weight_sum = 0.0f;
+        for (int32_t token = 0; token < kContext; token++) {
+            float weight = 0.0f;
+            if (token < valid_tokens) {
+                weight = fast_exp(scores[token] - running_max);
+                weight_sum += weight;
+            }
+            weights[q_head * kContext + token] = static_cast<bfloat16>(weight);
+        }
+        scalars[q_head * 2] = running_max;
+        scalars[q_head * 2 + 1] = weight_sum;
+    }
+    (void)window;
+    (void)q_dwords;
+    (void)k_dwords;
+    (void)carrier_dwords;
+}
+
+void qwen3_attention_bf16_init_accum(
+    int32_t *accum, int32_t *state, int32_t accum_lanes, int32_t state_dwords) {
+    float *accum_values = as_f32(accum);
+    float *state_values = as_f32(state);
+    VecF32 zero_vec = aie::zeros<float, kVecLanes>();
+    for (int32_t idx = 0; idx < kAccumLanes; idx += kVecLanes)
+        chess_prepare_for_pipelining chess_loop_range(16, 16) {
+        aie::store_v(accum_values + idx, zero_vec);
+    }
+    aie::vector<float, kStateDwords> zero_state = aie::zeros<float, kStateDwords>();
+    aie::store_v(state_values, zero_state);
+    (void)accum_lanes;
+    (void)state_dwords;
+}
+
+void qwen3_attention_bf16_accum_block(
+    int32_t *v_window, int32_t *carrier, int32_t *accum, int32_t *state,
+    int32_t block, int32_t v_dwords, int32_t carrier_dwords,
+    int32_t accum_lanes, int32_t state_dwords) {
+    bfloat16 *weights = reinterpret_cast<bfloat16 *>(carrier);
+    float *scalars = as_f32(carrier + kWeightDwords);
+    float *accum_values = as_f32(accum);
+    float *state_values = as_f32(state);
+    bfloat16 *v_values = as_bf16(v_window);
+    for (int32_t q_head = 0; q_head < kHeads; q_head++) {
+        const float block_max = scalars[q_head * 2];
+        const float block_sum = scalars[q_head * 2 + 1];
+        if (block_sum == 0.0f) continue;
+        const float old_max = state_values[q_head * 2];
+        const float old_sum = state_values[q_head * 2 + 1];
+        float new_max = block_max;
+        float old_scale = 0.0f;
+        float block_scale = 1.0f;
+        if (old_sum != 0.0f) {
+            new_max = old_max > block_max ? old_max : block_max;
+            old_scale = fast_exp(old_max - new_max);
+            block_scale = fast_exp(block_max - new_max);
+        }
+        accum_v_block_for_head(v_values, weights, accum_values, q_head, old_scale, block_scale);
+        state_values[q_head * 2] = new_max;
+        state_values[q_head * 2 + 1] = old_sum * old_scale + block_sum * block_scale;
+    }
+    (void)block;
+    (void)v_dwords;
+    (void)carrier_dwords;
+    (void)accum_lanes;
+    (void)state_dwords;
+}
+
+void qwen3_attention_bf16_finish_accum(
+    int32_t *accum, int32_t *state, int32_t *output, int32_t output_dwords,
+    int32_t accum_lanes, int32_t state_dwords) {
+    ::aie::set_rounding(aie::rounding_mode::conv_even);
+    float *accum_values = as_f32(accum);
+    float *state_values = as_f32(state);
+    bfloat16 *payload = reinterpret_cast<bfloat16 *>(output);
+    for (int32_t idx = 0; idx < output_dwords * 2; idx++)
+        payload[idx] = static_cast<bfloat16>(0.0f);
+    for (int32_t q_head = 0; q_head < kHeads; q_head++) {
+        const float weight_sum = state_values[q_head * 2 + 1];
+        const VecF32 inv_sum_vec = aie::broadcast<float, kVecLanes>(1.0f / weight_sum);
+        for (int32_t dim = 0; dim < kHeadDim; dim += kVecLanes)
+            chess_prepare_for_pipelining chess_loop_range(4, 4) {
+            const int32_t lane = q_head * kHeadDim + dim;
+            VecF32 accum_vec = aie::load_v<kVecLanes>(accum_values + lane);
+            AccF32 scaled = aie::mul(accum_vec, inv_sum_vec);
+            aie::store_v(payload + lane, scaled.template to_vector<bfloat16>());
+        }
+    }
+    (void)output_dwords;
+    (void)accum_lanes;
+    (void)state_dwords;
+}
+
+} // extern "C"

--- a/engine/npu/kernel/full_vector_station_06b.cc
+++ b/engine/npu/kernel/full_vector_station_06b.cc
@@ -1,0 +1,262 @@
+#include <aie_api/aie.hpp>
+#include <stdint.h>
+
+namespace {
+
+constexpr int32_t kRmsVecLanes = 32;
+constexpr int32_t kFullVectorBlockLanes = 512;
+constexpr int32_t kFullVectorAddLanes = 16;
+
+#ifdef QWEN3_ENABLE_FULL_VECTOR_CYCLE_PROFILE
+constexpr int32_t kFullVectorProfileMarker = 0x46564c50;
+static uint64_t g_input_norm_cycles = 0;
+static uint64_t g_post_norm_cycles = 0;
+static uint64_t g_o_cycles = 0;
+static uint64_t g_down_cycles = 0;
+static int32_t g_o_blocks = 0;
+static int32_t g_down_blocks = 0;
+
+__attribute__((always_inline)) static inline uint64_t current_cycles() {
+    return ::aie::tile::current().cycles();
+}
+
+__attribute__((always_inline)) static inline void store_u64_words(
+    int32_t *words,
+    int32_t index,
+    uint64_t value
+) {
+    words[index] = static_cast<int32_t>(value & 0xffffffffULL);
+    words[index + 1] = static_cast<int32_t>(value >> 32);
+}
+
+static void reset_profile() {
+    g_input_norm_cycles = 0;
+    g_post_norm_cycles = 0;
+    g_o_cycles = 0;
+    g_down_cycles = 0;
+    g_o_blocks = 0;
+    g_down_blocks = 0;
+}
+
+static void emit_profile_summary(int32_t *output) {
+    output[0] = kFullVectorProfileMarker;
+    store_u64_words(output, 1, g_input_norm_cycles);
+    store_u64_words(output, 3, g_post_norm_cycles);
+    store_u64_words(output, 5, g_o_cycles);
+    store_u64_words(output, 7, g_down_cycles);
+    output[9] = g_o_blocks;
+    output[10] = g_down_blocks;
+}
+#endif
+
+static bfloat16 *as_bf16(int32_t *words) {
+    return reinterpret_cast<bfloat16 *>(words);
+}
+
+static uint16_t bf16_bits(float value) {
+    union {
+        float f32;
+        uint32_t u32;
+    } bits = {value};
+    const uint32_t lsb = (bits.u32 >> 16) & 1u;
+    bits.u32 += 0x7fffu + lsb;
+    return static_cast<uint16_t>(bits.u32 >> 16);
+}
+
+static bfloat16 bf16_rne(float value) {
+    bfloat16 output;
+    reinterpret_cast<uint16_t *>(&output)[0] = bf16_bits(value);
+    return output;
+}
+
+static void store_bf16_rne(bfloat16 *values, int32_t lane, float value) {
+    reinterpret_cast<uint16_t *>(values)[lane] = bf16_bits(value);
+}
+
+static float fast_rsqrt(float value) {
+    if (value <= 0.0f) {
+        return 1.0f;
+    }
+    float y = 1.0f;
+    if (value < 0.000244140625f) {
+        y = 64.0f;
+    } else if (value < 0.0009765625f) {
+        y = 32.0f;
+    } else if (value < 0.00390625f) {
+        y = 16.0f;
+    } else if (value < 0.015625f) {
+        y = 8.0f;
+    } else if (value < 0.0625f) {
+        y = 4.0f;
+    } else if (value < 0.25f) {
+        y = 2.0f;
+    } else if (value > 1.0f) {
+        y = 0.5f;
+    }
+    if (value > 4.0f) {
+        y = 0.25f;
+    }
+    if (value > 16.0f) {
+        y = 0.125f;
+    }
+    const float half = value * 0.5f;
+    for (int32_t iter = 0; iter < 10; iter++)
+        chess_prepare_for_pipelining chess_loop_range(10, 10) {
+        y = y * (1.5f - half * y * y);
+    }
+    return y;
+}
+
+static float rms_scale(bfloat16 *__restrict values, int32_t lanes) {
+    const int32_t vector_lanes = lanes & ~(kRmsVecLanes - 1);
+    aie::accum<accfloat, kRmsVecLanes> sum_acc =
+        aie::zeros<accfloat, kRmsVecLanes>();
+    for (int32_t lane = 0; lane < vector_lanes; lane += kRmsVecLanes)
+        chess_prepare_for_pipelining chess_loop_range(128, 128) {
+        aie::vector<bfloat16, kRmsVecLanes> value_vec =
+            aie::load_v<kRmsVecLanes>(values + lane);
+        sum_acc = aie::mac(sum_acc, value_vec, value_vec);
+    }
+    float sum_sq = aie::reduce_add(sum_acc.template to_vector<float>());
+    for (int32_t lane = vector_lanes; lane < lanes; lane++) {
+        const float value = static_cast<float>(values[lane]);
+        sum_sq += value * value;
+    }
+    constexpr float eps = 0.000001f;
+    return fast_rsqrt(sum_sq / static_cast<float>(lanes) + eps);
+}
+
+static void write_weighted_rms_values(
+    bfloat16 *values,
+    bfloat16 *weight,
+    bfloat16 *payload,
+    int32_t lanes
+) {
+    const float scale = rms_scale(values, lanes);
+    for (int32_t lane = 0; lane < lanes; lane++)
+        chess_prepare_for_pipelining chess_loop_range(1, 4096) {
+        store_bf16_rne(
+            payload,
+            lane,
+            static_cast<float>(values[lane]) * scale * static_cast<float>(weight[lane])
+        );
+    }
+}
+
+static void add_bf16_block_inplace(
+    bfloat16 *__restrict values,
+    bfloat16 *__restrict rhs,
+    int32_t base
+) {
+    ::aie::set_rounding(aie::rounding_mode::conv_even);
+    for (int32_t lane = 0; lane < kFullVectorBlockLanes; lane += kFullVectorAddLanes)
+        chess_prepare_for_pipelining chess_loop_range(
+            kFullVectorBlockLanes / kFullVectorAddLanes,
+            kFullVectorBlockLanes / kFullVectorAddLanes
+        ) {
+        const int32_t global_lane = base + lane;
+        aie::vector<bfloat16, kFullVectorAddLanes> value_vec =
+            aie::load_v<kFullVectorAddLanes, aie_dm_resource::a>(values + global_lane);
+        aie::vector<bfloat16, kFullVectorAddLanes> rhs_vec =
+            aie::load_unaligned_v<kFullVectorAddLanes, aie_dm_resource::b>(rhs + lane, 2);
+        aie::accum<accfloat, kFullVectorAddLanes> value_acc(value_vec);
+        aie::accum<accfloat, kFullVectorAddLanes> rhs_acc(rhs_vec);
+        aie::accum<accfloat, kFullVectorAddLanes> sum = aie::add(value_acc, rhs_acc);
+        aie::store_v<aie_dm_resource::a>(values + global_lane, sum.template to_vector<bfloat16>());
+    }
+    chess_separator_scheduler();
+}
+
+static void add_bf16_block_out(
+    bfloat16 *__restrict lhs,
+    bfloat16 *__restrict rhs,
+    bfloat16 *__restrict output,
+    int32_t base
+) {
+    ::aie::set_rounding(aie::rounding_mode::conv_even);
+    for (int32_t lane = 0; lane < kFullVectorBlockLanes; lane += kFullVectorAddLanes)
+        chess_prepare_for_pipelining chess_loop_range(
+            kFullVectorBlockLanes / kFullVectorAddLanes,
+            kFullVectorBlockLanes / kFullVectorAddLanes
+        ) {
+        const int32_t global_lane = base + lane;
+        aie::vector<bfloat16, kFullVectorAddLanes> lhs_vec =
+            aie::load_v<kFullVectorAddLanes, aie_dm_resource::a>(lhs + global_lane);
+        aie::vector<bfloat16, kFullVectorAddLanes> rhs_vec =
+            aie::load_unaligned_v<kFullVectorAddLanes, aie_dm_resource::b>(rhs + lane, 2);
+        aie::accum<accfloat, kFullVectorAddLanes> lhs_acc(lhs_vec);
+        aie::accum<accfloat, kFullVectorAddLanes> rhs_acc(rhs_vec);
+        aie::accum<accfloat, kFullVectorAddLanes> sum = aie::add(lhs_acc, rhs_acc);
+        aie::store_v(output + global_lane, sum.template to_vector<bfloat16>());
+    }
+    chess_separator_scheduler();
+}
+
+} // namespace
+
+extern "C" {
+
+void full_c1r2_make_input_norm_payload(
+    int32_t *hidden,
+    int32_t *norm_weight,
+    int32_t *payload,
+    int32_t payload_dwords
+) {
+#ifdef QWEN3_ENABLE_FULL_VECTOR_CYCLE_PROFILE
+    reset_profile();
+    const uint64_t start = current_cycles();
+#endif
+    write_weighted_rms_values(as_bf16(hidden), as_bf16(norm_weight), as_bf16(payload), payload_dwords * 2);
+#ifdef QWEN3_ENABLE_FULL_VECTOR_CYCLE_PROFILE
+    g_input_norm_cycles = current_cycles() - start;
+#endif
+}
+
+void full_c1r2_add_o_compact_to_residual(int32_t *hidden, int32_t *compact, int32_t block) {
+    bfloat16 *residual = as_bf16(hidden);
+    bfloat16 *compact_payload = as_bf16(compact + 1);
+    const int32_t base = block * kFullVectorBlockLanes;
+#ifdef QWEN3_ENABLE_FULL_VECTOR_CYCLE_PROFILE
+    const uint64_t start = current_cycles();
+#endif
+    add_bf16_block_inplace(residual, compact_payload, base);
+#ifdef QWEN3_ENABLE_FULL_VECTOR_CYCLE_PROFILE
+    g_o_cycles += current_cycles() - start;
+    g_o_blocks += 1;
+#endif
+}
+
+void full_c1r2_make_post_norm_payload(
+    int32_t *residual,
+    int32_t *norm_weight,
+    int32_t *payload,
+    int32_t payload_dwords
+) {
+#ifdef QWEN3_ENABLE_FULL_VECTOR_CYCLE_PROFILE
+    const uint64_t start = current_cycles();
+#endif
+    write_weighted_rms_values(as_bf16(residual), as_bf16(norm_weight), as_bf16(payload), payload_dwords * 2);
+#ifdef QWEN3_ENABLE_FULL_VECTOR_CYCLE_PROFILE
+    g_post_norm_cycles = current_cycles() - start;
+#endif
+}
+
+void full_c1r2_write_down_block(int32_t *residual, int32_t *compact, int32_t *output, int32_t block) {
+    bfloat16 *residual_values = as_bf16(residual);
+    bfloat16 *compact_payload = as_bf16(compact + 1);
+    bfloat16 *output_values = as_bf16(output);
+    const int32_t base = block * kFullVectorBlockLanes;
+#ifdef QWEN3_ENABLE_FULL_VECTOR_CYCLE_PROFILE
+    const uint64_t start = current_cycles();
+#endif
+    add_bf16_block_out(residual_values, compact_payload, output_values, base);
+#ifdef QWEN3_ENABLE_FULL_VECTOR_CYCLE_PROFILE
+    g_down_cycles += current_cycles() - start;
+    g_down_blocks += 1;
+    if (block == 7) {
+        emit_profile_summary(output);
+    }
+#endif
+}
+
+} // extern "C"

--- a/engine/npu/kernel/mm_binary_q1.cc
+++ b/engine/npu/kernel/mm_binary_q1.cc
@@ -1,0 +1,84 @@
+//===- mm_binary_q1.cc -------------------------------------------*- C++ -*-===//
+//
+// Phase 4: Q1_0 (1-bit binary) AIE microkernel — XDNA 2 (NPU2)
+//
+// Q1_0 packs 1 bit per value: 128 sign bits + 1 fp16 scale per 128-element group.
+// bit = 0 → -scale, bit = 1 → +scale
+// Storage: ceil(K/128) * 18 bytes per column (vs 16 for TQ2, 13 for TQ1)
+//
+// Licensed under Apache 2.0 with LLVM Exceptions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie_kernel_utils.h"
+#include <aie_api/aie.hpp>
+
+constexpr int M_TILE = 32;
+constexpr int K_TILE = 64;
+constexpr int N_TILE = 128;
+
+// Q1_0: 128 elements per block, 16 bytes sign bits + 2 bytes fp16 scale = 18 bytes
+constexpr int Q1_BLOCK_K = 128;
+constexpr int Q1_BLOCK_BYTES = 18;
+constexpr int Q1_SIGN_BYTES = 16;
+constexpr int Q1_BYTES_PER_COL = (K_TILE + Q1_BLOCK_K - 1) / Q1_BLOCK_K * Q1_BLOCK_BYTES; // = 18 for K=64
+
+extern "C" {
+
+static int g_counter = 0;
+
+void binary_q1_gemv(bfloat16 *pA, uint8_t *pB,
+                     bfloat16 *pS, bfloat16 *pC) {
+    event0();
+    pC += g_counter * M_TILE * N_TILE;
+    if (g_counter == 3) g_counter = 0; else g_counter++;
+
+    // Decode 1-bit weights to int8 {-1, +1} × scale
+    alignas(32) int8_t w_dec[N_TILE * K_TILE];
+    for (int n = 0; n < N_TILE; n++) {
+        auto *src = pB + n * Q1_BYTES_PER_COL;
+        auto *dst = w_dec + n * K_TILE;
+        // One 128-bit block (K=64 < 128, so one block with 64 valid bits)
+        // fp16 scale at offset Q1_SIGN_BYTES
+        // We process the first 64 bits
+        uint16_t scale_bits;
+        __builtin_memcpy(&scale_bits, src + Q1_SIGN_BYTES, 2);
+        float scale = [](uint16_t h) {
+            uint32_t s = (h >> 15) & 1, e = (h >> 10) & 0x1f, m = h & 0x3ff;
+            float sign = s ? -1.0f : 1.0f;
+            if (e == 0) return sign * (float)m * 5.9604644775390625e-08f;
+            if (e == 31) return m ? 0.0f : sign * 1.0f / 0.0f;
+            return sign * (1.0f + (float)m / 1024.0f) * (float)(1 << (e - 15));
+        }(scale_bits);
+        // Load 8 bytes of sign bits (64 bits for K=64)
+        uint64_t bits;
+        __builtin_memcpy(&bits, src, 8);
+        for (int i = 0; i < K_TILE; i++) {
+            dst[i] = (bits & ((uint64_t)1 << i)) ? (int8_t)(scale) : (int8_t)(-scale);
+        }
+    }
+
+    // Accumulate
+    for (int m = 0; m < M_TILE; m++) {
+        for (int n = 0; n < N_TILE; n++) {
+            float sum = 0.0f;
+            auto *w = w_dec + n * K_TILE;
+            auto *a = pA + m * K_TILE;
+            for (int k = 0; k < K_TILE; k++) {
+                sum += (float)w[k] * (float)a[k];
+            }
+            pC[m * N_TILE + n] += (bfloat16)sum;
+        }
+    }
+
+    event1();
+}
+
+void zero_kernel_q1(bfloat16 *cOut) {
+    constexpr int N = M_TILE * N_TILE;
+    constexpr int r = 512 / 16;
+    auto zeros = aie::zeros<bfloat16, r>();
+    for (int i = 0; i < N; i += r)
+        aie::store_v(cOut + i, zeros);
+}
+}

--- a/engine/npu/kernel/mm_ternary_tq1.cc
+++ b/engine/npu/kernel/mm_ternary_tq1.cc
@@ -1,0 +1,124 @@
+// mm_ternary_tq1.cc — TQ1 1.58-bit ternary NPU kernel with base-3 LUT decode + ping-pong
+//
+// TQ1 packing: 5 ternary values per byte using base-3 encoding
+//   packed = code0 + code1*3 + code2*9 + code3*27 + code4*81
+//   codes: 0=-1, 1=0, 2=+1
+//   Per 5-element group: 1 BF16 scale + 1 byte codes (+ padding to 256 cols)
+//
+// Ping-pong: same as mm_ternary_tq2.cc — decode next K-block while MAC runs
+//
+// Licensed under Apache 2.0 with LLVM Exceptions.
+
+#include "aie_kernel_utils.h"
+#include <aie_api/aie.hpp>
+
+constexpr int M = 32, K = 64, N = 128;
+
+// TQ1 tile geometry: ceil(256/5) = 52 codes + 16 scales per tile row
+constexpr int TQ1_CODES_PER_ROW = 256;
+constexpr int TQ1_GROUPS_PER_ROW = (TQ1_CODES_PER_ROW + 4) / 5;  // 52
+constexpr int TQ1_SCALES_PER_ROW = TQ1_GROUPS_PER_ROW;
+
+extern "C" {
+
+// ── Base-3 LUT: maps byte (packed 5 ternary codes) to 5 int8 values ──
+// LUT[byte] = {v0, v1, v2, v3, v4} as packed bytes
+// code 0=-1, 1=0, 2=+1
+// Generated at compile time from the base-3 expansion
+static int8_t tq1_lut[243][5];  // 3^5 = 243 valid combinations
+
+// Initialize the LUT once at boot (called from init)
+void init_tq1_lut() {
+    for (int p = 0; p < 243; p++) {
+        int tmp = p;
+        for (int i = 0; i < 5; i++) {
+            int code = tmp % 3;
+            tmp /= 3;
+            tq1_lut[p][i] = (code == 0) ? -1 : (code == 2) ? 1 : 0;
+        }
+    }
+}
+
+// ── Ping-pong TQ1 ternary GEMV ──
+// pA: activations (M×K bf16)
+// pB: TQ1 packed codes + scales interleaved per tile row
+//     [n_tile_rows]: [r0: scales(52*2=104B) + codes(52B)] [r1: same] ...
+// pC: output (M×N bf16)
+void ternary_tq1_gemv(bfloat16 *pA, uint8_t *pB, bfloat16 *pS, bfloat16 *pC) {
+    event0();
+
+    alignas(32) bfloat16 wb_ping[N * K];
+    alignas(32) bfloat16 wb_pong[N * K];
+    alignas(32) bfp16ebs8 w_bfp_ping[N / 8 * K / 8];
+    alignas(32) bfp16ebs8 w_bfp_pong[N / 8 * K / 8];
+    alignas(32) bfp16ebs8 a_bfp[M * K / 64];
+    alignas(32) bfloat16 tmp[64];
+
+    bool ping = true;
+
+    // ── Stage 1: Decode first TQ1 block into ping ──
+    {
+        // TQ1 layout for N=128, K=64:
+        // pB has ceil(128/TILE_COLS)=1 tile row
+        // Each tile row: TQ1_GROUPS_PER_ROW scales + TQ1_GROUPS_PER_ROW codes
+        auto *d = wb_ping;
+        for (int n = 0; n < N; n++) {
+            int grp = n / 5;       // which group of 5 this n belongs to
+            int sub = n % 5;       // position within group
+            uint8_t packed = pB[grp];  // one code byte per group of 5
+            float scale = (float)((bfloat16*)pS)[grp];
+
+            // Base-3 decode: extract sub-th ternary value from packed byte
+            int tmp_v = packed;
+            for (int s = 0; s < sub; s++) tmp_v /= 3;
+            int code = tmp_v % 3;
+
+            float val = (code == 0) ? -scale : (code == 2) ? scale : 0.0f;
+            for (int k = 0; k < K; k++)
+                d[n * K + k] = (bfloat16)val;  // broadcast across K
+        }
+
+        // Convert to bfp16ebs8
+        aie::block_vector_output_buffer_stream<bfp16ebs8, 64> ws(w_bfp_ping);
+        for (int nb = 0; nb < N / 8; nb++)
+            for (int kb = 0; kb < K / 8; kb++) {
+                for (int r = 0; r < 8; r++)
+                    for (int c = 0; c < 8; c++)
+                        tmp[r * 8 + c] = wb_ping[(nb * 8 + r) * K + kb * 8 + c];
+                auto v = aie::load_v<64>(tmp);
+                aie::accum<accfloat, 64> acc; acc.from_vector(v, 0);
+                ws.push(acc.template to_vector<bfp16ebs8>());
+            }
+    }
+
+    // ── Activation blocks ──
+    {
+        aie::block_vector_output_buffer_stream<bfp16ebs8, 64> as(a_bfp);
+        for (int i = 0; i < M * K / 64; i++) {
+            auto v = aie::load_v<64>(pA + i * 64);
+            aie::accum<accfloat, 64> acc; acc.from_vector(v, 0);
+            as.push(acc.template to_vector<bfp16ebs8>());
+        }
+    }
+
+    // ── MAC ──
+    aie::block_vector_input_buffer_stream<bfp16ebs8, 64> ws_in(w_bfp_ping);
+    aie::block_vector_input_buffer_stream<bfp16ebs8, 64> as_in(a_bfp);
+
+    for (int mb = 0; mb < M / 16; mb++)
+        for (int nb = 0; nb < N / 16; nb++) {
+            auto *blk = pC + mb * N * 16 + nb * 16;
+            aie::accum<accfloat, 64> a0(aie::load_v<64>(blk));
+            aie::accum<accfloat, 64> a1(aie::load_v<64>(blk + 64));
+            for (int k = 0; k < K / 8; k++) {
+                auto A0 = as_in.pop(), A1 = as_in.pop();
+                auto B0 = ws_in.pop(), B1 = ws_in.pop();
+                a0 = mac_8x8_8x8T(A0, B0, a0);
+                a1 = mac_8x8_8x8T(A0, B1, a1);
+            }
+            aie::store_v(blk, a0.template to_vector<bfloat16>());
+            aie::store_v(blk + 64, a1.template to_vector<bfloat16>());
+        }
+    event1();
+}
+}

--- a/engine/npu/kernel/mm_ternary_tq2.cc
+++ b/engine/npu/kernel/mm_ternary_tq2.cc
@@ -1,0 +1,154 @@
+// mm_ternary_tq2.cc — TQ2 ternary native NPU kernel with ping-pong LUT decode pipelining
+//
+// Architecture:
+//   Two ping-pong buffers in L1 SRAM for weight decode:
+//     ping:  DMA-loads TQ2 codes+scales while pong runs through MAC
+//     pong:  runs through MAC while ping DMAs the next K-block
+//
+//   LUT-based ternary decode:
+//     LUT[256] = packed uint32_t where each byte = int8 value
+//     code 0→-1, 1→0, 2→+1, 3→0
+//     val = (int8_t*)(&LUT[byte])[code_idx]   // 1 load + 1 shift per 4 codes
+//
+//   Ping-pong state machine:
+//     1. Fill ping buffer (DMA codes + scales from L2 → L1)
+//     2. Kick MAC on ping, simultaneously DMA into pong
+//     3. Swap ping/pong
+//     4. Repeat
+//
+// Licensed under Apache 2.0 with LLVM Exceptions.
+
+#include "aie_kernel_utils.h"
+#include <aie_api/aie.hpp>
+
+constexpr int M = 32, K = 64, N = 128;
+
+// TQ2 tile geometry: each tile row = 256 cols = 8 groups of 32
+//   Per tile row: 8 BF16 scales (16 bytes) + 64 bytes packed 2-bit codes
+//   Total per tile row: 80 bytes
+//   Total per tile (32 rows): 2560 bytes (vs 5120 for Q4NX)
+constexpr int TILE_ROWS = 32;
+constexpr int TILE_COLS = 256;
+constexpr int TQ2_GROUPS_PER_ROW = TILE_COLS / 32;  // 8
+constexpr int TQ2_SCALES_BYTES_PER_ROW = TILE_ROWS * TQ2_GROUPS_PER_ROW * 2;  // 512 (bf16)
+constexpr int TQ2_CODES_BYTES_PER_ROW = TILE_ROWS * TILE_COLS / 4;  // 2048
+
+extern "C" {
+
+// ── LUT-based ternary decode ──
+// Each byte = 4 × 2-bit codes
+// LUT[-1,0,+1,0] per code position
+static const uint32_t ternary_lut[256] = {
+    0x00000000, 0x000000FF, 0x0000FF00, 0x0000FFFF,
+    0x00FF0000, 0x00FF00FF, 0x00FFFF00, 0x00FFFFFF,
+    0xFF000000, 0xFF0000FF, 0xFF00FF00, 0xFF00FFFF,
+    0xFFFF0000, 0xFFFF00FF, 0xFFFFFF00, 0xFFFFFFFF,
+    // ... remaining 240 entries follow same pattern:
+    // code 0=-1 (0xFF), 1=0 (0x00), 2=+1 (0x01), 3=0 (0x00)
+    // Full table omitted for brevity — generated at compile time
+};
+
+// ── Unpack 4 ternary codes from one byte into 4 int8 values ──
+// Returns packed uint32_t where each byte = one int8 value
+// Using LUT: one load, one shift per code position
+static inline uint32_t unpack_byte(uint8_t byte) {
+    return ternary_lut[byte];
+}
+
+// ── Ping-pong ternary GEMV ──
+// pA: activations (M×K bf16, contiguous)
+// pB: TQ2 packed codes (N × K/4 bytes)
+// pS: BF16 scales (N × 2)
+// pC: output (M×N bf16)
+void ternary_tq2_gemv(bfloat16 *pA, uint8_t *pB, bfloat16 *pS, bfloat16 *pC) {
+    event0();
+
+    // ── Two ping-pong buffer sets in L1 ──
+    // Each set: 1 K-block worth of unpacked weights in bfp16ebs8 format
+    alignas(32) bfp16ebs8 w_bfp_ping[N / 8 * K / 8];
+    alignas(32) bfp16ebs8 w_bfp_pong[N / 8 * K / 8];
+    alignas(32) bfp16ebs8 a_bfp[M * K / 64];   // activations (cached, no ping-pong needed)
+
+    // Intermediate buffers for ternary decode before bfp16ebs8 conversion
+    alignas(32) bfloat16 wb_ping[N * K];
+    alignas(32) bfloat16 wb_pong[N * K];
+    alignas(32) bfloat16 tmp[64];               // 8×8 contiguous assembly buffer
+
+    // LUT for ternary decode (precomputed — maps 2-bit code to int8)
+    alignas(32) int8_t lut[4] = {-1, 0, 1, 0};
+
+    bool ping = true;
+
+    // ── Stage 1: Fill ping buffer (first K-block) ──
+    {
+        auto *s = pB;  // codes: N × K/4 bytes
+        auto *d = wb_ping;
+        for (int n = 0; n < N; n++) {
+            auto *sc = pS + n * 2;
+            float s0 = (float)sc[0], s1 = (float)sc[1];
+            for (int i = 0; i < 16; i++) {
+                uint8_t b = s[n * (K/4) + i];
+                d[n*K + i*4 + 0] = (bfloat16)((int8_t)((b & 3) == 2 ? 1 : (b & 3) == 0 ? -1 : 0) * s0);
+                d[n*K + i*4 + 1] = (bfloat16)((int8_t)(((b>>2) & 3) == 2 ? 1 : ((b>>2) & 3) == 0 ? -1 : 0) * s0);
+                d[n*K + i*4 + 2] = (bfloat16)((int8_t)(((b>>4) & 3) == 2 ? 1 : ((b>>4) & 3) == 0 ? -1 : 0) * s1);
+                d[n*K + i*4 + 3] = (bfloat16)((int8_t)(((b>>6) & 3) == 2 ? 1 : ((b>>6) & 3) == 0 ? -1 : 0) * s1);
+            }
+        }
+        // Convert ping weights to bfp16ebs8
+        aie::block_vector_output_buffer_stream<bfp16ebs8, 64> ws(w_bfp_ping);
+        for (int nb = 0; nb < N / 8; nb++) {
+            for (int kb = 0; kb < K / 8; kb++) {
+                for (int r = 0; r < 8; r++)
+                    for (int c = 0; c < 8; c++)
+                        tmp[r * 8 + c] = wb_ping[(nb * 8 + r) * K + kb * 8 + c];
+                auto v = aie::load_v<64>(tmp);
+                aie::accum<accfloat, 64> acc; acc.from_vector(v, 0);
+                ws.push(acc.template to_vector<bfp16ebs8>());
+            }
+        }
+    }
+
+    // ── Activation blocks (constant, no ping-pong needed) ──
+    {
+        aie::block_vector_output_buffer_stream<bfp16ebs8, 64> as(a_bfp);
+        for (int i = 0; i < M * K / 64; i++) {
+            auto v = aie::load_v<64>(pA + i * 64);
+            aie::accum<accfloat, 64> acc; acc.from_vector(v, 0);
+            as.push(acc.template to_vector<bfp16ebs8>());
+        }
+    }
+
+    // ── Ping-pong MAC loop ──
+    // The first K-block is already in w_bfp_ping.
+    // We DMA the NEXT K-block into wb_pong while MAC runs on w_bfp_ping.
+    // Then swap and repeat for remaining K-blocks.
+    //
+    // For a single K=64 tile (no K-loop), we just MAC once.
+    // Multi-K-block is handled by the outer MLIR loop calling this repeatedly.
+
+    aie::block_vector_input_buffer_stream<bfp16ebs8, 64> ws_in(w_bfp_ping);
+    aie::block_vector_input_buffer_stream<bfp16ebs8, 64> as_in(a_bfp);
+
+    for (int mb = 0; mb < M / 16; mb++) {
+        for (int nb = 0; nb < N / 16; nb++) {
+            auto *blk = pC + mb * N * 16 + nb * 16;
+            aie::accum<accfloat, 64> a0(aie::load_v<64>(blk));
+            aie::accum<accfloat, 64> a1(aie::load_v<64>(blk + 64));
+            for (int k = 0; k < K / 8; k++) {
+                auto A0 = as_in.pop(), A1 = as_in.pop();
+                auto B0 = ws_in.pop(), B1 = ws_in.pop();
+                a0 = mac_8x8_8x8T(A0, B0, a0);
+                a1 = mac_8x8_8x8T(A0, B1, a1);
+            }
+            aie::store_v(blk, a0.template to_vector<bfloat16>());
+            aie::store_v(blk + 64, a1.template to_vector<bfloat16>());
+        }
+    }
+    event1();
+}
+
+void zero_kernel_ternary(bfloat16 *cOut) {
+    auto z = aie::zeros<bfloat16, 32>();
+    for (int i = 0; i < M * N; i += 32) aie::store_v(cOut + i, z);
+}
+}

--- a/engine/npu/kernel/postprocess_qkv_06b.cc
+++ b/engine/npu/kernel/postprocess_qkv_06b.cc
@@ -1,0 +1,294 @@
+#include <aie_api/aie.hpp>
+#include <stdint.h>
+
+namespace {
+
+constexpr int32_t kRmsVecLanes = 32;
+constexpr int32_t kCopyVecDwords = 16;
+constexpr int32_t kRecordPayloadDwords = 256;
+constexpr int32_t kQRecords = 4;
+constexpr int32_t kKvRecords = 2;
+
+__attribute__((always_inline)) static inline void copy_record_payload(
+    const int32_t *__restrict record_payload,
+    int32_t *__restrict target
+) {
+    for (int32_t idx = 0; idx < kRecordPayloadDwords; idx += kCopyVecDwords)
+        chess_prepare_for_pipelining
+        chess_loop_range(kRecordPayloadDwords / kCopyVecDwords, kRecordPayloadDwords / kCopyVecDwords) {
+        aie::vector<int32_t, kCopyVecDwords> words =
+            aie::load_v<kCopyVecDwords, aie_dm_resource::a>(record_payload + idx);
+        aie::store_v(target + idx, words);
+    }
+}
+
+static uint16_t bf16_bits(float value) {
+    union {
+        float f32;
+        uint32_t u32;
+    } bits = {value};
+    const uint32_t lsb = (bits.u32 >> 16) & 1u;
+    bits.u32 += 0x7fffu + lsb;
+    return static_cast<uint16_t>(bits.u32 >> 16);
+}
+
+static bfloat16 bf16_rne(float value) {
+    bfloat16 output;
+    reinterpret_cast<uint16_t *>(&output)[0] = bf16_bits(value);
+    return output;
+}
+
+static float fast_rsqrt(float value) {
+    if (value <= 0.0f) {
+        return 1.0f;
+    }
+    float y = 1.0f;
+    if (value < 0.000244140625f) {
+        y = 64.0f;
+    } else if (value < 0.0009765625f) {
+        y = 32.0f;
+    } else if (value < 0.00390625f) {
+        y = 16.0f;
+    } else if (value < 0.015625f) {
+        y = 8.0f;
+    } else if (value < 0.0625f) {
+        y = 4.0f;
+    } else if (value < 0.25f) {
+        y = 2.0f;
+    } else if (value > 1.0f) {
+        y = 0.5f;
+    }
+    if (value > 4.0f) {
+        y = 0.25f;
+    }
+    if (value > 16.0f) {
+        y = 0.125f;
+    }
+    const float half = value * 0.5f;
+    for (int32_t iter = 0; iter < 10; iter++) {
+        y = y * (1.5f - half * y * y);
+    }
+    return y;
+}
+
+static float head_rms_scale(bfloat16 *body, int32_t head, int32_t head_dim) {
+    const int32_t base = head * head_dim;
+    const int32_t vector_lanes = head_dim & ~(kRmsVecLanes - 1);
+    aie::accum<accfloat, kRmsVecLanes> sum_acc =
+        aie::zeros<accfloat, kRmsVecLanes>();
+    for (int32_t dim = 0; dim < vector_lanes; dim += kRmsVecLanes)
+        chess_prepare_for_pipelining chess_loop_range(4, 4) {
+        aie::vector<bfloat16, kRmsVecLanes> value_vec =
+            aie::load_v<kRmsVecLanes>(body + base + dim);
+        sum_acc = aie::mac(sum_acc, value_vec, value_vec);
+    }
+    float sum_sq = aie::reduce_add(sum_acc.template to_vector<float>());
+    for (int32_t dim = vector_lanes; dim < head_dim; dim++) {
+        const float value = static_cast<float>(body[base + dim]);
+        sum_sq += value * value;
+    }
+    constexpr float eps = 0.000001f;
+    return fast_rsqrt(sum_sq / static_cast<float>(head_dim) + eps);
+}
+
+static bfloat16 normalized_lane(
+    bfloat16 *body,
+    bfloat16 *norm_weight,
+    int32_t lane,
+    int32_t dim,
+    float scale
+) {
+    return bf16_rne(
+        static_cast<float>(body[lane]) * scale * static_cast<float>(norm_weight[dim])
+    );
+}
+
+static void write_rope_pair(
+    bfloat16 *body,
+    bfloat16 *norm_weight,
+    bfloat16 *rope_cos,
+    bfloat16 *rope_sin,
+    bfloat16 *output,
+    int32_t head,
+    int32_t dim,
+    float scale
+) {
+    constexpr int32_t head_dim = 128;
+    const int32_t lane = head * head_dim + dim;
+    const bfloat16 normalized_even = normalized_lane(body, norm_weight, lane, dim, scale);
+    const bfloat16 normalized_odd = normalized_lane(body, norm_weight, lane + 1, dim + 1, scale);
+    const float even = static_cast<float>(normalized_even);
+    const float odd = static_cast<float>(normalized_odd);
+    const int32_t pair = dim >> 1;
+    const float c = static_cast<float>(rope_cos[pair]);
+    const float s = static_cast<float>(rope_sin[pair]);
+    output[lane] = bf16_rne(even * c - odd * s);
+    output[lane + 1] = bf16_rne(even * s + odd * c);
+}
+
+static int32_t packed_rope_word(
+    bfloat16 *body,
+    bfloat16 *norm_weight,
+    bfloat16 *rope_cos,
+    bfloat16 *rope_sin,
+    int32_t logical_word,
+    float scale
+) {
+    constexpr int32_t head_dim = 128;
+    const int32_t lane = logical_word * 2;
+    const int32_t dim = lane % head_dim;
+    const bfloat16 normalized_even = normalized_lane(body, norm_weight, lane, dim, scale);
+    const bfloat16 normalized_odd = normalized_lane(body, norm_weight, lane + 1, dim + 1, scale);
+    const float even = static_cast<float>(normalized_even);
+    const float odd = static_cast<float>(normalized_odd);
+    const int32_t pair = dim >> 1;
+    const float c = static_cast<float>(rope_cos[pair]);
+    const float s = static_cast<float>(rope_sin[pair]);
+    bfloat16 packed[2];
+    packed[0] = bf16_rne(even * c - odd * s);
+    packed[1] = bf16_rne(even * s + odd * c);
+    return reinterpret_cast<int32_t *>(packed)[0];
+}
+
+static void write_qwen3_current_even_odd(
+    int32_t *k_body,
+    int32_t *v_body,
+    int32_t *qk_rope_side,
+    int32_t *current_k,
+    int32_t *current_v,
+    int32_t current_dwords
+) {
+    constexpr int32_t kv_heads = 8;
+    constexpr int32_t head_dim = 128;
+    bfloat16 *k_values = reinterpret_cast<bfloat16 *>(k_body);
+    bfloat16 *side = reinterpret_cast<bfloat16 *>(qk_rope_side);
+    bfloat16 *k_norm = side + head_dim;
+    bfloat16 *rope_cos = side + head_dim * 2;
+    bfloat16 *rope_sin = rope_cos + head_dim / 2;
+    const int32_t head_dwords = current_dwords / kv_heads;
+    const int32_t half_current_dwords = current_dwords / 2;
+    const int32_t half_head_dwords = head_dwords / 2;
+
+    float scales[kv_heads];
+    for (int32_t head = 0; head < kv_heads; head++) {
+        scales[head] = head_rms_scale(k_values, head, head_dim);
+    }
+
+    for (int32_t head = 0; head < kv_heads; head++) {
+        for (int32_t pair = 0; pair < half_head_dwords; pair++) {
+            const int32_t even_idx = head * head_dwords + pair * 2;
+            const int32_t odd_idx = even_idx + 1;
+            const int32_t even_stream_idx = head * half_head_dwords + pair;
+            const int32_t odd_stream_idx = half_current_dwords + even_stream_idx;
+            current_k[even_stream_idx] = packed_rope_word(
+                k_values,
+                k_norm,
+                rope_cos,
+                rope_sin,
+                even_idx,
+                scales[head]
+            );
+            current_k[odd_stream_idx] = packed_rope_word(
+                k_values,
+                k_norm,
+                rope_cos,
+                rope_sin,
+                odd_idx,
+                scales[head]
+            );
+            current_v[even_stream_idx] = v_body[even_idx];
+            current_v[odd_stream_idx] = v_body[odd_idx];
+        }
+    }
+}
+
+} // namespace
+
+extern "C" {
+
+void qwen3_postprocess_absorb_qkv_payload_record(
+    int32_t *record_payload,
+    int32_t *q_body,
+    int32_t *k_body,
+    int32_t *v_body,
+    int32_t record_index
+) {
+    int32_t *target = nullptr;
+    int32_t block = 0;
+    if (record_index < kQRecords) {
+        target = q_body;
+        block = record_index;
+    } else if (record_index < kQRecords + kKvRecords) {
+        target = k_body;
+        block = record_index - kQRecords;
+    } else if (record_index < kQRecords + kKvRecords * 2) {
+        target = v_body;
+        block = record_index - kQRecords - kKvRecords;
+    }
+    if (target == nullptr) {
+        return;
+    }
+    copy_record_payload(record_payload, target + block * kRecordPayloadDwords);
+}
+
+void qwen3_postprocess_q4nx_body_payload(
+    int32_t *q_body,
+    int32_t *k_body,
+    int32_t *v_body,
+    int32_t *qk_rope_side,
+    int32_t *q_payload,
+    int32_t *current_k,
+    int32_t *current_v,
+    int32_t *current_token_buf,
+    int32_t q_dwords,
+    int32_t current_dwords
+) {
+    constexpr int32_t q_heads = 16;
+    constexpr int32_t head_dim = 128;
+    bfloat16 *q_values = reinterpret_cast<bfloat16 *>(q_body);
+    bfloat16 *q_output = reinterpret_cast<bfloat16 *>(q_payload);
+    bfloat16 *side = reinterpret_cast<bfloat16 *>(qk_rope_side);
+    bfloat16 *q_norm = side;
+    bfloat16 *rope_cos = side + head_dim * 2;
+    bfloat16 *rope_sin = rope_cos + head_dim / 2;
+
+    for (int32_t head = 0; head < q_heads; head++) {
+        const float scale = head_rms_scale(q_values, head, head_dim);
+        for (int32_t dim = 0; dim < head_dim; dim += 2) {
+            write_rope_pair(q_values, q_norm, rope_cos, rope_sin, q_output, head, dim, scale);
+        }
+    }
+
+    write_qwen3_current_even_odd(k_body, v_body, qk_rope_side, current_k, current_v, current_dwords);
+    (void)current_token_buf;
+    (void)q_dwords;
+}
+
+void qwen3_postprocess_q4nx_qkv_payload(
+    int32_t *qkv_body,
+    int32_t *qk_rope_side,
+    int32_t *q_payload,
+    int32_t *current_k,
+    int32_t *current_v,
+    int32_t *current_token_buf,
+    int32_t q_dwords,
+    int32_t current_dwords
+) {
+    int32_t *q_body = qkv_body;
+    int32_t *k_body = qkv_body + q_dwords;
+    int32_t *v_body = k_body + current_dwords;
+    qwen3_postprocess_q4nx_body_payload(
+        q_body,
+        k_body,
+        v_body,
+        qk_rope_side,
+        q_payload,
+        current_k,
+        current_v,
+        current_token_buf,
+        q_dwords,
+        current_dwords
+    );
+}
+
+} // extern "C"

--- a/engine/npu/kernel/qwen3_constants_06b.h
+++ b/engine/npu/kernel/qwen3_constants_06b.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace qwen3 {
+
+constexpr int32_t kMainRowsPerTile = 32;
+constexpr int32_t kQ4KChunk = 256;
+constexpr int32_t kQ4GroupSize = 32;
+constexpr int32_t kRecordDwords = 17;
+constexpr int32_t kRecordPayloadDwords = kRecordDwords - 1;
+constexpr int32_t kRecordPayloadBf16 = kRecordPayloadDwords * 2;
+
+// Phase indices
+constexpr int32_t kQPhase = 0;
+constexpr int32_t kKPhase = 1;
+constexpr int32_t kVPhase = 2;
+constexpr int32_t kOPhase = 3;
+constexpr int32_t kUpPhase = 4;
+constexpr int32_t kGatePhase = 5;
+constexpr int32_t kDownPhase = 6;
+
+constexpr int32_t kMain16PhaseLimitQkv = kVPhase + 1;
+constexpr int32_t kMain16PhaseLimitQkvo = kOPhase + 1;
+constexpr int32_t kMain16PhaseLimitUpGate = kGatePhase + 1;
+constexpr int32_t kMain16PhaseLimitFull = kDownPhase + 1;
+
+// Compact packet IDs
+constexpr int32_t kQCompactPacketId = 0x1;
+constexpr int32_t kKCompactPacketId = 0x1;
+constexpr int32_t kVCompactPacketId = 0x1;
+constexpr int32_t kOCompactPacketId = 0x4;
+constexpr int32_t kFfnCompactPacketId = 0x8;
+constexpr int32_t kDownCompactPacketId = 0x4;
+
+// Lock IDs (same for all models)
+constexpr int32_t kMainActivationEmptyLock = 0;
+constexpr int32_t kMainActivationFullLock = 1;
+constexpr int32_t kMainWeightEmptyLock = 2;
+constexpr int32_t kMainWeightFullLock = 3;
+constexpr int32_t kMainRecordEmptyLock = 4;
+constexpr int32_t kMainRecordFullLock = 5;
+constexpr int32_t kCoreLocalLockBase = 0x30;
+constexpr int32_t kMainActivationEmptyCoreLock = kCoreLocalLockBase + kMainActivationEmptyLock;
+constexpr int32_t kMainActivationFullCoreLock = kCoreLocalLockBase + kMainActivationFullLock;
+constexpr int32_t kMainWeightEmptyCoreLock = kCoreLocalLockBase + kMainWeightEmptyLock;
+constexpr int32_t kMainWeightFullCoreLock = kCoreLocalLockBase + kMainWeightFullLock;
+constexpr int32_t kMainRecordEmptyCoreLock = kCoreLocalLockBase + kMainRecordEmptyLock;
+constexpr int32_t kMainRecordFullCoreLock = kCoreLocalLockBase + kMainRecordFullLock;
+
+// ===== Qwen3-0.6B specific body/chunk constants =====
+// Q:  H=1024 input, NH×HD=2048 output. 2048/512=4 body records, 1024/256=4 chunks/record
+// K:  H=1024 input, NKV×HD=1024 output. 1024/512=2 body records, 1024/256=4 chunks/record
+// V:  same as K
+// O:  NH×HD=2048 input, H=1024 output. 1024/512=2 body records, 2048/256=8 chunks/record
+// UP/GATE: H=1024 input, IM=3072 output. 3072/512=6 blocks total, 6 replays
+// DOWN: IM=3072 input, H=1024 output. 1024/512=2 body records, 3072/256=12 chunks/record
+
+constexpr int32_t kQBodyRecords = 4;          // 2048/512 (was 8 for 8B)
+constexpr int32_t kKvBodyRecords = 2;         // 1024/512 (same as 8B)
+constexpr int32_t kOBodyRecords = 2;          // 1024/512 (was 8 for 8B)
+constexpr int32_t kUpGateReplays = 12;        // (6+6) UP+GATE blocks (was 48 for 8B)
+constexpr int32_t kDownBodyRecords = 2;       // 1024/512 (was 8 for 8B)
+
+constexpr int32_t kQChunksPerRecord = 4;      // 1024/256 (was 16 for 8B)
+constexpr int32_t kKvChunksPerRecord = 4;     // 1024/256 (was 16 for 8B)
+constexpr int32_t kOChunksPerRecord = 8;      // 2048/256 (was 16 for 8B)
+constexpr int32_t kUpGateChunksPerReplay = 4; // 1024/256 (was 16 for 8B)
+constexpr int32_t kDownChunksPerRecord = 12;  // 3072/256 (was 48 for 8B)
+
+// Weight chunk base offsets (for weight streaming)
+constexpr int32_t kQWeightChunkBase = 0;                              // 0
+constexpr int32_t kKWeightChunkBase = 16;                             // 0 + 4×4
+constexpr int32_t kVWeightChunkBase = 24;                             // 16 + 2×4
+constexpr int32_t kFullLayerOWeightChunkBase = 32;                    // 24 + 2×4
+constexpr int32_t kFullLayerUpGateWeightChunkBase = 48;               // 32 + 2×8
+constexpr int32_t kFullLayerDownWeightChunkBase = 96;                 // 48 + 12×4
+}

--- a/engine/npu/kernel/qwen3_decode_kernels_06b.cc
+++ b/engine/npu/kernel/qwen3_decode_kernels_06b.cc
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <aie_api/aie.hpp>
+#include <aie_api/utils.hpp>
+#include <adf/intrinsics.h>
+#include <stdint.h>
+
+#include "qwen3_constants_06b.h"
+#include "record_format.h"
+
+namespace {
+
+#ifndef __SIGN_SIGNED
+#define __SIGN_SIGNED 1
+#endif
+
+constexpr int32_t kActSliceBf16 = 256;
+constexpr int32_t kGroupSize = qwen3::kQ4GroupSize;
+constexpr int32_t kGroupsPerChunk = kActSliceBf16 / kGroupSize;
+constexpr int32_t kQ4NxScaleBf16 = qwen3::kMainRowsPerTile * kGroupsPerChunk;
+constexpr int32_t kQ4NxScaleBytes = kQ4NxScaleBf16 * 2;
+constexpr int32_t kQ4NxOffsetBytes = kQ4NxScaleBytes;
+constexpr int32_t kQ4NxDataOffsetBytes = kQ4NxScaleBytes + kQ4NxOffsetBytes;
+constexpr int32_t kQ4NxRowsPerLane = qwen3::kMainRowsPerTile / 2;
+constexpr int32_t kQ4NxDataBytesPerLane =
+    kActSliceBf16 * (kQ4NxRowsPerLane / 2);
+constexpr int32_t kQ4NxGroupBytesPerLane =
+    kGroupSize * (kQ4NxRowsPerLane / 2);
+using Acc16 = aie::accum<accfloat, kQ4NxRowsPerLane>;
+
+__attribute__((always_inline)) static inline Acc16 zero_accum16() {
+  return aie::zeros<accfloat, kQ4NxRowsPerLane>();
+}
+
+__attribute__((always_inline)) static inline aie::vector<bfloat16, kQ4NxRowsPerLane * 4>
+load_q4_dim_quad(const uint8_t *__restrict group_data, unsigned dim_quad) {
+  const uint4 *__restrict q4_ptr = reinterpret_cast<const uint4 *>(
+      group_data + dim_quad * kQ4NxRowsPerLane * 2);
+  aie::vector<uint4, kQ4NxRowsPerLane * 4> q4 =
+      aie::load_v<kQ4NxRowsPerLane * 4, aie_dm_resource::d>(q4_ptr);
+  aie::vector<uint8, kQ4NxRowsPerLane * 4> q8 = aie::unpack(q4);
+  return aie::to_float<bfloat16>(q8, 0);
+}
+
+__attribute__((always_inline)) static inline void mac_q4_dim_quad(
+    Acc16 &acc,
+    const aie::vector<bfloat16, kQ4NxRowsPerLane * 4> &q_bf16,
+    const aie::vector<bfloat16, kQ4NxRowsPerLane> &scale_vec,
+    const aie::vector<bfloat16, kQ4NxRowsPerLane> &offset_vec,
+    const aie::vector<bfloat16, kGroupSize> &act_group,
+    int32_t dim) {
+  aie::vector<bfloat16, kQ4NxRowsPerLane> q0 =
+      q_bf16.template extract<kQ4NxRowsPerLane>(0);
+  Acc16 scaled0 = aie::mul(q0, scale_vec);
+  aie::vector<bfloat16, kQ4NxRowsPerLane> dequant0 =
+      aie::add(scaled0.template to_vector<bfloat16>(), offset_vec);
+  aie::vector<bfloat16, kQ4NxRowsPerLane> act0 =
+      aie::broadcast<bfloat16, kQ4NxRowsPerLane>(act_group.get(dim));
+  acc = aie::mac(acc, dequant0, act0);
+
+  aie::vector<bfloat16, kQ4NxRowsPerLane> q1 =
+      q_bf16.template extract<kQ4NxRowsPerLane>(1);
+  Acc16 scaled1 = aie::mul(q1, scale_vec);
+  aie::vector<bfloat16, kQ4NxRowsPerLane> dequant1 =
+      aie::add(scaled1.template to_vector<bfloat16>(), offset_vec);
+  aie::vector<bfloat16, kQ4NxRowsPerLane> act1 =
+      aie::broadcast<bfloat16, kQ4NxRowsPerLane>(act_group.get(dim + 1));
+  acc = aie::mac(acc, dequant1, act1);
+
+  aie::vector<bfloat16, kQ4NxRowsPerLane> q2 =
+      q_bf16.template extract<kQ4NxRowsPerLane>(2);
+  Acc16 scaled2 = aie::mul(q2, scale_vec);
+  aie::vector<bfloat16, kQ4NxRowsPerLane> dequant2 =
+      aie::add(scaled2.template to_vector<bfloat16>(), offset_vec);
+  aie::vector<bfloat16, kQ4NxRowsPerLane> act2 =
+      aie::broadcast<bfloat16, kQ4NxRowsPerLane>(act_group.get(dim + 2));
+  acc = aie::mac(acc, dequant2, act2);
+
+  aie::vector<bfloat16, kQ4NxRowsPerLane> q3 =
+      q_bf16.template extract<kQ4NxRowsPerLane>(3);
+  Acc16 scaled3 = aie::mul(q3, scale_vec);
+  aie::vector<bfloat16, kQ4NxRowsPerLane> dequant3 =
+      aie::add(scaled3.template to_vector<bfloat16>(), offset_vec);
+  aie::vector<bfloat16, kQ4NxRowsPerLane> act3 =
+      aie::broadcast<bfloat16, kQ4NxRowsPerLane>(act_group.get(dim + 3));
+  acc = aie::mac(acc, dequant3, act3);
+}
+
+__attribute__((always_inline)) static inline void accum_q4nx_group_lane(
+    Acc16 &acc, const uint8_t *__restrict group_data,
+    const bfloat16 *__restrict scale_group,
+    const bfloat16 *__restrict offset_group,
+    const aie::vector<bfloat16, kGroupSize> &act_group) {
+  aie::vector<bfloat16, kQ4NxRowsPerLane> scale_vec =
+      aie::load_v<kQ4NxRowsPerLane, aie_dm_resource::a>(scale_group);
+  aie::vector<bfloat16, kQ4NxRowsPerLane> offset_vec =
+      aie::load_v<kQ4NxRowsPerLane, aie_dm_resource::b>(offset_group);
+
+  aie::vector<bfloat16, kQ4NxRowsPerLane * 4> q_bf16_current =
+      load_q4_dim_quad(group_data, 0);
+  aie::pipelined_loop<kGroupSize / 4 - 1>(
+      kGroupSize / 4 - 1, [&](unsigned dim_quad) __aie_inline {
+    aie::vector<bfloat16, kQ4NxRowsPerLane * 4> q_bf16_next =
+        load_q4_dim_quad(group_data, dim_quad + 1);
+    mac_q4_dim_quad(acc, q_bf16_current, scale_vec, offset_vec, act_group,
+                    static_cast<int32_t>(dim_quad) * 4);
+    q_bf16_current = q_bf16_next;
+  });
+  mac_q4_dim_quad(acc, q_bf16_current, scale_vec, offset_vec, act_group,
+                  kGroupSize - 4);
+}
+
+__attribute__((always_inline)) static inline void
+accum_q4nx_chunk(Acc16 &acc0, Acc16 &acc1,
+                 const bfloat16 *__restrict packed_chunk,
+                 const int32_t *__restrict activation_words) {
+  const bfloat16 *__restrict scales = packed_chunk;
+  const bfloat16 *__restrict offsets = reinterpret_cast<const bfloat16 *>(
+      reinterpret_cast<const uint8_t *>(packed_chunk) + kQ4NxScaleBytes);
+  const uint8_t *__restrict packed_data =
+      reinterpret_cast<const uint8_t *>(packed_chunk) + kQ4NxDataOffsetBytes;
+  const bfloat16 *__restrict activation =
+      reinterpret_cast<const bfloat16 *>(activation_words);
+
+  aie::pipelined_loop<kGroupsPerChunk>(
+      kGroupsPerChunk, [&](unsigned qgroup) __aie_inline {
+    aie::vector<bfloat16, kGroupSize> act_group =
+        aie::load_v<kGroupSize, aie_dm_resource::c>(
+            activation + qgroup * kGroupSize);
+    const int32_t row_group = qgroup * qwen3::kMainRowsPerTile;
+    const int32_t data_group = qgroup * kQ4NxGroupBytesPerLane;
+    accum_q4nx_group_lane(acc0, packed_data + data_group, scales + row_group,
+                          offsets + row_group, act_group);
+    accum_q4nx_group_lane(acc1,
+                          packed_data + kQ4NxDataBytesPerLane + data_group,
+                          scales + row_group + kQ4NxRowsPerLane,
+                          offsets + row_group + kQ4NxRowsPerLane, act_group);
+  });
+}
+
+__attribute__((always_inline)) static inline void
+emit_record_payload(Acc16 &acc0, Acc16 &acc1, int32_t *record) {
+  bfloat16 *payload = reinterpret_cast<bfloat16 *>(record + 1);
+  aie::store_v(payload, acc0.template to_vector<bfloat16>());
+  aie::store_v(payload + kQ4NxRowsPerLane,
+               acc1.template to_vector<bfloat16>());
+}
+
+__attribute__((always_inline)) static inline void
+emit_record(Acc16 &acc0, Acc16 &acc1, int32_t *record, int32_t header) {
+  record[0] = header;
+  emit_record_payload(acc0, acc1, record);
+}
+
+#ifdef QWEN3_ENABLE_MAIN16_CYCLE_PROFILE
+__attribute__((always_inline)) static inline void store_u64_words(
+    int32_t *record, int32_t index, uint64_t value) {
+  record[index] = static_cast<int32_t>(value & 0xffffffffULL);
+  record[index + 1] = static_cast<int32_t>(value >> 32);
+}
+
+__attribute__((always_inline)) static inline void
+emit_cycle_record(Acc16 &acc0, Acc16 &acc1, int32_t *record, int32_t block,
+                  uint64_t total_cycles, uint64_t compute_cycles) {
+  record[0] = qwen3::kQCompactPacketId;
+  emit_record_payload(acc0, acc1, record);
+  record[1] = block;
+  store_u64_words(record, 2, total_cycles);
+  store_u64_words(record, 4, compute_cycles);
+  record[6] = qwen3::kQChunksPerRecord;
+  record[7] = kActSliceBf16;
+  record[8] = qwen3::kMainRowsPerTile;
+}
+#endif
+
+template <int32_t Records, int32_t ChunksPerRecord>
+// Keep phase bodies out of the dispatcher so Chess does not merge all phase
+// schedules into one larger program-memory footprint.
+__attribute__((noinline)) static void
+run_projection_body(const bfloat16 *__restrict wt_ping,
+                    const bfloat16 *__restrict wt_pong,
+                    const int32_t *__restrict act_ping,
+                    const int32_t *__restrict act_pong,
+                    int32_t *__restrict record_ping,
+                    int32_t *__restrict record_pong, int32_t record_header,
+                    int32_t *record_toggle) {
+  for (int32_t block = 0; block < Records; block++)
+      chess_loop_range(Records, Records) {
+    Acc16 acc0 = zero_accum16();
+    Acc16 acc1 = zero_accum16();
+
+    for (int32_t chunk = 0; chunk < ChunksPerRecord; chunk++)
+        chess_loop_range(ChunksPerRecord, ChunksPerRecord) {
+      acquire_greater_equal(qwen3::kMainActivationFullCoreLock, 1);
+      acquire_greater_equal(qwen3::kMainWeightFullCoreLock, 1);
+
+      const bfloat16 *__restrict wt = (chunk & 1) == 0 ? wt_ping : wt_pong;
+      const int32_t *__restrict act = (chunk & 1) == 0 ? act_ping : act_pong;
+      accum_q4nx_chunk(acc0, acc1, wt, act);
+
+      release(qwen3::kMainActivationEmptyCoreLock, 1);
+      release(qwen3::kMainWeightEmptyCoreLock, 1);
+    }
+
+    acquire_greater_equal(qwen3::kMainRecordEmptyCoreLock, 1);
+    int32_t *record = ((*record_toggle) & 1) == 0 ? record_ping : record_pong;
+    emit_record(acc0, acc1, record, record_header);
+    *record_toggle += 1;
+    release(qwen3::kMainRecordFullCoreLock, 1);
+  }
+}
+
+__attribute__((always_inline)) static inline void
+run_q_only_body(bfloat16 *wt_ping, bfloat16 *wt_pong, int32_t *act_ping,
+                int32_t *act_pong, int32_t *record_ping,
+                int32_t *record_pong, int32_t *record_toggle) {
+  run_projection_body<qwen3::kQBodyRecords, qwen3::kQChunksPerRecord>(
+      wt_ping, wt_pong, act_ping, act_pong, record_ping, record_pong,
+      qwen3::kQCompactPacketId, record_toggle);
+}
+
+__attribute__((always_inline)) static inline void
+run_qkv_body(bfloat16 *wt_ping, bfloat16 *wt_pong, int32_t *act_ping,
+             int32_t *act_pong, int32_t *record_ping, int32_t *record_pong,
+             int32_t *record_toggle) {
+  constexpr int32_t kQkvBodyRecords =
+      qwen3::kQBodyRecords + qwen3::kKvBodyRecords + qwen3::kKvBodyRecords;
+  run_projection_body<kQkvBodyRecords, qwen3::kQChunksPerRecord>(
+      wt_ping, wt_pong, act_ping, act_pong, record_ping, record_pong,
+      qwen3::kQCompactPacketId, record_toggle);
+}
+
+__attribute__((always_inline)) static inline void
+run_o_body(bfloat16 *wt_ping, bfloat16 *wt_pong, int32_t *act_ping,
+           int32_t *act_pong, int32_t *record_ping, int32_t *record_pong,
+           int32_t *record_toggle) {
+  run_projection_body<qwen3::kOBodyRecords, qwen3::kOChunksPerRecord>(
+      wt_ping, wt_pong, act_ping, act_pong, record_ping, record_pong,
+      qwen3::kOCompactPacketId, record_toggle);
+}
+
+__attribute__((always_inline)) static inline void
+run_upgate_body(bfloat16 *wt_ping, bfloat16 *wt_pong, int32_t *act_ping,
+                int32_t *act_pong, int32_t *record_ping,
+                int32_t *record_pong, int32_t *record_toggle) {
+  run_projection_body<qwen3::kUpGateReplays, qwen3::kUpGateChunksPerReplay>(
+      wt_ping, wt_pong, act_ping, act_pong, record_ping, record_pong,
+      qwen3::kFfnCompactPacketId, record_toggle);
+}
+
+__attribute__((always_inline)) static inline void
+run_down_body(bfloat16 *wt_ping, bfloat16 *wt_pong, int32_t *act_ping,
+              int32_t *act_pong, int32_t *record_ping,
+              int32_t *record_pong, int32_t *record_toggle) {
+  run_projection_body<qwen3::kDownBodyRecords, qwen3::kDownChunksPerRecord>(
+      wt_ping, wt_pong, act_ping, act_pong, record_ping, record_pong,
+      qwen3::kDownCompactPacketId, record_toggle);
+}
+
+} // namespace
+
+extern "C" {
+
+void q4nx_main16_layer_scheduler(bfloat16 *wt_ping, bfloat16 *wt_pong,
+                                 int32_t *act_ping, int32_t *act_pong,
+                                 int32_t *record_ping, int32_t *record_pong,
+                                 int32_t group, int32_t row, int32_t num_rows,
+                                 int32_t phase_limit) {
+  ::aie::set_rounding(aie::rounding_mode::conv_even);
+  (void)group;
+  (void)row;
+  (void)num_rows;
+  int32_t record_toggle = 0;
+  if (phase_limit == qwen3::kQPhase + 1) {
+    run_q_only_body(wt_ping, wt_pong, act_ping, act_pong, record_ping,
+                    record_pong, &record_toggle);
+    return;
+  }
+
+  if (phase_limit >= qwen3::kMain16PhaseLimitQkv) {
+    run_qkv_body(wt_ping, wt_pong, act_ping, act_pong, record_ping,
+                 record_pong, &record_toggle);
+  }
+  if (phase_limit >= qwen3::kMain16PhaseLimitQkvo) {
+    run_o_body(wt_ping, wt_pong, act_ping, act_pong, record_ping, record_pong,
+               &record_toggle);
+  }
+  if (phase_limit >= qwen3::kMain16PhaseLimitUpGate) {
+    run_upgate_body(wt_ping, wt_pong, act_ping, act_pong, record_ping,
+                    record_pong, &record_toggle);
+  }
+  if (phase_limit >= qwen3::kMain16PhaseLimitFull) {
+    run_down_body(wt_ping, wt_pong, act_ping, act_pong, record_ping,
+                  record_pong, &record_toggle);
+  }
+}
+
+#ifdef QWEN3_ENABLE_MAIN16_CYCLE_PROFILE
+void q4nx_main16_cycle_profile_scheduler(bfloat16 *wt_ping,
+                                         bfloat16 *wt_pong, int32_t *act_ping,
+                                         int32_t *act_pong,
+                                         int32_t *record_ping,
+                                         int32_t *record_pong, int32_t group,
+                                         int32_t row, int32_t num_rows,
+                                         int32_t phase_limit) {
+  ::aie::set_rounding(aie::rounding_mode::conv_even);
+  (void)group;
+  (void)row;
+  (void)num_rows;
+  (void)phase_limit;
+  int32_t record_toggle = 0;
+  ::aie::tile tile = ::aie::tile::current();
+
+  for (int32_t block = 0; block < qwen3::kQBodyRecords; block++)
+      chess_loop_range(qwen3::kQBodyRecords, qwen3::kQBodyRecords) {
+    Acc16 acc0 = zero_accum16();
+    Acc16 acc1 = zero_accum16();
+    uint64_t compute_cycles = 0;
+    uint64_t total_start = tile.cycles();
+
+    for (int32_t chunk = 0; chunk < qwen3::kQChunksPerRecord; chunk++)
+        chess_loop_range(qwen3::kQChunksPerRecord,
+                         qwen3::kQChunksPerRecord) {
+      acquire_greater_equal(qwen3::kMainActivationFullCoreLock, 1);
+      acquire_greater_equal(qwen3::kMainWeightFullCoreLock, 1);
+
+      bfloat16 *wt = (chunk & 1) == 0 ? wt_ping : wt_pong;
+      int32_t *act = (chunk & 1) == 0 ? act_ping : act_pong;
+      uint64_t compute_start = tile.cycles();
+      accum_q4nx_chunk(acc0, acc1, wt, act);
+      uint64_t compute_end = tile.cycles();
+      compute_cycles += compute_end - compute_start;
+
+      release(qwen3::kMainActivationEmptyCoreLock, 1);
+      release(qwen3::kMainWeightEmptyCoreLock, 1);
+    }
+
+    uint64_t total_end = tile.cycles();
+    acquire_greater_equal(qwen3::kMainRecordEmptyCoreLock, 1);
+    int32_t *record = (record_toggle & 1) == 0 ? record_ping : record_pong;
+    emit_cycle_record(acc0, acc1, record, block, total_end - total_start,
+                      compute_cycles);
+    record_toggle += 1;
+    release(qwen3::kMainRecordFullCoreLock, 1);
+  }
+}
+#endif
+
+} // extern "C"

--- a/engine/npu/kernel/record_format.h
+++ b/engine/npu/kernel/record_format.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <aie_api/aie.hpp>
+#include <stdint.h>
+
+#include "qwen3_constants.h"
+
+namespace qwen3 {
+
+static inline bfloat16 *record_payload_bf16(int32_t *record) {
+    return reinterpret_cast<bfloat16 *>(record + 1);
+}
+
+static inline int32_t mylm_record_header_for_phase(int32_t phase) {
+    if (phase == kQPhase || phase == kKPhase || phase == kVPhase) {
+        return 0x1;
+    }
+    if (phase == kOPhase || phase == kDownPhase) {
+        return 0x4;
+    }
+    if (phase == kUpPhase || phase == kGatePhase) {
+        return 0x8;
+    }
+    return 0;
+}
+
+static inline int32_t compact_packet_id_for_phase(int32_t phase) {
+    if (phase == kQPhase) {
+        return kQCompactPacketId;
+    }
+    if (phase == kKPhase) {
+        return kKCompactPacketId;
+    }
+    if (phase == kVPhase) {
+        return kVCompactPacketId;
+    }
+    if (phase == kOPhase) {
+        return kOCompactPacketId;
+    }
+    if (phase == kUpPhase || phase == kGatePhase) {
+        return kFfnCompactPacketId;
+    }
+    if (phase == kDownPhase) {
+        return kDownCompactPacketId;
+    }
+    return 0;
+}
+
+static inline int32_t projection_record_header(int32_t phase, int32_t group, int32_t row) {
+    (void)group;
+    (void)row;
+    return mylm_record_header_for_phase(phase);
+}
+
+static inline int32_t body_record_header(int32_t phase, int32_t block, int32_t group, int32_t row) {
+    (void)block;
+    (void)group;
+    (void)row;
+    return mylm_record_header_for_phase(phase);
+}
+
+} // namespace qwen3

--- a/engine/npu/kernel/ssm_selective_scan.cc
+++ b/engine/npu/kernel/ssm_selective_scan.cc
@@ -1,0 +1,121 @@
+// ssm_selective_scan.cc — AIE2 SSM selective scan kernel
+//
+// Maps Mamba2 selective scan onto AIE tiles:
+//   Per head: state = expm1(A) * state + dt * B * x  (state update)
+//             y    = state · C                        (output)
+//
+// Parallelism: 80 heads × 1 AIE tile each = 80 tiles (Strix Halo has 32,
+// so 32 heads per batch, 3 batches)
+//
+// Each tile handles d_state=64 elements via 512-bit vectors.
+//   state[64] × A[64] + dt × B[64] × x[64] = 128 MACs per step
+//   1 token step = ~200 cycles per tile
+//   32 tiles in parallel = ~6 cycles/token = ~6ns at 1GHz
+//
+// Licensed under Apache 2.0 with LLVM Exceptions.
+
+#include "aie_kernel_utils.h"
+#include <aie_api/aie.hpp>
+
+constexpr int D_STATE = 64;   // Mamba2 state dimension
+constexpr int N_HEADS = 32;   // heads per tile batch (80 total → 3 batches)
+
+extern "C" {
+
+// ── One AIE tile processes N_HEADS × D_STATE selective scan ──
+// Each head is independent — parallel across 32 AIE cores.
+//
+// Inputs (all bf16, contiguous per head):
+//   state_in:  [N_HEADS × D_STATE] — initial state
+//   A:         [N_HEADS × D_STATE] — log-state matrix (expm1 applied)
+//   dt:        [N_HEADS]           — discretization step
+//   B:         [N_HEADS × D_STATE] — input matrix
+//   C:         [N_HEADS × D_STATE] — output matrix
+//   x:         [N_HEADS × D_STATE] — input (from in_proj)
+//
+// Outputs:
+//   state_out: [N_HEADS × D_STATE] — updated state
+//   y:         [N_HEADS × D_STATE] — output (before gate)
+void ssm_selective_scan(
+    bfloat16 *state_in,
+    bfloat16 *A,
+    bfloat16 *dt,
+    bfloat16 *B,
+    bfloat16 *C,
+    bfloat16 *x,
+    bfloat16 *state_out,
+    bfloat16 *y
+) {
+    event0();
+
+    // Vectorized per-head: 64 elements = 8 × 8-element vectors
+    for (int h = 0; h < N_HEADS; h++) {
+        // Load state[64], A[64], B[64], C[64], x[64] as 8 vectors each
+        alignas(32) bfloat16 s_buf[D_STATE], a_buf[D_STATE];
+        alignas(32) bfloat16 b_buf[D_STATE], c_buf[D_STATE], x_buf[D_STATE];
+        alignas(32) bfloat16 dt_buf[1];
+
+        // Load from global memory via DMA
+        for (int i = 0; i < D_STATE; i += 8) {
+            auto vs = aie::load_v<8>(state_in + h * D_STATE + i);
+            aie::store_v(s_buf + i, vs);
+
+            auto va = aie::load_v<8>(A + h * D_STATE + i);
+            aie::store_v(a_buf + i, va);
+
+            auto vb = aie::load_v<8>(B + h * D_STATE + i);
+            aie::store_v(b_buf + i, vb);
+
+            auto vc = aie::load_v<8>(C + h * D_STATE + i);
+            aie::store_v(c_buf + i, vc);
+
+            auto vx = aie::load_v<8>(x + h * D_STATE + i);
+            aie::store_v(x_buf + i, vx);
+        }
+        dt_buf[0] = dt[h];
+
+        // ── State update ──
+        // state_new = expm1(A) * state + dt * B * x
+        //
+        // Vectorized across 64 elements:
+        //   s_new[i] = a[i] * s_old[i] + dt * b[i] * x[i]
+        // where a[i] = expm1(A[i]) (precomputed on host)
+        //
+        // All operations are bf16 × bf16 → bf16
+        alignas(32) bfloat16 s_new[D_STATE];
+        for (int i = 0; i < D_STATE; i += 8) {
+            auto vs = aie::load_v<8>(s_buf + i);
+            auto va = aie::load_v<8>(a_buf + i);
+            auto vb = aie::load_v<8>(b_buf + i);
+            auto vx = aie::load_v<8>(x_buf + i);
+
+            // state = A * state     (element-wise mul)
+            auto vs_new = aie::mul(va, vs);
+            // dt_B = dt * B         (scalar * vector)
+            auto vdt_b = aie::mul(dt_buf[0], vb);
+            // dt_B_x = dt_B * x
+            auto vdt_b_x = aie::mul(vdt_b, vx);
+            // state += dt * B * x
+            vs_new = aie::add(vs_new, vdt_b_x);
+
+            aie::store_v(s_new + i, vs_new);
+        }
+
+        // ── Output ──
+        // y = C · state           (element-wise mul, not dot product)
+        // y_output[h][d] = C[h][d] * state_new[h][d]
+        alignas(32) bfloat16 y_buf[D_STATE];
+        for (int i = 0; i < D_STATE; i += 8) {
+            auto vs = aie::load_v<8>(s_new + i);
+            auto vc = aie::load_v<8>(c_buf + i);
+            auto vy = aie::mul(vc, vs);
+            aie::store_v(y_buf + i, vy);
+
+            aie::store_v(state_out + h * D_STATE + i, vs);
+            aie::store_v(y + h * D_STATE + i, vy);
+        }
+    }
+
+    event1();
+}
+}

--- a/engine/npu/kernel/swiglu_06b.cc
+++ b/engine/npu/kernel/swiglu_06b.cc
@@ -1,0 +1,73 @@
+#include <aie_api/aie.hpp>
+#include <stdint.h>
+
+namespace {
+
+constexpr int32_t kSwigluLanes = 512;
+constexpr int32_t kMylmSwigluSegments = 64;
+
+#define SWIGLU_LUT_QUAD(s0, o0, s1, o1, s2, o2, s3, o3) \
+    s0, o0, s1, o1, s2, o2, s3, o3, s0, o0, s1, o1, s2, o2, s3, o3
+#define SWIGLU_LINEAR_APPROX_LUT_VALUES \
+    SWIGLU_LUT_QUAD(-0.0000000000e+00f, -0.0000000000e+00f, -8.0871582031e-04f, -2.8416510671e-02f, -9.9945068359e-04f, -3.4123960882e-02f, -1.2359619141e-03f, -4.0880300105e-02f), \
+    SWIGLU_LUT_QUAD(-1.5182495117e-03f, -4.8848759383e-02f, -1.8615722656e-03f, -5.8208428323e-02f, -2.2888183594e-03f, -6.9152273238e-02f, -2.7923583984e-03f, -8.1883266568e-02f), \
+    SWIGLU_LUT_QUAD(-3.4027099609e-03f, -9.6608236432e-02f, -4.1503906250e-03f, -1.1352804303e-01f, -5.0048828125e-03f, -1.3282361627e-01f, -6.0729980469e-03f, -1.5463614464e-01f), \
+    SWIGLU_LUT_QUAD(-7.2937011719e-03f, -1.7904028296e-01f, -8.7280273438e-03f, -2.0600858331e-01f, -1.0314941406e-02f, -2.3536635935e-01f, -1.2145996094e-02f, -2.6673564315e-01f), \
+    SWIGLU_LUT_QUAD(-1.4221191406e-02f, -2.9946959019e-01f, -1.6479492188e-02f, -3.3258017898e-01f, -1.8676757812e-02f, -3.6466687918e-01f, -2.0996093750e-02f, -3.9386045933e-01f), \
+    SWIGLU_LUT_QUAD(-2.2949218750e-02f, -4.1780564189e-01f, -2.4414062500e-02f, -4.3371707201e-01f, -2.4902343750e-02f, -4.3855389953e-01f, -2.3925781250e-02f, -4.2936223745e-01f), \
+    SWIGLU_LUT_QUAD(-2.0629882812e-02f, -4.0381985903e-01f, -1.4526367188e-02f, -3.6097243428e-01f, -4.7302246094e-03f, -3.0205962062e-01f, 9.4604492188e-03f, -2.3120641708e-01f), \
+    SWIGLU_LUT_QUAD(2.8320312500e-02f, -1.5563963354e-01f, 5.1757812500e-02f, -8.5079051554e-02f, 7.9101562500e-02f, -3.0141420662e-02f, 1.0937500000e-01f, 0.0000000000e+00f), \
+    SWIGLU_LUT_QUAD(1.4062500000e-01f, 0.0000000000e+00f, 1.7089843750e-01f, -3.0141420662e-02f, 1.9824218750e-01f, -8.5079051554e-02f, 2.2167968750e-01f, -1.5563963354e-01f), \
+    SWIGLU_LUT_QUAD(2.4023437500e-01f, -2.3120641708e-01f, 2.5390625000e-01f, -3.0205962062e-01f, 2.6367187500e-01f, -3.6097243428e-01f, 2.7148437500e-01f, -4.0381985903e-01f), \
+    SWIGLU_LUT_QUAD(2.7343750000e-01f, -4.2936223745e-01f, 2.7539062500e-01f, -4.3855389953e-01f, 2.7343750000e-01f, -4.3371707201e-01f, 2.7343750000e-01f, -4.1780564189e-01f), \
+    SWIGLU_LUT_QUAD(2.7148437500e-01f, -3.9386045933e-01f, 2.6953125000e-01f, -3.6466687918e-01f, 2.6562500000e-01f, -3.3258017898e-01f, 2.6367187500e-01f, -2.9946959019e-01f), \
+    SWIGLU_LUT_QUAD(2.6171875000e-01f, -2.6673564315e-01f, 2.5976562500e-01f, -2.3536635935e-01f, 2.5781250000e-01f, -2.0600858331e-01f, 2.5781250000e-01f, -1.7904028296e-01f), \
+    SWIGLU_LUT_QUAD(2.5585937500e-01f, -1.5463614464e-01f, 2.5585937500e-01f, -1.3282361627e-01f, 2.5390625000e-01f, -1.1352804303e-01f, 2.5390625000e-01f, -9.6608236432e-02f), \
+    SWIGLU_LUT_QUAD(2.5195312500e-01f, -8.1883266568e-02f, 2.5195312500e-01f, -6.9152273238e-02f, 2.5195312500e-01f, -5.8208428323e-02f, 2.5195312500e-01f, -4.8848759383e-02f), \
+    SWIGLU_LUT_QUAD(2.5195312500e-01f, -4.0880300105e-02f, 2.5195312500e-01f, -3.4123960882e-02f, 2.5000000000e-01f, -2.8416510671e-02f, 2.5000000000e-01f, -0.0000000000e+00f)
+
+alignas(aie::vector_decl_align) static const float swiglu_linear_lut_ab[kMylmSwigluSegments * 4] = {
+    SWIGLU_LINEAR_APPROX_LUT_VALUES
+};
+alignas(aie::vector_decl_align) static const float swiglu_linear_lut_cd[kMylmSwigluSegments * 4] = {
+    SWIGLU_LINEAR_APPROX_LUT_VALUES
+};
+#undef SWIGLU_LINEAR_APPROX_LUT_VALUES
+#undef SWIGLU_LUT_QUAD
+
+} // namespace
+
+extern "C" {
+
+void ffn_swiglu_slice_bf16_inputs(
+    int32_t *input,
+    bfloat16 *output,
+    int32_t dwords,
+    int32_t slice
+) {
+    (void)dwords;
+    (void)slice;
+    bfloat16 *__restrict values = reinterpret_cast<bfloat16 *>(input);
+    bfloat16 *__restrict up_values = values;
+    bfloat16 *__restrict gate_values = values + kSwigluLanes;
+
+    using Lut = aie::lut<4, float, bfloat16>;
+    Lut silu_lut(kMylmSwigluSegments, swiglu_linear_lut_ab, swiglu_linear_lut_cd);
+    aie::linear_approx<bfloat16, Lut> silu_approx(silu_lut, 0, 32, 0);
+    const aie::vector<bfloat16, 16> scale4 = aie::broadcast<bfloat16, 16>(4.0f);
+    const aie::vector<bfloat16, 16> one = aie::broadcast<bfloat16, 16>(1.0f);
+
+    for (int32_t idx = 0; idx < kSwigluLanes; idx += 16)
+        chess_prepare_for_pipelining chess_loop_range(kSwigluLanes / 16, kSwigluLanes / 16) {
+        const aie::vector<bfloat16, 16> up_vec = aie::load_v<16>(up_values + idx);
+        const aie::vector<bfloat16, 16> gate_vec = aie::load_v<16>(gate_values + idx);
+        const aie::vector<bfloat16, 16> gate_scaled =
+            aie::mul(gate_vec, scale4).template to_vector<bfloat16>();
+        const aie::vector<float, 16> silu_vec = silu_approx.compute(gate_scaled).template to_vector<float>();
+        const auto up_float = aie::mul(up_vec, one);
+        const auto output_acc = aie::mul(up_float.template to_vector<float>(), silu_vec);
+        aie::store_v(output + idx, output_acc.template to_vector<bfloat16>());
+    }
+}
+
+} // extern "C"

--- a/engine/npu/kernel/zr1_constants.h
+++ b/engine/npu/kernel/zr1_constants.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace zr1 {
+
+// Standard NPU tile constants (same for all models)
+constexpr int32_t kMainRowsPerTile = 32;
+constexpr int32_t kQ4KChunk = 256;
+constexpr int32_t kQ4GroupSize = 32;
+constexpr int32_t kRecordDwords = 17;
+constexpr int32_t kRecordPayloadDwords = kRecordDwords - 1;
+constexpr int32_t kRecordPayloadBf16 = kRecordPayloadDwords * 2;
+
+// Phase indices
+constexpr int32_t kQPhase = 0;
+constexpr int32_t kKPhase = 1;
+constexpr int32_t kVPhase = 2;
+constexpr int32_t kOPhase = 3;
+constexpr int32_t kUpPhase = 4;
+constexpr int32_t kGatePhase = 5;
+constexpr int32_t kDownPhase = 6;
+
+constexpr int32_t kMain16PhaseLimitQkv = kVPhase + 1;
+constexpr int32_t kMain16PhaseLimitQkvo = kOPhase + 1;
+constexpr int32_t kMain16PhaseLimitUpGate = kGatePhase + 1;
+constexpr int32_t kMain16PhaseLimitFull = kDownPhase + 1;
+
+// Compact packet IDs
+constexpr int32_t kQCompactPacketId = 0x1;
+constexpr int32_t kKCompactPacketId = 0x1;
+constexpr int32_t kVCompactPacketId = 0x1;
+constexpr int32_t kOCompactPacketId = 0x4;
+constexpr int32_t kFfnCompactPacketId = 0x8;
+constexpr int32_t kDownCompactPacketId = 0x4;
+
+// Lock IDs
+constexpr int32_t kMainActivationEmptyLock = 0;
+constexpr int32_t kMainActivationFullLock = 1;
+constexpr int32_t kMainWeightEmptyLock = 2;
+constexpr int32_t kMainWeightFullLock = 3;
+constexpr int32_t kMainRecordEmptyLock = 4;
+constexpr int32_t kMainRecordFullLock = 5;
+constexpr int32_t kCoreLocalLockBase = 0x30;
+
+// ===== ZR1-1.5B specific body/chunk constants =====
+// Q:  H=1536 input, NH×HD=1536 output. 1536/512=3 body records, 1536/256=6 chunks/record
+// K:  H=1536 input, NKV×HD=256 output. 256/512=1 body record, 1536/256=6 chunks/record
+// V:  same as K
+// O:  NH×HD=1536 input, H=1536 output. 1536/512=3 body records, 1536/256=6 chunks/record
+// UP/GATE: H=1536 input, IM=8960 output. 8960/512=18 blocks total, 18 replays each → 36 total
+// DOWN: IM=8960 input, H=1536 output. 1536/512=3 body records, 8960/256=35 chunks/record
+
+constexpr int32_t kQBodyRecords = 3;           // 1536/512
+constexpr int32_t kKvBodyRecords = 1;          // 256/512
+constexpr int32_t kOBodyRecords = 3;           // 1536/512
+constexpr int32_t kUpGateReplays = 36;         // (18+18) UP+GATE blocks
+constexpr int32_t kDownBodyRecords = 3;        // 1536/512
+
+constexpr int32_t kQChunksPerRecord = 6;       // 1536/256
+constexpr int32_t kKvChunksPerRecord = 6;      // 1536/256
+constexpr int32_t kOChunksPerRecord = 6;       // 1536/256
+constexpr int32_t kUpGateChunksPerReplay = 6;  // 1536/256
+constexpr int32_t kDownChunksPerRecord = 35;   // 8960/256
+
+// Weight chunk base offsets
+constexpr int32_t kQWeightChunkBase = 0;                          // 0
+constexpr int32_t kKWeightChunkBase = 18;                         // 0 + 3×6
+constexpr int32_t kVWeightChunkBase = 24;                         // 18 + 1×6
+constexpr int32_t kFullLayerOWeightChunkBase = 30;                // 24 + 1×6
+constexpr int32_t kFullLayerUpGateWeightChunkBase = 48;           // 30 + 3×6
+constexpr int32_t kFullLayerDownWeightChunkBase = 264;            // 48 + 36×6
+}

--- a/npu-infer/include/model.h
+++ b/npu-infer/include/model.h
@@ -21,7 +21,7 @@ typedef struct {
     char     dtype[16];       // offset 188
 } TensorDesc;
 #ifdef __cplusplus
-static_assert(sizeof(TensorDesc) == 204, "TensorDesc padding mismatch");
+static_assert(sizeof(TensorDesc) == 208, "TensorDesc padding mismatch");
 #endif
 
 // Per-layer weights

--- a/npu-infer/src/ffi_bridge.cpp
+++ b/npu-infer/src/ffi_bridge.cpp
@@ -1,0 +1,106 @@
+/// ffi_bridge.cpp — C-compatible FFI wrappers around the NPU inference engine
+/// Exposes flat C functions that Rust can call via `extern "C"`.
+#include "engine.h"
+#include "common.h"
+#include <cstring>
+#include <mutex>
+
+// We wrap the C++ engine in an opaque handle for FFI safety
+extern "C" {
+
+// Opaque handle — Rust holds this as a *mut c_void
+struct NpuEngineHandle {
+    NpuInferenceEngine engine;
+    bool initialized;
+    int last_error;
+    char error_msg[256];
+};
+
+// ── Lifecycle ───────────────────────────────────────────────────
+
+NpuEngineHandle* npu_engine_create() {
+    auto* h = new NpuEngineHandle();
+    h->initialized = false;
+    h->last_error = 0;
+    h->error_msg[0] = '\0';
+    return h;
+}
+
+int npu_engine_destroy(NpuEngineHandle* h) {
+    if (!h) return -1;
+    delete h;
+    return 0;
+}
+
+// ── Initialization ──────────────────────────────────────────────
+
+int npu_engine_init(NpuEngineHandle* h, const char* model_path) {
+    if (!h) return -1;
+    
+    bool ok = h->engine.init(model_path);
+    h->initialized = ok;
+    
+    if (!ok) {
+        h->last_error = 1;
+        snprintf(h->error_msg, sizeof(h->error_msg),
+                 "Engine init failed: %s", model_path ? model_path : "null");
+        return -1;
+    }
+    return 0;
+}
+
+int npu_engine_is_initialized(NpuEngineHandle* h) {
+    return (h && h->initialized) ? 1 : 0;
+}
+
+const char* npu_engine_last_error(NpuEngineHandle* h) {
+    return (h) ? h->error_msg : "null handle";
+}
+
+// ── Inference ───────────────────────────────────────────────────
+
+/// Generate tokens from a prompt.
+/// @return Number of output tokens written, or -1 on error.
+int npu_engine_generate(
+    NpuEngineHandle* h,
+    const int* input_tokens,
+    int num_input_tokens,
+    int* output_tokens,
+    int max_output_tokens
+) {
+    if (!h || !h->initialized) return -1;
+    if (!input_tokens || num_input_tokens <= 0) return -1;
+    if (!output_tokens || max_output_tokens <= 0) return -1;
+    
+    try {
+        int n = h->engine.generate(input_tokens, num_input_tokens,
+                                    output_tokens, max_output_tokens);
+        return n;
+    } catch (const std::exception& e) {
+        h->last_error = 2;
+        snprintf(h->error_msg, sizeof(h->error_msg),
+                 "Generate failed: %s", e.what());
+        return -1;
+    } catch (...) {
+        h->last_error = 3;
+        snprintf(h->error_msg, sizeof(h->error_msg),
+                 "Generate failed: unknown error");
+        return -1;
+    }
+}
+
+// ── Configuration ───────────────────────────────────────────────
+
+/// Get the model configuration (vocab_size, hidden_size, etc.)
+int npu_engine_get_config(NpuEngineHandle* h, int* out_vocab_size,
+                           int* out_hidden_size, int* out_num_layers) {
+    if (!h || !h->initialized) return -1;
+    // The ModelConfig is embedded in the engine. We'd need to expose it.
+    // For now, return from the hardcoded config.
+    if (out_vocab_size) *out_vocab_size = 151936;
+    if (out_hidden_size) *out_hidden_size = 1024;
+    if (out_num_layers) *out_num_layers = 28;
+    return 0;
+}
+
+} // extern "C"

--- a/npu-infer/tools/npu_gemm_runner.cpp
+++ b/npu-infer/tools/npu_gemm_runner.cpp
@@ -1,0 +1,188 @@
+/**
+ * npu_gemm_runner — stdin/stdout NPU GEMM runner.
+ *
+ * Usage:
+ *   npu_gemm_runner <xclbin_path> <insts_path> M K N [n_aie_rows]
+ *     < A_float32_binary > C_float32_binary
+ *
+ * Stdin:  M*K float32 (A) + K*N float32 (B), raw binary, row-major
+ * Stdout: M*N float32 (C), raw binary, row-major (after inverse layout)
+ * Stderr: timing and GFLOPS info
+ *
+ * The binary handles ALL data layout internally:
+ *   - A: shuffled via layout_A_L1_2x1_8x8block, converted to BF16 uint16
+ *   - B: transposed+shuffled via layout_transpose_L1_1x2_8x8block, BFP16 ebs8 encoded
+ *   - C: read back as BF16, converted to float32, inverse layout applied
+ *
+ * This matches the IRON MLIR config1 design expectations (n1_core_bf16 / n2_core_placed).
+ */
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+#include <vector>
+#include <chrono>
+#include <iostream>
+#include <fstream>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+#include "helper.h"
+#include "gemm_atb_layout.h"
+
+static inline float bf16_to_float(uint16_t v) {
+    uint32_t bits = ((uint32_t)v) << 16; float f; memcpy(&f, &bits, sizeof(f)); return f;
+}
+static inline uint16_t float_to_bf16(float v) {
+    uint32_t bits; memcpy(&bits, &v, sizeof(bits));
+    uint32_t r = ((bits >> 16) & 1) + 0x7FFF; return (uint16_t)((bits + r) >> 16);
+}
+
+static inline int64_t now_us() {
+    auto now = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
+}
+
+static std::vector<uint32_t> load_instructions(const char* path) {
+    std::vector<uint32_t> instrs;
+    FILE* f = fopen(path, "rb");
+    if (!f) { fprintf(stderr, "Error: Cannot open instruction file: %s\n", path); return instrs; }
+    fseek(f, 0, SEEK_END);
+    long sz = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    instrs.resize(sz / 4);
+    size_t n = fread(instrs.data(), 4, instrs.size(), f);
+    fclose(f);
+    fprintf(stderr, "  Loaded %zu instructions from %s (%ld bytes)\n", n, path, sz);
+    return instrs;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 6) {
+        fprintf(stderr, "Usage: npu_gemm_runner <xclbin_path> <insts_path> M K N [n_aie_rows]\n");
+        fprintf(stderr, "  Reads A (M*K float32) and B (K*N float32) from stdin\n");
+        fprintf(stderr, "  Writes C (M*N float32) to stdout\n");
+        return 1;
+    }
+
+    const char* xclbin_path = argv[1];
+    const char* insts_path  = argv[2];
+    int M = atoi(argv[3]);
+    int K = atoi(argv[4]);
+    int N = atoi(argv[5]);
+    int n_aie_rows = (argc > 6) ? atoi(argv[6]) : 1;
+
+    const int m_tile = 128, k_tile = 64, n_tile = 128;
+    int L1_block_m = n_aie_rows * m_tile;
+
+    fprintf(stderr, "  Config: %dx%dx%d tiles=%dx%dx%d rows=%d L1_block_m=%d\n",
+            M, K, N, m_tile, k_tile, n_tile, n_aie_rows, L1_block_m);
+
+    // Read A and B from stdin
+    size_t A_count = (size_t)M * K;
+    size_t B_count = (size_t)K * N;
+    std::vector<float> A_float(A_count);
+    std::vector<float> B_float(B_count);
+
+    size_t A_bytes = A_count * sizeof(float);
+    size_t B_bytes = B_count * sizeof(float);
+
+    size_t nread_A = fread(A_float.data(), 1, A_bytes, stdin);
+    if (nread_A != A_bytes) {
+        fprintf(stderr, "Error: expected %zu bytes of A, got %zu\n", A_bytes, nread_A);
+        return 1;
+    }
+    size_t nread_B = fread(B_float.data(), 1, B_bytes, stdin);
+    if (nread_B != B_bytes) {
+        fprintf(stderr, "Error: expected %zu bytes of B, got %zu\n", B_bytes, nread_B);
+        return 1;
+    }
+    fprintf(stderr, "  Read A (%zu floats) and B (%zu floats) from stdin\n", A_count, B_count);
+
+    int64_t t0 = now_us();
+
+    // Load xclbin and instructions
+    auto instr_v = load_instructions(insts_path);
+    if (instr_v.empty()) return 1;
+
+    // Open device, register xclbin, get kernel
+    auto device = xrt::device(0);
+    auto xclbin = xrt::xclbin(std::string(xclbin_path));
+    device.register_xclbin(xclbin);
+    auto hw_ctx = xrt::hw_context(device, xclbin.get_uuid());
+    auto kernel = xrt::kernel(hw_ctx, "MLIR_AIE");
+
+    int64_t t1 = now_us();
+    fprintf(stderr, "  NPU init: %ld us\n", (long)(t1 - t0));
+
+    // --- Data layout transformations ---
+
+    // A: convert to BF16 directly (NPU-side A_transformations handle the shuffle)
+    std::vector<uint16_t> A_bf16(M * K);
+    for (int i = 0; i < M * K; i++) {
+        A_bf16[i] = float_to_bf16(A_float[i]);
+    }
+
+    // B: layout_transpose_L1_1x2_8x8block(k=64, n=128) then BFP16 ebs8 encode
+    auto B_shuffled = gemm_atb::layout_transpose_L1_1x2_8x8block(B_float, K, N, k_tile, n_tile);
+    auto B_bfp = floatToBfp16(8, K * N, B_shuffled.data(), 0);
+
+    // --- Create XRT BOs ---
+    auto bo_instr = xrt::bo(device, instr_v.size() * 4, XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+    auto bo_A = xrt::bo(device, M * K * 2, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+    auto bo_B = xrt::bo(device, B_bfp.size(), XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+    auto bo_C = xrt::bo(device, M * N * 2, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+
+    // Upload
+    memcpy(bo_instr.map(), instr_v.data(), instr_v.size() * 4);
+    bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    memcpy(bo_A.map(), A_bf16.data(), M * K * 2);
+    bo_A.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    memcpy(bo_B.map(), B_bfp.data(), B_bfp.size());
+    bo_B.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    memset(bo_C.map(), 0, M * N * 2);
+    bo_C.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+    // Run kernel
+    auto run = kernel((unsigned)3, bo_instr, instr_v.size(), bo_A, bo_B, bo_C);
+    run.wait();
+
+    int64_t t2 = now_us();
+    fprintf(stderr, "  NPU exec: %ld us\n", (long)(t2 - t1));
+
+    // Read back C
+    bo_C.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+    uint16_t* C_bf16_raw = (uint16_t*)bo_C.map();
+
+    // Convert BF16 to float
+    std::vector<float> C_raw_float(M * N);
+    for (int i = 0; i < M * N; i++) {
+        C_raw_float[i] = bf16_to_float(C_bf16_raw[i]);
+    }
+
+    // Read C directly — the C_transformations + DMA produce data that
+    // is either row-major (empty transformations) or in a format where
+    // the host-side layout_inverse_C does not match (known pre-existing
+    // layout mismatch documented in task-3-report.md). Constant data
+    // tests (identity under shuffling) verify pipeline correctness.
+    std::vector<float> C_float = std::move(C_raw_float);
+
+    // Write C to stdout as raw float32
+    size_t written = fwrite(C_float.data(), sizeof(float), M * N, stdout);
+    if (written != (size_t)M * N) {
+        fprintf(stderr, "Error: failed to write C to stdout\n");
+        return 1;
+    }
+    fflush(stdout);
+
+    // GFLOPS
+    double us = (double)(t2 - t1);
+    double gflops = 2.0 * M * K * N / (us * 1000.0);
+    fprintf(stderr, "  GFLOPS: %.2f\n", gflops);
+
+    return 0;
+}

--- a/packaging/binary/server.cpp
+++ b/packaging/binary/server.cpp
@@ -1,0 +1,154 @@
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <thread>
+#include <chrono>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+
+static std::string run_engine(const std::string& prompt, int max_tokens=8) {
+    (void)prompt;
+    const char* engine = getenv("NPU_ENGINE_BIN");
+    if (!engine || !*engine) engine = "./engine/npu/build/npu_engine_cb";
+    const char* libpath = getenv("NPU_LD_LIBRARY_PATH");
+
+    auto has_metachar = [](const char* s) -> bool {
+        for (const char* p = s; *p; ++p) {
+            if (*p <= 32 || *p == ';' || *p == '|' || *p == '&' || *p == '$' || *p == '`' ||
+                *p == '(' || *p == ')' || *p == '{' || *p == '}' || *p == '<' || *p == '>' ||
+                *p == '!' || *p == '~' || *p == '\'' || *p == '"' || *p == '\\') return true;
+        }
+        return false;
+    };
+    if (has_metachar(engine)) {
+        fprintf(stderr, "[1bit-server] refused: NPU_ENGINE_BIN contains shell metacharacters\n");
+        return "{\"error\": \"invalid engine path\"}";
+    }
+    if (libpath && *libpath && has_metachar(libpath)) {
+        fprintf(stderr, "[1bit-server] refused: NPU_LD_LIBRARY_PATH contains shell metacharacters\n");
+        return "{\"error\": \"invalid library path\"}";
+    }
+
+    std::string cmd;
+    if (libpath && *libpath) cmd += std::string("LD_LIBRARY_PATH=") + libpath + " ";
+    cmd += std::string(engine) + " 9 " + std::to_string(max_tokens) + " 2>/dev/null";
+    FILE* f = popen(cmd.c_str(), "r");
+    if (!f) return "{\"error\": \"engine not found\"}";
+    char buf[8192]; std::string out;
+    while (fgets(buf, sizeof(buf), f)) out += buf;
+    pclose(f);
+
+    std::vector<std::string> tokens;
+    size_t pos = 0;
+    while ((pos = out.find("] ", pos)) != std::string::npos) {
+        pos += 2;
+        size_t end = out.find(" (", pos);
+        if (end != std::string::npos) tokens.push_back(out.substr(pos, end - pos));
+    }
+
+    std::string speed = "unknown";
+    if (auto p = out.rfind("ms/tok"); p != std::string::npos) {
+        auto start = out.rfind(" ", p - 2);
+        if (start != std::string::npos) speed = out.substr(start + 1, p - start - 1) + " ms/tok";
+    }
+
+    std::string json = "{\"object\":\"chat.completion\",\"model\":\"qwen3-0.6b-npu\",";
+    json += "\"speed\":\"" + speed + "\",";
+    json += "\"choices\":[{\"message\":{\"content\":\"";
+    for (size_t i = 0; i < tokens.size(); i++) {
+        if (i > 0) json += " ";
+        json += "[tok:" + tokens[i] + "]";
+    }
+    json += "\"}}],";
+    json += "\"usage\":{\"total_tokens\":" + std::to_string(tokens.size()) + "}";
+    json += "}";
+    return json;
+}
+
+static std::string extract_content(const std::string& req) {
+    std::string prompt = "Hello";
+    size_t pos = 0;
+    while (true) {
+        pos = req.find("\"content\"", pos);
+        if (pos == std::string::npos) break;
+        size_t ck = pos + 9;
+        while (ck < req.size() && (req[ck] == ' ' || req[ck] == '\t')) ++ck;
+        if (ck < req.size() && req[ck] == ':') {
+            size_t vs = ck + 1;
+            while (vs < req.size() && (req[vs] == ' ' || req[vs] == '\t')) ++vs;
+            if (vs < req.size() && req[vs] == '"') {
+                ++vs; size_t ve = vs;
+                while (ve < req.size() && req[ve] != '"') {
+                    if (req[ve] == '\\' && ve + 1 < req.size()) ve += 2;
+                    else ++ve;
+                }
+                prompt = req.substr(vs, ve - vs);
+                size_t w = 0; std::string unescaped;
+                while (w < prompt.size()) {
+                    if (prompt[w] == '\\' && w + 1 < prompt.size()) {
+                        switch (prompt[w+1]) {
+                            case 'n': unescaped += '\n'; break;
+                            case 'r': unescaped += '\r'; break;
+                            case 't': unescaped += '\t'; break;
+                            case '"': unescaped += '"'; break;
+                            case '\\': unescaped += '\\'; break;
+                            default: unescaped += prompt[w+1]; break;
+                        }
+                        w += 2;
+                    } else { unescaped += prompt[w++]; }
+                }
+                prompt = unescaped;
+            }
+            break;
+        }
+        pos = ck;
+    }
+    return prompt;
+}
+
+static void handle_client(int fd) {
+    std::string req;
+    char buf[4096];
+    for (int i = 0; i < 64; i++) {
+        ssize_t n = read(fd, buf, sizeof(buf));
+        if (n <= 0) break;
+        req.append(buf, n);
+        if (n < (ssize_t)sizeof(buf)) break;
+    }
+    if (req.empty()) { close(fd); return; }
+
+    std::string prompt = extract_content(req);
+    std::string body = run_engine(prompt, 4);
+    std::string response =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: application/json\r\n"
+        "Access-Control-Allow-Origin: " + (getenv("ZAYA_CORS_ORIGIN") ? std::string(getenv("ZAYA_CORS_ORIGIN")) : std::string("http://127.0.0.1")) + "\r\n"
+        "Connection: close\r\n"
+        "Content-Length: " + std::to_string(body.size()) + "\r\n"
+        "\r\n" + body;
+    write(fd, response.c_str(), response.size());
+    close(fd);
+}
+
+int main(int argc, char** argv) {
+    int port = (argc > 1) ? atoi(argv[1]) : 8080;
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    int opt = 1;
+    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+    struct sockaddr_in addr = {};
+    addr.sin_family = AF_INET;
+    const char* bind_all = getenv("ONEBIT_BIND_ALL");
+    addr.sin_addr.s_addr = (bind_all && *bind_all == '1') ? INADDR_ANY : htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(port);
+    bind(sock, (struct sockaddr*)&addr, sizeof(addr));
+    listen(sock, 5);
+    printf("1bit.systems NPU API -> http://localhost:%d/v1/chat/completions\n", port);
+    printf("  Model: Qwen3-0.6B INT8\n\n");
+    while (true) {
+        int client = accept(sock, nullptr, nullptr);
+        std::thread(handle_client, client).detach();
+    }
+}

--- a/tests/test_tokenizer_logprobs.cpp
+++ b/tests/test_tokenizer_logprobs.cpp
@@ -23,10 +23,6 @@ static bool create_test_htok(const char* path) {
     // Magic
     f.write("HTOK", 4);
 
-    // Format version (the loader reads a version field after the magic)
-    uint32_t version = 2;
-    f.write((const char*)&version, 4);
-
     // Small test vocabulary (20 tokens) + merges (10 merges)
     uint32_t vocab_size = 20;
     uint32_t num_merges = 10;
@@ -79,10 +75,6 @@ static bool create_test_htok(const char* path) {
         f.write((const char*)&b, 4);
         f.write((const char*)&merged, 4);
     }
-
-    // v2 trailer: special-token count (none in this test vocab)
-    uint32_t num_special = 0;
-    f.write((const char*)&num_special, 4);
 
     return true;
 }

--- a/tools/convert_gguf_to_h1b.cpp
+++ b/tools/convert_gguf_to_h1b.cpp
@@ -1,0 +1,808 @@
+// convert_gguf_to_h1b — Convert a Bonsai F16 GGUF to .h1b + sidecar GGUF.
+//
+// Reads a Bonsai-format F16 GGUF, ternarizes the weights to TQ2_0_g128 format,
+// and writes:
+//   output.h1b         — BONSAI_TQ2 weight format, zeroed norms/embedding
+//   output.gguf        — sidecar GGUF with norms + embedding (FP32)
+//
+// The output.h1b + output.gguf pair is loadable by rcpp_bitnet_load_h1b().
+//
+// Usage:
+//   convert_gguf_to_h1b --input model-f16.gguf --output model [--config model-tq2.gguf]
+//
+// --config is optional: if the F16 GGUF doesn't have config, read from
+// a separate TQ2 GGUF config file.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+#include <cmath>
+#include <algorithm>
+
+// ========================================================================
+// Minimal GGUF v3 reader (same structure as h1b_loader.cpp)
+// ========================================================================
+struct GgufTensorInfo {
+    std::vector<uint64_t> shape;
+    uint32_t dtype;
+    uint64_t offset;
+};
+
+class GgufReader {
+public:
+    bool open(const std::string& path) {
+        f_.open(path, std::ios::binary);
+        if (!f_) return false;
+        char magic[4];
+        f_.read(magic, 4);
+        if (std::strncmp(magic, "GGUF", 4) != 0) return false;
+        if (!read_u32(version_)) return false;
+        if (version_ != 2 && version_ != 3) {
+            fprintf(stderr, "[gguf] unsupported version %u\n", version_);
+            return false;
+        }
+        uint64_t n_tensors, n_kv;
+        if (!read_u64(n_tensors) || !read_u64(n_kv)) return false;
+
+        for (uint64_t i = 0; i < n_kv; ++i) {
+            std::string key;
+            if (!read_string(key)) return false;
+            uint32_t vt;
+            if (!read_u32(vt)) return false;
+            if (key == "general.architecture" && vt == 8) {
+                if (!read_string(arch_)) return false;
+            } else if (key == "general.alignment" && vt == 4) {
+                uint32_t a;
+                if (!read_u32(a)) return false;
+                alignment_ = a ? a : 32;
+            } else if ((key == "llm.hidden_size" || key == "qwen3.hidden_size") && vt == 4) {
+                read_u32(cfg_.hidden_size);
+            } else if ((key == "llm.intermediate_size" || key == "qwen3.intermediate_size") && vt == 4) {
+                read_u32(cfg_.intermediate_size);
+            } else if ((key == "llm.block_count" || key == "qwen3.block_count") && vt == 4) {
+                read_u32(cfg_.num_layers);
+            } else if ((key == "llm.attention.head_count" || key == "qwen3.attention.head_count") && vt == 4) {
+                read_u32(cfg_.num_heads);
+            } else if ((key == "llm.attention.head_count_kv" || key == "qwen3.attention.head_count_kv") && vt == 4) {
+                read_u32(cfg_.num_kv_heads);
+            } else if ((key == "llm.vocab_size" || key == "qwen3.vocab_size") && vt == 4) {
+                read_u32(cfg_.vocab_size);
+            } else if ((key == "llm.max_position_embeddings" || key == "qwen3.max_position_embeddings") && vt == 4) {
+                read_u32(cfg_.max_seq_len);
+            } else if ((key == "llm.rope.freq_base" || key == "qwen3.rope.freq_base") && vt == 4) {
+                read_u32(cfg_.rope_theta_u32);
+            } else if ((key == "llm.rope.freq_base" || key == "qwen3.rope.freq_base") && vt == 10) {
+                float v; read_raw(&v, 4); cfg_.rope_theta_float = v;
+            } else if (key == "general.name" && vt == 8) {
+                read_string(cfg_.model_name);
+            } else {
+                if (!skip_value(vt)) return false;
+            }
+        }
+
+        for (uint64_t i = 0; i < n_tensors; ++i) {
+            std::string name;
+            if (!read_string(name)) return false;
+            uint32_t ndim;
+            if (!read_u32(ndim)) return false;
+            GgufTensorInfo info;
+            info.shape.resize(ndim);
+            for (uint32_t d = 0; d < ndim; ++d) {
+                if (!read_u64(info.shape[d])) return false;
+            }
+            if (!read_u32(info.dtype)) return false;
+            if (!read_u64(info.offset)) return false;
+            tensors_[name] = info;
+        }
+
+        data_start_ = (uint64_t)f_.tellg();
+        uint64_t rem = data_start_ % alignment_;
+        if (rem) data_start_ += alignment_ - rem;
+        return true;
+    }
+
+    const std::string& arch() const { return arch_; }
+
+    struct Config {
+        uint32_t hidden_size = 0;
+        uint32_t intermediate_size = 0;
+        uint32_t num_layers = 0;
+        uint32_t num_heads = 0;
+        uint32_t num_kv_heads = 0;
+        uint32_t vocab_size = 0;
+        uint32_t max_seq_len = 0;
+        uint32_t rope_theta_u32 = 0;
+        float rope_theta_float = 500000.0f;
+        std::string model_name;
+    };
+
+    const Config& config() const { return cfg_; }
+
+    const GgufTensorInfo* info(const std::string& name) const {
+        auto it = tensors_.find(name);
+        return it != tensors_.end() ? &it->second : nullptr;
+    }
+
+    bool read_tensor_bytes(const std::string& name, size_t expected_bytes,
+                           std::vector<uint8_t>& out) {
+        auto it = tensors_.find(name);
+        if (it == tensors_.end()) return false;
+        const GgufTensorInfo& ti = it->second;
+        uint64_t off = data_start_ + ti.offset;
+        f_.seekg(off);
+        if (!f_) return false;
+        out.resize(expected_bytes);
+        f_.read(reinterpret_cast<char*>(out.data()), expected_bytes);
+        return (size_t)f_.gcount() == expected_bytes;
+    }
+
+    bool read_tensor_f32(const std::string& name, std::vector<float>& out) {
+        auto it = tensors_.find(name);
+        if (it == tensors_.end()) return false;
+        const GgufTensorInfo& ti = it->second;
+        if (ti.dtype != 0) { // F32
+            fprintf(stderr, "[gguf] tensor %s dtype=%u (expected 0=F32)\n", name.c_str(), ti.dtype);
+            return false;
+        }
+        size_t n = 1;
+        for (auto d : ti.shape) n *= d;
+        uint64_t off = data_start_ + ti.offset;
+        f_.seekg(off);
+        if (!f_) return false;
+        out.resize(n);
+        f_.read(reinterpret_cast<char*>(out.data()), n * sizeof(float));
+        return (size_t)f_.gcount() == n * sizeof(float);
+    }
+
+    bool read_tensor_f16(const std::string& name, std::vector<uint16_t>& out) {
+        auto it = tensors_.find(name);
+        if (it == tensors_.end()) return false;
+        const GgufTensorInfo& ti = it->second;
+        if (ti.dtype != 1) { // F16
+            fprintf(stderr, "[gguf] tensor %s dtype=%u (expected 1=F16)\n", name.c_str(), ti.dtype);
+            return false;
+        }
+        size_t n = 1;
+        for (auto d : ti.shape) n *= d;
+        uint64_t off = data_start_ + ti.offset;
+        f_.seekg(off);
+        if (!f_) return false;
+        out.resize(n);
+        f_.read(reinterpret_cast<char*>(out.data()), n * sizeof(uint16_t));
+        return (size_t)f_.gcount() == n * sizeof(uint16_t);
+    }
+
+private:
+    bool read_u32(uint32_t& v) { return read_raw(&v, 4); }
+    bool read_u64(uint64_t& v) { return read_raw(&v, 8); }
+    bool read_raw(void* buf, size_t n) {
+        f_.read(static_cast<char*>(buf), n);
+        return !!f_;
+    }
+    bool read_string(std::string& s) {
+        uint64_t len;
+        if (!read_u64(len)) return false;
+        s.resize((size_t)len);
+        f_.read(s.data(), len);
+        return !!f_;
+    }
+    bool skip_value(uint32_t vt) {
+        switch (vt) {
+            case 0: { uint8_t v; return read_raw(&v, 1); }
+            case 1: { uint8_t v; return read_raw(&v, 1); }
+            case 2: { uint16_t v; return read_raw(&v, 2); }
+            case 3: { int16_t v; return read_raw(&v, 2); }
+            case 4: { uint32_t v; return read_raw(&v, 4); }
+            case 5: { int32_t v; return read_raw(&v, 4); }
+            case 6: { float v; return read_raw(&v, 4); }
+            case 7: { bool v; return read_raw(&v, 1); }
+            case 8: { std::string s; return read_string(s); }
+            case 10: { double v; return read_raw(&v, 8); }
+            case 11: { uint64_t v; return read_raw(&v, 8); }
+            case 12: { int64_t v; return read_raw(&v, 8); }
+            case 13: { uint64_t v; return read_raw(&v, 8); } // array
+            default: return false;
+        }
+    }
+
+    std::ifstream f_;
+    uint32_t version_ = 0;
+    uint64_t data_start_ = 0;
+    uint32_t alignment_ = 32;
+    std::string arch_;
+    Config cfg_;
+    std::map<std::string, GgufTensorInfo> tensors_;
+};
+
+// ========================================================================
+// FP16 helpers — must be defined before TQ2 packer that uses them
+// ========================================================================
+static inline float fp16_to_float(uint16_t h) {
+    // FP16 -> FP32 conversion
+    uint32_t sign = (h >> 15) & 1;
+    uint32_t exp  = (h >> 10) & 0x1f;
+    uint32_t mant = h & 0x3ff;
+    uint32_t f;
+    if (exp == 0) {
+        // Subnormal or zero
+        if (mant == 0) {
+            f = sign << 31;
+        } else {
+            int e = -1;
+            uint32_t m = mant;
+            while ((m & 0x400) == 0) { m <<= 1; --e; }
+            exp = e + 127;
+            mant = m & 0x3ff;
+            f = (sign << 31) | (exp << 23) | (mant << 13);
+        }
+    } else if (exp == 31) {
+        // Inf/NaN
+        f = (sign << 31) | 0x7f800000 | (mant << 13);
+    } else {
+        f = (sign << 31) | ((exp + 112) << 23) | (mant << 13);
+    }
+    float result;
+    memcpy(&result, &f, 4);
+    return result;
+}
+
+static inline uint16_t float_to_fp16(float v) {
+    uint32_t f;
+    memcpy(&f, &v, 4);
+    uint32_t sign = (f >> 31) & 1;
+    int32_t exp  = (f >> 23) & 0xff;
+    uint32_t mant = f & 0x7fffff;
+    uint16_t h;
+    if (exp == 0) {
+        h = (sign << 15);
+    } else if (exp == 0xff) {
+        h = (sign << 15) | 0x7c00;
+        if (mant) h |= 0x200; // NaN
+    } else {
+        int32_t newexp = exp - 127 + 15;
+        if (newexp >= 31) {
+            h = (sign << 15) | 0x7c00;
+        } else if (newexp <= 0) {
+            // Flush to zero
+            h = (sign << 15);
+        } else {
+            h = (sign << 15) | (newexp << 10) | (mant >> 13);
+        }
+    }
+    return h;
+}
+
+static inline float valRatio(float w, float d) {
+    if (d < 1e-10f) return 0.0f;
+    return w / d;
+}
+
+// ========================================================================
+// TQ2_0_g128 packer — ternarize float weights to 34-byte blocks of 128
+// ========================================================================
+
+// Convert float to ternary {-1, 0, +1} with threshold around 2 std devs
+// that ensures ~50% zeros for BitNet-style models.
+static inline int8_t ternarize(float v, float threshold) {
+    if (v > threshold) return 1;
+    if (v < -threshold) return -1;
+    return 0;
+}
+
+// Pack a row of 128 floats into TQ2_0_g128 block (34 bytes).
+// Layout: 32 bytes of 2-bit codes (weights in {-1,0,+1} → codes {0,1,2})
+//         + 2 bytes FP16 block scale d.
+void pack_tq2_block(const float* vals, int n, uint8_t* out) {
+    // Find the right threshold for 50% zeros
+    float max_abs = 0.0f;
+    double sum_abs = 0.0;
+    for (int i = 0; i < n; ++i) {
+        float a = std::fabs(vals[i]);
+        if (a > max_abs) max_abs = a;
+        sum_abs += a;
+    }
+    float mean_abs = (float)(sum_abs / n);
+    float threshold = 0.7f * mean_abs;
+    if (threshold < 1e-10f) threshold = 1e-10f;
+
+    int8_t ternary[128];
+    float max_mag = 0.0f;
+    for (int i = 0; i < n; ++i) {
+        ternary[i] = ternarize(vals[i], threshold);
+        if (ternary[i] != 0) {
+            float mag = std::fabs(vals[i]);
+            if (mag > max_mag) max_mag = mag;
+        }
+    }
+    if (max_mag < 1e-10f) max_mag = 1.0f;
+
+    uint16_t d_fp16 = float_to_fp16(max_mag);
+    float d = fp16_to_float(d_fp16);
+
+    for (int i = 0; i < 32; ++i) {
+        uint8_t byte = 0;
+        for (int j = 0; j < 4; ++j) {
+            int idx = i * 4 + j;
+            int code;
+            float w = (float)ternary[idx] * max_mag / d;
+            float ratio = valRatio(w, d);
+            (void)ratio;
+            if (w > d * 0.5f) code = 2;
+            else if (w < -d * 0.5f) code = 0;
+            else code = 1;
+            byte |= (uint8_t)(code << (j * 2));
+        }
+        out[i] = byte;
+    }
+    memcpy(out + 32, &d_fp16, 2);
+}
+
+void ternarize_and_pack_tq2(const float* data, int rows, int cols,
+                            std::vector<uint8_t>& packed) {
+    const int gs = 128;
+    const int block_bytes = 34;
+    const int blocks_per_row = cols / gs;
+    const size_t row_bytes = blocks_per_row * block_bytes;
+    packed.resize(rows * row_bytes);
+
+    for (int r = 0; r < rows; ++r) {
+        for (int b = 0; b < blocks_per_row; ++b) {
+            pack_tq2_block(data + r * cols + b * gs, gs,
+                          packed.data() + r * row_bytes + b * block_bytes);
+        }
+    }
+}
+
+// ========================================================================
+// Sidecar GGUF writer — writes FP32 norms + embedding 
+// ========================================================================
+class GgufWriter {
+public:
+    GgufWriter(const std::string& path) : f_(path, std::ios::binary) {}
+
+    bool write_header(uint64_t n_tensors, uint64_t n_kv) {
+        f_.write("GGUF", 4);
+        write_u32(3); // version 3
+        write_u64(n_tensors);
+        write_u64(n_kv);
+        return !!f_;
+    }
+
+    void write_kv_string(const std::string& key, const std::string& val) {
+        write_string(key);
+        write_u32(8); // string type
+        write_string(val);
+    }
+
+    void write_kv_u32(const std::string& key, uint32_t val) {
+        write_string(key);
+        write_u32(4); // u32 type
+        write_u32(val);
+    }
+
+    void write_kv_f32(const std::string& key, float val) {
+        write_string(key);
+        write_u32(6); // float32 type
+        write_raw(&val, 4);
+    }
+
+    void write_tensor_info(const std::string& name,
+                           const std::vector<uint64_t>& shape,
+                           uint32_t dtype,
+                           uint64_t offset) {
+        write_string(name);
+        write_u32((uint32_t)shape.size());
+        for (auto d : shape) write_u64(d);
+        write_u32(dtype);
+        write_u64(offset);
+    }
+
+    void write_tensor_data(const void* data, size_t bytes) {
+        f_.write(static_cast<const char*>(data), bytes);
+    }
+
+    void align_to(uint32_t alignment) {
+        uint64_t pos = f_.tellp();
+        uint64_t rem = pos % alignment;
+        if (rem) {
+            uint64_t pad = alignment - rem;
+            for (uint64_t i = 0; i < pad; ++i) f_.put(0);
+        }
+    }
+
+    uint64_t tell() { return (uint64_t)f_.tellp(); }
+
+private:
+    void write_u32(uint32_t v) { write_raw(&v, 4); }
+    void write_u64(uint64_t v) { write_raw(&v, 8); }
+    void write_string(const std::string& s) {
+        write_u64(s.size());
+        write_raw(s.data(), s.size());
+    }
+    void write_raw(const void* d, size_t n) {
+        f_.write(static_cast<const char*>(d), n);
+    }
+    std::ofstream f_;
+};
+
+// ========================================================================
+// Main
+// ========================================================================
+int main(int argc, char** argv) {
+    const char* input_path = nullptr;
+    const char* output_path = nullptr;
+    const char* config_path = nullptr;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if (a == "--input" && i + 1 < argc) input_path = argv[++i];
+        else if (a == "--output" && i + 1 < argc) output_path = argv[++i];
+        else if (a == "--config" && i + 1 < argc) config_path = argv[++i];
+        else if (a == "--help" || a == "-h") {
+            fprintf(stderr, "Usage: %s --input model-f16.gguf --output basename [--config model-tq2.gguf]\n", argv[0]);
+            return 0;
+        }
+    }
+
+    if (!input_path || !output_path) {
+        fprintf(stderr, "Usage: %s --input model-f16.gguf --output basename\n", argv[0]);
+        return 1;
+    }
+
+    std::string h1b_path = std::string(output_path) + ".h1b";
+    std::string gguf_path = std::string(output_path) + ".gguf";
+
+    fprintf(stderr, "[convert] loading GGUF: %s\n", input_path);
+    GgufReader reader;
+    if (!reader.open(input_path)) {
+        fprintf(stderr, "[convert] failed to open GGUF: %s\n", input_path);
+        return 1;
+    }
+
+    const auto& cfg = reader.config();
+    fprintf(stderr, "[convert] arch=%s hs=%d is=%d layers=%d heads=%d kv_heads=%d vocab=%d\n",
+            reader.arch().c_str(),
+            cfg.hidden_size, cfg.intermediate_size, cfg.num_layers,
+            cfg.num_heads, cfg.num_kv_heads, cfg.vocab_size);
+
+    uint32_t hs = cfg.hidden_size;
+    uint32_t is_ = cfg.intermediate_size;
+    uint32_t nh = cfg.num_heads;
+    uint32_t nkv = cfg.num_kv_heads;
+    uint32_t hd = hs / nh;
+    uint32_t num_layers = cfg.num_layers;
+    uint32_t vocab_size = cfg.vocab_size;
+
+    if (hs == 0 || is_ == 0 || num_layers == 0) {
+        fprintf(stderr, "[convert] incomplete config from GGUF\n");
+        return 1;
+    }
+
+    // ==================================================================
+    // Step 1: Ternarize all weight matrices → TQ2 packed format
+    // ==================================================================
+    struct TensorData {
+        std::vector<float> data_f32;
+        std::vector<uint16_t> data_f16;
+    };
+
+    // Read all F16 weight tensors
+    auto read_weight_f16 = [&](const std::string& name) -> TensorData {
+        TensorData td;
+        // Try F16 first
+        if (reader.read_tensor_f16(name, td.data_f16)) {
+            return td;
+        }
+        // Fall back to F32
+        if (reader.read_tensor_f32(name, td.data_f32)) {
+            return td;
+        }
+        fprintf(stderr, "[convert] WARNING: could not read tensor %s\n", name.c_str());
+        return td;
+    };
+
+    auto get_float = [&](const TensorData& td, size_t i) -> float {
+        if (!td.data_f32.empty()) return td.data_f32[i];
+        if (!td.data_f16.empty()) {
+            uint16_t h = td.data_f16[i];
+            return fp16_to_float(h);
+        }
+        return 0.0f;
+    };
+
+    auto tensor_size = [&](const TensorData& td) -> size_t {
+        if (!td.data_f32.empty()) return td.data_f32.size();
+        return td.data_f16.size();
+    };
+
+    // Collect weights per layer
+    struct LayerWeights {
+        TensorData q, k, v, o, gate, up, down;
+        TensorData attn_norm, ffn_norm, attn_q_norm, attn_k_norm;
+    };
+    std::vector<LayerWeights> layers(num_layers);
+
+    for (uint32_t l = 0; l < num_layers; ++l) {
+        std::string prefix = "blk." + std::to_string(l) + ".";
+        layers[l].q       = read_weight_f16(prefix + "attn_q.weight");
+        layers[l].k       = read_weight_f16(prefix + "attn_k.weight");
+        layers[l].v       = read_weight_f16(prefix + "attn_v.weight");
+        layers[l].o       = read_weight_f16(prefix + "attn_output.weight");
+        layers[l].gate    = read_weight_f16(prefix + "ffn_gate.weight");
+        layers[l].up      = read_weight_f16(prefix + "ffn_up.weight");
+        layers[l].down    = read_weight_f16(prefix + "ffn_down.weight");
+        layers[l].attn_norm   = read_weight_f16(prefix + "attn_norm.weight");
+        layers[l].ffn_norm    = read_weight_f16(prefix + "ffn_norm.weight");
+        layers[l].attn_q_norm = read_weight_f16(prefix + "attn_q_norm.weight");
+        layers[l].attn_k_norm = read_weight_f16(prefix + "attn_k_norm.weight");
+
+        fprintf(stderr, "[convert] layer %d: q=%zu k=%zu v=%zu o=%zu gate=%zu up=%zu down=%zu\n",
+                l,
+                tensor_size(layers[l].q) / (hs * 2),  // rough: rows * cols div by 2 for F16
+                tensor_size(layers[l].k) / (hs * 2),
+                tensor_size(layers[l].v) / (hs * 2),
+                tensor_size(layers[l].o) / (nh * hd * 2),
+                tensor_size(layers[l].gate) / (hs * 2),
+                tensor_size(layers[l].up) / (hs * 2),
+                tensor_size(layers[l].down) / (is_ * 2));
+    }
+
+    // Read embedding + output_norm
+    TensorData token_embd = read_weight_f16("token_embd.weight");
+    TensorData output_norm = read_weight_f16("output_norm.weight");
+
+    // ==================================================================
+    // Common vars shared by step 2 (h1b) and step 3 (sidecar GGUF)
+    float rope_theta = cfg.rope_theta_float;
+    float rms_norm_eps = 1e-5f;
+
+    // Step 2: Write .h1b file
+    // ==================================================================
+    {
+        fprintf(stderr, "[convert] writing h1b: %s\n", h1b_path.c_str());
+        std::ofstream f(h1b_path, std::ios::binary);
+        if (!f) { fprintf(stderr, "[convert] cannot write: %s\n", h1b_path.c_str()); return 1; }
+
+        // Magic "H1B\0"
+        f.write("H1B\0", 4);
+
+        // Version (use version 1 for BONSAI_TQ2)
+        int32_t version = 1;
+        f.write(reinterpret_cast<const char*>(&version), 4);
+
+        // cfg[9]
+        int32_t cfg9[9] = {
+            (int32_t)hs, (int32_t)is_, (int32_t)num_layers,
+            (int32_t)nh, (int32_t)nkv, (int32_t)vocab_size,
+            (int32_t)cfg.max_seq_len ? (int32_t)cfg.max_seq_len : 4096,
+            1, // tie_embeddings
+            (int32_t)0x8u // H1B_FLAG_BONSAI_TQ2
+        };
+        // If max_seq_len is 0, use a reasonable default
+        if (cfg9[6] <= 0) cfg9[6] = 4096;
+        f.write(reinterpret_cast<const char*>(cfg9), sizeof(cfg9));
+
+        // Extra fp32[2]: rope_theta, rms_norm_eps (version >= 2)
+        f.write(reinterpret_cast<const char*>(&rope_theta), 4);
+        f.write(reinterpret_cast<const char*>(&rms_norm_eps), 4);
+
+        // Embedding: vocab_size * hs floats (zeros — sidecar will fill)
+        std::vector<float> zero_embd(vocab_size * hs, 0.0f);
+        f.write(reinterpret_cast<const char*>(zero_embd.data()),
+                zero_embd.size() * sizeof(float));
+
+        // Final norm: hs floats (zeros)
+        std::vector<float> zero_norm(hs, 0.0f);
+        f.write(reinterpret_cast<const char*>(zero_norm.data()),
+                zero_norm.size() * sizeof(float));
+
+        // Per-layer norms (zeros for BONSAI_QWEN3)
+        const int norms_per_layer = 2 + 4 + 2; // input_norm, post_attn_norm, 
+                                                 // attn_sub_norm, 4 skip, ffn_sub_norm
+        for (uint32_t l = 0; l < num_layers; ++l) {
+            // input_norm (hs floats)
+            f.write(reinterpret_cast<const char*>(zero_norm.data()), hs * sizeof(float));
+            // post_attn_norm (hs floats)
+            f.write(reinterpret_cast<const char*>(zero_norm.data()), hs * sizeof(float));
+            // attn_sub_norm (hs floats)
+            f.write(reinterpret_cast<const char*>(zero_norm.data()), hs * sizeof(float));
+            // 4 skip copies of attn_sub (4 * hs floats)
+            f.write(reinterpret_cast<const char*>(zero_norm.data()), hs * sizeof(float));
+            f.write(reinterpret_cast<const char*>(zero_norm.data()), hs * sizeof(float));
+            f.write(reinterpret_cast<const char*>(zero_norm.data()), hs * sizeof(float));
+            f.write(reinterpret_cast<const char*>(zero_norm.data()), hs * sizeof(float));
+            // ffn_sub_norm (is floats)
+            std::vector<float> zero_is_norm(is_, 0.0f);
+            f.write(reinterpret_cast<const char*>(zero_is_norm.data()), is_ * sizeof(float));
+        }
+
+        // Ternary weights — TQ2 packed blocks
+        const int block_bytes = 34;
+        const int gs = 128;
+
+        auto write_tq2_weight = [&](const TensorData& td, int rows, int cols) {
+            if (tensor_size(td) == 0) {
+                fprintf(stderr, "[convert] WARNING: empty tensor, writing zeros\n");
+                std::vector<uint8_t> zeros(rows * (cols / gs) * block_bytes);
+                f.write(reinterpret_cast<const char*>(zeros.data()), zeros.size());
+                return;
+            }
+            size_t n = tensor_size(td);
+            std::vector<float> f32(n);
+            for (size_t i = 0; i < n; ++i) {
+                f32[i] = get_float(td, i);
+            }
+            std::vector<uint8_t> packed;
+            ternarize_and_pack_tq2(f32.data(), rows, cols, packed);
+            f.write(reinterpret_cast<const char*>(packed.data()), packed.size());
+        };
+
+        for (uint32_t l = 0; l < num_layers; ++l) {
+            write_tq2_weight(layers[l].q,    nh * hd, hs);
+            write_tq2_weight(layers[l].k,    nkv * hd, hs);
+            write_tq2_weight(layers[l].v,    nkv * hd, hs);
+            write_tq2_weight(layers[l].o,    hs, nh * hd);
+            write_tq2_weight(layers[l].gate, is_, hs);
+            write_tq2_weight(layers[l].up,   is_, hs);
+            write_tq2_weight(layers[l].down, hs, is_);
+        }
+
+        f.close();
+        fprintf(stderr, "[convert] h1b written: %s\n", h1b_path.c_str());
+    }
+
+    // ==================================================================
+    // Step 3: Write sidecar GGUF with FP32 norms + embedding
+    // ==================================================================
+    {
+        fprintf(stderr, "[convert] writing sidecar GGUF: %s\n", gguf_path.c_str());
+
+        // Count tensors we'll write
+        // Per layer: attn_norm, ffn_norm, attn_q_norm, attn_k_norm (4) × num_layers
+        // + output_norm + token_embd (TQ2_0_g128, dtype 42)
+        uint64_t n_tensors = 4 * num_layers + 2;
+        uint64_t n_kv = 8; // architecture + model dimensions
+
+        GgufWriter w(gguf_path);
+        w.write_header(n_tensors, n_kv);
+
+        // KV metadata
+        w.write_kv_string("general.architecture", "qwen3");
+        if (!cfg.model_name.empty())
+            w.write_kv_string("general.name", cfg.model_name);
+        w.write_kv_u32("qwen3.hidden_size", hs);
+        w.write_kv_u32("qwen3.intermediate_size", is_);
+        w.write_kv_u32("qwen3.block_count", num_layers);
+        w.write_kv_u32("qwen3.attention.head_count", nh);
+        w.write_kv_u32("qwen3.attention.head_count_kv", nkv);
+        w.write_kv_u32("qwen3.vocab_size", vocab_size);
+        uint32_t max_seq = cfg.max_seq_len ? cfg.max_seq_len : 4096;
+        w.write_kv_u32("qwen3.max_position_embeddings", max_seq);
+        w.write_kv_f32("qwen3.rope.freq_base", rope_theta);
+
+        w.align_to(32);
+        uint64_t data_start = w.tell();
+        uint64_t offset = 0;
+
+        // Write tensor info headers first
+        // Per-layer norms: F32
+        for (uint32_t l = 0; l < num_layers; ++l) {
+            std::vector<uint64_t> shape_1d = {hs};
+            w.write_tensor_info("blk." + std::to_string(l) + ".attn_norm.weight",
+                                shape_1d, 0, offset);
+            offset += hs * sizeof(float);
+
+            w.write_tensor_info("blk." + std::to_string(l) + ".ffn_norm.weight",
+                                shape_1d, 0, offset);
+            offset += hs * sizeof(float);
+
+            std::vector<uint64_t> shape_hd = {hd};
+            w.write_tensor_info("blk." + std::to_string(l) + ".attn_q_norm.weight",
+                                shape_hd, 0, offset);
+            offset += hd * sizeof(float);
+
+            w.write_tensor_info("blk." + std::to_string(l) + ".attn_k_norm.weight",
+                                shape_hd, 0, offset);
+            offset += hd * sizeof(float);
+        }
+
+        // token_embd.weight: [vocab_size, hs] F32
+        {
+            std::vector<uint64_t> shape_2d = {(uint64_t)vocab_size, (uint64_t)hs};
+            w.write_tensor_info("token_embd.weight", shape_2d, 0, offset);
+            offset += (uint64_t)vocab_size * hs * sizeof(float);
+        }
+
+        // output_norm.weight: [hs] F32
+        {
+            std::vector<uint64_t> shape_1d = {(uint64_t)hs};
+            w.write_tensor_info("output_norm.weight", shape_1d, 0, offset);
+            offset += hs * sizeof(float);
+        }
+
+        // ── Write actual data ─────────────────────────────────────
+        w.align_to(32);
+
+        // Per-layer norms: read from source GGUF and write to sidecar
+        for (uint32_t l = 0; l < num_layers; ++l) {
+            auto write_norm = [&](const TensorData& td) {
+                if (tensor_size(td) == 0) {
+                    // Fallback: write identity-like weights (all 1s for RMSNorm)
+                    std::vector<float> ones(tensor_size(layers[l].attn_norm) > 0
+                        ? tensor_size(layers[l].attn_norm) : hs, 1.0f);
+                    w.write_tensor_data(ones.data(), ones.size() * sizeof(float));
+                } else {
+                    size_t n = tensor_size(td);
+                    std::vector<float> f32(n);
+                    for (size_t i = 0; i < n; ++i) f32[i] = get_float(td, i);
+                    w.write_tensor_data(f32.data(), n * sizeof(float));
+                }
+            };
+            write_norm(layers[l].attn_norm);
+            write_norm(layers[l].ffn_norm);
+            // attn_q_norm and attn_k_norm are shape [hd], not [hs]
+            {
+                auto& td = layers[l].attn_q_norm;
+                if (tensor_size(td) == 0) {
+                    std::vector<float> ones(hd, 1.0f);
+                    w.write_tensor_data(ones.data(), hd * sizeof(float));
+                } else {
+                    size_t n = tensor_size(td);
+                    std::vector<float> f32(n);
+                    for (size_t i = 0; i < n; ++i) f32[i] = get_float(td, i);
+                    w.write_tensor_data(f32.data(), n * sizeof(float));
+                }
+            }
+            {
+                auto& td = layers[l].attn_k_norm;
+                if (tensor_size(td) == 0) {
+                    std::vector<float> ones(hd, 1.0f);
+                    w.write_tensor_data(ones.data(), hd * sizeof(float));
+                } else {
+                    size_t n = tensor_size(td);
+                    std::vector<float> f32(n);
+                    for (size_t i = 0; i < n; ++i) f32[i] = get_float(td, i);
+                    w.write_tensor_data(f32.data(), n * sizeof(float));
+                }
+            }
+        }
+
+        // token_embd.weight
+        {
+            size_t n = tensor_size(token_embd);
+            if (n == 0) {
+                std::vector<float> zeros(vocab_size * hs, 0.0f);
+                w.write_tensor_data(zeros.data(), zeros.size() * sizeof(float));
+            } else {
+                std::vector<float> f32(n);
+                for (size_t i = 0; i < n; ++i) f32[i] = get_float(token_embd, i);
+                w.write_tensor_data(f32.data(), n * sizeof(float));
+            }
+        }
+
+        // output_norm.weight
+        {
+            size_t n = tensor_size(output_norm);
+            if (n == 0) {
+                std::vector<float> ones(hs, 1.0f);
+                w.write_tensor_data(ones.data(), hs * sizeof(float));
+            } else {
+                std::vector<float> f32(n);
+                for (size_t i = 0; i < n; ++i) f32[i] = get_float(output_norm, i);
+                w.write_tensor_data(f32.data(), n * sizeof(float));
+            }
+        }
+
+        w.align_to(32);
+        fprintf(stderr, "[convert] sidecar GGUF written: %s (data=%lu bytes)\n",
+                gguf_path.c_str(), (unsigned long)w.tell());
+    }
+
+    fprintf(stderr, "[convert] done. Run with: zaya_server --model %s\n",
+            h1b_path.c_str());
+    return 0;
+}

--- a/tools/convert_zaya_to_h1b.cpp
+++ b/tools/convert_zaya_to_h1b.cpp
@@ -1,0 +1,605 @@
+// convert_zaya_to_h1b — Convert Zaya F16 GGUF → ternary-packed .h1b v6
+// Run once (build-time tool). Inference uses bitnet_decode (pure C++, no Python).
+//
+// Build:
+//   g++ -std=c++17 -O3 -o convert_zaya_to_h1b convert_zaya_to_h1b.cpp -lgguf
+//   ./convert_zaya_to_h1b /path/to/model.gguf /path/to/output.h1b
+//
+// Or without libgguf (standalone GGUF reader):
+//   g++ -std=c++17 -O3 -o convert_zaya_to_h1b convert_zaya_to_h1b.cpp
+//   ./convert_zaya_to_h1b model.gguf model.h1b
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cmath>
+#include <fstream>
+#include <string>
+#include <map>
+#include <vector>
+#include <algorithm>
+
+// ═══════════════════════════════════════════════════════════════
+//  GGUF reader (zero external dependencies)
+// ═══════════════════════════════════════════════════════════════
+
+struct GgufTensor {
+    std::string name;
+    std::vector<uint64_t> shape;
+    uint32_t dtype;
+    uint64_t offset;
+    size_t file_offset; // absolute byte offset in GGUF file
+};
+
+class GgufReader {
+public:
+    std::ifstream f;
+    uint64_t data_start = 0;
+    uint32_t alignment = 32;
+    std::string arch;
+    // Zaya-specific config
+    uint32_t hs=0, is_=0, layers=0, heads=0, kv=0, vocab=0, maxseq=0;
+    uint32_t num_experts=0, top_k=0, expert_hidden=0;
+    uint32_t conv_kernel=0, cca_heads=0;
+    uint32_t head_dim=0;
+    float rope_theta=5000000.0f, rms_eps=1e-5f;
+    float rope_dim=64.0f;
+    std::map<std::string,GgufTensor> tensors;
+
+    bool open(const std::string& path) {
+        f.open(path, std::ios::binary); if (!f) return false;
+        char magic[4]; f.read(magic,4);
+        if (std::strncmp(magic,"GGUF",4)!=0) return false;
+
+        auto ru32=[&](uint32_t&v){f.read((char*)&v,4);return!!f;};
+        auto ru64=[&](uint64_t&v){f.read((char*)&v,8);return!!f;};
+        auto rstr=[&](std::string&s){
+            uint64_t l; if(!ru64(l))return false;
+            if(l>0){s.resize((size_t)l);f.read(&s[0],l);}else s.clear();
+            return!!f;
+        };
+        auto skip=[&](uint32_t vt){
+            switch(vt){
+                case 0:case 1:case 7:f.seekg(1,std::ios::cur);break;
+                case 2:case 3:f.seekg(2,std::ios::cur);break;
+                case 4:case 5:case 6:f.seekg(4,std::ios::cur);break;
+                case 8:{std::string s;rstr(s);}break;
+                case 9:{uint32_t at;ru32(at);uint64_t al;ru64(al);
+                    if(at==8)for(uint64_t j=0;j<al;++j){std::string s;rstr(s);}
+                    else f.seekg((long)(al*4),std::ios::cur);}break;
+                case 10:case 11:case 12:f.seekg(8,std::ios::cur);break;
+            }
+        };
+        auto rufloat=[&](float&v)->bool{
+            uint32_t u; if(!ru32(u))return false;
+            memcpy(&v,&u,4); return true;
+        };
+
+        uint32_t ver; ru32(ver);
+        uint64_t nt, nk; ru64(nt); ru64(nk);
+        for(uint64_t i=0;i<nk;++i){
+            std::string k; rstr(k); uint32_t vt; ru32(vt);
+            auto match=[&](const std::string& pat)->bool{
+                if(pat.size()>k.size())return false;
+                // Check if k ends with pat (for "zaya.*" keys)
+                return k.size()>=pat.size() && k.substr(k.size()-pat.size())==pat;
+            };
+            auto read_val=[&]()->std::string{
+                std::string vs; rstr(vs); return vs;
+            };
+            if(vt==8){std::string v;rstr(v);
+                if(k=="general.architecture")arch=v;
+                else if(k.find("hidden_size")!=std::string::npos||k.find("embedding_length")!=std::string::npos)hs=(uint32_t)std::stoul(v);
+                else if(k.find("feed_forward_length")!=std::string::npos)is_=(uint32_t)std::stoul(v);
+                else if(k.find("block_count")!=std::string::npos)layers=(uint32_t)std::stoul(v);
+                else if(k.find("head_count")!=std::string::npos&&k.find("kv")==std::string::npos)heads=(uint32_t)std::stoul(v);
+                else if(k.find("head_count_kv")!=std::string::npos)kv=(uint32_t)std::stoul(v);
+                else if(k.find("vocab_size")!=std::string::npos)vocab=(uint32_t)std::stoul(v);
+                else if(k.find("context_length")!=std::string::npos)maxseq=(uint32_t)std::stoul(v);
+                else if(k.find("expert_count")!=std::string::npos)num_experts=(uint32_t)std::stoul(v);
+                else if(k.find("expert_used_count")!=std::string::npos)top_k=(uint32_t)std::stoul(v);
+                else if(k.find("expert_feed_forward_length")!=std::string::npos)expert_hidden=(uint32_t)std::stoul(v);
+                else if(k.find("key_length")!=std::string::npos)head_dim=(uint32_t)std::stoul(v);
+                else if(k.find("conv_kernel")!=std::string::npos)conv_kernel=(uint32_t)std::stoul(v);
+            }else if(vt==4){uint32_t vu;ru32(vu);
+                if(k.find("expert_feed_forward_length")!=std::string::npos){}
+                else if(k.find("feed_forward_length")!=std::string::npos)is_=vu;
+                else if(k.find("embedding_length")!=std::string::npos)hs=vu;
+                else if(k.find("hidden_size")!=std::string::npos)hs=vu;
+                else if(k.find("block_count")!=std::string::npos)layers=vu;
+                else if(k.find("head_count")!=std::string::npos&&k.find("kv")==std::string::npos)heads=vu;
+                else if(k.find("head_count_kv")!=std::string::npos)kv=vu;
+                else if(k.find("vocab_size")!=std::string::npos)vocab=vu;
+                else if(k.find("context_length")!=std::string::npos)maxseq=vu;
+                else if(k.find("expert_count")!=std::string::npos)num_experts=vu;
+                else if(k.find("expert_used_count")!=std::string::npos)top_k=vu;
+                else if(k.find("key_length")!=std::string::npos)head_dim=vu;
+                else if(k.find("value_length")!=std::string::npos){}
+                else if(k.find("dimension_count")!=std::string::npos)rope_dim=(float)vu;
+                else if(k.find("conv_kernel")!=std::string::npos)conv_kernel=vu;
+            }else if(vt==6){float vf;f.read((char*)&vf,4);
+                if(k.find("freq_base")!=std::string::npos)rope_theta=vf;
+                else if(k.find("rms_epsilon")!=std::string::npos)rms_eps=vf;
+            }else skip(vt);
+        }
+        cca_heads = heads + kv; // default: total Q+K heads for conv
+
+        uint64_t tens_off = (uint64_t)f.tellg();
+        for(uint64_t i=0;i<nt;++i){
+            GgufTensor t; rstr(t.name); uint32_t nd; ru32(nd);
+            t.shape.resize(nd);
+            for(uint32_t d=0;d<nd;++d)ru64(t.shape[d]);
+            ru32(t.dtype); ru64(t.offset);
+            t.file_offset = tens_off + t.offset;
+            tensors[t.name] = t;
+        }
+        // data_start is implicit — tensor offsets are from after the tensor info
+        data_start = (uint64_t)f.tellg();
+        return true;
+    }
+
+    // Read a tensor's raw data into a float vector (handles FP16 GGUF dtype).
+    std::vector<float> read_tensor_f32(const std::string& name) {
+        auto it = tensors.find(name);
+        if (it == tensors.end()) {
+            fprintf(stderr, "[WARN] tensor not found: %s\n", name.c_str());
+            return {};
+        }
+        auto& t = it->second;
+        size_t n = 1;
+        for (auto s : t.shape) n *= (size_t)s;
+
+        std::vector<float> result(n);
+        if (t.dtype == 0) { // FP32
+            f.seekg((long)(data_start + t.offset));
+            f.read((char*)result.data(), n * 4);
+        } else if (t.dtype == 1) { // FP16
+            f.seekg((long)(data_start + t.offset));
+            std::vector<uint16_t> half(n);
+            f.read((char*)half.data(), n * 2);
+            for (size_t i = 0; i < n; i++) {
+                // FP16 → FP32
+                uint32_t sign = (half[i] >> 15) & 1;
+                uint32_t exp  = (half[i] >> 10) & 0x1F;
+                uint32_t mant = half[i] & 0x3FF;
+                uint32_t f32;
+                if (exp == 0) {
+                    f32 = sign << 31 | (mant != 0 ? 0x7B800000 | (mant << 13) : 0);
+                } else if (exp == 31) {
+                    f32 = sign << 31 | 0x7F800000 | (mant << 13);
+                } else {
+                    f32 = sign << 31 | ((exp + 112) << 23) | (mant << 13);
+                }
+                memcpy(&result[i], &f32, 4);
+            }
+        } else {
+            fprintf(stderr, "[WARN] unsupported dtype %d for %s\n", t.dtype, name.c_str());
+            return {};
+        }
+        return result;
+    }
+
+    // Read tensor as FP16 (native half)
+    std::vector<uint16_t> read_tensor_f16(const std::string& name) {
+        auto it = tensors.find(name);
+        if (it == tensors.end()) return {};
+        auto& t = it->second;
+        size_t n = 1;
+        for (auto s : t.shape) n *= (size_t)s;
+
+        std::vector<uint16_t> result(n);
+        if (t.dtype == 0) { // FP32 → truncate to FP16
+            auto f32 = read_tensor_f32(name);
+            for (size_t i = 0; i < n; i++) {
+                uint32_t u; memcpy(&u, &f32[i], 4);
+                uint32_t sign = (u >> 31) & 1;
+                int32_t exp  = (int32_t)((u >> 23) & 0xFF) - 127 + 15;
+                uint32_t mant = (u >> 13) & 0x3FF;
+                if (exp >= 31) { exp = 31; mant = 0; } // Inf
+                else if (exp <= 0) { exp = 0; mant = 0; } // Zero
+                result[i] = (uint16_t)((sign << 15) | (exp << 10) | mant);
+            }
+        } else if (t.dtype == 1) { // FP16 native
+            f.seekg((long)(data_start + t.offset));
+            f.read((char*)result.data(), n * 2);
+        }
+        return result;
+    }
+};
+
+// ═══════════════════════════════════════════════════════════════
+//  TQ1 packing helper — matches read_ternary_tq1 in h1b_loader.cpp
+// ═══════════════════════════════════════════════════════════════
+
+// TQ1: base-3 ternary packing (1.6 bpw, 5 ternaries per byte).
+//   d_i  ∈ {-1, 0, +1}  →  t_i ∈ {0, 1, 2}
+//   byte = t0 + t1*3 + t2*9 + t3*27 + t4*81
+static int8_t encode_ternary(float v) {
+    if (v > 0.5f) return 2;  // +1
+    if (v < -0.5f) return 0;  // -1
+    return 1;                  // 0
+}
+
+static void tq1_pack(const float* weights, int rows, int cols,
+                     std::vector<uint8_t>& packed, std::vector<float>& scales) {
+    // K padded to multiple of 20 (5 ternaries per byte × 4 bytes per u32 row).
+    int k_pad = ((cols + 19) / 20) * 20;
+    packed.resize((size_t)rows * k_pad / 5);
+    scales.resize((size_t)rows);
+    memset(packed.data(), 0, packed.size());
+
+    for (int r = 0; r < rows; r++) {
+        const float* row = weights + (size_t)r * cols;
+
+        // Compute per-row scale: 1/mean(|w|)
+        double sum_abs = 0;
+        for (int c = 0; c < cols; c++) sum_abs += fabs(row[c]);
+        float scale = (float)(sum_abs / cols);
+        if (scale < 1e-10f) scale = 1.0f;
+        float inv_scale = 1.0f / scale;
+        scales[r] = scale;
+
+        // Quantize to ternary and pack
+        for (int c = 0; c < k_pad; c += 5) {
+            int byte_idx = (r * k_pad + c) / 5;
+            uint8_t byte = 0;
+            for (int i = 0; i < 5; i++) {
+                float val = (c + i < cols) ? row[c + i] * inv_scale : 0.0f;
+                int8_t t = encode_ternary(val);
+                byte += (uint8_t)(t * (int)pow(3, i));
+            }
+            packed[byte_idx] = byte;
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+//  .h1b writer (v6 — Zaya format)
+// ═══════════════════════════════════════════════════════════════
+
+static void write_f32_as_f16(std::ofstream& f, const float* data, int n) {
+    for (int i = 0; i < n; i++) {
+        float v = data[i];
+        uint32_t u; memcpy(&u, &v, 4);
+        uint32_t sign = (u >> 31) & 1;
+        int32_t exp  = (int32_t)((u >> 23) & 0xFF) - 127 + 15;
+        uint32_t mant = (u >> 13) & 0x3FF;
+        if (exp >= 31) { exp = 31; mant = 0; }
+        else if (exp <= 0) { exp = 0; mant = 0; }
+        uint16_t h = (uint16_t)((sign << 15) | (exp << 10) | mant);
+        f.write((char*)&h, 2);
+    }
+}
+
+static void write_fp16(std::ofstream& f, const uint16_t* data, int n) {
+    f.write((const char*)data, (size_t)n * 2);
+}
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s <model.gguf> <output.h1b>\n", argv[0]);
+        return 1;
+    }
+
+    // ── 1. Read GGUF ──────────────────────────────────────────
+    fprintf(stderr, "[convert] Reading %s ...\n", argv[1]);
+    GgufReader gguf;
+    if (!gguf.open(argv[1])) {
+        fprintf(stderr, "[ERROR] Failed to open GGUF file\n");
+        return 1;
+    }
+
+    int H = gguf.hs, IS = gguf.is_, L = gguf.layers,
+        NH = gguf.heads, NKV = gguf.kv, V = gguf.vocab;
+    int NE = gguf.num_experts, TK = gguf.top_k, EH = gguf.expert_hidden;
+    int CK = gguf.conv_kernel, CCA = gguf.cca_heads;
+    // Zaya stores head_dim in attention.key_length (not derived from H/NH).
+    int HD = gguf.head_dim;
+    if (HD <= 0) HD = H / NH;  // fallback for non-Zaya models
+    fprintf(stderr, "[convert] HD=%d (head_dim)\n", HD);
+
+    fprintf(stderr, "[convert] Zaya: H=%d IS=%d L=%d NH=%d NKV=%d V=%d\n",
+            H, IS, L, NH, NKV, V);
+    // Zaya's expert_hidden = hidden_size (each expert replaces the full FFN).
+    // The GGUF field expert_feed_forward_length is actually the router hidden size (256),
+    // not the expert's working dimension. Patch expert_hidden from H when it looks wrong.
+    if (EH == 0 || EH < 64) EH = H;
+
+    fprintf(stderr, "[convert] MoE: experts=%d top_k=%d expert_hidden=%d\n",
+            NE, TK, EH);
+    fprintf(stderr, "[convert] CCA: conv_kernel=%d cca_heads=%d\n", CK, CCA);
+    fprintf(stderr, "[convert] Config: rope_theta=%.0f eps=%g\n",
+            gguf.rope_theta, gguf.rms_eps);
+
+    if (gguf.arch != "zaya") {
+        fprintf(stderr, "[ERROR] Expected arch=zaya, got %s\n", gguf.arch.c_str());
+        return 1;
+    }
+
+    // ── 2. Open output .h1b ────────────────────────────────────
+    std::ofstream out(argv[2], std::ios::binary);
+    if (!out) { fprintf(stderr, "[ERROR] Cannot write %s\n", argv[2]); return 1; }
+
+    // ── 3. Write standard .h1b header ─────────────────────────
+    int32_t cfg[9] = { H, IS, L, NH, NKV, V, 4096, 6, 0 };  // v6
+    out.write((char*)cfg, sizeof(cfg));
+
+    // Zaya extended config (5 int32_t)
+    int32_t zcfg[5] = { NE, TK, EH, CK, CCA };
+    out.write((char*)zcfg, sizeof(zcfg));
+
+    // Helper: write a layer's norm weights (FP32 → FP16)
+    auto write_norm = [&](const std::vector<float>& w) {
+        write_f32_as_f16(out, w.data(), (int)w.size());
+    };
+
+    // ── 4. Process each layer ──────────────────────────────────
+    for (int l = 0; l < L; l++) {
+        std::string p = "blk." + std::to_string(l) + ".";
+        fprintf(stderr, "[convert] Layer %d/%d\r", l+1, L);
+
+        // ── Norms ────────────────────────────────────────────────
+        // Zaya has: attn_norm (pre-attn), attn_norm_2 (2nd attn), ffn_norm (router)
+        auto in_norm  = gguf.read_tensor_f32(p + "attn_norm.weight");
+        auto pa_norm  = gguf.read_tensor_f32(p + "attn_norm_2.weight"); // 2nd attn norm
+        auto fn_norm  = gguf.read_tensor_f32(p + "ffn_norm.weight");    // router norm
+        if (in_norm.empty() || pa_norm.empty()) {
+            fprintf(stderr, "\n[ERROR] Missing norms for layer %d\n", l);
+            return 1;
+        }
+        // Write input_norm + 6 filler slots + post_attn_norm to match BitNet layout.
+        // Zaya only has 2 attn norms; we pad to match the larger expected layout.
+        write_norm(in_norm);  // input_norm
+        write_norm(pa_norm);  // attn_norm_2 (used as 2nd attention norm)
+        for (int i = 0; i < 4; i++) { // 4 more filler slots
+            for (int j = 0; j < H; j++) { uint16_t z = 0; out.write((char*)&z, 2); }
+        }
+        if (!fn_norm.empty()) { // ffn_norm (router norm) — stored in ffn_sub_norm slot
+            write_norm(fn_norm);
+        } else {
+            for (int j = 0; j < H; j++) { uint16_t z = 0; out.write((char*)&z, 2); }
+        }
+
+        // ── 7 standard projections (TQ1-packed, with transpose) ─
+        // Zaya stores weights as [input_dim, output_dim] instead of [output_dim, input_dim].
+        // We transpose during conversion so existing ternary_gemv kernels work.
+        auto read_and_transpose = [&](const std::string& name, int rows_out, int cols_in) {
+            auto w = gguf.read_tensor_f32(name);
+            if (w.empty()) return w;
+            // w is currently [cols_in, rows_out] (GGUF layout)
+            // We need [rows_out, cols_in] (our layout)
+            std::vector<float> t(w.size());
+            for (int r = 0; r < rows_out; r++)
+                for (int c = 0; c < cols_in; c++)
+                    t[(size_t)r * cols_in + c] = w[(size_t)c * rows_out + r];
+            return t;
+        };
+
+        auto write_tq1 = [&](const std::vector<float>& w, int rows, int cols) {
+            std::vector<uint8_t> packed;
+            std::vector<float> scales;
+            tq1_pack(w.data(), rows, cols, packed, scales);
+            out.write((char*)packed.data(), packed.size());
+            out.write((char*)scales.data(), (size_t)rows * 4);
+        };
+
+        int qd = NH * HD, kd = NKV * HD;
+
+        // Q proj: GGUF has attn_q.weight [H, QD] → transpose to [QD, H]
+        { auto w = read_and_transpose(p + "attn_q.weight", qd, H);
+          if (w.empty()) return 1; write_tq1(w, qd, H); }
+        // K proj: GGUF has attn_k.weight [H, KD] → transpose to [KD, H]
+        { auto w = read_and_transpose(p + "attn_k.weight", kd, H);
+          if (w.empty()) return 1; write_tq1(w, kd, H); }
+        // V proj: Zaya uses val_proj1 + val_proj2 [H, 128] each.
+        // Combine by stacking: result = [val_proj1_T, val_proj2_T] = [256, H]
+        // But we need [nkv*HD, H] = [256, H]. Concatenate transposed projs.
+        {
+            auto v1 = gguf.read_tensor_f32(p + "cca_val_proj1.weight"); // [H, 128]
+            auto v2 = gguf.read_tensor_f32(p + "cca_val_proj2.weight"); // [H, 128]
+            if (v1.empty() || v2.empty()) return 1;
+            std::vector<float> v_combined((size_t)kd * H);
+            // Transpose each and concatenate
+            for (int r = 0; r < kd/2; r++)
+                for (int c = 0; c < H; c++) {
+                    v_combined[(size_t)r * H + c] = v1[(size_t)c * (kd/2) + r];
+                    v_combined[((size_t)r + kd/2) * H + c] = v2[(size_t)c * (kd/2) + r];
+                }
+            write_tq1(v_combined, kd, H);
+        }
+        // O proj: attn_output.weight [QD/2, H] — only half-dim for CCA!
+        { auto w = gguf.read_tensor_f32(p + "attn_output.weight"); // [QD/2, H]
+          if (w.empty()) return 1;
+          // Transpose [QD/2, H] → [H, QD/2]… actually no. We need [H, QD/2] for the kernel.
+          // The GGUF stores it as [oh, H] where oh = QD/2 = 1024.
+          // O proj output dim = H (residual), input dim = QD/2.
+          // Our layout: [output_dims=M, K] = [H, QD/2]
+          int oh = (int)w.size() / H;
+          std::vector<float> w_t((size_t)H * oh);
+          for (int r = 0; r < H; r++)
+              for (int c = 0; c < oh; c++)
+                  w_t[(size_t)r * oh + c] = w[(size_t)c * H + r];
+          write_tq1(w_t, H, oh);
+        }
+        // Standard gate/up/down are not used by Zaya (MoE replaces FFN).
+        // Write dummy TQ1-packed tensors to fill the expected slots.
+        { std::vector<float> w((size_t)IS * H, 0); write_tq1(w, IS, H); }
+        { std::vector<float> w((size_t)IS * H, 0); write_tq1(w, IS, H); }
+        { std::vector<float> w((size_t)H * IS, 0); write_tq1(w, H, IS); }
+
+        // ── MoE expert weights ──────────────────────────────────
+        // Zaya stores combined gate+up experts: ffn_gate_up_exps.weight [H, 2*EH, NE]
+        // We split into separate TQ1-packed gate_experts [NE, EH, H] and up_experts [NE, EH, H].
+        auto expert_gu = gguf.read_tensor_f32(p + "ffn_gate_up_exps.weight");
+        if (expert_gu.empty()) {
+            fprintf(stderr, "\n[ERROR] Missing ffn_gate_up_exps.weight for layer %d\n", l);
+            return 1;
+        }
+        // expert_gu is flat [H * 2*EH * NE]. Reshape: [NE, 2*EH, H]
+        // where dim 1 = [0..EH-1] is gate, [EH..2*EH-1] is up
+        {
+            std::vector<float> gate_experts((size_t)NE * EH * H);
+            std::vector<float> up_experts((size_t)NE * EH * H);
+            for (int e = 0; e < NE; e++) {
+                for (int i = 0; i < EH; i++) {
+                    for (int j = 0; j < H; j++) {
+                        size_t src_idx = (size_t)e * 2 * EH * H + (size_t)i * H + j;
+                        size_t dst_idx = (size_t)e * EH * H + (size_t)i * H + j;
+                        gate_experts[dst_idx] = expert_gu[src_idx];
+                        up_experts[dst_idx]   = expert_gu[src_idx + (size_t)EH * H];
+                    }
+                }
+            }
+            // TQ1-pack gate experts
+            { std::vector<uint8_t> p; std::vector<float> s;
+              tq1_pack(gate_experts.data(), NE, EH * H, p, s);
+              out.write((char*)p.data(), p.size());
+              out.write((char*)s.data(), NE * 4); }
+            // TQ1-pack up experts
+            { std::vector<uint8_t> p; std::vector<float> s;
+              tq1_pack(up_experts.data(), NE, EH * H, p, s);
+              out.write((char*)p.data(), p.size());
+              out.write((char*)s.data(), NE * 4); }
+        }
+
+        // ── EDA router (3-layer MLP) ───────────────────────────
+        // Zaya's router is: inp[H] → W1[H,256] → ReLU → W2[256,256] → ReLU → W3[256,NE+1]
+        // Store all 3 weight matrices + biases as FP16.
+        // b/c the decode path composes them as 3 sequential GEMVs.
+        auto w1 = gguf.read_tensor_f32(p + "ffn_gate_inp.weight");   // [H, 256]
+        auto b1 = gguf.read_tensor_f32(p + "ffn_gate_inp.bias");     // [256]
+        auto w2 = gguf.read_tensor_f32(p + "zaya_router_mlp2.weight"); // [256, 256]
+        auto b2 = gguf.read_tensor_f32(p + "zaya_router_mlp2.bias");   // [256]
+        auto w3 = gguf.read_tensor_f32(p + "zaya_router_mlp4.weight"); // [256, NE+1]
+        auto b3 = gguf.read_tensor_f32(p + "zaya_router_biases.weight"); // [NE+1]
+        int n_route = NE + 1; // experts + 1 for "no expert" slot
+
+        if (w1.empty() || w3.empty()) {
+            fprintf(stderr, "\n[ERROR] Missing router weights for layer %d\n", l);
+            return 1;
+        }
+        // Write W1: [256, H] (transposed from [H, 256])
+        {
+            std::vector<float> wt((size_t)256 * H);
+            for (int r = 0; r < 256; r++)
+                for (int c = 0; c < H; c++)
+                    wt[(size_t)r * H + c] = w1[(size_t)c * 256 + r];
+            write_f32_as_f16(out, wt.data(), 256 * H);
+        }
+        write_f32_as_f16(out, b1.data(), 256);
+        // Write W2: [256, 256] (transposed from [256, 256])
+        {
+            std::vector<float> wt((size_t)256 * 256);
+            for (int r = 0; r < 256; r++)
+                for (int c = 0; c < 256; c++)
+                    wt[(size_t)r * 256 + c] = w2[(size_t)c * 256 + r];
+            write_f32_as_f16(out, wt.data(), 256 * 256);
+        }
+        write_f32_as_f16(out, b2.data(), 256);
+        // Write W3: [n_route, 256] (transposed from [256, n_route])
+        {
+            std::vector<float> wt((size_t)n_route * 256);
+            for (int r = 0; r < n_route; r++)
+                for (int c = 0; c < 256; c++)
+                    wt[(size_t)r * 256 + c] = w3[(size_t)c * n_route + r];
+            write_f32_as_f16(out, wt.data(), n_route * 256);
+        }
+        if (!b3.empty()) write_f32_as_f16(out, b3.data(), n_route);
+        else for (int i = 0; i < n_route; i++) { uint16_t z = 0; out.write((char*)&z, 2); }
+
+        // ── CCA grouped conv weights ────────────────────────────
+        // Zaya uses cca_conv_grp.weight [2, 128, 1280] — depthwise grouped conv
+        // across 1280 channel groups. Store as-is for the CCA kernel.
+        auto cg = gguf.read_tensor_f32(p + "cca_conv_grp.weight");
+        if (cg.empty()) {
+            fprintf(stderr, "\n[ERROR] Missing cca_conv_grp.weight for layer %d\n", l);
+            return 1;
+        }
+        write_f32_as_f16(out, cg.data(), (int)cg.size());
+        // cca_conv_grp bias
+        auto cgb = gguf.read_tensor_f32(p + "cca_conv_grp.bias");
+        if (!cgb.empty()) write_f32_as_f16(out, cgb.data(), (int)cgb.size());
+        else for (int i = 0; i < 1280; i++) { uint16_t z = 0; out.write((char*)&z, 2); }
+
+        // ── SSM conv1d weights ─────────────────────────────────
+        auto sc = gguf.read_tensor_f32(p + "ssm_conv1d.weight"); // [2, 1280]
+        auto sb = gguf.read_tensor_f32(p + "ssm_conv1d.bias");   // [1280]
+        if (sc.empty()) {
+            fprintf(stderr, "\n[ERROR] Missing ssm_conv1d.weight for layer %d\n", l);
+            return 1;
+        }
+        write_f32_as_f16(out, sc.data(), 2 * 1280);
+        if (!sb.empty()) write_f32_as_f16(out, sb.data(), 1280);
+        else for (int i = 0; i < 1280; i++) { uint16_t z = 0; out.write((char*)&z, 2); }
+
+        // ── CCA k_scale ────────────────────────────────────────
+        auto ks = gguf.read_tensor_f32(p + "cca_k_scale.weight"); // [2]
+        if (!ks.empty()) write_f32_as_f16(out, ks.data(), 2);
+        else { uint16_t z[2] = {0,0}; out.write((char*)z, 4); }
+
+        // ── Residual scales (res_scale_hs, res_scale_res) ──────
+        auto rsh = gguf.read_tensor_f32(p + "res_scale_hs.weight");
+        auto rsr = gguf.read_tensor_f32(p + "res_scale_res.weight");
+        if (!rsh.empty()) write_f32_as_f16(out, rsh.data(), H);
+        else for (int i = 0; i < H; i++) { uint16_t z = 0x3C00; out.write((char*)&z, 2); } // 1.0
+        if (!rsr.empty()) write_f32_as_f16(out, rsr.data(), H);
+        else for (int i = 0; i < H; i++) { uint16_t z = 0x3C00; out.write((char*)&z, 2); } // 1.0
+    }
+    fprintf(stderr, "\n[convert] All %d layers written.\n", L);
+
+    // ── 5. Embedding / LM head ─────────────────────────────────
+    // token_embd.weight shape: [2048, 262272] = [H, V] — transposed!
+    // We need [V, H].
+    fprintf(stderr, "[convert] Writing embeddings...\n");
+    auto embed = gguf.read_tensor_f32("token_embd.weight");
+    if (embed.empty()) {
+        fprintf(stderr, "[ERROR] token_embd.weight not found\n");
+        return 1;
+    }
+    // transpose [H, V] → [V, H]
+    {
+        std::vector<uint16_t> embed_t((size_t)V * H);
+        for (int r = 0; r < V; r++)
+            for (int c = 0; c < H; c++) {
+                float v = embed[(size_t)c * V + r];
+                uint32_t u; memcpy(&u, &v, 4);
+                uint32_t sign = (u >> 31) & 1;
+                int32_t exp  = (int32_t)((u >> 23) & 0xFF) - 127 + 15;
+                uint32_t mant = (u >> 13) & 0x3FF;
+                if (exp >= 31) { exp = 31; mant = 0; }
+                else if (exp <= 0) { exp = 0; mant = 0; }
+                embed_t[(size_t)r * H + c] = (uint16_t)((sign << 15) | (exp << 10) | mant);
+            }
+        write_fp16(out, embed_t.data(), V * H);
+    }
+
+    // ── 6. Final norm ──────────────────────────────────────────
+    fprintf(stderr, "[convert] Writing final norm...\n");
+    auto final_norm = gguf.read_tensor_f32("output_norm.weight");
+    if (final_norm.empty()) final_norm = gguf.read_tensor_f32("final_norm.weight");
+    if (final_norm.empty()) {
+        fprintf(stderr, "[WARN] final_norm not found, writing identity\n");
+        for (int i = 0; i < H; i++) { float one = 1.0f; write_f32_as_f16(out, &one, 1); }
+    } else {
+        write_f32_as_f16(out, final_norm.data(), H);
+    }
+
+    // ── 7. LM head (output weight) ────────────────────────────
+    fprintf(stderr, "[convert] Writing output weight...\n");
+    // The LM head is tied to embedding (tie_word_embeddings=true).
+    // We already wrote the transposed embedding above.
+    // For the LM head, the decode path uses the same embedding weight
+    // via rcpp_embedding_lookup_fp16/rcpp_fp16_gemv.
+    // Write it again as output weight (same data, already transposed).
+    // Actually — skip this since tied embeddings mean LM head = embedding.
+    // The .h1b format expects output weight separately though.
+    // Write a zero-length sentinel (0 elements) to indicate tied.
+    {
+        int zero = 0;
+        out.write((char*)&zero, 4);
+    }
+
+    out.close();
+    fprintf(stderr, "[convert] ✅ Written %s\n", argv[2]);
+    return 0;
+}

--- a/tools/gguf_to_h1b.cpp
+++ b/tools/gguf_to_h1b.cpp
@@ -1,0 +1,264 @@
+// gguf_to_h1b — Convert Bonsai F16 GGUF → .h1b + sidecar .gguf
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <map>
+#include <vector>
+#include <cmath>
+
+struct GgufTensor {
+    std::string name;
+    std::vector<uint64_t> shape;
+    uint32_t dtype;
+    uint64_t offset;
+};
+
+class GgufReader {
+public:
+    std::ifstream f;
+    uint64_t data_start = 0;
+    uint32_t version = 0, alignment = 32;
+    std::string arch;
+    uint32_t hs=0, is_=0, layers=0, heads=0, kv=0, vocab=0, maxseq=0;
+    float rope_theta = 1000000.0f;
+    std::map<std::string,GgufTensor> tensors;
+
+    bool open(const std::string& path) {
+        f.open(path, std::ios::binary); if (!f) return false;
+        char magic[4]; f.read(magic,4);
+        if (std::strncmp(magic,"GGUF",4)!=0) return false;
+        auto ru32=[&](uint32_t&v){f.read((char*)&v,4);return!!f;};
+        auto ru64=[&](uint64_t&v){f.read((char*)&v,8);return!!f;};
+        auto rstr=[&](std::string&s){
+            uint64_t l; if(!ru64(l))return false;
+            if(l>0){s.resize((size_t)l);f.read(&s[0],l);}else s.clear();
+            return!!f;
+        };
+        auto skip=[&](uint32_t vt){
+            switch(vt){
+                case 0:case 1:case 7:f.seekg(1,std::ios::cur);break;
+                case 2:case 3:f.seekg(2,std::ios::cur);break;
+                case 4:case 5:case 6:f.seekg(4,std::ios::cur);break;
+                case 8:{std::string s;rstr(s);}break;
+                case 9:{uint32_t at;ru32(at);uint64_t al;ru64(al);
+                    if(at==8)for(uint64_t j=0;j<al;++j){std::string s;rstr(s);}
+                    else f.seekg((long)(al*4),std::ios::cur);
+                }break;
+                case 10:case 11:case 12:f.seekg(8,std::ios::cur);break;
+            }
+        };
+
+        ru32(version);
+        uint64_t nt, nk; ru64(nt); ru64(nk);
+        for(uint64_t i=0;i<nk;++i){
+            std::string k; rstr(k); uint32_t vt; ru32(vt);
+            if(vt==8){std::string v;rstr(v);
+                if(k=="general.architecture")arch=v;
+                else if(k=="qwen3.hidden_size"||k=="qwen3.embedding_length")hs=(uint32_t)std::stoul(v);
+                else if(k=="qwen3.intermediate_size"||k=="qwen3.feed_forward_length")is_=(uint32_t)std::stoul(v);
+                else if(k=="qwen3.block_count")layers=(uint32_t)std::stoul(v);
+                else if(k=="qwen3.attention.head_count")heads=(uint32_t)std::stoul(v);
+                else if(k=="qwen3.attention.head_count_kv")kv=(uint32_t)std::stoul(v);
+                else if(k=="qwen3.vocab_size")vocab=(uint32_t)std::stoul(v);
+            }else if(vt==4){uint32_t vu;ru32(vu);
+                if(k=="qwen3.hidden_size"||k=="qwen3.embedding_length")hs=vu;
+                else if(k=="qwen3.intermediate_size"||k=="qwen3.feed_forward_length")is_=vu;
+                else if(k=="qwen3.block_count")layers=vu;
+                else if(k=="qwen3.attention.head_count")heads=vu;
+                else if(k=="qwen3.attention.head_count_kv")kv=vu;
+                else if(k=="qwen3.vocab_size")vocab=vu;
+                else if(k=="qwen3.max_position_embeddings")maxseq=vu;
+            }else if(vt==6){float vf;f.read((char*)&vf,4);
+                if(k=="qwen3.rope.freq_base")rope_theta=vf;
+            }else skip(vt);
+        }
+        for(uint64_t i=0;i<nt;++i){
+            GgufTensor t; rstr(t.name); uint32_t nd; ru32(nd);
+            t.shape.resize(nd);
+            for(uint32_t d=0;d<nd;++d)ru64(t.shape[d]);
+            ru32(t.dtype); ru64(t.offset);
+            tensors[t.name]=t;
+        }
+        if(vocab==0){
+            auto it=tensors.find("token_embd.weight");
+            if(it!=tensors.end()&&it->second.shape.size()>=2)
+                vocab=(uint32_t)it->second.shape[1];
+        }
+        data_start=(uint64_t)f.tellg();
+        uint64_t rem=data_start%alignment;
+        if(rem)data_start+=alignment-rem;
+        return true;
+    }
+
+    bool read_f32(const std::string& name, std::vector<float>& out) {
+        auto it=tensors.find(name);
+        if(it==tensors.end())return false;
+        const auto& t=it->second;
+        size_t n=1; for(auto d:t.shape)n*=(size_t)d;
+        if(t.dtype!=0&&t.dtype!=1)return false;
+        f.seekg(data_start+(std::streamoff)t.offset);
+        if(t.dtype==0){out.resize(n);f.read((char*)out.data(),n*4);return(size_t)f.gcount()==n*4;}
+        std::vector<uint16_t> f16(n); f.read((char*)f16.data(),n*2);
+        if((size_t)f.gcount()!=n*2)return false;
+        out.resize(n);
+        for(size_t i=0;i<n;++i){
+            uint16_t h=f16[i]; uint32_t s=(h>>15)&1,e=(h>>10)&0x1f,m=h&0x3ff;
+            uint32_t b;
+            if(e==0){if(m==0)b=s<<31;else{int e2=-1;uint32_t m2=m;while(!(m2&0x400)){m2<<=1;--e2;}b=(s<<31)|((e2+127)<<23)|((m2&0x3ff)<<13);}}
+            else if(e==31)b=(s<<31)|0x7f800000|(m<<13);
+            else b=(s<<31)|((e+112)<<23)|(m<<13);
+            memcpy(&out[i],&b,4);
+        }
+        return true;
+    }
+};
+
+static uint16_t f32_to_f16(float v){
+    uint32_t f; memcpy(&f,&v,4);
+    uint32_t s=(f>>31)&1; int32_t e=(f>>23)&0xff; uint32_t m=f&0x7fffff;
+    if(e==0)return(uint16_t)(s<<15);
+    if(e==0xff)return(uint16_t)((s<<15)|0x7c00|(m?0x200:0));
+    e=e-127+15; if(e>=31)return(uint16_t)((s<<15)|0x7c00);
+    if(e<=0)return(uint16_t)(s<<15);
+    return(uint16_t)((s<<15)|(e<<10)|(m>>13));
+}
+
+static void pack_tq2_block(const float* vals, uint8_t* out){
+    double sa=0; float ma=0;
+    for(int i=0;i<128;++i){float a=fabsf(vals[i]);sa+=a;if(a>ma)ma=a;}
+    float th=0.7f*(float)(sa/128.0); if(th<1e-10f)th=1e-10f;
+    int8_t t[128]; float mm=0;
+    for(int i=0;i<128;++i){
+        t[i]=(vals[i]>th)?1:((vals[i]<-th)?-1:0);
+        if(t[i]!=0){float m=fabsf(vals[i]);if(m>mm)mm=m;}
+    }
+    if(mm<1e-10f)mm=1.0f;
+    uint16_t d=f32_to_f16(mm);
+    for(int i=0;i<32;++i){uint8_t b=0;for(int j=0;j<4;++j){int c=t[i*4+j]+1;b|=(uint8_t)(c<<(j*2));}out[i]=b;}
+    memcpy(out+32,&d,2);
+}
+
+static void ternarize_to_tq2(const float* d, int rows, int cols, std::vector<uint8_t>& out){
+    const int gs=128,bb=34,bpr=cols/gs;
+    out.resize((size_t)rows*bpr*bb);
+    for(int r=0;r<rows;++r)
+        for(int b=0;b<bpr;++b)
+            pack_tq2_block(d+r*cols+b*gs,out.data()+r*bpr*bb+b*bb);
+}
+
+int main(int argc,char**argv){
+    const char* in=nullptr,*out=nullptr;
+    for(int i=1;i<argc;++i){
+        std::string a=argv[i];
+        if(a=="--input"&&i+1<argc)in=argv[++i];
+        else if(a=="--output"&&i+1<argc)out=argv[++i];
+    }
+    if(!in||!out){fprintf(stderr,"usage: gguf_to_h1b --input f16.gguf --output base\n");return 1;}
+
+    GgufReader re;
+    if(!re.open(in)){fprintf(stderr,"[err] cannot open %s\n",in);return 1;}
+    if(re.arch!="qwen3"){fprintf(stderr,"[err] arch=%s\n",re.arch.c_str());return 1;}
+    uint32_t hs=re.hs,is=re.is_,nl=re.layers,nh=re.heads,nkv=re.kv,voc=re.vocab,hd=hs/nh;
+    float rt=re.rope_theta;
+    fprintf(stderr,"[conv] hs=%u is=%u L=%u nh=%u nkv=%u hd=%u voc=%u\n",hs,is,nl,nh,nkv,hd,voc);
+    if(hs==0||is==0||nl==0||voc==0){fprintf(stderr,"[err] bad config\n");return 1;}
+
+    auto rd=[&](const std::string& nm)->std::vector<float>{
+        std::vector<float> v; re.read_f32(nm,v);
+        if(v.empty())fprintf(stderr,"[warn] missing %s\n",nm.c_str());
+        return v;
+    };
+    auto te=rd("token_embd.weight"),on=rd("output_norm.weight");
+    struct N{std::vector<float> an,fn,qn,kn;};
+    struct W{std::vector<float> q,k,v,o,g,u,d;};
+    std::vector<N> nn(nl);
+    std::vector<W> ww(nl);
+    for(uint32_t l=0;l<nl;++l){
+        std::string p="blk."+std::to_string(l)+".";
+        nn[l].an=rd(p+"attn_norm.weight"); nn[l].fn=rd(p+"ffn_norm.weight");
+        nn[l].qn=rd(p+"attn_q_norm.weight"); nn[l].kn=rd(p+"attn_k_norm.weight");
+        ww[l].q=rd(p+"attn_q.weight"); ww[l].k=rd(p+"attn_k.weight");
+        ww[l].v=rd(p+"attn_v.weight"); ww[l].o=rd(p+"attn_output.weight");
+        ww[l].g=rd(p+"ffn_gate.weight"); ww[l].u=rd(p+"ffn_up.weight");
+        ww[l].d=rd(p+"ffn_down.weight");
+    }
+
+    // Write h1b
+    std::string h1b=std::string(out)+".h1b";
+    fprintf(stderr,"[write] %s\n",h1b.c_str());
+    {
+        std::ofstream f(h1b,std::ios::binary); if(!f){fprintf(stderr,"[err] write %s\n",h1b.c_str());return 1;}
+        f.write("H1B\0",4); int32_t ver=1; f.write((const char*)&ver,4);
+        int32_t c9[9]={(int32_t)hs,(int32_t)is,(int32_t)nl,(int32_t)nh,(int32_t)nkv,(int32_t)voc,4096,1,(int32_t)0x8u};
+        f.write((const char*)c9,36);
+        float ex[2]={rt,1e-5f}; f.write((const char*)ex,8);
+        // Embedding zeros
+        std::vector<float> zv((size_t)voc*hs,0); f.write((const char*)zv.data(),zv.size()*4);
+        std::vector<float> zh(hs,0); f.write((const char*)zh.data(),zh.size()*4);
+        // Per-layer norm zeros
+        for(uint32_t l=0;l<nl;++l){
+            for(int i=0;i<8;++i)f.write((const char*)zh.data(),hs*4);
+            std::vector<float> zi(is,0); f.write((const char*)zi.data(),is*4);
+        }
+        // Packed weights
+        auto pw=[&](const std::vector<float>& d,int r,int c){
+            if(d.empty()){size_t sz=r*(c/128)*34;std::vector<uint8_t>z(sz,0);f.write((const char*)z.data(),sz);return;}
+            std::vector<uint8_t> pk; ternarize_to_tq2(d.data(),r,c,pk); f.write((const char*)pk.data(),pk.size());
+        };
+        for(uint32_t l=0;l<nl;++l){
+            pw(ww[l].q,nh*hd,hs); pw(ww[l].k,nkv*hd,hs); pw(ww[l].v,nkv*hd,hs);
+            pw(ww[l].o,hs,nh*hd); pw(ww[l].g,is,hs); pw(ww[l].u,is,hs); pw(ww[l].d,hs,is);
+        }
+    }
+
+    // Write sidecar GGUF
+    std::string gguf=std::string(out)+".gguf";
+    fprintf(stderr,"[write] %s\n",gguf.c_str());
+    {
+        std::ofstream f(gguf,std::ios::binary); if(!f){fprintf(stderr,"[err] write %s\n",gguf.c_str());return 1;}
+        auto w32=[&](uint32_t v){f.write((const char*)&v,4);};
+        auto w64=[&](uint64_t v){f.write((const char*)&v,8);};
+        auto wstr=[&](const std::string& s){w64(s.size());f.write(s.data(),s.size());};
+        auto wkvstr=[&](const std::string& k,const std::string& v){wstr(k);w32(8);wstr(v);};
+        auto wkvu32=[&](const std::string& k,uint32_t v){wstr(k);w32(4);w32(v);};
+        auto wtinfo=[&](const std::string& n,const std::vector<uint64_t>& sh,uint32_t dt,uint64_t off){
+            wstr(n);w32((uint32_t)sh.size());for(auto d:sh)w64(d);w32(dt);w64(off);
+        };
+        auto walign=[&](uint32_t a){
+            uint64_t p=(uint64_t)f.tellp(),r=p%a;
+            if(r)for(uint64_t i=0;i<a-r;++i)f.put(0);
+        };
+        uint64_t nt=4*nl+2,nk=9;
+        f.write("GGUF",4);w32(3);w64(nt);w64(nk);
+        wkvstr("general.architecture","qwen3");
+        wkvu32("qwen3.hidden_size",hs); wkvu32("qwen3.feed_forward_length",is);
+        wkvu32("qwen3.block_count",nl); wkvu32("qwen3.attention.head_count",nh);
+        wkvu32("qwen3.attention.head_count_kv",nkv); wkvu32("qwen3.vocab_size",voc);
+        wkvu32("qwen3.max_position_embeddings",4096); wkvu32("qwen3.rope.freq_base",(uint32_t)rt);
+        uint64_t off=0;
+        for(uint32_t l=0;l<nl;++l){
+            wtinfo("blk."+std::to_string(l)+".attn_norm.weight",{hs},0,off);off+=hs*4;
+            wtinfo("blk."+std::to_string(l)+".ffn_norm.weight",{hs},0,off);off+=hs*4;
+            wtinfo("blk."+std::to_string(l)+".attn_q_norm.weight",{hd},0,off);off+=hd*4;
+            wtinfo("blk."+std::to_string(l)+".attn_k_norm.weight",{hd},0,off);off+=hd*4;
+        }
+        wtinfo("output_norm.weight",{hs},0,off);off+=hs*4;
+        wtinfo("token_embd.weight",{hs,voc},42,off); walign(32);
+        for(uint32_t l=0;l<nl;++l){
+            f.write((const char*)nn[l].an.data(),hs*4);
+            f.write((const char*)nn[l].fn.data(),hs*4);
+            f.write((const char*)nn[l].qn.data(),hd*4);
+            f.write((const char*)nn[l].kn.data(),hd*4);
+        }
+        f.write((const char*)on.data(),hs*4);
+        {
+            std::vector<uint8_t> te_packed;
+            ternarize_to_tq2(te.data(),(int)voc,(int)hs,te_packed);
+            f.write((const char*)te_packed.data(),te_packed.size());
+        }
+    }
+    fprintf(stderr,"[done] %s + %s\n",h1b.c_str(),gguf.c_str());
+    return 0;
+}

--- a/tools/onebp_to_trg.cpp
+++ b/tools/onebp_to_trg.cpp
@@ -1,0 +1,493 @@
+#include "cpu_q4nx_loader.h"
+// tools/onebp_to_trg.cpp — Convert 1BP models to .trg format
+// Full pipeline: 1BP → Q4NX (re-wrap) → TRG packing
+//
+// Build: g++ -std=c++17 -O3 -march=native -fopenmp \
+//        -I engine/fusion -I include -I . \
+//        tools/onebp_to_trg.cpp engine/fusion/cpu_layer.cpp \
+//        -o build/onebp_to_trg -lm -lpthread
+//
+// Run: ./build/onebp_to_trg model.1bp output.trg
+//      ./build/onebp_to_trg model.1bp output.q4nx  (save intermediate Q4NX)
+
+#include "onebp_format.h"
+#include "cpu_layer.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+#include <string>
+#include <map>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <chrono>
+#include <fstream>
+
+// Tiled size calculation (Q4NX: scales + zero_points + packed)
+static uint64_t tiled_size_q4nx(uint32_t rows, uint32_t cols, uint32_t tr, uint32_t tc, uint32_t gs) {
+    uint32_t ntr = (rows + tr - 1) / tr;
+    uint32_t ntc = (cols + tc - 1) / tc;
+    uint32_t gpr = tc / gs;
+    uint64_t tile = (uint64_t)tr * gpr * 2  // scales bf16
+                  + (uint64_t)tr * gpr * 2  // zero_points bf16
+                  + (uint64_t)tr * tc / 2;  // 4-bit packed
+    return ntr * ntc * tile;
+}
+
+// Pack one projection to TRG format (ternary with per-block scales)
+// This is extracted from trg_save.cpp's pack_proj
+static void pack_proj(const float* src, uint32_t* packed, float* scales,
+                      int OUT, int IN, int n_blocks) {
+    int pp = (IN + 15) / 16;
+    for (int r = 0; r < OUT; r++) {
+        // Per-block scale: mean |weight| within each 256-value block
+        for (int b = 0; b < n_blocks; b++) {
+            double sa = 0; int nz = 0;
+            int blk_start = b * 256;
+            int blk_end = (b + 1) * 256;
+            if (blk_end > IN) blk_end = IN;
+            for (int c = blk_start; c < blk_end; c++) {
+                float v = src[r*IN+c]; sa += fabs(v); if (v != 0) nz++;
+            }
+            scales[r * n_blocks + b] = (nz > 0) ? (float)(sa / nz) : 0;
+        }
+        for (int u = 0; u < pp; u++) {
+            uint32_t w = 0;
+            for (int v = 0; v < 16; v++) {
+                int c = u*16+v;
+                float val = (c < IN) ? src[r*IN+c] : 0;
+                w |= ((val > 0 ? 0x1u : (val < 0 ? 0x2u : 0)) << (v*2));
+            }
+            packed[r*pp+u] = w;
+        }
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        fprintf(stderr, "Usage: %s input.1bp output.trg [--save-q4nx path.q4nx]\n", argv[0]);
+        return 1;
+    }
+
+    bool save_q4nx = false;
+    std::string q4nx_path;
+    for (int i = 3; i < argc; i++) {
+        if (strcmp(argv[i], "--save-q4nx") == 0 && i+1 < argc) {
+            save_q4nx = true;
+            q4nx_path = argv[++i];
+        }
+    }
+
+    // Memory-map the 1BP file
+    int fd = open(argv[1], O_RDONLY);
+    if (fd < 0) { perror("open"); return 1; }
+    size_t fsz = lseek(fd, 0, SEEK_END);
+    auto data = (const uint8_t*)mmap(0, fsz, PROT_READ, MAP_PRIVATE, fd, 0);
+    close(fd);
+    if (data == MAP_FAILED) { perror("mmap"); return 1; }
+
+    // Parse 1BP header
+    OnebpHeader hdr;
+    memcpy(&hdr, data, sizeof(hdr));
+    if (!hdr.valid()) {
+        fprintf(stderr, "Invalid 1BP header (magic=0x%08x)\n", hdr.magic);
+        munmap((void*)data, fsz); return 1;
+    }
+
+    int H = hdr.hidden_size;
+    int L = hdr.num_layers;
+    int NH = hdr.num_attention_heads;
+    int NKV = hdr.num_kv_heads ? hdr.num_kv_heads : NH;
+    int HD = hdr.head_dim ? hdr.head_dim : (NH ? H / NH : 64);
+    int V = hdr.vocab_size;
+    int IM = hdr.intermediate_size;
+    int tr = 32, tc = 256, gs = 32;
+
+    printf("=== 1BP → TRG: %s\n", argv[1]);
+    printf("  H=%d L=%d NH=%d NKV=%d HD=%d V=%d IM=%d\n", H, L, NH, NKV, HD, V, IM);
+    printf("  arch=%u quant=%u tensors=%u\n", hdr.arch, hdr.quant, hdr.tensor_count);
+
+    // Walk tensor index
+    struct TensorInfo {
+        std::string name;
+        uint64_t offset, bytes;
+        int rows, cols;
+    };
+    std::vector<TensorInfo> tensors;
+    
+    uint64_t idx_off = sizeof(OnebpHeader);
+    uint64_t weight_data_off = fsz;
+
+    for (uint32_t i = 0; i < hdr.tensor_count; i++) {
+        TensorInfo ti;
+        uint32_t nlen;
+        if (idx_off + 4 > fsz) break;
+        memcpy(&nlen, data + idx_off, 4); idx_off += 4;
+        if (nlen > 255 || idx_off + nlen > fsz) break;
+        ti.name.assign((const char*)(data + idx_off), nlen);
+        idx_off += nlen + 1; // skip null terminator
+        
+        uint32_t ndim;
+        if (idx_off + 4 > fsz) break;
+        memcpy(&ndim, data + idx_off, 4); idx_off += 4;
+        
+        uint32_t shape[3] = {0};
+        for (uint32_t d = 0; d < ndim && d < 3; d++) {
+            if (idx_off + 4 > fsz) break;
+            memcpy(&shape[d], data + idx_off, 4); idx_off += 4;
+        }
+        
+        if (idx_off + 16 > fsz) break;
+        memcpy(&ti.offset, data + idx_off, 8); idx_off += 8;
+        memcpy(&ti.bytes, data + idx_off, 8); idx_off += 8;
+        
+        ti.rows = shape[0];
+        ti.cols = ndim > 1 ? shape[1] : 1;
+        
+        if (ti.offset < weight_data_off) weight_data_off = ti.offset;
+        
+        // Only process 2D weight tensors (skip norms, embeddings that are BF16)
+        if (ndim == 2 && ti.rows > 0 && ti.cols > 0 && ti.bytes > 0) {
+            tensors.push_back(ti);
+        }
+    }
+
+    printf("  Tensors: %zu (2D weights), data at offset %lu\n", 
+           tensors.size(), (unsigned long)weight_data_off);
+    
+    if (tensors.empty()) {
+        fprintf(stderr, "No 2D weight tensors found\n");
+        munmap((void*)data, fsz); return 1;
+    }
+
+    // ── Step 1: Generate Q4NX JSON header ─────────────────────
+    std::string json = "{";
+    for (size_t i = 0; i < tensors.size(); i++) {
+        auto& t = tensors[i];
+        // Q4NX tile shape: [n_blocks, 5120]
+        uint32_t ntr = (t.rows + tr - 1) / tr;
+        uint32_t ntc = (t.cols + tc - 1) / tc;
+        uint32_t n_blocks = ntr * ntc;
+        // Data offsets relative to start of weight data
+        uint64_t data_start = t.offset - weight_data_off;
+        uint64_t data_end = data_start + t.bytes;
+        
+        if (i > 0) json += ",";
+        json += "\"" + t.name + "\":{";
+        json += "\"dtype\":\"I8\",";
+        json += "\"shape\":[" + std::to_string(n_blocks) + ",5120],";
+        json += "\"data_offsets\":[" + std::to_string(data_start) + "," + std::to_string(data_end) + "]";
+        json += "}";
+    }
+    json += "}";
+    
+    if (save_q4nx) {
+        // Write Q4NX file
+        FILE* fq = fopen(q4nx_path.c_str(), "wb");
+        if (!fq) { perror("fopen q4nx"); return 1; }
+        uint64_t json_size = json.size();
+        fwrite(&json_size, 8, 1, fq);
+        fwrite(json.data(), 1, json.size(), fq);
+        fwrite(data + weight_data_off, 1, fsz - weight_data_off, fq);
+        fclose(fq);
+        printf("  Q4NX saved: %s (%.1f MB)\n", q4nx_path.c_str(), 
+               (json_size + fsz - weight_data_off) / (1024.0*1024.0));
+    }
+
+    // ── Step 2: Dequantize weights via cpu_layer ────────────────
+    // For TRG packing, we need FP32 weights. The Q4NX loader handles
+    // this, but we can also do it directly from the 1BP tile data.
+    // 
+    // For now: load the Q4NX (if saved) via trg_save, or do direct
+    // dequant in future. The key bridge is the Q4NX generation above.
+    
+    printf("\n  Q4NX JSON header: %zu bytes, %zu tensors\n", json.size(), tensors.size());
+    printf("  Pipeline: 1BP → Q4NX → trg_save convert → .trg\n");
+    printf("  Run: ./build/trg_save save <q4nx_path> <output.trg>\n");
+
+    // ── Step 3: Load Q4NX and pack to TRG ──────────────────────
+    // Temporarily write Q4NX to temp file for loading
+    std::string tmp_q4nx = "/tmp/onebp_to_trg_tmp.q4nx";
+    FILE* fq = fopen(tmp_q4nx.c_str(), "wb");
+    if (!fq) { perror("fopen temp"); return 1; }
+    uint64_t json_size = json.size();
+    fwrite(&json_size, 8, 1, fq);
+    fwrite(json.data(), 1, json.size(), fq);
+    fwrite(data + weight_data_off, 1, fsz - weight_data_off, fq);
+    fclose(fq);
+    
+    // Load Q4NX model (this dequantizes tiles to FP32)
+    printf("  Loading Q4NX for TRG packing...\n");
+    // Use our own direct tile reader instead of the full Q4NX loader
+    // to avoid format mismatch. Read tiles directly from mmap'd 1BP data.
+    
+    // ── Step 4: Write TRG header and pack weights ──────────────
+    // TRG v2 format (per-block ternary scales):
+    //   [TrgHeader: 512 bytes] magic="TRG2", dims, offsets
+    //   [Embedding: V*H fp32]
+    //   [Final norm: H fp32]
+    //   [LM head: V*H fp32]  
+    //   [Norms: L*(H+H+HD+HD) fp32]
+    //   [Packed ternary weights: per-layer QKV+GUD]
+    //   [Per-block scales: per-layer]
+    
+    auto t0 = std::chrono::high_resolution_clock::now();
+    
+    // Build weights map: group tensors by layer
+    struct LayerWeights {
+        float* q=0,* k=0,* v=0,* o=0,* gate=0,* up=0,* down=0;
+        int qs=0,ks=0,vs=0,os=0,gs=0,us=0,ds=0;
+    };
+    std::map<int, LayerWeights> layers;
+    
+    // Helper: find tensor and mmap its tile data
+    auto get_tensor_data = [&](const std::string& name) -> std::vector<float> {
+        for (auto& t : tensors) {
+            if (t.name == name) {
+                // Buffer for dequantized output
+                std::vector<float> fp32(t.rows * t.cols);
+                // Read tile data from mmap
+                const uint8_t* tile_data = data + t.offset;
+                uint32_t ntr = (t.rows + tr - 1) / tr;
+                uint32_t ntc = (t.cols + tc - 1) / tc;
+                
+                for (uint32_t bi = 0; bi < ntr * ntc; bi++) {
+                    const uint8_t* block = tile_data + bi * 5120;
+                    int tile_row = bi / ntc;
+                    int tile_col = bi % ntc;
+                    
+                    // Dequantize I8 block → FP32
+                    const uint16_t* scales = (const uint16_t*)block;
+                    const uint16_t* zps    = (const uint16_t*)(block + 512);
+                    const uint8_t*  packed = block + 1024;
+                    
+                    for (int lr = 0; lr < 32; lr++) {
+                        int row = tile_row * 32 + lr;
+                        if (row >= t.rows) continue;
+                        int lane = lr / 16;
+                        int lr2 = lr % 16;
+                        int bi_e = lr2 / 2;
+                        int ns = lr % 2;
+                        
+                        for (int g = 0; g < 8; g++) {
+                            float s = bf16_to_f32(scales[g * 32 + lr]);
+                            float z = bf16_to_f32(zps[g * 32 + lr]);
+                            for (int c = 0; c < 32; c++) {
+                                int col = tile_col * 256 + g * 32 + c;
+                                if (col >= t.cols) continue;
+                                uint8_t bv = packed[lane * 2048 + col * 8 + bi_e];
+                                int cd = (ns == 0) ? (bv & 0x0F) : ((bv >> 4) & 0x0F);
+                                fp32[row * t.cols + col] = (float)cd * s + z;
+                            }
+                        }
+                    }
+                }
+                return fp32;
+            }
+        }
+        return {};
+    };
+    
+    // Count weight tensors for TRG header
+    int per_layer = 0;
+    int rows7[7];
+    // Q, K, V, O, gate, up, down dimensions per layer
+    // Derived from first layer's tensors
+    if (tensors.size() >= 7) {
+        auto& t0_w = tensors[0];
+        (void)t0_w;
+    }
+    
+    // Determine model architecture from weight names
+    bool is_qwen3 = false;
+    for (auto& t : tensors) {
+        if (t.name.find("self_attn.q_proj") != std::string::npos) is_qwen3 = true;
+        if (t.name.find("q_proj") != std::string::npos && 
+            t.name.find("self_attn") == std::string::npos) is_qwen3 = false;
+    }
+    
+    // Map tensor names to 7 projections based on naming convention
+    std::string qn, kn, vn, on, gn, un, dn;
+    if (is_qwen3) {
+        qn = "model.layers.0.self_attn.q_proj.weight";
+        kn = "model.layers.0.self_attn.k_proj.weight";
+        vn = "model.layers.0.self_attn.v_proj.weight";
+        on = "model.layers.0.self_attn.o_proj.weight";
+        gn = "model.layers.0.mlp.gate_proj.weight";
+        un = "model.layers.0.mlp.up_proj.weight";
+        dn = "model.layers.0.mlp.down_proj.weight";
+    }
+    
+    // Find first layer dims
+    int qr=0, qc=0, kr=0, kc=0, vr=0, vc=0, or_=0, oc=0;
+    int gr=0, gc=0, ur_=0, uc=0, dr=0, dc=0;
+    for (auto& t : tensors) {
+        if (t.name.find("layers.0.") != std::string::npos) {
+            if (t.name.find("q_proj") != std::string::npos) { qr=t.rows; qc=t.cols; }
+            if (t.name.find("k_proj") != std::string::npos) { kr=t.rows; kc=t.cols; }
+            if (t.name.find("v_proj") != std::string::npos) { vr=t.rows; vc=t.cols; }
+            if (t.name.find("o_proj") != std::string::npos) { or_=t.rows; oc=t.cols; }
+            if (t.name.find("gate_proj") != std::string::npos) { gr=t.rows; gc=t.cols; }
+            if (t.name.find("up_proj") != std::string::npos) { ur_=t.rows; uc=t.cols; }
+            if (t.name.find("down_proj") != std::string::npos) { dr=t.rows; dc=t.cols; }
+        }
+    }
+    
+    // Gather embedding, final norm, lm_head
+    std::vector<float> embed, final_norm, lm_head;
+    for (auto& t : tensors) {
+        if (t.name.find("token_embd") != std::string::npos || 
+            t.name.find("embed_tokens") != std::string::npos) {
+            embed = get_tensor_data(t.name);
+        }
+        if (t.name.find("output_norm") != std::string::npos || 
+            t.name.find("final_norm") != std::string::npos) {
+            final_norm = get_tensor_data(t.name);
+        }
+    }
+    
+    // Check for lm_head (may be tied with embedding)
+    for (auto& t : tensors) {
+        if (t.name.find("lm_head") != std::string::npos) {
+            lm_head = get_tensor_data(t.name);
+        }
+    }
+    if (lm_head.empty() && !embed.empty()) {
+        lm_head = embed; // tied embeddings
+    }
+    
+    printf("  Layer 0 dims: Q=%dx%d K=%dx%d V=%dx%d O=%dx%d Gate=%dx%d Up=%dx%d Down=%dx%d\n",
+           qr, qc, kr, kc, vr, vc, or_, oc, gr, gc, ur_, uc, dr, dc);
+    printf("  Embed: %s (%zu elements)\n", embed.empty() ? "missing" : "ok", embed.size());
+    printf("  Final norm: %s (%zu elements)\n", final_norm.empty() ? "missing" : "ok", final_norm.size());
+    
+    // Write TRG file
+    FILE* ftrg = fopen(argv[2], "wb");
+    if (!ftrg) { perror("fopen trg"); return 1; }
+    
+    // TRG v2 header (512 bytes)
+    struct __attribute__((packed)) TrgHeader {
+        char magic[4] = {'T','R','G','2'};
+        int32_t H, IM, NH, NKV, HD, V, L, GQA;
+        int32_t ps[7];
+        int32_t bs[7];
+        uint64_t o_emb, o_fn, o_lm, o_norms, o_pk, o_sc, file_size;
+        uint8_t reserved[512 - 4 - 8*4 - 7*4 - 7*4 - 8*7];
+    };
+    static_assert(sizeof(TrgHeader) == 512, "TrgHeader must be exactly 512 bytes");
+    
+    TrgHeader th;
+    memset(&th, 0, sizeof(th));
+    th.H = H; th.IM = IM; th.NH = NH; th.NKV = NKV; th.HD = HD; th.V = V; th.L = L;
+    th.GQA = NH / (NKV ? NKV : 1);
+    
+    int pp[] = { (NH*HD+15)/16, (NKV*HD+15)/16, (NKV*HD+15)/16, (H+15)/16, (IM+15)/16, (IM+15)/16, (H+15)/16 };
+    int bb[] = { qc/256, kc/256, vc/256, oc/256, gc/256, uc/256, dc/256 };
+    memcpy(th.ps, pp, sizeof(pp));
+    memcpy(th.bs, bb, sizeof(bb));
+    
+    uint64_t off = sizeof(TrgHeader);
+    th.o_emb = off; off += embed.size() * 4;
+    th.o_fn  = off; off += final_norm.size() * 4;
+    th.o_lm  = off; off += lm_head.size() * 4;
+    
+    // Norms: input_norm + post_attn_norm + q_norm + k_norm per layer
+    // For now, approximate size. In practice norms are loaded separately.
+    th.o_norms = off; off += L * (H + H + HD + HD) * 4;
+    th.o_pk = off; off += L * 7 * pp[0]; // approx
+    th.o_sc = off; off += L * 7 * bb[0]; // approx
+    th.file_size = 0; // filled later
+    
+    fwrite(&th, sizeof(th), 1, ftrg);
+    
+    // Write embedding
+    if (!embed.empty()) fwrite(embed.data(), 4, embed.size(), ftrg);
+    else { for (int i = 0; i < V*H; i++) { float z=0; fwrite(&z,4,1,ftrg); } }
+    
+    // Write final norm
+    if (!final_norm.empty()) fwrite(final_norm.data(), 4, final_norm.size(), ftrg);
+    else { for (int i = 0; i < H; i++) { float z=0; fwrite(&z,4,1,ftrg); } }
+    
+    // Write LM head
+    if (!lm_head.empty()) fwrite(lm_head.data(), 4, lm_head.size(), ftrg);
+    else if (!embed.empty()) fwrite(embed.data(), 4, embed.size(), ftrg);
+    else { for (int i = 0; i < V*H; i++) { float z=0; fwrite(&z,4,1,ftrg); } }
+    
+    // Write norms (placeholder zeros for now)
+    size_t norms_size = L * (H + H + HD + HD);
+    for (size_t i = 0; i < norms_size; i++) { float z=0; fwrite(&z,4,1,ftrg); }
+    
+    // Write packed weights per layer
+    auto t1 = std::chrono::high_resolution_clock::now();
+    printf("  Packing %d layers...\n", L);
+    fflush(stdout);
+    
+    for (int layer = 0; layer < L && layer < 100; layer++) {
+        std::string prefix = "model.layers." + std::to_string(layer) + ".";
+        
+        // Find tensors for this layer
+        auto find_tensor = [&](const std::string& suffix) -> std::vector<float> {
+            for (auto& t : tensors) {
+                if (t.name == prefix + suffix) {
+                    return get_tensor_data(t.name);
+                }
+            }
+            return {};
+        };
+        
+        auto wq = find_tensor("self_attn.q_proj.weight");
+        auto wk = find_tensor("self_attn.k_proj.weight");
+        auto wv = find_tensor("self_attn.v_proj.weight");
+        auto wo = find_tensor("self_attn.o_proj.weight");
+        auto wg = find_tensor("mlp.gate_proj.weight");
+        auto wu = find_tensor("mlp.up_proj.weight");
+        auto wd = find_tensor("mlp.down_proj.weight");
+        
+        // Pack each projection
+        auto pack_write = [&](const std::vector<float>& w, int out_d, int in_d) {
+            if (w.empty() || out_d <= 0 || in_d <= 0) return;
+            int n_blocks = in_d / 256;
+            int n_packed = ((in_d + 15) / 16) * sizeof(uint32_t);
+            std::vector<uint32_t> packed(out_d * ((in_d+15)/16));
+            std::vector<float> scales(out_d * n_blocks);
+            pack_proj(w.data(), packed.data(), scales.data(), out_d, in_d, n_blocks);
+            fwrite(packed.data(), 1, packed.size() * 4, ftrg);
+            th.o_sc = ftell(ftrg); // update scale offset
+            fwrite(scales.data(), 4, scales.size(), ftrg);
+        };
+        
+        pack_write(wq, NH*HD, H);
+        pack_write(wk, NKV*HD, H);
+        pack_write(wv, NKV*HD, H);
+        pack_write(wo, H, NH*HD);
+        pack_write(wg, IM, H);
+        pack_write(wu, IM, H);
+        pack_write(wd, H, IM);
+        
+        if (layer % 8 == 0) { printf("  layer %d/%d\r", layer+1, L); fflush(stdout); }
+    }
+    
+    // Update header with actual file size
+    th.file_size = ftell(ftrg);
+    fseek(ftrg, 0, SEEK_SET);
+    fwrite(&th, sizeof(th), 1, ftrg);
+    fclose(ftrg);
+    
+    auto t2 = std::chrono::high_resolution_clock::now();
+    double elapsed = std::chrono::duration<double>(t2 - t0).count();
+    
+    struct stat st;
+    stat(argv[2], &st);
+    
+    printf("\n  ✅ TRG saved: %s (%.1f MB) in %.0fs\n", 
+           argv[2], st.st_size / (1024.0*1024.0), elapsed);
+    
+    // Cleanup
+    remove(tmp_q4nx.c_str());
+    munmap((void*)data, fsz);
+    return 0;
+}

--- a/tools/run_zamba2.cpp
+++ b/tools/run_zamba2.cpp
@@ -1,0 +1,150 @@
+// tools/run_zamba2.cpp — Standalone Zamba2 inference test
+//
+// Build: g++ -std=c++17 -O3 -I. -o run_zamba2 \
+//   tools/run_zamba2.cpp src/mamba2_kernels.cpp src/zamba2_engine.cpp
+//
+// Run:   ./run_zamba2 /path/to/zamba2.gguf "Hello, world!"
+//
+// This is a minimal test that loads a Zamba2 model from GGUF and
+// generates text. It does not depend on the 1bit.systems engine,
+// making it safe to compile on any machine with a C++17 compiler.
+
+#include "../src/zamba2_engine.h"
+#include "../src/gguf_zamba2_loader.cpp"
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <chrono>
+#include <cmath>
+
+// ── Minimal BPE tokenizer (Mistral v0.1 compatible) ──
+// For now, we use a simple byte-level fallback.
+// In production, use the tokenizer from the GGUF file or HuggingFace tokenizers.
+struct SimpleTokenizer {
+    std::vector<std::string> id_to_token;
+    int vocab_size = 32000;
+    int bos = 1, eos = 2;
+
+    void init(int vocab) {
+        vocab_size = vocab;
+        id_to_token.resize(vocab_size);
+        for (int i = 0; i < vocab_size; ++i) {
+            id_to_token[i] = "<" + std::to_string(i) + ">";
+        }
+        id_to_token[bos] = "<s>";
+        id_to_token[eos] = "</s>";
+    }
+
+    std::vector<int> encode(const std::string& text) {
+        // Stub: just use byte-level fallback
+        std::vector<int> ids = {bos};
+        for (char c : text) {
+            ids.push_back((unsigned char)c + 3); // shift to avoid special tokens
+        }
+        return ids;
+    }
+
+    std::string decode(const std::vector<int>& ids) {
+        std::string out;
+        for (int id : ids) {
+            if (id > 0 && id < vocab_size) {
+                // Skip special tokens for display
+                if (id >= 3) {
+                    out += (char)(id - 3);
+                }
+            }
+        }
+        return out;
+    }
+};
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <model.gguf> [prompt]\n", argv[0]);
+        return 1;
+    }
+
+    std::string model_path = argv[1];
+    std::string prompt = argc > 2 ? argv[2] : "Hello, world!";
+
+    fprintf(stderr, "╔══════════════════════════════════════╗\n");
+    fprintf(stderr, "║   Zamba2 Inference Test              ║\n");
+    fprintf(stderr, "╚══════════════════════════════════════╝\n");
+    fprintf(stderr, "Model: %s\n", model_path.c_str());
+    fprintf(stderr, "Prompt: %s\n\n", prompt.c_str());
+
+    // ── Load model ──
+    Zamba2Model model;
+    if (!load_zamba2_from_gguf(model_path, model)) {
+        fprintf(stderr, "Failed to load model\n");
+        return 1;
+    }
+
+    // ── Init tokenizer ──
+    SimpleTokenizer tokenizer;
+    tokenizer.init(model.cfg.vocab_size);
+
+    // ── Encode prompt ──
+    auto input_ids = tokenizer.encode(prompt);
+    fprintf(stderr, "Input tokens: ");
+    for (int id : input_ids) fprintf(stderr, "%d ", id);
+    fprintf(stderr, "\n\n");
+
+    // ── Generate ──
+    const int max_tokens = 100;
+    std::vector<int> output_ids;
+    std::vector<float> logits(model.cfg.vocab_size);
+
+    auto start = std::chrono::high_resolution_clock::now();
+
+    for (int t = 0; t < max_tokens; ++t) {
+        int token_id;
+        if (t < (int)input_ids.size()) {
+            token_id = input_ids[t];
+        } else {
+            // Argmax
+            token_id = 0;
+            float max_val = logits[0];
+            for (int i = 1; i < model.cfg.vocab_size; ++i) {
+                if (logits[i] > max_val) {
+                    max_val = logits[i];
+                    token_id = i;
+                }
+            }
+        }
+
+        // Forward
+        if (!model.forward(token_id, logits.data())) {
+            fprintf(stderr, "Forward failed at token %d\n", t);
+            break;
+        }
+
+        if (t >= (int)input_ids.size()) {
+            output_ids.push_back(token_id);
+
+            // Print as we go
+            std::string chunk = tokenizer.decode({token_id});
+            printf("%s", chunk.c_str());
+            fflush(stdout);
+
+            // Stop at EOS
+            if (token_id == tokenizer.eos) break;
+        }
+    }
+
+    auto end = std::chrono::high_resolution_clock::now();
+    float ms = std::chrono::duration<float, std::milli>(end - start).count();
+    int gen_tokens = (int)output_ids.size();
+    float tok_per_sec = gen_tokens > 0 ? (gen_tokens / (ms / 1000.0f)) : 0;
+
+    printf("\n\n╔══════════════════════════════════════╗\n");
+    printf("║   Generation Complete                ║\n");
+    printf("╠══════════════════════════════════════╣\n");
+    printf("║ Tokens generated: %d                  ║\n", gen_tokens);
+    printf("║ Time: %.1f ms                        ║\n", ms);
+    printf("║ Speed: %.1f tok/s                    ║\n", tok_per_sec);
+    printf("╚══════════════════════════════════════╝\n");
+
+    return 0;
+}

--- a/tools/unified_router.cpp
+++ b/tools/unified_router.cpp
@@ -7,13 +7,16 @@
 //   unified_router --port 18181 --npu-backend http://127.0.0.1:18101 --gpu-backend http://127.0.0.1:18102
 
 #include <algorithm>
+#include <atomic>
 #include <cctype>
+#include <chrono>
 #include <csignal>
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <unordered_set>
 #include <vector>
 
@@ -379,16 +382,24 @@ Options:
         res.status = 200;
     });
 
-    // Signal handling (fixes #1324: std::exit not async-signal-safe)
+    // Signal handling (fixes #1324: std::exit not async-signal-safe).
+    // #1325 regression: the flag was never polled, so SIGINT/SIGTERM stopped
+    // working entirely. Watchdog pattern from vision_server (#1292): poll the
+    // flag, then svr.stop() to unblock listen().
     static volatile sig_atomic_t g_shutdown = 0;
     std::signal(SIGINT, [](int) { g_shutdown = 1; });
     std::signal(SIGTERM, [](int) { g_shutdown = 1; });
 
     std::cout << "Router listening on " << bind_addr << ":" << port << std::endl;
-    if (!svr.listen(bind_addr.c_str(), port)) {
-        std::cerr << "Failed to bind to " << bind_addr << ":" << port << std::endl;
-        return 1;
-    }
-
+    std::thread listener([&]() {
+        if (!svr.listen(bind_addr.c_str(), port)) {
+            std::cerr << "Failed to bind to " << bind_addr << ":" << port << std::endl;
+            _exit(1);
+        }
+    });
+    while (!g_shutdown)
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    svr.stop();
+    listener.join();
     return 0;
 }


### PR DESCRIPTION
### **User description**
## What

The ponytail purge (#1325, `21b6202aa`, −54K lines / 192 files) cut files that were still load-bearing. Full audit (3 parallel reviews + build verification) of every deletion found 6 build breaks, 2 lost workflow capabilities, and 2 regressions in kept files. This PR restores them.

## Build breaks restored

| File | What broke |
|---|---|
| `packaging/binary/server.cpp` | Dockerfile, snapcraft.yaml, AUR PKGBUILD, packaging/Makefile (deb) all compile/copy it → docker/snap/aur/deb builds fail |
| `npu-infer/src/ffi_bridge.cpp` | `npu-infer/rust/build.rs` compiles it; `lib.rs` externs fns implemented only there → cargo build fails |
| `npu-infer/tools/npu_gemm_runner.cpp` | kept `verify_gemm.py` compiles it at runtime |
| `engine/npu/kernel/*` (15 files) | `build_npu_ternary.sh` hard-errors (tq1/tq2/q1 kernel sources gone); only rebuild path for the attention/ternary/SSM xclbins that `npu_engine_universal.cpp`/`npu_engine_cb.cpp` still load |
| `tools/run_zamba2.cpp` | `Makefile.zamba2` `all` target |
| `tests/test_tokenizer_logprobs.cpp` | CMake target still present (`CMakeLists.txt:787`) |

## Workflow capability restored

- `tools/gguf_to_h1b.cpp`, `convert_gguf_to_h1b.cpp`, `convert_zaya_to_h1b.cpp` — the only writers of v1 FP16 / v3 SHERRY_FP16 `.h1b`, formats still read by `h1b_loader.cpp` (lines 29, 612), `backend_hip_1bp.cpp`, `onebitd`, `unified_server`. Added ~20 days pre-purge (`aeb274422`). Kept `hadamard_export` covers v5 WMMA_I8 only.
- `tools/onebp_to_trg.cpp` — .trg producer for 1bp models; consumer `engine/fusion/gpu_verify_opt.cpp` is kept.

## Regressions in kept files fixed

- **`tools/unified_router.cpp`** — the purge replaced `std::exit` signal handlers with a `sig_atomic_t` flag **nothing polls**: SIGINT/SIGTERM silently stopped terminating the server ("zero behavior change" claim was wrong). Restored with the house watchdog pattern from `vision_server` (#1292) and verified live.
- **`npu-infer/include/model.h`** — the #1336 field reorder added `static_assert(sizeof(TensorDesc) == 204)` but actual size is 208 (tail padding to 8-byte alignment). Dormant while no C++ TU included it; would have broken the restored `ffi_bridge.cpp`/rust build. Fixed to 208 — all consumers use `sizeof`, ABI unchanged.

## Verified

- Full CMake build green (108/108 targets)
- `make -f Makefile.zamba2 all` builds `run_zamba2`
- `packaging/binary/server.cpp` compiles with the Dockerfile flags
- Every restored TU syntax-checks; `ffi_bridge.cpp` compiles with `build.rs` flags
- All other ~165 deletions confirmed genuinely dead (never compiled/never referenced) — see commit message detail

Note: `npu-infer/tools/verify_gemm.py` compiles `npu_gemm_runner.cpp` with only torch2aie includes — that include-path gap predates the purge (needs `-Iengine/npu/include`), flagged but not changed here.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Restore files deleted by ponytail purge that were still needed

- Fix build breaks in packaging, NPU kernels, and tools

- Restore workflow capabilities for model conversion formats

- Fix regressions in signal handling and struct padding


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Purge #1325"] --> B["Restore files"]
  B --> C["Build breaks"]
  B --> D["Workflow capabilities"]
  B --> E["Regressions"]
  C --> F["server.cpp"]
  C --> G["ffi_bridge.cpp"]
  C --> H["NPU kernels"]
  D --> I["convert_gguf_to_h1b"]
  D --> J["convert_zaya_to_h1b"]
  D --> K["onebp_to_trg"]
  E --> L["unified_router.cpp"]
  E --> M["model.h"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>convert_gguf_to_h1b.cpp</strong><dd><code>Add GGUF to h1b converter tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-e801541a415f430a204becd2a16238d6dd0ea76944cb58072b89078163ee14e8">+808/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>convert_zaya_to_h1b.cpp</strong><dd><code>Add Zaya GGUF to h1b converter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-0b601fd79aba699b5e3caa19f6750d680afb81bca16f0cb9aec365d14d9657a0">+605/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>onebp_to_trg.cpp</strong><dd><code>Add 1BP to TRG converter tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-f9931a38825d03288baedea9bbe20c7dffa38f48239947f385331c559a8d7e3f">+493/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>edge_attention_06b_compact.cc</strong><dd><code>Add compact attention kernel for 0.6B</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-c4f531143c369e86b45031852629b73f7a1bc5acc3af043ed29e0fa5948e3ee0">+234/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>qwen3_decode_kernels_06b.cc</strong><dd><code>Add decode kernels for 0.6B model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-94b1a5750c3ef625ad895d5907b5b760eb9c1faafc5eb575d8ba9cbf6fe16b04">+349/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>gguf_to_h1b.cpp</strong><dd><code>Add GGUF to h1b conversion tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-21e8894853014192f3a270520692af74386fa2036fa27c71cac825e0535ea9b7">+264/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>edge_attention.cc</strong><dd><code>Add edge attention kernel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-d087b0abf88aa7dfd0159c9073562cd12bccb0d3dda87a20102dcbf3f8bad4f2">+356/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>postprocess_qkv_06b.cc</strong><dd><code>Add QKV postprocessing kernel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-6397d14ca34e569b805b941811969f736a9bb79552a0c49613eb50d21539f7e5">+294/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>full_vector_station_06b.cc</strong><dd><code>Add full vector station kernel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-c881d2b8b0c45a4becc800a23f295ec3962c5c6f6ffff7c888633509082d8e0c">+262/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>swiglu_06b.cc</strong><dd><code>Add SwiGLU kernel for 0.6B</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-8bd33a8300f6b9fb7190a573f1115f7ac723e0f114d1c323dc4a1b1c803de1b6">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mm_ternary_tq2.cc</strong><dd><code>Add ternary matrix multiply kernel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-bbeafd323fa62869d6f8e673b45130812a8f15f42fb463688f91e105d4980e11">+154/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>npu_gemm_runner.cpp</strong><dd><code>Restore NPU GEMM runner tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-561e809b236b59c75947d403e04ddcac7795f8b0e014d95e4aa76f658d7ee09f">+188/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mm_ternary_tq1.cc</strong><dd><code>Add ternary TQ1 kernel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-3cb32a8adf771e4fd79e53237a43fede98e45c4cbebc4daf705a66a4b138ef19">+124/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ssm_selective_scan.cc</strong><dd><code>Add SSM selective scan kernel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-8dc73c877510920d1eb64ddb87f97c2e1f87694a873887399c8c3953830d7a7b">+121/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>run_zamba2.cpp</strong><dd><code>Restore Zamba2 runner tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-aabd47a5d1935a9e411e04f95ef719b7b9a59e9e1fcf425c093ecc13c6ad59c5">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mm_binary_q1.cc</strong><dd><code>Add binary Q1 kernel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-148cf279ec9043182efbdfcf4cb8e53d2bd450901c461f34ec9a9961a870ef2c">+84/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_tokenizer_logprobs.cpp</strong><dd><code>Restore tokenizer logprobs test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-68a0c226962b3f63b447074c7b5b46477c936ebab43e17a415050072b72843d6">+181/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>server.cpp</strong><dd><code>Restore binary server source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-a4f52ec1871cae599649c86476c3fa6bf921a009990cc371afa1afd246cc1293">+154/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ffi_bridge.cpp</strong><dd><code>Restore FFI bridge for Rust bindings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-90d940518c295c2a529171f74f9b6d20eac47c1d5d92542c534242caa2bb645a">+106/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>build_06b_kernels.sh</strong><dd><code>Add build script for 0.6B kernels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-0536ae21cf5a1670a5cc0a9d2abd642b6430580d93c625b9e0714735865275e1">+78/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-a318b7955accae776da844ab93a3a31743f989b38e737674912228c3c977ffce">+95/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>qwen3_constants_06b.h</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-fcacb3dec6171b1778e7fa4ced8f068135b058f4553ccc9e9865bb83cf6ea93a">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>record_format.h</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-e7d02e1a0e6455287708c13c4ee1b9903227b04065f50f1e2007bf604f1b7624">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zr1_constants.h</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-e340a493c76130b16738716c2d0134d00fef8bba1435be55ad3fa611ebb30448">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>model.h</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-da73791c79e0810b693d231a1380630350ef5c69e4ac6a81cff0bda6e522d37b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>unified_router.cpp</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1390/files#diff-fc6cd0e876fbe5113340876f3bcb26a873ad3895107d7750a86b1c1ad62062e7">+17/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

