### PR TITLE
chore(llama.cpp): sync fork to 0807d70be (paged-KV merge + Vulkan fixes), fix ggml-vulkan build hint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **1bit-systems** (21911 symbols, 39552 relationships, 231 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **1bit-systems** (18519 symbols, 32295 relationships, 203 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 
@@ -47,4 +47,3 @@ This project is indexed by GitNexus as **1bit-systems** (21911 symbols, 39552 re
 
 - **When your job is done, stop.** Do not continue working, do not invent follow-up tasks, do not spawn new work, do not linger. Deliver the result and exit.
 - Never leave background processes, scheduled runs, or partial downloads behind. Clean up anything you started before finishing.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to 1bit.systems. Versioning is **date-based** (`YYYY.MM.DD`),
 matching the GitHub release tags (`vYYYY.MM.DD`).
 
+## 2026.08.02 — llama.cpp fork synced to b10015-76-g0807d70be + build-hint fix 🔧
+
+- **llama.cpp fork synced** — `third_party/llama.cpp` moved from the paged-KV PR
+  head (`329cb3241`) to the documented sync point `0807d70be` (merge of PR #2 +
+  873-commit upstream catch-up; +93 commits incl. Vulkan fixes #24362
+  (FA mask_opt off on GCN), #25240 (submission threshold for small AMD GPUs),
+  #25351/#25432 (SET_ROWS f16)). Rebuilt `-DGGML_VULKAN=ON -DBUILD_SHARED_LIBS=OFF`,
+  Vulkan verified on Strix Halo (Radeon 8060S RADV, KHR_coopmat); `unified_server`
+  relinked against the synced statics. Sync record: `docs/llama.cpp-fork.md`.
+- **Build-hint fix** — the ggml-vulkan import warning in `CMakeLists.txt` now
+  includes `-DBUILD_SHARED_LIBS=OFF`; without it ggml builds shared libs and the
+  static import check silently fails even after a successful build.
+
 ## 2026.08.01 — Pure-C++ video-lora backend + fresh benchmark sweep + scope guard 🚀
 
 - **Lemonade SDK embedded** — `unified_server` links Lemonade's server core

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,7 +472,7 @@ if(EXISTS "${GGML_BUILD_DIR}/ggml/src/ggml-vulkan/libggml-vulkan.a")
     target_include_directories(ggml INTERFACE "${GGML_VULKAN_DIR}/ggml/include")
     message(STATUS "llama.cpp ggml-vulkan: FOUND")
 else()
-    message(WARNING "llama.cpp ggml-vulkan not built — cd third_party/llama.cpp && cmake -B build -G Ninja -DGGML_VULKAN=ON && cmake --build build -j8")
+    message(WARNING "llama.cpp ggml-vulkan not built — cd third_party/llama.cpp && cmake -B build -G Ninja -DGGML_VULKAN=ON -DBUILD_SHARED_LIBS=OFF && cmake --build build -j8")
 endif()
 
 # -- libbackend_manager : Backend abstraction layer (requires rocm_cpp for HIP) ---------

--- a/docs/llama.cpp-fork.md
+++ b/docs/llama.cpp-fork.md
@@ -10,6 +10,10 @@ sync record. Bump it whenever the fork moves.
 - **Merge commit**: `0807d70be21914a2ed616b500f7b10258d029f7a`
 - **Date**: 2026-08-01
 - **Source PR**: bong-water-water-bong/llama.cpp#2 — *feat: paged KV cache — fixed-pool GPU tensors with CPU backing store*
+- **Local checkout**: synced to this commit 2026-08-02 (was at PR head `329cb3241`), rebuilt `-DGGML_VULKAN=ON -DBUILD_SHARED_LIBS=OFF`
+  (static libs required by `zaya_server` import — without `BUILD_SHARED_LIBS=OFF` ggml builds shared and the
+  import check in `CMakeLists.txt` silently fails). Vulkan backend verified on Strix Halo: `llama-bench` sees
+  Radeon 8060S (RADV, KHR_coopmat); `unified_server` relinked against the synced statics.
 
 ## What shipped in this sync
 


### PR DESCRIPTION
### **User description**
## What

Syncs `third_party/llama.cpp` from the paged-KV PR head (`329cb3241`) to the documented sync point **`0807d70be`** (merge of bong-water-water-bong/llama.cpp#2 + 873-commit upstream catch-up; +93 commits).

### Included Vulkan fixes (Strix Halo / Radeon 8060S relevant)
- **#24362** — disable FA mask_opt on GCN (perf)
- **#25240** — lower submission threshold for small AMD GPUs (perf)
- **#25351 / #25432** — SET_ROWS f16 support (correctness)

### Changes
| File | Change |
|------|--------|
| `third_party/llama.cpp` (gitlink) | `329cb3241` → `0807d70be` |
| `CMakeLists.txt` | ggml-vulkan import warning now includes `-DBUILD_SHARED_LIBS=OFF` — without it ggml builds shared libs and the static import check silently fails even after a successful build |
| `docs/llama.cpp-fork.md` | local checkout sync record |
| `CHANGELOG.md` | 2026.08.02 entry |
| `AGENTS.md` | GitNexus index numbers refreshed by analyzer |

## Verified
- Rebuilt `-DGGML_VULKAN=ON -DBUILD_SHARED_LIBS=OFF` (Release, gcc) — statics present at the paths `CMakeLists.txt` imports
- `llama-bench --list-devices` → Radeon 8060S (RADV, KHR_coopmat matrix cores)
- `unified_server` relinked against the synced statics (build green)


___

### **PR Type**
Other, Documentation


___

### **Description**
- Sync `third_party/llama.cpp` submodule to `0807d70be` (+93 commits).

- Includes Vulkan fixes for small AMD GPUs (Strix Halo).

- Fix ggml-vulkan build hint with `-DBUILD_SHARED_LIBS=OFF`.

- Update docs, changelog, and GitNexus index numbers.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["llama.cpp fork 329cb3241"] -- "sync +93 commits" --> B["0807d70be"]
  B -- "Vulkan fixes" --> C["Strix Halo Radeon 8060S"]
  D["CMakeLists.txt"] -- "hint" --> E["BUILD_SHARED_LIBS=OFF static import"]
  B -- "docs" --> F["docs/llama.cpp-fork.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llama.cpp</strong><dd><code>Bump llama.cpp submodule to sync point</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/llama.cpp

<ul><li>Submodule gitlink bumped from <code>329cb3241</code> to <code>0807d70be</code>.<br> <li> Merge of paged-KV PR #2 plus 873-commit upstream catch-up.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1400/files#diff-323b73a231ec4405be25a8c20273187be6c68fb65badf8d36b96ab04ca7c6215">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Refresh GitNexus index statistics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Refresh GitNexus index numbers (18519 symbols, 32295 relationships, <br>203 flows).<br> <li> Removed trailing blank line.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1400/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for fork sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Add <code>2026.08.02</code> entry for llama.cpp fork sync.<br> <li> Document Vulkan fixes and build-hint fix.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1400/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>llama.cpp-fork.md</strong><dd><code>Update fork sync record</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/llama.cpp-fork.md

<ul><li>Record local checkout sync to <code>0807d70be</code> on 2026-08-02.<br> <li> Note Vulkan backend verified on Strix Halo.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1400/files#diff-dd6ffa1645842112bff6b47e1973a5263ed643a5ea968947d4f9ce591b50518b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Fix ggml-vulkan build hint command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CMakeLists.txt

<ul><li>Add <code>-DBUILD_SHARED_LIBS=OFF</code> to ggml-vulkan build hint.<br> <li> Prevents silent failure of static import check.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1400/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

