### PR TITLE
fix(backend): reuse per-token host staging in FusedBackend — kill #1428 arena creep

### DIFF
--- a/src/backend_fused.cpp
+++ b/src/backend_fused.cpp
@@ -258,6 +258,10 @@ struct FusedBackend : Backend {
     std::future<bool> npu_future_;
 
     std::vector<float> cpu_embed, cpu_final_norm, cpu_output;
+    // Reusable per-token host staging — allocated once in init(), reused every
+    // token. Stack-local vectors here churned 4 KB + VOCAB*4 (~608 KB) per
+    // token, fragmenting the glibc arena into unbounded RSS creep (issue #1428).
+    std::vector<float> h_stage, logit_stage;
     struct CpuL { std::vector<float> w1, w2, w3; };
     std::vector<CpuL> cpu_L;
     int pos = 0;
@@ -357,6 +361,7 @@ struct FusedBackend : Backend {
             }
         }
 
+        h_stage.resize(H); logit_stage.resize(VOCAB);
         gpu_ok = true; initialized = true;
         printf(npu_ok ? "[fused] ✅ Fused GPU+NPU\n" : "[fused] ✅ GPU-only\n");
         return true;
@@ -625,10 +630,9 @@ struct FusedBackend : Backend {
     }
 
     int generate(int token_id) override {
-        std::vector<float> h(H);
-        if (!forward(token_id, h.data())) return -1;
-        std::vector<float> l(VOCAB); int n=-1;
-        if (!lm_head(h.data(), l.data(), &n)) return -1;
+        if (!forward(token_id, h_stage.data())) return -1;
+        int n = -1;
+        if (!lm_head(h_stage.data(), logit_stage.data(), &n)) return -1;
         return n;
     }
 
@@ -666,6 +670,8 @@ struct FusedBackend : Backend {
         if (stream) { HIP_CHECK_D(hipStreamDestroy(stream)); stream = nullptr; }
         npu_state_destroy(npu); npu = nullptr;
         cpu_L.clear(); cpu_embed.clear(); cpu_final_norm.clear(); cpu_output.clear();
+        h_stage.clear(); h_stage.shrink_to_fit();
+        logit_stage.clear(); logit_stage.shrink_to_fit();
         gpu_ok = false; npu_ok = false; initialized = false;
     }
 };


### PR DESCRIPTION
### **User description**
## What

`FusedBackend::generate()` allocated two `std::vector<float>` on the stack **every token** — `h(H)` (~4 KB) and `l(VOCAB)` (~608 KB for Qwen3) — freeing both per call. This PR hoists them to reusable members (`h_stage`, `logit_stage`), sized once in `init()` and reused every token.

```diff
 int generate(int token_id) override {
-    std::vector<float> h(H);
-    if (!forward(token_id, h.data())) return -1;
-    std::vector<float> l(VOCAB); int n=-1;
-    if (!lm_head(h.data(), l.data(), &n)) return -1;
+    if (!forward(token_id, h_stage.data())) return -1;
+    int n = -1;
+    if (!lm_head(h_stage.data(), logit_stage.data(), &n)) return -1;
     return n;
 }
```

## Why (root cause of #1428)

The creep was **not a true leak** — every allocation was freed. It's glibc **arena fragmentation** via the dynamic mmap-threshold trap:

- The 608 KB `l(VOCAB)` starts `mmap`'d, but after the first free glibc raises its mmap threshold and services later same-size requests from the **brk arena** instead.
- Those 608 KB blocks then interleave with the many small per-token HIP/kernel-launch allocations, so the top of the heap never becomes trimmable → host RSS creeps up and never returns to the OS.

This matches every reported symptom in #1428: monotonic `VmData` growth, stable `/proc/maps` (brk, not mmap), and a rate that **tracks tokens** (≈1.4 MB/req at `max_tokens=8`, ≈1.8 MB/req at `max_tokens=128`).

A `heaptrack` capture confirmed the diagnosis: **zero** unfreed bytes on the `generate`/`forward`/`lm_head` path — nothing leaks, it fragments.

## Verification

Strix Halo, Qwen3-0.6B-q8-q4nx, new binary with the `MALLOC_MMAP_THRESHOLD_`/`TRIM_THRESHOLD_` service band-aid **OFF** (naive glibc — the original repro condition):

| Load | Old (issue #1428) | This PR |
|---|---|---|
| `mt=8`, per 10 reqs | ~14 MB, monotonic | plateaus by round 4 at **+44 kB** |
| `mt=128`, per 10 reqs | **+17 MB**, monotonic → 6.8 GB | decays 208 → 184 → 172 → 76 → 76 → 84 → 32 → **20 kB** and still falling |

Over 80 `mt=128` requests (~10k tokens) total host growth ≈ **0.85 MB** vs ~136 MB for the old binary — ~160× less and asymptotically flat (arena high-water-mark settling, not a leak). Driver stayed clean through minutes of sustained decode.

## Safety

Inference is already serialized by `g_inference_mutex` (the whole `generate_completion` decode loop holds it), so the shared staging buffers introduce no data race — same single-inference-at-a-time invariant as the already-shared `pos` / KV cache / device scratch. Signature and return value of `generate()` are unchanged; the edit is body-only, semantically inert to all callers.

## Follow-up

Once this lands, the `MALLOC_MMAP_THRESHOLD_=131072` / `MALLOC_TRIM_THRESHOLD_=131072` env band-aid on `1bit-systems.service` becomes unnecessary (the allocation it was masking is gone, and reuse also drops the per-token `mmap`/`munmap` syscalls the band-aid incurred). Not removed here — that's an ops/unit change for a separate call.

Closes #1428.


___

### **PR Type**
Bug fix


___

### **Description**
- Root cause: glibc arena fragmentation, not leak.

- Reuse `h_stage`/`logit_stage` across tokens in `generate()`.

- Size buffers once in `init()`; clear in `destroy()`.

- Eliminates per-token churn, fixing #1428 heap creep.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Per-token std::vector h/l"] --> B["glibc arena fragmentation"]
  B --> C["Monotonic RSS creep (#1428)"]
  D["Reusable h_stage/logit_stage"] --> E["Zero per-token host allocation"]
  E --> F["Heap plateaus"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_fused.cpp</strong><dd><code>Reuse per-token host staging to stop heap creep</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_fused.cpp

<ul><li>Adds <code>h_stage</code> and <code>logit_stage</code> reusable <code>std::vector<float></code> members.<br> <li> Sizes them once in <code>init()</code> and reuses them every token in <code>generate()</code>.<br> <li> Removes per-token stack allocations for hidden state and logits.<br> <li> Clears/frees staging buffers in <code>destroy()</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1440/files#diff-7c92f1f525d2aad11e434c364f206f2af82f8b1984c0535866b4f8e9fa211e4f">+10/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

