### PR TITLE
fix(server): clean shutdown — _exit() instead of static-dtor crash (SEGV/ABRT on every stop)

### DIFF
--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -1926,5 +1926,13 @@ int main(int argc, char** argv) {
     }
     mgr.destroy();
     printf("Done.\n");
-    return 0;
+    fflush(stdout);
+    fflush(stderr);
+    // Exit WITHOUT static-dtor teardown: the DynamicRouter holds its own
+    // BackendEntry refs, so the 4 backends (HIP, Vulkan, XRT NPU) are actually
+    // destroyed at exit() in the wrong order — reproduced SIGSEGV in the
+    // Vulkan validation layer, and ABRT from XRT "Failed to destroy DRM BO"
+    // (EBADF) bursts in production. _exit() lets the kernel reclaim the GPU
+    // contexts deterministically.
+    _exit(0);
 }


### PR DESCRIPTION
### **User description**
## What

Every stop/restart of `1bit-systems.service` crashes with SIGABRT (production) or SIGSEGV in the Vulkan validation layer (reproduced under gdb). The service restarts automatically, so the crash is invisible — but it was aborting on every CI `systemctl stop`, and the accumulated state contributed to the "VRAM creeps up and crashes everything" reports.

## Root cause

`BackendManager::destroy()` only clears `backends_`. The `DynamicRouter` holds its own `BackendEntry` `shared_ptr`s to all 4 backends (HIP, Vulkan, XRT NPU), so they are actually destroyed at **static-destructor time** during `exit()` — in the wrong order:

- gdb reproduction: `BackendManager::~BackendManager → DynamicRouter::~DynamicRouter → BackendEntry::~BackendEntry → VulkanBackend::destroy() → SIGSEGV` inside `libVkLayer_khronos_validation.so`
- production: burst of `Failed to destroy DRM BO: DRM_IOCTL_GEM_CLOSE IOCTL failed (err=-9): Bad file descriptor` from `libxrt_driver_xdna.so` (the xdna pdev fd is closed before the NPU BOs are destroyed), then ABRT

## Fix

`_exit(0)` after `mgr.destroy()` + `fflush`. The kernel reclaims GPU/NPU contexts deterministically; user-space teardown of 4 GPU stacks at exit is a minefield (Vulkan VVL teardown bugs, XRT teardown-order bugs) with no upside for a server.

## Verification

- Test instance: SIGTERM → `Shutting down... Done.` → clean exit, zero crash signatures (was: SEGV/ABRT + EBADF burst)
- Production service restarted on the new binary: active, generating at ~35 tok/s, RSS 4.3GB fresh vs 6.8GB leaked

## Follow-up (separate issue)

~0.1–1.7MB/request heap growth measured on the running server (generation only; `/v1/health` is flat). Exact site not yet pinned — candidates are per-token VOCAB-sized host allocations in the fused backend's `generate()`. Slow leak (~90MB/hr at load), not the crash cause.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `return 0` with `_exit(0)` after flushing streams

- Skip static-destructor teardown of Vulkan/XRT backend refs

- Avoid SIGSEGV/ABRT from out-of-order backend destruction

- Let kernel deterministically reclaim GPU/NPU contexts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mgr.destroy()"] --> B["fflush stdout/stderr"]
  B --> C["_exit(0)"]
  C --> D["Kernel reclaims GPU/NPU contexts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>unified_server.cpp</strong><dd><code>Clean shutdown with _exit to avoid backend teardown crash</code></dd></summary>
<hr>

tools/unified_server.cpp

<ul><li>Replace <code>return 0</code> with <code>_exit(0)</code> to bypass static destructors<br> <li> Add <code>fflush(stdout)</code> and <code>fflush(stderr)</code> before hard exit<br> <li> Document root cause: DynamicRouter backend refs destroyed at exit</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1426/files#diff-108a4e5ad06a8667d81e8da41605283a4dff15e0519645becad615fded67977c">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

