### PR TITLE
fix(release): unbreak tag builds — runner instead of container, drop libxrt-dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
   server:
     name: Build release (C++ HIP kernels + server + CLI) — TheRock 7.15.0a
     runs-on: ubuntu-24.04
-    # Plain Ubuntu base — the build uses ONLY TheRock 7.15.0a (installed below).
-    # Never a rocm/dev-ubuntu-*:7.2.4* container: the repo never builds against
-    # system ROCm 7.2.4.
-    container: ubuntu:24.04
+    # Bare runner, not a container: the `ubuntu:24.04` container image stopped
+    # shipping git, which broke actions/checkout's submodule clone. The runner
+    # has git and no system ROCm, so TheRock 7.15.0a (installed below) stays the
+    # ONLY ROCm in the build — same environment CI's C++ job uses.
     timeout-minutes: 90
     permissions:
       contents: write
@@ -32,11 +32,6 @@ jobs:
           apt-get install -y -qq git cmake ninja-build build-essential \
             libvulkan-dev uuid-dev python3-pip python3-venv \
             libcurl4-openssl-dev libzstd-dev libwebsockets-dev
-
-          # XRT (Xilinx Runtime) for NPU fused engine compilation.
-          # backend_fused.cpp/backend_fused_npu.cpp need xrt headers at compile time.
-          apt-get install -y -qq libxrt-dev 2>/dev/null || \
-            echo "::warning::libxrt-dev not available — fused NPU backends stubbed"
 
           # Install TheRock nightly ROCm SDK (AMD's C++ toolchain for Strix Halo).
           # TheRock 7.15.0a (with the built-in FastFlowLM flm binary) is the ONLY


### PR DESCRIPTION
### **User description**
See commit message. The last three Release runs failed (v2026.07.30, v2026.08.01, v2026.08.02 — zero assets published); root causes:

1. `libxrt-dev` install (#1224) flips the fused-backend CMake gate ON but the XRT include dirs never reach the HIP compile → `xrt/xrt_bo.h` not found.
2. `ubuntu:24.04` container no longer ships git → actions/checkout fails on submodule clone.

Fix: drop the libxrt-dev line (gate disables fused backend safely, as designed) + run on the ubuntu-24.04 runner (same env as the passing CI C++ job).


___

### **PR Type**
Bug fix


___

### **Description**
- Switch Release job from `ubuntu:24.04` container to bare `ubuntu-24.04` runner

- Remove `libxrt-dev` install to prevent fused-backend CMake gate failures

- Align release build environment with CI's passing C++ job

- Unblock tag builds after three failed release runs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release workflow"] -- "runner instead of container" --> B["ubuntu-24.04 runner"]
  A -- "drop libxrt-dev" --> C["No XRT header compile failure"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Fix Release workflow environment and drop XRT install</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Replace <code>ubuntu:24.04</code> container with bare <code>ubuntu-24.04</code> runner<br> <li> Remove <code>libxrt-dev</code> installation for fused NPU backend<br> <li> Update comments explaining environment rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1404/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+4/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

