### PR TITLE
perf(backend): free dead host weight copies in FusedBackend after load (part 1 of #1427)

### DIFF
--- a/src/backend_fused.cpp
+++ b/src/backend_fused.cpp
@@ -425,6 +425,18 @@ struct FusedBackend : Backend {
             }
             printf("[fused] NPU weights packed via C++ module\n");
         }
+        // Host-side f32 weight copies are dead past this point: compute copies
+        // live on GPU (L[*].w*, d_embed, d_final_norm, d_output) and in the
+        // packed NPU state. Free them to reclaim ~2.4 GB host RAM per model
+        // (issue #1427). Reload (#1021) re-reads from disk into empty vectors.
+        cpu_embed.clear(); cpu_embed.shrink_to_fit();
+        cpu_final_norm.clear(); cpu_final_norm.shrink_to_fit();
+        cpu_output.clear(); cpu_output.shrink_to_fit();
+        for (auto& cl : cpu_L) {
+            cl.w1.clear(); cl.w1.shrink_to_fit();
+            cl.w2.clear(); cl.w2.shrink_to_fit();
+            cl.w3.clear(); cl.w3.shrink_to_fit();
+        }
         printf("[fused] 1BP loaded — %d layers (q_norm=%s, k_norm=%s)\n", NC,
                L[0].q_norm ? "yes" : "no", L[0].k_norm ? "yes" : "no");
         return true;


### PR DESCRIPTION
### **User description**
## What (Part 1 of #1427)

After `load_1bp()` finishes uploading weights to GPU and packing NPU state, FusedBackend's host-side f32 weight copies are **provably dead** — but were kept alive for the process lifetime. This frees them at the end of `load_1bp()`:

- `cpu_embed`, `cpu_final_norm`, `cpu_output` → uploaded to `d_embed`, `d_final_norm`, `d_output`; `forward()`/`lm_head()` use device pointers only
- `cpu_L[l].w1/w2/w3` → packed once into NPU state via `npu_state_pack_layer()`; per-layer FFN runs on NPU internals, never reads `cpu_L`

Verified line-by-line: `forward()`, `lm_head()`, `generate()`, `reset()` read **none** of the freed vectors.

## Why

#1427: the server holds multiple full model copies across backends (~15 GB for a 0.6B model). This removes the largest pure-waste copy — **~2.4 GB host RAM per model** (f32) — with zero behavior change. (Part 2, init top-1 + CPU fallback only, to follow.)

## Safety

- **Reload-safe (#1021):** `GgufReader::get_tensor_f32()` does `out.resize(numel)` — a model switch re-reads from disk into the empty vectors.
- `destroy()`'s existing clears are now no-ops on already-empty vectors.
- Inference verified identical after the change.

## Measured

Strix Halo, Qwen3-0.6B-q8-q4nx, fresh instance:

| Metric | Before | After |
|---|---|---|
| RSS after load | 6768 MB | **5163 MB** |
| VmData | 7260 MB | **5655 MB** |

Completion output unchanged (`"...capital of France is Paris"`).

Part of #1427 (memory reduction; does not fully close it — the multi-backend init remains for part 2).


___

### **PR Type**
Enhancement


___

### **Description**
- Release dead host weights after FusedBackend load

- Reclaims ~2.4 GB host RAM per model

- RSS drops 6768 MB to 5163 MB

- Reload-safe; inference output unchanged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["load_1bp uploads weights to GPU/NPU"] --> B["npu_state_pack_layer() packs cpu_L"]
  B --> C["Free cpu_embed/cpu_final_norm/cpu_output"]
  B --> D["Free cpu_L w1/w2/w3"]
  C --> E["~2.4 GB host RAM reclaimed"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_fused.cpp</strong><dd><code>Free dead host weight copies after FusedBackend load</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_fused.cpp

<ul><li>Frees <code>cpu_embed</code>, <code>cpu_final_norm</code>, and <code>cpu_output</code> after GPU upload in <br><code>load_1bp()</code><br> <li> Clears and <code>shrink_to_fit()</code>s <code>cpu_L[l].w1/w2/w3</code> after packing into NPU <br>state<br> <li> Reclaims ~2.4 GB host RAM per 0.6B model; RSS 6768→5163 MB, VmData <br>7260→5655 MB<br> <li> Reload-safe: <code>GgufReader::get_tensor_f32()</code> resizes vectors on model <br>switch</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1441/files#diff-7c92f1f525d2aad11e434c364f206f2af82f8b1984c0535866b4f8e9fa211e4f">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

