### PR TITLE
chore(ci): PR Agent on local Ollama model (gpt-oss:20b)

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -13,22 +13,28 @@ permissions:
 
 jobs:
   pr_agent:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    runs-on: strix-halo-runner
+    timeout-minutes: 15
     # Only run for same-repo PRs and trusted commenters (not external forks)
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'issue_comment' && github.event.comment.author_association == 'OWNER')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      # Local model backend: Ollama runs as a systemd service on this host
+      # (127.0.0.1:11434, 100% GPU via ROCm/gfx1151). Pull is idempotent —
+      # no-op when the model is already present.
+      - name: Ensure local model (ollama)
+        run: |
+          curl -fsS http://127.0.0.1:11434/api/tags >/dev/null
+          ollama pull qwen2.5-coder:7b
       - name: PR Agent
         uses: qodo-ai/pr-agent@d82f7d3e696cd00822694aaa3096265d3889f3f1  # v0.34
         env:
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-          # SECURITY: GITHUB_TOKEN with contents:write scope is passed to the
-          # third-party action qodo-ai/pr-agent. Mitigation: the job-level `if`
-          # guard above restricts execution to same-repo PRs only; external
-          # forks are never processed. Consider a fine-grained PAT or
-          # GitHub App token for tighter scope in the future.
+          # SECURITY: third-party action running on a SELF-HOSTED runner with
+          # contents:write scope = arbitrary code execution on the host. The
+          # job-level `if` guard restricts execution to same-repo PRs and
+          # OWNER comments only; external forks are never processed. Keep the
+          # action pinned to this SHA.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG_FILE: .pr_agent.toml

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   pr_agent:
-    runs-on: strix-halo-runner
+    runs-on: [self-hosted, strix-halo]
     timeout-minutes: 15
     # Only run for same-repo PRs and trusted commenters (not external forks)
     if: |

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Ensure local model (ollama)
         run: |
           curl -fsS http://127.0.0.1:11434/api/tags >/dev/null
-          ollama pull qwen2.5-coder:7b
+          ollama pull gpt-oss:20b
       - name: PR Agent
         uses: qodo-ai/pr-agent@d82f7d3e696cd00822694aaa3096265d3889f3f1  # v0.34
         env:

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,6 @@
 [pr_agent]
-model = "deepseek/deepseek-chat"
-model_turbo = "deepseek/deepseek-chat"
+model = "ollama/qwen2.5-coder:7b"
+model_turbo = "ollama/qwen2.5-coder:7b"
 fallback_models = []
 verbosity_level = 2
 publish_output = true
@@ -34,12 +34,15 @@ push_changelog_changes = true
 enable_help_text = false
 
 [config]
-model = "deepseek/deepseek-chat"
+model = "ollama/qwen2.5-coder:7b"
 fallback_models = []
 ignore_pr_labels = []
-# deepseek/deepseek-chat isn't registered in pr-agent's internal MAX_TOKENS
-# table, so every review/description/suggestion call was throwing
-# "Ensure deepseek/deepseek-chat is defined in MAX_TOKENS ... or set a
-# positive value for it in config.custom_model_max_tokens" and failing
-# silently on every PR. 64000 matches DeepSeek-V3's published context window.
-custom_model_max_tokens = 64000
+# Local model served by Ollama on the strix-halo-runner host (100% GPU,
+# gfx1151). Runs through litellm's "ollama/" provider — api_base defaults to
+# http://localhost:11434 but is set explicitly below.
+# "ollama/qwen2.5-coder:7b" isn't in pr-agent's internal MAX_TOKENS table,
+# so custom_model_max_tokens is required; 32768 = qwen2.5-coder context.
+custom_model_max_tokens = 32768
+
+[ollama]
+api_base = "http://localhost:11434"

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,7 +1,7 @@
 [pr_agent]
-model = "ollama/qwen2.5-coder:7b"
-model_turbo = "ollama/qwen2.5-coder:7b"
-fallback_models = []
+model = "ollama_chat/gpt-oss:20b"
+model_turbo = "ollama_chat/qwen3.5:9b"
+fallback_models = ["ollama_chat/qwen3.5:9b"]
 verbosity_level = 2
 publish_output = true
 publish_output_progress = false
@@ -34,14 +34,14 @@ push_changelog_changes = true
 enable_help_text = false
 
 [config]
-model = "ollama/qwen2.5-coder:7b"
-fallback_models = []
+model = "ollama_chat/gpt-oss:20b"
+fallback_models = ["ollama_chat/qwen3.5:9b"]
 ignore_pr_labels = []
 # Local model served by Ollama on the strix-halo-runner host (100% GPU,
-# gfx1151). Runs through litellm's "ollama/" provider — api_base defaults to
-# http://localhost:11434 but is set explicitly below.
-# "ollama/qwen2.5-coder:7b" isn't in pr-agent's internal MAX_TOKENS table,
-# so custom_model_max_tokens is required; 32768 = qwen2.5-coder context.
+# gfx1151). Runs through litellm's "ollama_chat/" provider — api_base defaults
+# to http://localhost:11434 but is set explicitly below.
+# gpt-oss:20b isn't in pr-agent's internal MAX_TOKENS table, so
+# custom_model_max_tokens is required; 32768 is a safe cap below its 128k ctx.
 custom_model_max_tokens = 32768
 
 [ollama]


### PR DESCRIPTION
Move PR-Agent review off cloud deepseek-chat onto the self-hosted strix-halo-runner (100% GPU, gfx1151):

- `.pr_agent.toml`: model → `ollama_chat/gpt-oss:20b` (was `ollama/qwen2.5-coder:7b`), turbo + fallback → `ollama_chat/qwen3.5:9b` — same pairing as `run-pr-agent.sh`
- `pr-agent.yml`: self-hosted runner, idempotent `ollama pull gpt-oss:20b`
- Review stays on-box: NPU inference code never leaves the host

Same-repo PRs only + OWNER commenters (fork PRs and external comments never reach the runner).