### PR TITLE
fix(release): onebit_bin -> onebin — re-apply #1406 after sync merges clobbered it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
             zaya_server \
             onebitd \
             onebit \
-            onebit_bin \
+            onebin \
             unified_router \
             unified_server \
             zaya_agent \

--- a/docs/archive/rust-DEPRECATED.md
+++ b/docs/archive/rust-DEPRECATED.md
@@ -21,4 +21,4 @@ toolchain. They use the same dependencies already fetched by CMake:
 This directory is kept for reference only. All CI/CD (`.github/workflows/ci.yml`,
 `.github/workflows/release.yml`) has been updated to build C++ targets exclusively.
 
-To build: `cmake -B build && ninja -C build onebitd onebit onebit_bin bitnet_tui`
+To build: `cmake -B build && ninja -C build onebitd onebit onebin bitnet_tui`


### PR DESCRIPTION
### **User description**
Tag release builds are dying at `ninja: error: unknown target 'onebit_bin'` (also killed the v2026.08.02 tag release — no release was published for it).

`onebin` (OUTPUT_NAME '1bit') is the real target since the one-ELF commit. #1406 fixed this, but the local sync merges (7416af487 / 151217a21, shipped in #1423) resolved `release.yml` back to the stale `onebit_bin`.

Also updates the one stale ref in `docs/archive/rust-DEPRECATED.md`.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Rename ninja target `onebit_bin` to `onebin` (release.yml)

- Fix tag build failure on `unknown target`

- Update stale ref in `rust-DEPRECATED.md`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["release.yml: onebit_bin"] -- "renamed" --> B["onebin"]
  B -- "fixes ninja build" --> C["release ELF"]
  D["rust-DEPRECATED.md"] -- "updated" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Rename stale ninja target to onebin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Replaced stale ninja build target <code>onebit_bin</code> with <code>onebin</code><br> <li> Restores tag release builds broken by the one-ELF rename</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1425/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rust-DEPRECATED.md</strong><dd><code>Fix stale binary target in archived docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/archive/rust-DEPRECATED.md

<ul><li>Updated build command reference from <code>onebit_bin</code> to <code>onebin</code><br> <li> Keeps archived docs aligned with current C++ targets</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1425/files#diff-1b3dbededa446f61d7853b86a383fd93b40fdb1efa3a38b9c9ed5fade429c9d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

