### PR TITLE
ci(codeql): c-cpp build-mode none — autobuild can't build the ROCm/HIP stack on runners

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         include:
           - language: c-cpp
-            build-mode: autobuild
+            build-mode: none  # ROCm/HIP toolchain not installable on runners — buildless extraction
           - language: actions
             build-mode: none
           - language: python


### PR DESCRIPTION
### **User description**
CodeQL's C++ autobuild fails on **every** PR since #1445 enabled it:

```
A fatal error occurred: Exit status 1 from command: [.../codeql/cpp/tools/autobuild.sh]
##[error]We were unable to automatically build your code. Please change the build
mode for this language to manual and specify build steps
```

The runner (ubuntu-24.04) has no ROCm/HIP toolchain — the repo can't be autobuilt there. Per CodeQL's own guidance ("buildless extraction... should be used in cases where it is not possible to build the code"), switch c-cpp to `build-mode: none`. Python/JS/Actions already use `none`.

Trade-off: buildless C++ extraction is less precise (no dataflow through the build), but a red check on 100% of PRs is worse — this unblocks PRs and still scans the tree for obvious issues. If precise C++ dataflow is needed later, a manual build step with the ROCm SDK would be the upgrade path.


___

### **PR Type**
Bug fix


___

### **Description**
- Switch CodeQL c-cpp build mode from `autobuild` to `none`

- Fixes autobuild failure due to missing ROCm/HIP toolchain on runners

- Unblocks CodeQL check on every PR; keeps other languages buildless


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CodeQL C++ autobuild"] -- "fails on runner" --> B["build-mode: none"]
  B -- "buildless extraction" --> C["PR checks unblocked"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codeql.yml</strong><dd><code>Switch CodeQL C++ to buildless extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/codeql.yml

<ul><li>Change c-cpp build mode from <code>autobuild</code> to <code>none</code><br> <li> Work around missing ROCm/HIP toolchain on CI runners<br> <li> Unblocks CodeQL check on every PR</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1450/files#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

