### PR TITLE
fix: resolve 10 audited bugs (issues #1429–#1438)

### DIFF
--- a/engine/npu/src/npu_engine_cb.cpp
+++ b/engine/npu/src/npu_engine_cb.cpp
@@ -9,6 +9,8 @@
 #include <cstring>
 #include <cmath>
 #include <csignal>
+#include <ctime>
+#include <utility>
 #include <vector>
 #include <chrono>
 #include <fcntl.h>
@@ -61,8 +63,64 @@ void packB(int l,const float*w,int K,int N,float&sout){float amax=0;for(int i=0;
 inline void go(int l,const float*A,int am,int ak,float ascale,float Bscale,float*C,int an){float ais=1.0f/ascale;for(int m=0;m<am;m++){for(int k=0;k<ak;k++){float v=A[m*ak+k];if(!std::isfinite(v))v=0;int q=(int)roundf(v*ais);if(q>127)q=127;else if(q<-127)q=-127;Am[m*KD+k]=(int8_t)q;}if(ak<KD)memset(Am+m*KD+ak,0,(size_t)(KD-ak));}if(am<MD)memset(Am+(size_t)am*KD,0,(size_t)(MD-am)*KD);bA->sync(XCL_BO_SYNC_BO_TO_DEVICE);auto r=(*k)((unsigned)3,*bI,(unsigned)ins.size(),*bA,*layerB[l],*bC);r.wait();bC->sync(XCL_BO_SYNC_BO_FROM_DEVICE);float cs=ascale*Bscale;for(int m=0;m<am;m++)for(int n=0;n<an;n++){float val=(float)Cm[m*ND+n]*cs;if(!std::isfinite(val))val=0;C[m*an+n]=val;}}
 };
 
+// ─── LoRA module ──────────────────────────────────────────────────────
+// Compact binary format: header + per-layer module A/B matrices.
+struct LoraModule { int mod_id, rank, in_dim, out_dim; float* A; float* B; };
+
+// Load a .lora file into modules[NC]. Validates the magic, bounds every header
+// field, and checks malloc/fread before use — a corrupt or truncated file used
+// to cause unbounded loops, NULL derefs, and leaks (issue #1432). On failure,
+// frees everything it pushed so callers can pass an empty array safely.
+static bool load_lora_file(const char* path, std::vector<LoraModule>* modules, float* scale) {
+    FILE* lf = fopen(path, "rb");
+    if (!lf) { fprintf(stderr, "ERROR: cannot open %s\n", path); return false; }
+    auto fail = [&](const char* msg) {
+        fprintf(stderr, "ERROR: %s\n", msg);
+        for (int l = 0; l < NC; l++)
+            for (auto& lm : modules[l]) { free(lm.A); free(lm.B); }
+        for (int l = 0; l < NC; l++) modules[l].clear();
+        fclose(lf);
+        return false;
+    };
+    char magic[4];
+    if (fread(magic, 1, 4, lf) != 4 || memcmp(magic, "LORA", 4) != 0)
+        return fail("bad .lora magic");
+    uint32_t num_layers = 0;
+    if (fread(&num_layers, 4, 1, lf) != 1 || fread(scale, 4, 1, lf) != 1)
+        return fail("truncated .lora header");
+    if (num_layers > (uint32_t)NC)
+        return fail(".lora layer count exceeds engine layers");
+    for (uint32_t l = 0; l < num_layers; l++) {
+        uint32_t num_mods = 0;
+        if (fread(&num_mods, 4, 1, lf) != 1 || num_mods > 64)
+            return fail("invalid module count in .lora");
+        for (uint32_t m = 0; m < num_mods; m++) {
+            LoraModule lm;
+            if (fread(&lm.mod_id, 4, 1, lf) != 1 || fread(&lm.rank, 4, 1, lf) != 1 ||
+                fread(&lm.in_dim, 4, 1, lf) != 1 || fread(&lm.out_dim, 4, 1, lf) != 1)
+                return fail("truncated .lora module header");
+            if (lm.rank <= 0 || lm.rank > 4096 || lm.in_dim <= 0 || lm.in_dim > H * 8 ||
+                lm.out_dim <= 0 || lm.out_dim > H * 8)
+                return fail("implausible .lora module dims");
+            size_t a_sz = (size_t)lm.rank * (size_t)lm.in_dim;
+            size_t b_sz = (size_t)lm.out_dim * (size_t)lm.rank;
+            lm.A = (float*)malloc(a_sz * 4);
+            lm.B = (float*)malloc(b_sz * 4);
+            if (!lm.A || !lm.B) { free(lm.A); free(lm.B); return fail("OOM loading .lora"); }
+            if (fread(lm.A, 4, a_sz, lf) != a_sz || fread(lm.B, 4, b_sz, lf) != b_sz) {
+                free(lm.A); free(lm.B);
+                return fail("truncated .lora body");
+            }
+            modules[l].push_back(lm);
+        }
+    }
+    fclose(lf);
+    return true;
+}
+
 int main(int argc,char**argv){
     setvbuf(stdout,NULL,_IONBF,0);
+    srand((unsigned)time(nullptr) ^ (unsigned)getpid()); // issue #1431: sampling was deterministic
     const char* lora_path = nullptr;
     int npt = 9, ng = 16;
     for (int i = 1; i < argc; i++) {
@@ -102,40 +160,11 @@ int main(int argc,char**argv){
     cd.init(dev,D"/final_i8_D_v.xclbin",  D"/insts_i8_D_v.txt",  4);
 
     // ─── LoRA: load .lora file ──────────────────────────────────────
-    // Compact binary format: header + per-layer module A/B matrices
-    struct LoraModule { int mod_id, rank, in_dim, out_dim; float* A; float* B; };
     std::vector<LoraModule> lora_modules[NC];
     float lora_scale = 1.0f;
     
     if (lora_path) {
-        FILE* lf = fopen(lora_path, "rb");
-        if (!lf) { fprintf(stderr, "ERROR: cannot open %s\n", lora_path); return 1; }
-        char magic[4];
-        if (fread(magic, 1, 4, lf) != 4 || memcmp(magic, "LORA", 4) != 0) {
-            fprintf(stderr, "ERROR: bad .lora magic\n"); fclose(lf); return 1;
-        }
-        uint32_t num_layers;
-        fread(&num_layers, 4, 1, lf);
-        fread(&lora_scale, 4, 1, lf);
-        for (uint32_t l = 0; l < num_layers && l < (uint32_t)NC; l++) {
-            uint32_t num_mods;
-            fread(&num_mods, 4, 1, lf);
-            for (uint32_t m = 0; m < num_mods; m++) {
-                LoraModule lm;
-                fread(&lm.mod_id, 4, 1, lf);
-                fread(&lm.rank, 4, 1, lf);
-                fread(&lm.in_dim, 4, 1, lf);
-                fread(&lm.out_dim, 4, 1, lf);
-                size_t a_sz = (size_t)lm.rank * lm.in_dim;
-                size_t b_sz = (size_t)lm.out_dim * lm.rank;
-                lm.A = (float*)malloc(a_sz * 4);
-                lm.B = (float*)malloc(b_sz * 4);
-                fread(lm.A, 4, a_sz, lf);
-                fread(lm.B, 4, b_sz, lf);
-                lora_modules[l].push_back(lm);
-            }
-        }
-        fclose(lf);
+        if (!load_lora_file(lora_path, lora_modules, &lora_scale)) return 1;
         printf("LoRA: loaded %s (scale=%.2f)\n", lora_path, lora_scale);
     }
     signal(SIGHUP, lora_sighup);
@@ -246,34 +275,24 @@ int main(int argc,char**argv){
         if (g_lora_reload && lora_path) {
             g_lora_reload = 0;
             printf("\n--- LoRA hot-swap: reloading %s ---\n", lora_path);
-            // Free old modules
-            for (int l = 0; l < NC; l++)
-                for (auto& lm : lora_modules[l]) { free(lm.A); free(lm.B); }
-            for (int l = 0; l < NC; l++) lora_modules[l].clear();
-            // Reload .lora file
-            FILE* lf = fopen(lora_path, "rb");
-            if (lf) {
-                char magic[4]; fread(magic, 1, 4, lf);
-                uint32_t nl; fread(&nl, 4, 1, lf); fread(&lora_scale, 4, 1, lf);
-                for (uint32_t l = 0; l < nl && l < (uint32_t)NC; l++) {
-                    uint32_t nm; fread(&nm, 4, 1, lf);
-                    for (uint32_t m = 0; m < nm; m++) {
-                        LoraModule lm;
-                        fread(&lm.mod_id, 4, 1, lf); fread(&lm.rank, 4, 1, lf);
-                        fread(&lm.in_dim, 4, 1, lf); fread(&lm.out_dim, 4, 1, lf);
-                        lm.A = (float*)malloc((size_t)lm.rank * lm.in_dim * 4);
-                        lm.B = (float*)malloc((size_t)lm.out_dim * lm.rank * 4);
-                        fread(lm.A, 4, (size_t)lm.rank * lm.in_dim, lf);
-                        fread(lm.B, 4, (size_t)lm.out_dim * lm.rank, lf);
-                        lora_modules[l].push_back(lm);
-                    }
+            // Load into a fresh array; only swap on success so a bad file keeps
+            // the previous weights (issue #1432).
+            std::vector<LoraModule> fresh[NC];
+            float new_scale = 1.0f;
+            if (load_lora_file(lora_path, fresh, &new_scale)) {
+                for (int l = 0; l < NC; l++) {
+                    for (auto& lm : lora_modules[l]) { free(lm.A); free(lm.B); }
+                    lora_modules[l].clear();
+                    lora_modules[l] = std::move(fresh[l]);
                 }
-                fclose(lf);
+                lora_scale = new_scale;
                 repack();  // re-apply LoRA to all weights
                 // Reset KV cache (old cached states are now invalid with new weights)
                 for (int l = 0; l < NC; l++) kv[l].n = 0;
                 sp = 0;
                 printf("--- LoRA hot-swap done ---\n\n");
+            } else {
+                fprintf(stderr, "--- LoRA hot-swap FAILED; keeping previous weights ---\n");
             }
         }
         for(int l=0;l<NC;l++){
@@ -308,5 +327,7 @@ int main(int argc,char**argv){
     }
     double tts=std::chrono::duration<double>(std::chrono::steady_clock::now()-tgs).count();
     printf("\n=== %.0f ms/tok ===\n",tts*1000/ng);
+    for (int l = 0; l < NC; l++)
+        for (auto& lm : lora_modules[l]) { free(lm.A); free(lm.B); }
     munmap(md,st.st_size);return 0;
 }

--- a/engine/npu/src/npu_engine_hybrid.cpp
+++ b/engine/npu/src/npu_engine_hybrid.cpp
@@ -232,17 +232,21 @@ int main(int argc,char**argv){
     std::vector<WS> wsc(NC);
     fprintf(stderr,"O packOK ");
     for(int l=0;l<NC;l++){
-        int qr,kr,vr,or_,gr,ur,dr,unused;
+        int qr=0,kr=0,vr=0,or_=0,gr=0,ur=0,dr=0,unused=0;
         float*qw=dequant_i8_to_float(i8p(lo[l].qp),256,&qr,&unused),*kw=dequant_i8_to_float(i8p(lo[l].kp),128,&kr,&unused),*vw=dequant_i8_to_float(i8p(lo[l].vp),128,&vr,&unused);
+        if(!qw||!kw||!vw){fprintf(stderr,"dequant failed (qkv) layer %d\n",l);free(qw);free(kw);free(vw);return 1;}
         int t=qr+kr+vr;std::vector<float>w((size_t)H*t);
         for(int k=0;k<H;k++){memcpy(&w[k*t],&qw[k*qr],qr*4);memcpy(&w[k*t+qr],&kw[k*kr],kr*4);memcpy(&w[k*t+qr+kr],&vw[k*vr],vr*4);}
         cq.packB(l,w.data(),H,t,wsc[l].qk);free(qw);free(kw);free(vw);
         float*ow=dequant_i8_to_float(i8p(lo[l].op),256,&or_,&unused);if(ow){co.packB(l,ow,or_,H,wsc[l].o_);free(ow);}
         float*gw=dequant_i8_to_float(i8p(lo[l].gp),384,&gr,&unused),*uw=dequant_i8_to_float(i8p(lo[l].up),384,&ur,&unused);
+        if(!gw||!uw){fprintf(stderr,"dequant failed (gu) layer %d\n",l);free(gw);free(uw);return 1;}
         int t2=gr+ur;std::vector<float>w2((size_t)H*t2);
         for(int k=0;k<H;k++){memcpy(&w2[k*t2],&gw[k*gr],gr*4);memcpy(&w2[k*t2+gr],&uw[k*ur],ur*4);}
         cg.packB(l,w2.data(),H,t2,wsc[l].g_);free(gw);free(uw);
-        float*dw=dequant_i8_to_float(i8p(lo[l].dp),384,&dr,&unused);cd.packB(l,dw,dr,H,wsc[l].d_);free(dw);
+        float*dw=dequant_i8_to_float(i8p(lo[l].dp),384,&dr,&unused);
+        if(!dw){fprintf(stderr,"dequant failed (d) layer %d\n",l);return 1;}
+        cd.packB(l,dw,dr,H,wsc[l].d_);free(dw);
     }
     fprintf(stderr,"  %.0fms\n",std::chrono::duration<double,std::milli>(std::chrono::steady_clock::now()-tp).count());
 

--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -5,6 +5,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <cmath>
+#include <ctime>
+#include <filesystem>
 #include <vector>
 #include <chrono>
 #include <exception>
@@ -129,9 +131,13 @@ static inline void ra(float*x,int hd,int p){int hd2=hd/2;for(int d=0;d<hd2;d++){
 // so the heap corruption root cause can be debugged. The measured results
 // are flushed to stderr before the re-raise.
 static void sigabrt_handler(int sig) {
-    fprintf(stderr, "\n[NPU engine] caught SIGABRT (likely heap corruption from free(): invalid size)\n");
-    fprintf(stderr, "[NPU engine] re-raising for core dump — see core.{pid} for backtrace\n");
-    fflush(stderr);
+    // Async-signal-safe only (issue #1433): fprintf/fflush can deadlock when
+    // SIGABRT fires from heap corruption while stdio/arena locks are held.
+    static const char m1[] = "\n[NPU engine] caught SIGABRT (likely heap corruption from free(): invalid size)\n";
+    static const char m2[] = "[NPU engine] re-raising for core dump — see core.{pid} for backtrace\n";
+    ssize_t r1 = write(2, m1, sizeof(m1) - 1);
+    ssize_t r2 = write(2, m2, sizeof(m2) - 1);
+    (void)r1; (void)r2;
     // Reset handler to default and re-raise to get a core dump
     signal(SIGABRT, SIG_DFL);
     raise(SIGABRT);
@@ -510,6 +516,7 @@ inline void lm_topk_omp(const float*hidden,float*lg,int*top_ids,int K,int NV,int
 
 int main(int argc,char**argv){
     setvbuf(stdout,NULL,_IONBF,0);
+    srand((unsigned)time(nullptr) ^ (unsigned)getpid()); // issue #1431: sampling was deterministic
     // Install SIGABRT handler for issue #202: heap corruption during decode
     // causes free(): invalid size → SIGABRT. The handler prints diagnostic
     // info, then re-raises with SIG_DFL restored to produce a core dump.
@@ -718,23 +725,21 @@ int main(int argc,char**argv){
                 f = fopen(flm_mm_path.c_str(), "rb");
                 if (f) { fclose(f); flm_xclbin_available = true; }
                 else {
-                    // Third try: search with ls (broad match)
+                    // Third try: recursive search (no shell — issue #1435;
+                    // popen("find " + env_dir) broke on spaces and was injectable)
                     fprintf(stderr, "  Searching for mm.xclbin under %s ...\n", flm_xd.c_str());
-                    // Simple fallback: use tagged name directly
-                    std::string alt = std::string("find ") + flm_xd +
-                        " -name mm.xclbin 2>/dev/null | head -5";
-                    FILE* pf = popen(("find " + flm_xd +
-                        " -name mm.xclbin 2>/dev/null | head -1").c_str(), "r");
-                    if (pf) {
-                        char buf[512] = {};
-                        if (fgets(buf, sizeof(buf), pf)) {
-                            size_t len = strlen(buf);
-                            if (len > 0 && buf[len-1] == '\n') buf[len-1] = '\0';
-                            flm_mm_path = buf;
-                            FILE* cf = fopen(flm_mm_path.c_str(), "rb");
-                            if (cf) { fclose(cf); flm_xclbin_available = true; }
+                    std::error_code ec;
+                    for (auto it = std::filesystem::recursive_directory_iterator(flm_xd, ec), end = std::filesystem::recursive_directory_iterator();
+                         it != end; it.increment(ec)) {
+                        if (ec) break;
+                        if (it->is_regular_file(ec) && it->path().filename() == "mm.xclbin") {
+                            flm_mm_path = it->path().string();
+                            break;
                         }
-                        pclose(pf);
+                    }
+                    if (!flm_mm_path.empty()) {
+                        FILE* cf = fopen(flm_mm_path.c_str(), "rb");
+                        if (cf) { fclose(cf); flm_xclbin_available = true; }
                     }
                 }
             } else {

--- a/engine/npu/tokenizer/tokenize.cpp
+++ b/engine/npu/tokenizer/tokenize.cpp
@@ -126,7 +126,12 @@ int load_tokenizer(const char *path) {
     }
     auto *json = static_cast<char *>(std::malloc(sz + 1));
     if (!json) { std::fclose(f); return -1; }
-    std::fread(json, 1, sz, f);
+    if (std::fread(json, 1, sz, f) != (size_t)sz) {
+        std::fprintf(stderr, "Failed to read %s (short read)\n", path);
+        std::free(json);
+        std::fclose(f);
+        return -1;
+    }
     json[sz] = '\0';
     std::fclose(f);
 

--- a/tools/bench_fused.cpp
+++ b/tools/bench_fused.cpp
@@ -17,7 +17,10 @@ int main(int argc, char** argv) {
     if (!b) { fprintf(stderr, "FAIL: create_fused_backend\n"); return 1; }
     ModelConfig cfg; cfg.model_path = path; cfg.format = ModelFormat::ONEBP;
     uint8_t hdr[256];
-    FILE* f = fopen(path, "rb"); fread(hdr, 1, 256, f); fclose(f);
+    FILE* f = fopen(path, "rb");
+    if (!f) { fprintf(stderr, "cannot open %s\n", path); return 1; }
+    if (fread(hdr, 1, 256, f) != 256) { fprintf(stderr, "%s: file too short for 1BP header\n", path); fclose(f); return 1; }
+    fclose(f);
     memcpy(&cfg.hidden_size, hdr+20, 4); memcpy(&cfg.num_layers, hdr+24, 4);
     cfg.num_heads = 16; cfg.num_kv_heads = 8; cfg.head_dim = 128;
     cfg.intermediate_size = 3072; cfg.vocab_size = 151936;

--- a/tools/dspark_gpu_bench.cpp
+++ b/tools/dspark_gpu_bench.cpp
@@ -205,7 +205,7 @@ int main(int argc, char** argv) {
         std::vector<float> layer_out(n_target*H);
         float hidden[4096];memcpy(hidden,hd,H*4);
         for(int l=0;l<n_target;l++){
-            float res[4096];memcpy(res.data(),hidden,H*4);
+            float res[4096];memcpy(res,hidden,H*4);
             auto pw=U(o_pk)+l*per_layer;auto sw=F(o_sc)+l*per_sc;
             cpu_rmsnorm(hidden,F(o_norms)+l*H,hidden,H,1e-6f);
             cpu_ternary_gemv(pw,hidden,sw,qkvv.data(),rows[0],KK[0]);pw+=ps[0];sw+=rows[0];
@@ -218,7 +218,7 @@ int main(int argc, char** argv) {
             for(int h=0;h<NKV;h++){memcpy(&kcv[l*4096*NKV*HD+pos*NKV*HD+h*HD],qkvv.data()+NH*HD+h*HD,HD*4);memcpy(&vcv[l*4096*NKV*HD+pos*NKV*HD+h*HD],qkvv.data()+NH*HD+NKV*HD+h*HD,HD*4);}
             cpu_attention(qkvv.data(),&kcv[l*4096*NKV*HD],&vcv[l*4096*NKV*HD],atv.data(),NH,NKV,HD,pos+1,GQA);
             cpu_ternary_gemv(pw,atv.data(),sw,hidden,rows[3],KK[3]);pw+=ps[3];sw+=rows[3];
-            for(int i=0;i<H;i++)hidden[i]=res[i]+hidden[i];memcpy(res.data(),hidden,H*4);
+            for(int i=0;i<H;i++)hidden[i]=res[i]+hidden[i];memcpy(res,hidden,H*4);
             cpu_rmsnorm(hidden,F(o_norms)+L*H+l*H,hidden,H,1e-6f);
             cpu_ternary_gemv(pw,hidden,sw,ffv.data(),rows[4],KK[4]);pw+=ps[4];sw+=rows[4];
             cpu_ternary_gemv(pw,hidden,sw,ffv.data()+IM,rows[5],KK[5]);pw+=ps[5];sw+=rows[5];

--- a/tools/jarvis_server.cpp
+++ b/tools/jarvis_server.cpp
@@ -219,14 +219,38 @@ static void run_clone_job(const std::string& id) {
                                                : repo_root.string();
 
     auto run = [&](const std::vector<std::string>& argv) -> bool {
+        // No shell (issue #1438): popen("PYTHONPATH=" + env + " " + py)
+        // let CLONE_PYTHON/PYTHONPATH inject shell commands and broke on
+        // spaces. Build an argv array and execvp directly.
         std::string cmd = "PYTHONPATH=" + pypath + " " + py;
         for (auto& a : argv) cmd += " \"" + a + "\"";
         append_log("$ " + cmd);
-        FILE* pipe = popen((cmd + " 2>&1").c_str(), "r");
-        if (!pipe) { append_log("popen failed"); return false; }
+        int pfd[2];
+        if (pipe(pfd) != 0) { append_log("pipe failed"); return false; }
+        pid_t pid = fork();
+        if (pid < 0) { close(pfd[0]); close(pfd[1]); append_log("fork failed"); return false; }
+        if (pid == 0) {
+            close(pfd[0]);
+            dup2(pfd[1], STDOUT_FILENO);
+            dup2(pfd[1], STDERR_FILENO);
+            close(pfd[1]);
+            setenv("PYTHONPATH", pypath.c_str(), 1);
+            std::vector<char*> cargv;
+            cargv.reserve(argv.size() + 2);
+            cargv.push_back(const_cast<char*>(py.c_str()));
+            for (const auto& a : argv) cargv.push_back(const_cast<char*>(a.c_str()));
+            cargv.push_back(nullptr);
+            execvp(py.c_str(), cargv.data());
+            _exit(127);
+        }
+        close(pfd[1]);
         char buf[1024];
-        while (fgets(buf, sizeof(buf), pipe)) append_log(std::string(buf));
-        int rc = pclose(pipe);
+        ssize_t n;
+        while ((n = read(pfd[0], buf, sizeof(buf) - 1)) > 0) { buf[n] = '\0'; append_log(std::string(buf)); }
+        close(pfd[0]);
+        int status = 0;
+        waitpid(pid, &status, 0);
+        int rc = WIFEXITED(status) ? WEXITSTATUS(status) : 1;
         if (rc != 0) { append_log("exit code " + std::to_string(rc)); return false; }
         return true;
     };

--- a/tools/test_mamba1_backend.cpp
+++ b/tools/test_mamba1_backend.cpp
@@ -4,6 +4,7 @@
 #include "backend.h"
 #include "gguf_reader.h"
 // Route is handled inline — we call create_mamba1_backend directly
+#include <cmath>
 #include <cstdio>
 #include <chrono>
 #include <vector>
@@ -120,7 +121,7 @@ int main(int argc, char** argv) {
     float sum_ms = 0, sum_sq = 0;
     for (int r = 0; r < kRuns; r++) { sum_ms += runs_ms[r]; sum_sq += runs_ms[r] * runs_ms[r]; }
     float mean_ms = sum_ms / kRuns;
-    float std_ms = sqrtf((sum_sq - sum_ms * sum_ms / kRuns) / (kRuns - 1));
+    float std_ms = std::sqrt((sum_sq - sum_ms * sum_ms / kRuns) / (kRuns - 1));
     float mean_tok_s = n_tokens / (mean_ms / 1000.0f);
     fprintf(stderr, "\n  %d tokens: %.1f ± %.1f ms = %.1f ± %.1f tok/s\n",
             n_tokens, mean_ms, std_ms, mean_tok_s, mean_tok_s * std_ms / mean_ms);


### PR DESCRIPTION
### **User description**
Fixes all 10 issues from the audit sweep. Each fix is small, targeted, and verified.

Fixes #1429, #1430, #1431, #1432, #1433, #1434, #1435, #1436, #1437, #1438

## Build fixes
- **#1429** `test_mamba1_backend.cpp` — add `<cmath>`, `std::sqrt` (was `sqrtf` undeclared on toolchains without transitive include)
- **#1430** `dspark_gpu_bench.cpp` — `memcpy(res.data(), …)` → `memcpy(res, …)` on `float res[4096]`; broke any build with hipblas present

## Crash / correctness
- **#1434** `bench_fused.cpp` — NULL-check `fopen`, verify full 256-byte header read
- **#1432** `npu_engine_cb.cpp` — hardened `.lora` loader: magic checked on hot-reload too, layer/module counts bounded, `malloc` + `fread` validated, reload swaps in fresh state on success (bad file keeps old weights), module pointers freed on exit
- **#1436** `npu_engine_hybrid.cpp` — init dequant out-params to 0, NULL-check `gw/uw/dw` (was inconsistent with `ow`)
- **#1437** `tokenize.cpp` — verify `fread` count before JSON parse (was parsing uninitialized memory on short read)

## Determinism
- **#1431** both NPU engines — `srand(time ^ pid)` per process; temperature sampling was fully deterministic (zero `srand` anywhere)

## Signal safety
- **#1433** `npu_engine_universal.cpp` — SIGABRT handler now `write(2)`-only; `fprintf` could deadlock under heap corruption, exactly when the handler is needed

## Security
- **#1435** `npu_engine_universal.cpp` — `recursive_directory_iterator` replaces `popen("find " + NPU_XCLBIN_DIR)`: paths with spaces work, no shell injection
- **#1438** `jarvis_server.cpp` — `fork`/`execvp` with argv replaces `popen` built from `CLONE_PYTHON`/`PYTHONPATH`; Python stays optional and documented for the voice-clone endpoint only

## Verification
- Clean build on Strix Halo (TheRock `/opt/rocm-therock`, XRT + NPU targets) and x86_64 (Vulkan + ROCm stub)
- 22/22 runnable ctest pass (remaining 33 are Not-Run targets, same as before)
- `tools/dspark_gpu_bench.cpp` + `tools/test_mamba1_backend.cpp` now compile on non-ROCm toolchains (previously the whole build failed at 85%)
- Purity re-checked: shipped `1bit` ELF contains zero Rust refs; Python refs are only the documented optional voice-clone endpoint + TheRock's pip-installed lib dirs (native .so)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix toolchain build breaks: missing `<cmath>`, C-array `.data()`

- Harden `.lora` loader with bounds checks and swap-on-success

- Seed `rand()` per process to fix deterministic sampling

- Remove shell `popen`; use fork/exec and filesystem


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["10 audited bugs"] --> B["Build fixes"]
  A --> C["Correctness fixes"]
  A --> D["Determinism"]
  A --> E["Safety/security"]
  B --> B1["test_mamba1_backend.cpp"]
  B --> B2["dspark_gpu_bench.cpp"]
  C --> C1["npu_engine_cb.cpp"]
  C --> C2["npu_engine_hybrid.cpp"]
  C --> C3["tokenize.cpp"]
  C --> C4["bench_fused.cpp"]
  D --> D1["srand seeding"]
  E --> E1["write(2) handler"]
  E --> E2["fork/execvp"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>npu_engine_cb.cpp</strong><dd><code>Harden LoRA loader and seed rand()</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1439/files#diff-1d047129143ebac68cbcbf56e789250a1e78767e18d7afc79573087e6b8c6540">+73/-52</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>npu_engine_universal.cpp</strong><dd><code>Async-safe SIGABRT handler and no-shell search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1439/files#diff-63677a636d5ff19712cf034cc1e2c15a96b194137caee54d8bd6883b0b76a10b">+23/-18</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tokenize.cpp</strong><dd><code>Verify tokenizer file read before parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1439/files#diff-bb136ab471838467f8d177aeacb49f96372963b08321bdef4f098f4fa18e440e">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bench_fused.cpp</strong><dd><code>Check file open and header read</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1439/files#diff-7f57db4fbee3f0438127d6bdf4b53b8ad9a84bfe2cc893e38ffd3f97a399c0e5">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dspark_gpu_bench.cpp</strong><dd><code>Fix C array .data() usage in memcpy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1439/files#diff-484ce724324d86f4065006c9d195b2f07b4965531091c6bc5c4fb03d3edcf580">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>jarvis_server.cpp</strong><dd><code>Replace popen with fork/execvp subprocess</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1439/files#diff-7b1e2d203e21efac45ca8e9b9745856529d5a59dec4643f79df5dcef24581145">+28/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_mamba1_backend.cpp</strong><dd><code>Add <cmath> and use std::sqrt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1439/files#diff-5c06a2a65a7b79f02ceef0d17f3517a93bd0ba50604c6f8fa4e72d0a21cea9a3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>npu_engine_hybrid.cpp</strong><dd><code>Add NULL checks for dequantized weights</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1439/files#diff-4055c93a579914680c952cc3162e5323564da04f7f0af12267e921acefc5ce24">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

