### PR TITLE
fix(release): onebit_bin -> onebin (one-ELF rename)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
             zaya_server \
             onebitd \
             onebit \
-            onebit_bin \
+            onebin \
             unified_router \
             unified_server \
             zaya_agent \


### PR DESCRIPTION
### **User description**
Tag build #3 failed at ninja: unknown target 'onebit_bin' — the one-ELF commit renamed the target to `onebin`. One-line fix; grep confirms no other stale references.


___

### **PR Type**
Bug fix


___

### **Description**
- Renamed `onebit_bin` to `onebin` in `.github/workflows/release.yml`.

- Fixes tag build #3 unknown-target failure.

- Aligns release workflow with one-ELF rename (OUTPUT_NAME '1bit').


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["release.yml: onebit_bin"] -- "renamed" --> B["onebin"]
  B -- "builds" --> C["1bit single ELF"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Rename onebit_bin to onebin in release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Replaced stale ninja build target <code>onebit_bin</code> with renamed <code>onebin</code>.<br> <li> Fixes release tag build failure at 'unknown target onebit_bin'.<br> <li> Verified no other stale <code>onebit_bin</code> references remain.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1406/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

