### PR TITLE
feat(server): wire temperature/top_k sampling into decode loop

### DIFF
--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -354,12 +354,16 @@ static json health_json(BackendManager& mgr) {
 }
 
 // ── Sampling: temperature + top-k from raw logits ──
-// Returns a sampled token id. temperature<=0 && top_k<=0 → argmax (greedy).
-// Callers serialize decode under g_inference_mutex, so a plain static RNG is safe.
-static uint64_t g_sample_state = 0;
+// Returns a sampled token id. temperature<=0 → argmax (greedy), matching
+// OpenAI convention that temp 0 is deterministic even when top_k is set.
+// Thread-local RNG + scratch: decode may run on multiple threads, so the
+// sampler must not depend on an external locking invariant (PR #1398 review).
+static thread_local uint64_t g_sample_state = 0;
+static thread_local std::vector<float> g_sample_scaled;
+static thread_local std::vector<float> g_sample_sorted;
 static int sample_from_logits(const float* logits, int vs, float temperature, int top_k) {
     if (vs <= 0 || !logits) return 0;
-    if (temperature <= 0.0f && top_k <= 0) {  // greedy
+    if (temperature <= 0.0f) {  // greedy
         int best = 0; float bv = logits[0];
         for (int v = 1; v < vs; v++) if (logits[v] > bv) { bv = logits[v]; best = v; }
         return best;
@@ -375,9 +379,11 @@ static int sample_from_logits(const float* logits, int vs, float temperature, in
     float max_l = -1e30f;
     for (int v = 0; v < vs; v++) if (logits[v] > max_l) max_l = logits[v];
     float t = temperature > 0.0f ? temperature : 1.0f;
-    std::vector<float> scaled(vs);
+    auto& scaled = g_sample_scaled;
+    scaled.resize(vs);
     if (top_k > 0 && top_k < vs) {
-        std::vector<float> sorted(logits, logits + vs);
+        auto& sorted = g_sample_sorted;
+        sorted.assign(logits, logits + vs);
         std::nth_element(sorted.begin(), sorted.begin() + top_k - 1, sorted.end(),
                          std::greater<float>());
         float cutoff = sorted[top_k - 1];
@@ -1395,11 +1401,13 @@ int main(int argc, char** argv) {
         int max_tokens = body.value("max_tokens", 256);
         if (max_tokens < 1) max_tokens = 1;
         if (max_tokens > 32768) max_tokens = 32768;
-        float temperature = body.value("temperature", 0.0f);
-        if (temperature < 0.0f) temperature = 0.0f;
-        if (temperature > 5.0f) temperature = 5.0f;
         int top_k = body.value("top_k", 0);
         if (top_k < 0) top_k = 0;
+        // temperature<=0 is greedy (OpenAI convention); default to 1.0 when
+        // only top_k is supplied so top-k-only sampling still samples.
+        float temperature = body.value("temperature", top_k > 0 ? 1.0f : 0.0f);
+        if (temperature < 0.0f) temperature = 0.0f;
+        if (temperature > 5.0f) temperature = 5.0f;
         std::string req_model = body.value("model", "");
 
         // ── Serialize all compute against the single shared backend context ──
@@ -1649,11 +1657,13 @@ int main(int argc, char** argv) {
         int max_tokens = body.value("max_tokens", 256);
         if (max_tokens < 1) max_tokens = 1;
         if (max_tokens > 32768) max_tokens = 32768;
-        float temperature = body.value("temperature", 0.0f);
-        if (temperature < 0.0f) temperature = 0.0f;
-        if (temperature > 5.0f) temperature = 5.0f;
         int top_k = body.value("top_k", 0);
         if (top_k < 0) top_k = 0;
+        // temperature<=0 is greedy (OpenAI convention); default to 1.0 when
+        // only top_k is supplied so top-k-only sampling still samples.
+        float temperature = body.value("temperature", top_k > 0 ? 1.0f : 0.0f);
+        if (temperature < 0.0f) temperature = 0.0f;
+        if (temperature > 5.0f) temperature = 5.0f;
 
         std::vector<double> empty_logprobs;
         json gen_result;

--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -353,6 +353,46 @@ static json health_json(BackendManager& mgr) {
     return j;
 }
 
+// ── Sampling: temperature + top-k from raw logits ──
+// Returns a sampled token id. temperature<=0 && top_k<=0 → argmax (greedy).
+// Callers serialize decode under g_inference_mutex, so a plain static RNG is safe.
+static uint64_t g_sample_state = 0;
+static int sample_from_logits(const float* logits, int vs, float temperature, int top_k) {
+    if (vs <= 0 || !logits) return 0;
+    if (temperature <= 0.0f && top_k <= 0) {  // greedy
+        int best = 0; float bv = logits[0];
+        for (int v = 1; v < vs; v++) if (logits[v] > bv) { bv = logits[v]; best = v; }
+        return best;
+    }
+    // xorshift64* — cheap, deterministic-enough for sampling
+    if (g_sample_state == 0)
+        g_sample_state = (uint64_t)std::chrono::steady_clock::now().time_since_epoch().count();
+    uint64_t x = g_sample_state;
+    x ^= x >> 12; x ^= x << 25; x ^= x >> 27;
+    g_sample_state = x;
+    uint64_t r = x * 0x2545F4914F6CDD1Dull;
+
+    float max_l = -1e30f;
+    for (int v = 0; v < vs; v++) if (logits[v] > max_l) max_l = logits[v];
+    float t = temperature > 0.0f ? temperature : 1.0f;
+    std::vector<float> scaled(vs);
+    if (top_k > 0 && top_k < vs) {
+        std::vector<float> sorted(logits, logits + vs);
+        std::nth_element(sorted.begin(), sorted.begin() + top_k - 1, sorted.end(),
+                         std::greater<float>());
+        float cutoff = sorted[top_k - 1];
+        for (int v = 0; v < vs; v++)
+            scaled[v] = logits[v] < cutoff ? 0.0f : expf((logits[v] - max_l) / t);
+    } else {
+        for (int v = 0; v < vs; v++) scaled[v] = expf((logits[v] - max_l) / t);
+    }
+    float sum = 0; for (int v = 0; v < vs; v++) sum += scaled[v];
+    if (!(sum > 0)) return 0;  // degenerate logits — fall back to token 0
+    double rnd = (double)(r >> 11) / 9007199254740992.0 * (double)sum;
+    for (int v = 0; v < vs; v++) { rnd -= scaled[v]; if (rnd <= 0) return v; }
+    return vs - 1;
+}
+
 // ── Generate completion with per-token strategy routing ──
 // Returns { text, tokens, backend_used, ms_per_tok, tok_s }
 // When strategy_engine is provided, routes each token through the strategy
@@ -363,7 +403,9 @@ static json generate_completion(BackendManager& mgr,
                                  int max_tokens,
                                  const std::string& backend_id,
                                  StrategyEngine* strategy_engine = nullptr,
-                                 const std::string& user_message = "") {
+                                 const std::string& user_message = "",
+                                 float temperature = 0.0f,
+                                 int top_k = 0) {
     json result;
 
     // Select fixed backend if specified (overrides strategy routing).
@@ -486,13 +528,16 @@ static json generate_completion(BackendManager& mgr,
         }
 
         // ── Generate token ──
-        // When strategy engine needs logprobs (cascade/adaptive), use
-        // forward()+lm_head() separately for real model confidence.
-        // Otherwise, use fast generate() which does both in one call.
+        // When strategy engine needs logprobs (cascade/adaptive) or the caller
+        // requested temperature/top-k sampling, use forward()+lm_head()
+        // separately for real logits. Otherwise, use fast generate() which
+        // does both in one call.
         bool need_logprobs = strategy_engine && (
             strategy_engine->name() == std::string("cascade") ||
             strategy_engine->name() == std::string("adaptive")
         );
+        bool want_sampling = temperature > 0.0f || top_k > 0;
+        bool use_logits_path = need_logprobs || want_sampling;
 
         int next = -1;
         double token_logprob = 0.0;
@@ -508,12 +553,14 @@ static json generate_completion(BackendManager& mgr,
             if (mcfg.hidden_size > 0) hs = mcfg.hidden_size;
             else if (mcfg.hidden > 0) hs = mcfg.hidden;
         }
-        if (i == 0 && need_logprobs && output_logprobs.empty()) {
+        if (i == 0 && use_logits_path && output_logprobs.empty()) {
             std::vector<float> hidden_buf(hs);
             std::vector<float> logits_buf(vs);
             if (mgr.forward(last_token, hidden_buf.data())) {
                 int tmp_id = -1;
                 if (mgr.lm_head(hidden_buf.data(), logits_buf.data(), &tmp_id)) {
+                    if (want_sampling)
+                        tmp_id = sample_from_logits(logits_buf.data(), vs, temperature, top_k);
                     float max_l = -1e30f;
                     for (int v = 0; v < vs; v++)
                         if (logits_buf[v] > max_l) max_l = logits_buf[v];
@@ -527,12 +574,14 @@ static json generate_completion(BackendManager& mgr,
                 }
                 next = tmp_id;
             }
-        } else if (need_logprobs) {
+        } else if (use_logits_path) {
             // Slow path: forward + lm_head + softmax for real logprobs
             std::vector<float> hidden_buf(hs);
             std::vector<float> logits_buf(vs);
             if (mgr.forward(last_token, hidden_buf.data())) {
                 if (mgr.lm_head(hidden_buf.data(), logits_buf.data(), &next)) {
+                    if (want_sampling)
+                        next = sample_from_logits(logits_buf.data(), vs, temperature, top_k);
                     float max_l = -1e30f;
                     for (int v = 0; v < vs; v++)
                         if (logits_buf[v] > max_l) max_l = logits_buf[v];
@@ -1346,6 +1395,11 @@ int main(int argc, char** argv) {
         int max_tokens = body.value("max_tokens", 256);
         if (max_tokens < 1) max_tokens = 1;
         if (max_tokens > 32768) max_tokens = 32768;
+        float temperature = body.value("temperature", 0.0f);
+        if (temperature < 0.0f) temperature = 0.0f;
+        if (temperature > 5.0f) temperature = 5.0f;
+        int top_k = body.value("top_k", 0);
+        if (top_k < 0) top_k = 0;
         std::string req_model = body.value("model", "");
 
         // ── Serialize all compute against the single shared backend context ──
@@ -1455,7 +1509,8 @@ int main(int argc, char** argv) {
         // Generate with strategy-aware routing (#696 fix: no global lock held)
         json gen_result = generate_completion(mgr, prompt_tokens, prompt_logprobs,
                                                max_tokens, backend_id,
-                                               se, last_user_msg);
+                                               se, last_user_msg,
+                                               temperature, top_k);
 
         // Build OpenAI-compatible response
         json response;
@@ -1594,11 +1649,17 @@ int main(int argc, char** argv) {
         int max_tokens = body.value("max_tokens", 256);
         if (max_tokens < 1) max_tokens = 1;
         if (max_tokens > 32768) max_tokens = 32768;
+        float temperature = body.value("temperature", 0.0f);
+        if (temperature < 0.0f) temperature = 0.0f;
+        if (temperature > 5.0f) temperature = 5.0f;
+        int top_k = body.value("top_k", 0);
+        if (top_k < 0) top_k = 0;
 
         std::vector<double> empty_logprobs;
         json gen_result;
         try {
-            gen_result = generate_completion(mgr, prompt_tokens, empty_logprobs, max_tokens, backend_id);
+            gen_result = generate_completion(mgr, prompt_tokens, empty_logprobs, max_tokens, backend_id,
+                                             nullptr, "", temperature, top_k);
         } catch (const std::exception& e) {
             fprintf(stderr, "[completions] generate error: %s\n", e.what());
             gen_result = {{"error", std::string("Generation failed: ") + e.what()}};


### PR DESCRIPTION
### **User description**
## What & why

`temperature`/`top_k` were documented in the API schema but never read — generation was pure argmax, which locks tiny q4nx models into a fixed repetition loop (e.g. `"Paris. The capital of France is"` ×N at temp 0 — the loop seen in the #1397 verification table).

## Changes

- **`sample_from_logits()`** — temperature scaling + optional top-k filter, softmax, xorshift64* multinomial draw. Greedy fallback (argmax) when both params unset.
- **`generate_completion()`** — takes `temperature`/`top_k`; when either is set, uses the `forward()+lm_head()` logits path (already wired for cascade/adaptive logprobs) and samples instead of argmax. Unset params = byte-identical to before.
- **Both endpoints** (`/v1/chat/completions`, `/v1/completions`) parse + clamp the params.

## Verification (Strix Halo, Qwen3-0.6B q4nx, fused_gpu_npu)

| Request | Output |
|---|---|
| temp 0 (greedy) | `" Paris. The capital of France is Paris. The capital of France is Paris"` (unchanged loop — expected greedy) |
| temp 1.0 | `" **4,353,580 square kilometers**.\n\nThis"` — loop broken, varied |
| temp 1.0 again | `" located in which part of the geographical??\nA) North America\nB"` — non-deterministic |
| temp 0.5 | `" Paris, and the capital of Italy is Rome."` |
| top_k 50 | `" Rome. The capital of the Netherlands is (A"` — in-vocab |
| host ctest | 6/6 pass (test_backend skipped by design) |


___

### **PR Type**
Enhancement


___

### **Description**
- Implement `sample_from_logits()` for greedy, temperature, and top-k sampling

- Route decode through logits path when sampling is requested

- Parse and clamp `temperature`/`top_k` in both API endpoints


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API request temperature/top_k"] --> B["generate_completion"]
  B --> C{"sampling requested?"}
  C -- "yes" --> D["forward + lm_head logits"]
  D --> E["sample_from_logits (temperature/top-k)"]
  C -- "no" --> F["fast generate argmax"]
  E --> G["token"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>unified_server.cpp</strong><dd><code>Wire temperature/top_k sampling into decode loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/unified_server.cpp

<ul><li>Add <code>sample_from_logits()</code> with greedy argmax, temperature scaling, <br>optional top-k filter, and xorshift64* multinomial sampling<br> <li> Extend <code>generate_completion()</code> with <code>temperature</code>/<code>top_k</code> params and use the <br><code>forward()</code>+<code>lm_head()</code> logits path when sampling is requested<br> <li> Parse and clamp <code>temperature</code> and <code>top_k</code> in both <code>/v1/chat/completions</code> and <br><code>/v1/completions</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1398/files#diff-108a4e5ad06a8667d81e8da41605283a4dff15e0519645becad615fded67977c">+69/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

