### PR TITLE
fix(rocm): migrate install docs to multi-arch pip index

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(NOT _RC_LLVM_BIN)
     else()
         message(FATAL_ERROR
             "rocm-cpp needs an AMD clang: set THEROCK_PIP_ROOT env var, install "
-            "via 'pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ rocm[devel,libraries]', "
+            "via 'pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \"rocm[libraries,devel,device-gfx1151]\"', "
             "or install system ROCm at /opt/rocm.")
     endif()
 endif()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,8 +110,8 @@ See [docs/guides/building.md](docs/guides/building.md) for full prerequisites an
 
 **TheRock 7.15.0a installation (pip):**
 ```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
-  rocm[devel,libraries]
+pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+  "rocm[libraries,devel,device-gfx1151]"
 export THEROCK_PIP_ROOT="$HOME/.cache/pip/therock"
 ```
 

--- a/docs/guides/building.md
+++ b/docs/guides/building.md
@@ -31,8 +31,8 @@ sudo apt install -y cmake ninja-build build-essential git
 
 ```bash
 # Install TheRock HIP SDK for gfx1151 (Strix Halo)
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
-  rocm[devel,libraries]
+pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+  "rocm[libraries,devel,device-gfx1151]"
 export THEROCK_PIP_ROOT="$HOME/.cache/pip/therock"
 
 # Verify

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -39,8 +39,8 @@ cd 1bit-systems
 ## 2. Install TheRock 7.15.0a
 
 ```bash
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
-  rocm[devel,libraries]
+pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+  "rocm[libraries,devel,device-gfx1151]"
 export THEROCK_PIP_ROOT="$HOME/.cache/pip/therock"
 ```
 

--- a/hackathon/spec-document-track1.md
+++ b/hackathon/spec-document-track1.md
@@ -143,7 +143,7 @@
 git clone https://github.com/bong-water-water-bong/1bit-systems
 cd 1bit-systems
 # Install TheRock 7.15.0a
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ rocm[devel,libraries]
+pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ "rocm[libraries,devel,device-gfx1151]"
 export THEROCK_PIP_ROOT="$HOME/.cache/pip/therock"
 # Build
 cmake -B build -DCMAKE_HIP_ARCHITECTURES=gfx1151

--- a/hackathon/spec-document-track3.md
+++ b/hackathon/spec-document-track3.md
@@ -160,7 +160,7 @@ First project to adopt and validate **TheRock** — AMD's nightly pip-installabl
 git clone https://github.com/bong-water-water-bong/1bit-systems
 cd 1bit-systems
 # Install TheRock 7.15.0a — native gfx1151 HIP SDK
-pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ rocm[devel,libraries]
+pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ "rocm[libraries,devel,device-gfx1151]"
 # Build
 cmake -B build -DCMAKE_HIP_ARCHITECTURES=gfx1151
 cmake --build build -j$(nproc)

--- a/install.sh
+++ b/install.sh
@@ -74,8 +74,8 @@ install_deps() {
     # TheRock 7.15.0a — pip-installed HIP SDK for gfx1151
     if ! command -v amdclang++ &>/dev/null; then
         log "Installing TheRock 7.15.0a SDK..."
-        python3 -m pip install --index-url https://rocm.nightlies.amd.com/v2/gfx1151/ \
-            rocm[devel,libraries] 2>/dev/null || {
+        python3 -m pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+            "rocm[libraries,devel,device-gfx1151]" 2>/dev/null || {
             warn "TheRock pip install failed. Set THEROCK_PIP_ROOT manually."
             warn "See: https://github.com/bong-water-water-bong/TheRock"
         }


### PR DESCRIPTION
### **User description**
## What

The per-family TheRock pip index (`https://rocm.nightlies.amd.com/v2/gfx1151/`) is deprecated — TheRock now publishes **multi-arch** releases where GPU-specific device code is split into separate `rocm-sdk-device-{target}` packages and selected via a `[device-*]` extra.

This PR migrates the 7 remaining stale references to the current index (`https://rocm.nightlies.amd.com/whl-multi-arch/`) with the explicit `device-gfx1151` extra, matching what `scripts/setup-therock.sh` and CI already do.

## Files

- `CMakeLists.txt` — HIP compiler discovery error hint
- `CONTRIBUTING.md`, `install.sh`
- `docs/guides/building.md`, `docs/guides/getting-started.md`
- `hackathon/spec-document-track1.md`, `hackathon/spec-document-track3.md`

## Validation

The exact command was run on Strix Halo (Ryzen AI MAX+ 395 / gfx1151, Ubuntu 26.04):

```bash
pip install --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
  "rocm[libraries,devel,device-gfx1151]"
```

ROCm 7.14.0 stable (from `repo.amd.com/rocm/whl-multi-arch/`) installs, `rocm-sdk test` passes 27/27, and the full project builds + runs HIP inference (Bonsai-1.7B TQ2: 20 tok/s, no regression vs 21.9 baseline).


___

### **PR Type**
Documentation, Bug fix


___

### **Description**
- Migrate deprecated TheRock pip index to multi-arch

- Add device-gfx1151 extra to rocm install commands

- Update install.sh, CMakeLists hint, and docs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Old["rocm.nightlies.amd.com/v2/gfx1151/"] -- "deprecated" --> New["rocm.nightlies.amd.com/whl-multi-arch/"]
  New -- "device-gfx1151 extra" --> Cmd["pip install rocm[libraries,devel,device-gfx1151]"]
  Cmd --> Files["install.sh, CMakeLists.txt, docs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>install.sh</strong><dd><code>Update TheRock pip install command to multi-arch index</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1399/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>CMakeLists.txt</strong><dd><code>Update HIP compiler discovery error hint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1399/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CONTRIBUTING.md</strong><dd><code>Refresh TheRock installation instructions for contributors</code></dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1399/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>building.md</strong><dd><code>Update TheRock HIP SDK install command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1399/files#diff-18e2edb5c2c50a6bf1f33d16b61b342737b7ee528c42222949b32010cba52d49">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>getting-started.md</strong><dd><code>Update TheRock 7.15.0a installation steps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1399/files#diff-cfabf1cf40f1208bf2a9e4198f0fa64a0fb3de07c1e2a005a3965e1a699a9e37">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec-document-track1.md</strong><dd><code>Migrate TheRock pip index in track one spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1399/files#diff-5bf1897362db7e538c588731e585de383791be6bcc4a3129984560f6fa6b7485">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spec-document-track3.md</strong><dd><code>Migrate TheRock pip index in track three spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1399/files#diff-b0db3a5da928ed298c53dca504d235a151b64a718b121b65a5b28fa18aa14664">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

