### PR TITLE
chore: gitignore local work artifacts (model conv sources, appimage build, heaptrack, tool state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,12 @@ build/*.ninja*
 *.AppImage
 scripts/.reconvert.lock
 research/ws05-1bp-v2/RECONVERT-REPORT.md.tmp
+
+# ── Local work artifacts (not for VCS) ──
+.codewhale/
+appimage-build/
+appimagetool
+heaptrack*
+models/_src_q8/
+npu-infer/mlir-aie
+reasonix.toml


### PR DESCRIPTION
Adds the local work artifacts that have been polluting `git status` (31 untracked files) to `.gitignore`:

- `models/_src_q8/` — 36 GB of downloaded Q4NX conversion source models (issue #1243 reconversion)
- `appimage-build/` + `appimagetool` — regenerated AppImage packaging outputs
- `heaptrack*` — heap-profile dumps (e.g. the #1428 repro capture)
- `.codewhale/` — codewhale tool state
- `npu-infer/mlir-aie` — LLVM IR build artifact from the MLIR-AIE runtime lib
- `reasonix.toml` — local tool config