### PR TITLE
fix(release): sudo for apt/venv on runner — container ran as root, runner doesn't

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,21 +28,21 @@ jobs:
 
       - name: Install build tools + TheRock nightly ROCm
         run: |
-          apt-get update -qq
-          apt-get install -y -qq git cmake ninja-build build-essential \
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq git cmake ninja-build build-essential \
             libvulkan-dev uuid-dev python3-pip python3-venv \
             libcurl4-openssl-dev libzstd-dev libwebsockets-dev
 
           # Install TheRock nightly ROCm SDK (AMD's C++ toolchain for Strix Halo).
           # TheRock 7.15.0a (with the built-in FastFlowLM flm binary) is the ONLY
-          # ROCm in this build — the base image has no system ROCm, so CMake's
+          # ROCm in this build — the runner has no system ROCm, so CMake's
           # /opt/rocm fallback can never be reached. CMakeLists.txt auto-detects
           # /opt/rocm-therock.
-          python3 -m venv /opt/rocm-therock
-          /opt/rocm-therock/bin/pip install \
+          sudo python3 -m venv /opt/rocm-therock
+          sudo /opt/rocm-therock/bin/pip install \
             "rocm[libraries,devel,device-gfx1151]" \
             --index-url https://rocm.nightlies.amd.com/whl-multi-arch/
-          /opt/rocm-therock/bin/rocm-sdk init
+          sudo /opt/rocm-therock/bin/rocm-sdk init
 
       - name: Build all C++ targets (TheRock 7.15.0a HIP kernels + servers + CLI)
         run: |


### PR DESCRIPTION
### **User description**
Follow-up to #1404: the Release job now runs on the runner, where steps are non-root — `apt-get update` died instantly with 'E: Could not open lock file' (exit 100). Mirrors CI's cpp job, which does the identical install on the same runner: `sudo` for apt-get, venv creation, pip install, and rocm-sdk init.


___

### **PR Type**
Bug fix


___

### **Description**
- Add sudo to apt and pip install commands

- Workflow runs on non-root GitHub runner

- Fixes apt lock file error exit 100

- Aligns release job with CI cpp job


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release workflow on ubuntu-24.04 runner"] -- "non-root user" --> B["sudo apt-get install tools"]
  A -- "TheRock ROCm setup" --> C["sudo python3 venv + pip install"]
  B --> D["Build C++ targets"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Add sudo to Release workflow install commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Add sudo to apt-get update/install to avoid lock file error<br> <li> Add sudo to venv creation, pip install and rocm-sdk init<br> <li> Update comment to say runner instead of base image<br> <li> Fixes release job failures on non-root GitHub runner</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1405/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

