### PR TITLE
fix(release): complete dep list — libdrm-dev for lemonade, glslc/spirv-headers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,12 @@ jobs:
       - name: Install build tools + TheRock nightly ROCm
         run: |
           sudo apt-get update -qq
+          # Same dep set as CI's cpp job (proven on this runner): libdrm-dev
+          # for lemonade's amdxdna (drm.h), glslc + spirv-headers for zinc_cpp
+          # and ggml-vulkan, python3-venv for the TheRock SDK venv.
           sudo apt-get install -y -qq git cmake ninja-build build-essential \
-            libvulkan-dev uuid-dev python3-pip python3-venv \
-            libcurl4-openssl-dev libzstd-dev libwebsockets-dev
+            python3 python3-venv libcurl4-openssl-dev libzstd-dev libwebsockets-dev \
+            libvulkan-dev glslc uuid-dev libdrm-dev spirv-headers
 
           # Install TheRock nightly ROCm SDK (AMD's C++ toolchain for Strix Halo).
           # TheRock 7.15.0a (with the built-in FastFlowLM flm binary) is the ONLY
@@ -83,7 +86,7 @@ jobs:
             zaya_server \
             onebitd \
             onebit \
-            onebin \
+            onebit_bin \
             unified_router \
             unified_server \
             zaya_agent \


### PR DESCRIPTION
### **User description**
Tag build #4: fatal error 'libdrm/drm.h' not found in lemonade-server-core. The container-era dep list predates targets that CI's cpp job already covers — align release install with CI's proven list.


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing `libdrm-dev`, `glslc`, `spirv-headers` to release apt deps

- Align release dependency set with CI's proven cpp job

- Fix ninja target name from `onebin` to `onebit_bin`

- Resolve release build failure on missing `drm.h` and wrong target


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Release["Release workflow"] --> Apt["apt-get install"]
  Apt --> Deps["libdrm-dev, glslc, spirv-headers"]
  Release --> Ninja["ninja build targets"]
  Ninja --> Target["onebit_bin (fixed)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Fix release deps and ninja target name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Added <code>libdrm-dev</code>, <code>glslc</code>, <code>spirv-headers</code> to the apt install list<br> <li> Added comment explaining deps match CI's cpp job<br> <li> Reordered Python and Vulkan packages in the install command<br> <li> Renamed ninja target from <code>onebin</code> to <code>onebit_bin</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1408/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

