### PR TITLE
perf(backend): init only top accelerator + CPU fallback, lazy-init the rest (part 2 of #1427)

### DIFF
--- a/src/backend_manager.cpp
+++ b/src/backend_manager.cpp
@@ -443,7 +443,13 @@ bool BackendManager::init_in_order(const ModelConfig& cfg, const std::string& we
         pilot_active_ = false;
     }
 
-    // Try ALL backends. Multiple can init — DynamicRouter routes per-token.
+    // #1427: init only the top accelerator + one CPU fallback. Extra backends
+    // each hold a full model copy (~4x model RAM) while per-token cross-backend
+    // routing is KV-incoherent anyway (each backend keeps a private KV
+    // cache/pos — a token routed to a backend that never saw the prefix
+    // attends to empty KV). Skipped backends stay discoverable and initialize
+    // lazily via failover() on first failure.
+    bool kept_accel = false, kept_cpu = false;
     bool any_ok = false;
     for (size_t idx : order) {
         auto& info = backends_[idx];
@@ -478,6 +484,18 @@ bool BackendManager::init_in_order(const ModelConfig& cfg, const std::string& we
             continue;
         }
         if (init_ok) {
+            bool is_cpu = (info.tier == BackendTier::T3_CPU);
+            if ((kept_accel && !is_cpu) || (kept_cpu && is_cpu)) {
+                printf("  → skipped (issue #1427: keeping top backend + CPU fallback only)\n");
+                // Reload (#1021): if a previous model had this backend
+                // registered, drop it so its old instance isn't kept alive by
+                // the router's shared_ptr instead of freed.
+                router_.remove_backend(info.id);
+                destroy_instance(info);
+                continue;
+            }
+            if (is_cpu) kept_cpu = true; else kept_accel = true;
+
             if (!info.instance->can_infer()) {
                 // Detected and initialized, but cannot actually run inference
                 // (e.g. the NPU stub). Report as available but not selectable (fixes #82).


### PR DESCRIPTION
### **User description**
## What (Part 2 of #1427)

`BackendManager::init_in_order()` now keeps **the first successful accelerator + one CPU fallback** and skips the rest — instead of loading every backend × full model copy.

```
BackendManager: trying fused_gpu_npu... → ✅ initialized
BackendManager: trying vulkan_hpp_gpu... → skipped (issue #1427)
BackendManager: trying hip_1bp_gpu...    → skipped (issue #1427)
BackendManager: trying cpu_generic...    → ✅ initialized (fallback)
```

## Why

The 4× footprint (f32 GPU + host, bf16 GPU, Vulkan pools, f32 CPU RAM ≈ **15 GB / 7 GB RSS + 8.2 GB GTT** for a 0.6B model) paid for per-token cross-backend routing — which was **KV-incoherent**:

- Each backend keeps a **private KV cache + pos** (`dynamic_router.cpp` `GPU_BACKFILL`/`NPU_BACKFILL` round-robin tokens GPU↔NPU mid-sequence — a token routed to a backend that never saw the prefix attends to empty KV)
- `add_backend()` overwrites the router's global `strategy_` with the last registration, so it collapses to `FASTEST` anyway — one backend serves each sequence in practice

So the extra loaded backends were dead weight except as between-request failover — and failover already creates backends **on demand** (`failover()` at backend_manager.cpp:857: `if (!info.instance) { create_instance_rt + init }`).

## Safety

- Skipped backends stay `available`; they initialize lazily on first failure via the existing failover path (per-request coherent)
- Reload (#1021): skipped backends are removed from the router so a previous model's instance isn't kept alive by the router's shared_ptr
- `active_idx_`/monitor/router registration only happen for kept backends (skip check runs before all of them)
- All routes flow through the same choke point; a route whose first backend fails init still falls through the order as before

## Measured

Qwen3-0.6B-q8-q4nx on Strix Halo:

| Metric | Before (all 4) | After (fused + cpu) |
|---|---|---|
| Instance GTT | ~8.2 GB | **~2.6 GB** |
| Backends functional | 4 | 2 (fused + cpu_generic) |
| Completion | — | unchanged (`"...capital of France is Paris"`) |

Part of #1427 (closes it together with #1441 — free dead host weights).


___

### **PR Type**
Enhancement


___

### **Description**
- Limit backend init to top accelerator plus one CPU fallback

- Skip extra full-model backends, cutting multi-backend RAM footprint

- Skipped backends lazy-init via existing failover() on first failure

- Remove skipped backends from router on reload to free old instances


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BackendManager::init_in_order()"] --> B{"backend init_ok?"}
  B -- "yes" --> C{"is CPU backend?"}
  C -- "no" --> D{"kept_accel already?"}
  D -- "yes" --> E["skip: router_.remove_backend + destroy_instance"]
  D -- "no" --> F["keep accelerator"]
  C -- "yes" --> G{"kept_cpu already?"}
  G -- "yes" --> E
  G -- "no" --> H["keep CPU fallback"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_manager.cpp</strong><dd><code>Limit backend init to top accelerator plus CPU fallback</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/backend_manager.cpp

<ul><li>Added <code>kept_accel</code>/<code>kept_cpu</code> flags in <code>init_in_order()</code><br> <li> Keeps first accelerator + one CPU fallback, skips extra backends<br> <li> Removes skipped backend from router and destroys instance on reload<br> <li> Skipped backends stay discoverable and lazy-init via <code>failover()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1442/files#diff-f2ed10bacc975dc1c4ed35af9a62ab967874cf0273695b07cceb6059ed53a1cf">+19/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

