### PR TITLE
feat(diffusion): video generation end-to-end — txt2vid/img2vid, WebM encode, ROCm backend, ComfyUI node

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **1bit-systems** (18519 symbols, 32295 relationships, 203 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **1bit-systems** (18785 symbols, 32851 relationships, 210 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1785,37 +1785,86 @@ endif()
 option(USE_DIFFUSION "Build stable-diffusion.cpp integration" OFF)
 if(USE_DIFFUSION)
     # Find sd.cpp library (built separately or via submodule)
-    # The sd.cpp library is named libstable-diffusion.a
-    set(SD_CPP_DIR "${CMAKE_SOURCE_DIR}/third_party/stable-diffusion.cpp/build")
-    find_library(SD_CPP_LIB stable-diffusion PATHS
-        ${SD_CPP_DIR}
+    # The sd.cpp library is named libstable-diffusion.a. build-rocm is the
+    # ROCm/HIP build, build-webm the webm-enabled CPU build, plain build/ the
+    # fallback. All three are produced by the sd.cpp submodule's own CMake.
+    set(SD_CPP_DIRS
+        "${CMAKE_SOURCE_DIR}/third_party/stable-diffusion.cpp/build-rocm"
+        "${CMAKE_SOURCE_DIR}/third_party/stable-diffusion.cpp/build-webm"
+        "${CMAKE_SOURCE_DIR}/third_party/stable-diffusion.cpp/build")
+    find_library(SD_CPP_LIB stable-diffusion PATHS ${SD_CPP_DIRS}
         /usr/local/lib /usr/lib NO_DEFAULT_PATH)
     if(NOT SD_CPP_LIB)
-        find_library(SD_CPP_LIB stable-diffusion PATHS
-            ${SD_CPP_DIR}
+        find_library(SD_CPP_LIB stable-diffusion PATHS ${SD_CPP_DIRS}
             /usr/local/lib /usr/lib)
     endif()
     
     if(SD_CPP_LIB)
         # Diffusion bridge library
-        add_library(diffusion_bridge STATIC src/diffusion_bridge.cpp)
+        add_library(diffusion_bridge STATIC src/diffusion_bridge.cpp
+            third_party/stable-diffusion.cpp/examples/common/media_io.cpp
+            third_party/stable-diffusion.cpp/examples/common/log.cpp)
         target_include_directories(diffusion_bridge PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party/stable-diffusion.cpp/include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party/stable-diffusion.cpp/ggml/include>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party/stable-diffusion.cpp/examples/common>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party/stable-diffusion.cpp/thirdparty>
             $<INSTALL_INTERFACE:include>)
         target_compile_options(diffusion_bridge PRIVATE -O3 -std=c++23)
         # Also find ggml libs that sd.cpp depends on
-        set(SD_GGML_DIR "${SD_CPP_DIR}/ggml/src")
-        find_library(SD_GGML_LIB ggml PATHS ${SD_GGML_DIR} NO_DEFAULT_PATH)
-        find_library(SD_GGML_CPU_LIB ggml-cpu PATHS ${SD_GGML_DIR} NO_DEFAULT_PATH)
-        find_library(SD_GGML_BASE_LIB ggml-base PATHS ${SD_GGML_DIR} NO_DEFAULT_PATH)
+        set(SD_GGML_DIRS)
+        foreach(d IN LISTS SD_CPP_DIRS)
+            list(APPEND SD_GGML_DIRS "${d}/ggml/src")
+        endforeach()
+        find_library(SD_GGML_LIB ggml PATHS ${SD_GGML_DIRS} NO_DEFAULT_PATH)
+        find_library(SD_GGML_CPU_LIB ggml-cpu PATHS ${SD_GGML_DIRS} NO_DEFAULT_PATH)
+        find_library(SD_GGML_BASE_LIB ggml-base PATHS ${SD_GGML_DIRS} NO_DEFAULT_PATH)
+        find_library(SD_GGML_HIP_LIB ggml-hip PATHS
+            "${CMAKE_SOURCE_DIR}/third_party/stable-diffusion.cpp/build-rocm/ggml/src/ggml-hip"
+            NO_DEFAULT_PATH)
+        
+        # Optional WebM/WebP video containers: light up automatically when the
+        # sd.cpp submodule build has SD_WEBM=ON (build-webm/build-rocm, produces
+        # libwebm.a/libwebp.a/libwebpmux.a in its build dir). Without them the
+        # encoder falls back to MJPG AVI, same as sd.cpp's own server default.
+        set(SD_WEBM_BUILD_DIR "${CMAKE_SOURCE_DIR}/third_party/stable-diffusion.cpp/build-webm")
+        find_library(SD_WEBM_LIB webm PATHS ${SD_WEBM_BUILD_DIR}/thirdparty/libwebm NO_DEFAULT_PATH)
+        find_library(SD_WEBP_LIB webp PATHS ${SD_WEBM_BUILD_DIR}/thirdparty/libwebp NO_DEFAULT_PATH)
+        find_library(SD_WEBPMUX_LIB webpmux PATHS ${SD_WEBM_BUILD_DIR}/thirdparty/libwebp NO_DEFAULT_PATH)
+        find_library(SD_SHARPYUV_LIB sharpyuv PATHS ${SD_WEBM_BUILD_DIR}/thirdparty/libwebp NO_DEFAULT_PATH)
+        if(SD_WEBM_LIB AND SD_WEBP_LIB AND SD_WEBPMUX_LIB)
+            target_compile_definitions(diffusion_bridge PRIVATE SD_USE_WEBM SD_USE_WEBP)
+            target_include_directories(diffusion_bridge PUBLIC
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party/stable-diffusion.cpp/thirdparty/libwebm>
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party/stable-diffusion.cpp/thirdparty/libwebp/src>)
+            target_link_libraries(diffusion_bridge PUBLIC ${SD_WEBM_LIB} ${SD_WEBP_LIB} ${SD_WEBPMUX_LIB} ${SD_SHARPYUV_LIB})
+            message(STATUS "diffusion: webm/webp video containers enabled")
+        else()
+            message(STATUS "diffusion: webm/webp not found, video outputs use MJPG AVI")
+        endif()
+        
+        # ROCm build (build-rocm): static libs don't carry runtime deps, so
+        # link the HIP runtime explicitly and rpath it into the server.
+        # Same TheRock SDK location the top of this file pins for HIP builds.
+        set(_RC_SDK_LIB "/opt/rocm-therock/lib/python3.14/site-packages/_rocm_sdk_libraries/lib")
+        set(_RC_SDK_CORE "/opt/rocm-therock/lib/python3.14/site-packages/_rocm_sdk_core/lib")
+        # Versioned .so names only (no unversioned symlinks) — link exact paths.
+        set(SD_AMD_HIP64_LIB "${_RC_SDK_CORE}/libamdhip64.so.7")
+        set(SD_ROCBLAS_LIB "${_RC_SDK_LIB}/librocblas.so.5")
+        set(SD_HIPBLAS_LIB "${_RC_SDK_LIB}/libhipblas.so.3")
+        if(SD_CPP_LIB MATCHES "build-rocm")
+            target_link_libraries(diffusion_bridge PUBLIC ${SD_AMD_HIP64_LIB} ${SD_ROCBLAS_LIB} ${SD_HIPBLAS_LIB})
+            set(_SD_HIP_RPATH "${_RC_SDK_LIB}:${_RC_SDK_CORE}")  # applied to image_server below
+            message(STATUS "diffusion: ROCm/HIP runtime linked (${_RC_SDK_LIB})")
+        endif()
         
         target_link_libraries(diffusion_bridge PUBLIC
             ${SD_CPP_LIB}
             ${SD_GGML_LIB}
             ${SD_GGML_CPU_LIB}
             ${SD_GGML_BASE_LIB}
+            ${SD_GGML_HIP_LIB}
             vl_image m pthread)
         if(OpenMP_CXX_FOUND)
             target_link_libraries(diffusion_bridge PUBLIC OpenMP::OpenMP_CXX)
@@ -1828,6 +1877,9 @@ if(USE_DIFFUSION)
         target_link_libraries(image_server PRIVATE
             diffusion_bridge vl_image backend_manager
             httplib::httplib nlohmann_json::nlohmann_json)
+        if(_SD_HIP_RPATH)
+            set_target_properties(image_server PROPERTIES BUILD_RPATH "${_SD_HIP_RPATH}")
+        endif()
         
         message(STATUS "diffusion: stable-diffusion.cpp integration enabled (${SD_CPP_LIB})")
     else()

--- a/include/diffusion_bridge.h
+++ b/include/diffusion_bridge.h
@@ -82,8 +82,13 @@ public:
     DiffusionEngine& operator=(const DiffusionEngine&) = delete;
     
     // ── Model lifecycle ──
+    // ── Model lifecycle ──
+    // t5xxl_path/clip_vision_path: companion text/vision encoders (required
+    // for Wan video: t5 = umt5-xxl; i2v also needs clip_vision).
     bool load_model(const std::string& model_path,
-                    const std::string& vae_path = "");
+                    const std::string& vae_path = "",
+                    const std::string& t5xxl_path = "",
+                    const std::string& clip_vision_path = "");
     void unload_model();
     bool is_loaded() const;
     bool supports_video() const;
@@ -108,8 +113,15 @@ public:
     void clear_loras();
 
 private:
+    // Shared video pipeline (generate_video -> container encode). Pass
+    // init_image for image-to-video (strength taken from params).
+    DiffusionResult generate_video_impl(const DiffusionParams& params,
+                                        const sd_image_t* init_image);
+
     std::string model_path_;
     std::string vae_path_;
+    std::string t5xxl_path_;
+    std::string clip_vision_path_;
     sd_ctx_t* sd_ctx_     = nullptr;
     upscaler_ctx_t* up_ctx_ = nullptr;
 };

--- a/integrations/comfyui/README.md
+++ b/integrations/comfyui/README.md
@@ -52,11 +52,19 @@ Vision-language understanding. Send an image + question, get a description.
 
 ### 1BP Image Generate
 Text-to-image generation via stable-diffusion.cpp backend.
-- Input: text prompt, negative prompt
-- Parameters: width, height, steps, CFG scale, seed
+- Input: text prompt, negative prompt; optional IMAGE for image-to-image
+- Parameters: width, height, steps, CFG scale, seed, strength
 - Supports: SD, SDXL, FLUX, Qwen-Image, Z-Image, and more
 - Optional: LoRA path + strength
 - Output: image tensor (compatible with ComfyUI image pipeline)
+
+### 1BP Video Generate
+Text-to-video / image-to-video generation (Wan, LTX, Hunyuan) via the stable-diffusion.cpp backend.
+- Input: text prompt, negative prompt; optional first-frame IMAGE (image-to-video)
+- Parameters: width, height, frames, fps, steps, CFG scale, seed, strength
+- Optional: LoRA path + strength, output format (webm/avi)
+- Output: video file saved to ComfyUI's output directory
+- Container: WebM by default (in-browser preview); `avi` selects MJPG AVI
 
 ### 1BP Text-to-Speech
 Synthesize speech from text.

--- a/integrations/comfyui/__init__.py
+++ b/integrations/comfyui/__init__.py
@@ -22,8 +22,10 @@ import json
 import os
 import base64
 import io
+from datetime import datetime
 from urllib.parse import urlparse
 import httpx
+import folder_paths
 from PIL import Image
 import numpy as np
 import torch
@@ -32,6 +34,13 @@ import torch
 DEFAULT_UNIFIED_URL = "http://127.0.0.1:8088/v1"
 DEFAULT_IMAGE_URL   = "http://127.0.0.1:8089/v1"
 DEFAULT_AUDIO_URL   = "http://127.0.0.1:8090/v1"
+
+# ComfyUI IMAGE tensor (B,H,W,C float 0..1) -> base64 PNG for the server.
+def tensor_to_png_b64(img_tensor):
+    img_np = (img_tensor.squeeze(0).detach().cpu().numpy() * 255.0).clip(0, 255).astype(np.uint8)
+    buf = io.BytesIO()
+    Image.fromarray(img_np).save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
 
 # ComfyUI's threat model is untrusted shared workflow JSON — a workflow can set
 # server_url to an arbitrary value. Without an allowlist that's an SSRF
@@ -210,6 +219,8 @@ class OneBP_Image_Generate:
             },
             "optional": {
                 "negative_prompt": ("STRING", {"multiline": True, "default": ""}),
+                "init_image": ("IMAGE",),  # img2img: supply an input image
+                "strength": ("FLOAT", {"default": 0.75, "min": 0.0, "max": 1.0}),
                 "lora_path": ("STRING", {"default": ""}),
                 "lora_strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0}),
                 "seed": ("INT", {"default": -1}),
@@ -218,7 +229,8 @@ class OneBP_Image_Generate:
         }
     
     def generate(self, prompt, width, height, steps, cfg_scale, model,
-                 negative_prompt="", lora_path="", lora_strength=1.0,
+                 negative_prompt="", init_image=None, strength=0.75,
+                 lora_path="", lora_strength=1.0,
                  seed=-1, server_url=DEFAULT_IMAGE_URL):
         params = {
             "model": model,
@@ -230,6 +242,9 @@ class OneBP_Image_Generate:
             "cfg_scale": cfg_scale,
             "seed": seed,
         }
+        if init_image is not None:
+            params["init_image_b64"] = tensor_to_png_b64(init_image)
+            params["strength"] = strength
         if lora_path:
             params["lora_paths"] = [lora_path]
             params["lora_strengths"] = [lora_strength]
@@ -237,8 +252,9 @@ class OneBP_Image_Generate:
         try:
             validate_server_url(server_url)
             with httpx.Client(timeout=300.0) as client:
+                endpoint = "/images/edits" if init_image is not None else "/images/generations"
                 resp = client.post(
-                    f"{server_url}/images/generations",
+                    f"{server_url}{endpoint}",
                     json=params
                 )
                 resp.raise_for_status()
@@ -310,6 +326,101 @@ class OneBP_TTS:
             return ({"waveform": b"", "sample_rate": 24000},)
 
 # ═══════════════════════════════════════════════════════════════════
+# Node: 1BP Video Generate (text-to-video / image-to-video)
+# ═══════════════════════════════════════════════════════════════════
+class OneBP_Video_Generate:
+    """Generate video (Wan, LTX, Hunyuan) via the 1bit image_server.
+
+    Requires the image_server built with -DUSE_DIFFUSION=ON and a video
+    model (wan/ltx/hunyuan) loaded. Saves the clip to ComfyUI's output
+    directory.
+
+    Container: WebM by default (in-browser preview in ComfyUI); 'avi'
+    selects MJPG AVI (video/x-msvideo).
+    """
+
+    CATEGORY = "1bit-systems/Video"
+    FUNCTION = "generate"
+    RETURN_TYPES = ()
+    OUTPUT_NODE = True
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "prompt": ("STRING", {"multiline": True, "default": "Cinematic establishing shot, slow dolly in, volumetric light, 35mm film"}),
+                "width": ("INT", {"default": 832, "min": 128, "max": 2048, "step": 16}),
+                "height": ("INT", {"default": 480, "min": 128, "max": 2048, "step": 16}),
+                "frames": ("INT", {"default": 81, "min": 8, "max": 1024}),
+                "fps": ("INT", {"default": 16, "min": 1, "max": 60}),
+                "steps": ("INT", {"default": 20, "min": 1, "max": 150}),
+                "cfg_scale": ("FLOAT", {"default": 7.0, "min": 1.0, "max": 20.0}),
+                "model": ("STRING", {"default": "wan-2.1"}),
+            },
+            "optional": {
+                "negative_prompt": ("STRING", {"multiline": True, "default": "blurry, low quality, watermark, text"}),
+                "output_format": (["avi", "webm"], {"default": "webm"}),
+                "init_image": ("IMAGE",),  # image-to-video: first frame
+                "strength": ("FLOAT", {"default": 0.75, "min": 0.0, "max": 1.0}),
+                "lora_path": ("STRING", {"default": ""}),
+                "lora_strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0}),
+                "seed": ("INT", {"default": -1}),
+                "server_url": ("STRING", {"default": DEFAULT_IMAGE_URL}),
+            }
+        }
+
+    def generate(self, prompt, width, height, frames, fps, steps, cfg_scale, model,
+                 negative_prompt="", output_format="webm", init_image=None, strength=0.75,
+                 lora_path="", lora_strength=1.0,
+                 seed=-1, server_url=DEFAULT_IMAGE_URL):
+        params = {
+            "model": model,
+            "prompt": prompt,
+            "negative_prompt": negative_prompt,
+            "width": width,
+            "height": height,
+            "frames": frames,
+            "fps": fps,
+            "steps": steps,
+            "cfg_scale": cfg_scale,
+            "seed": seed,
+            "output_format": output_format,
+        }
+        if init_image is not None:
+            params["init_image_b64"] = tensor_to_png_b64(init_image)
+            params["strength"] = strength
+        if lora_path:
+            params["lora_paths"] = [lora_path]
+            params["lora_strengths"] = [lora_strength]
+
+        try:
+            validate_server_url(server_url)
+            # Video gen is slow (minutes); match the server's patience.
+            with httpx.Client(timeout=3600.0) as client:
+                resp = client.post(
+                    f"{server_url}/video/generations",
+                    json=params
+                )
+                resp.raise_for_status()
+                data = resp.json()
+
+                b64 = data["data"][0]["b64_json"]
+                video_bytes = base64.b64decode(b64)
+                if len(video_bytes) > MAX_DECODED_IMAGE_BYTES * 8:
+                    raise ValueError(f"decoded video too large: {len(video_bytes)} bytes")
+
+                ext = "webm" if output_format == "webm" else "avi"
+                filename = f"onebit_{datetime.now().strftime('%Y%m%d_%H%M%S')}.{ext}"
+                path = os.path.join(folder_paths.get_output_directory(), filename)
+                with open(path, "wb") as f:
+                    f.write(video_bytes)
+
+                return {"ui": {"gifs": [{"filename": filename, "subfolder": "", "type": "output"}]}}
+        except Exception as e:
+            print(f"[ERROR] OneBP Video Generate: {e}")
+            return {"ui": {"gifs": []}}
+
+# ═══════════════════════════════════════════════════════════════════
 # Node: 1BP LoRA Loader (for LLM text gen)
 # ═══════════════════════════════════════════════════════════════════
 class OneBP_LoRA_Loader:
@@ -357,6 +468,7 @@ NODE_CLASS_MAPPINGS = {
     "OneBP_LLM_Generate": OneBP_LLM_Generate,
     "OneBP_VLM_Understand": OneBP_VLM_Understand,
     "OneBP_Image_Generate": OneBP_Image_Generate,
+    "OneBP_Video_Generate": OneBP_Video_Generate,
     "OneBP_TTS": OneBP_TTS,
     "OneBP_LoRA_Loader": OneBP_LoRA_Loader,
 }
@@ -365,6 +477,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "OneBP_LLM_Generate": "1BP LLM Generate",
     "OneBP_VLM_Understand": "1BP VLM Analyze Image",
     "OneBP_Image_Generate": "1BP Image Generate",
+    "OneBP_Video_Generate": "1BP Video Generate",
     "OneBP_TTS": "1BP Text-to-Speech",
     "OneBP_LoRA_Loader": "1BP LoRA Loader",
 }

--- a/src/diffusion_bridge.cpp
+++ b/src/diffusion_bridge.cpp
@@ -3,6 +3,7 @@
 
 #include "diffusion_bridge.h"
 #include "stable-diffusion.h"
+#include "media_io.h"   // create_video_from_sd_images_to_vector (sd.cpp examples/common)
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -20,18 +21,25 @@ DiffusionEngine::~DiffusionEngine() {
 }
 
 bool DiffusionEngine::load_model(const std::string& model_path,
-                                  const std::string& vae_path) {
+                                  const std::string& vae_path,
+                                  const std::string& t5xxl_path,
+                                  const std::string& clip_vision_path) {
     unload_model();
     if (model_path.empty()) return false;
     
     model_path_ = model_path;
     vae_path_ = vae_path;
+    t5xxl_path_ = t5xxl_path;
+    clip_vision_path_ = clip_vision_path;
     
     sd_ctx_params_t params;
     sd_ctx_params_init(&params);
     
     params.model_path = model_path.c_str();
     params.vae_path = vae_path.empty() ? nullptr : vae_path.c_str();
+    params.t5xxl_path = t5xxl_path.empty() ? nullptr : t5xxl_path.c_str();
+    params.clip_vision_path = clip_vision_path.empty() ? nullptr
+                                : clip_vision_path.c_str();
     params.n_threads = 8;
     params.wtype = SD_TYPE_F32;
     params.rng_type = CUDA_RNG;
@@ -53,6 +61,8 @@ void DiffusionEngine::unload_model() {
     if (up_ctx_) { ::free_upscaler_ctx(up_ctx_); up_ctx_ = nullptr; }
     model_path_.clear();
     vae_path_.clear();
+    t5xxl_path_.clear();
+    clip_vision_path_.clear();
 }
 
 bool DiffusionEngine::is_loaded() const { return sd_ctx_ != nullptr; }
@@ -77,13 +87,13 @@ DiffusionResult DiffusionEngine::txt2img(const DiffusionParams& params,
     gp.height = params.height;
     gp.seed = params.seed;
     gp.batch_count = 1;
-    gp.strength = params.cfg_scale;
     
     sd_sample_params_t sp;
     sd_sample_params_init(&sp);
     sp.sample_steps = params.steps;
     sp.sample_method = EULER_A_SAMPLE_METHOD;
     sp.scheduler = KARRAS_SCHEDULER;
+    sp.guidance.txt_cfg = params.cfg_scale;
     gp.sample_params = sp;
     
     // LoRAs
@@ -146,7 +156,7 @@ DiffusionResult DiffusionEngine::img2img(const DiffusionParams& params,
     gp.width = params.width;
     gp.height = params.height;
     gp.seed = params.seed;
-    gp.strength = params.cfg_scale;
+    gp.strength = params.strength;
     gp.batch_count = 1;
     
     sd_sample_params_t sp;
@@ -154,17 +164,38 @@ DiffusionResult DiffusionEngine::img2img(const DiffusionParams& params,
     sp.sample_steps = params.steps;
     sp.sample_method = EULER_A_SAMPLE_METHOD;
     sp.scheduler = KARRAS_SCHEDULER;
+    sp.guidance.txt_cfg = params.cfg_scale;
     gp.sample_params = sp;
     
-    // TODO: load init_image from params.init_image_path
-    // sd_image_t init = load_image(params.init_image_path);
-    // gp.init_image = init;
-    // gp.strength (img2img) = params.strength;
+    // Init image + optional mask (stbi-allocated; freed below).
+    sd_image_t init{}, mask{};
+    bool have_init = false, have_mask = false;
+    if (!params.init_image_path.empty()) {
+        have_init = load_sd_image_from_file(&init, params.init_image_path.c_str());
+        if (have_init) {
+            gp.init_image = init;
+        } else {
+            fprintf(stderr, "diffusion: failed to load init image %s\n",
+                    params.init_image_path.c_str());
+        }
+    }
+    if (!params.mask_image_path.empty()) {
+        have_mask = load_sd_image_from_file(&mask, params.mask_image_path.c_str());
+        if (have_mask) {
+            gp.mask_image = mask;
+        } else {
+            fprintf(stderr, "diffusion: failed to load mask %s\n",
+                    params.mask_image_path.c_str());
+        }
+    }
     
     sd_image_t* images_out = nullptr;
     int num_images = 0;
     bool ok = generate_image(sd_ctx_, &gp, &images_out, &num_images);
     auto t1 = std::chrono::steady_clock::now();
+    
+    if (have_init) std::free(init.data);
+    if (have_mask) std::free(mask.data);
     
     if (!ok || !images_out || num_images < 1) return {};
     
@@ -185,15 +216,115 @@ DiffusionResult DiffusionEngine::img2img(const DiffusionParams& params,
 
 DiffusionResult DiffusionEngine::txt2vid(const DiffusionParams& params,
                                           DiffusionProgressFn progress) {
-    if (!sd_ctx_ || !supports_video()) return {};
-    // TODO: video generation via generate_video()
-    fprintf(stderr, "diffusion: video generation not yet wired\n");
-    return {};
+    return generate_video_impl(params, nullptr);
 }
 
 DiffusionResult DiffusionEngine::img2vid(const DiffusionParams& params,
                                           DiffusionProgressFn progress) {
-    return {};
+    if (!sd_ctx_ || !supports_video()) return {};
+    sd_image_t init{};
+    bool have_init = false;
+    if (!params.init_image_path.empty()) {
+        have_init = load_sd_image_from_file(&init, params.init_image_path.c_str());
+        if (!have_init) {
+            fprintf(stderr, "diffusion: failed to load init image %s\n",
+                    params.init_image_path.c_str());
+        }
+    }
+    DiffusionResult r = generate_video_impl(params, have_init ? &init : nullptr);
+    if (have_init) std::free(init.data);  // stbi-allocated
+    return r;
+}
+
+DiffusionResult DiffusionEngine::generate_video_impl(const DiffusionParams& params,
+                                                      const sd_image_t* init_image) {
+    if (!sd_ctx_ || !supports_video()) return {};
+    auto t0 = std::chrono::steady_clock::now();
+    
+    sd_vid_gen_params_t vp;
+    sd_vid_gen_params_init(&vp);
+    
+    vp.prompt = params.prompt.c_str();
+    vp.negative_prompt = params.negative_prompt.empty() ? nullptr
+                         : params.negative_prompt.c_str();
+    vp.width = params.width;
+    vp.height = params.height;
+    vp.seed = params.seed;
+    vp.strength = params.strength;
+    vp.video_frames = params.video_frames;
+    vp.fps = params.video_fps;
+    if (init_image) {
+        vp.init_image = *init_image;
+        vp.strength = params.strength;
+    }
+    
+    sd_sample_params_t sp;
+    sd_sample_params_init(&sp);
+    sp.sample_steps = params.steps;
+    sp.sample_method = EULER_A_SAMPLE_METHOD;
+    sp.scheduler = KARRAS_SCHEDULER;
+    sp.guidance.txt_cfg = params.cfg_scale;
+    vp.sample_params = sp;
+    
+    // LoRAs (same pattern as txt2img)
+    std::vector<sd_lora_t> loras;
+    for (size_t i = 0; i < params.lora_paths.size(); i++) {
+        sd_lora_t l;
+        l.path = params.lora_paths[i].c_str();
+        l.multiplier = i < params.lora_weights.size() ?
+                       params.lora_weights[i] : 1.0f;
+        l.is_high_noise = false;
+        loras.push_back(l);
+    }
+    vp.loras = loras.data();
+    vp.lora_count = (uint32_t)loras.size();
+    
+    sd_image_t* frames_out = nullptr;
+    int num_frames = 0;
+    sd_audio_t* audio_out = nullptr;
+    bool ok = generate_video(sd_ctx_, &vp, &frames_out, &num_frames, &audio_out);
+    auto t1 = std::chrono::steady_clock::now();
+    
+    if (!ok || !frames_out || num_frames < 1) {
+        free_sd_audio(audio_out);
+        fprintf(stderr, "diffusion: generate_video failed\n");
+        return {};
+    }
+    
+    DiffusionResult result;
+    result.width = (int)frames_out[0].width;
+    result.height = (int)frames_out[0].height;
+    result.frames = num_frames;
+    
+    // Encode container exactly like sd.cpp's own server: webm/webp when the
+    // submodule build has SD_USE_WEBM/WEBP, else MJPG AVI (video/x-msvideo).
+    result.data = create_video_from_sd_images_to_vector(
+        params.video_output_format, frames_out, num_frames,
+        params.video_fps, params.output_quality, audio_out);
+    free_sd_audio(audio_out);
+    free_sd_images(frames_out, num_frames);
+    
+    if (result.data.empty()) {
+        fprintf(stderr, "diffusion: video encode failed\n");
+        return {};
+    }
+    
+    // Sniff the actual container rather than trusting the requested format:
+    // without SD_USE_WEBM/WEBP every request encodes as MJPG AVI, so a
+    // "webm" request would otherwise come back mislabeled.
+    result.mime_type = "video/x-msvideo";
+    if (result.data.size() >= 4 &&
+        memcmp(result.data.data(), "\x1A\x45\xDF\xA3", 4) == 0) {   // EBML magic
+        result.mime_type = "video/webm";
+    } else if (result.data.size() >= 12 &&
+               memcmp(result.data.data(), "RIFF", 4) == 0 &&
+               memcmp(result.data.data() + 8, "WEBP", 4) == 0) {
+        result.mime_type = "image/webp";
+    }
+    result.generation_time_ms = std::chrono::duration_cast<
+        std::chrono::milliseconds>(t1 - t0).count();
+    result.seed_used = (int)vp.seed;
+    return result;
 }
 
 // ─── Upscaling ────────────────────────────────────────────────────

--- a/tests/vid_encoder_check.cpp
+++ b/tests/vid_encoder_check.cpp
@@ -1,0 +1,55 @@
+// Standalone check for the video-encode path in src/diffusion_bridge.cpp:
+// generate_video() -> create_video_from_sd_images_to_vector("avi", ...).
+// Fails if the AVI/MJPG container isn't produced from RGB frames.
+//
+// Build & run:
+//   g++ -std=c++17 -O1 \
+//     -I third_party/stable-diffusion.cpp/examples/common \
+//     -I third_party/stable-diffusion.cpp/thirdparty \
+//     -I third_party/stable-diffusion.cpp/include \
+//     tests/vid_encoder_check.cpp \
+//     third_party/stable-diffusion.cpp/examples/common/media_io.cpp \
+//     third_party/stable-diffusion.cpp/examples/common/log.cpp \
+//     -o /tmp/vid_encoder_check && /tmp/vid_encoder_check
+#include "media_io.h"
+#include <cstdio>
+#include <cstring>
+#include <vector>
+#include <cassert>
+
+static bool has(const std::vector<uint8_t>& v, const char* fourcc) {
+    for (size_t i = 0; i + 4 <= v.size(); i++)
+        if (memcmp(v.data() + i, fourcc, 4) == 0) return true;
+    return false;
+}
+
+int main() {
+    const int W = 8, H = 8, N = 3;
+    std::vector<sd_image_t> frames(N);
+    std::vector<std::vector<uint8_t>> pixels(N);
+    for (int i = 0; i < N; i++) {
+        pixels[i].assign((size_t)W * H * 3, (uint8_t)(i * 80)); // gray ramp per frame
+        frames[i] = {(uint32_t)W, (uint32_t)H, 3, pixels[i].data()};
+    }
+    auto avi = create_video_from_sd_images_to_vector("avi", frames.data(), N, 16, 90, nullptr);
+    assert(!avi.empty());
+    assert(memcmp(avi.data(), "RIFF", 4) == 0);
+    assert(memcmp(avi.data() + 8, "AVI ", 4) == 0);
+    assert(has(avi, "MJPG"));
+
+#ifdef SD_USE_WEBM
+    // WebM build: real EBML container, playable in browsers/ComfyUI.
+    auto webm = create_video_from_sd_images_to_vector("webm", frames.data(), N, 16, 90, nullptr);
+    assert(!webm.empty());
+    assert(memcmp(webm.data(), "\x1A\x45\xDF\xA3", 4) == 0);
+    printf("ok: avi=%zu bytes MJPG; webm=%zu bytes EBML container\n", avi.size(), webm.size());
+#else
+    // No webm in this build: a webm request must degrade to AVI bytes, not
+    // crash — the bridge sniffs the container, so the mime stays honest.
+    auto webm = create_video_from_sd_images_to_vector("webm", frames.data(), N, 16, 90, nullptr);
+    assert(!webm.empty());
+    assert(memcmp(webm.data(), "RIFF", 4) == 0 && has(webm, "MJPG"));
+    printf("ok: avi=%zu bytes, 3 frames 8x8 MJPG container; webm degrades to AVI\n", avi.size());
+#endif
+    return 0;
+}

--- a/tools/image_server.cpp
+++ b/tools/image_server.cpp
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <mutex>
 #include <unordered_map>
+#include <array>
 
 #include "httplib.h"
 #include "nlohmann/json.hpp"
@@ -48,6 +49,46 @@ static std::string base64_encode(const uint8_t* data, size_t len) {
     return out;
 }
 
+// Minimal base64 decode (std::string in, bytes out)
+static bool base64_decode(const std::string& in, std::string& out) {
+    static const auto tbl = []() {
+        std::array<int8_t, 256> t{};
+        t.fill(-1);
+        const char* abc = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        for (int i = 0; abc[i]; i++) t[(uint8_t)abc[i]] = (int8_t)i;
+        return t;
+    }();
+    out.clear();
+    out.reserve(in.size() / 4 * 3);
+    uint32_t acc = 0;
+    int bits = 0;
+    for (char c : in) {
+        if (c == '=' || c == '\n' || c == '\r') continue;
+        int8_t v = tbl[(uint8_t)c];
+        if (v < 0) return false;
+        acc = (acc << 6) | (uint32_t)v;
+        bits += 6;
+        if (bits >= 8) {
+            bits -= 8;
+            out.push_back((char)((acc >> bits) & 0xFF));
+        }
+    }
+    return true;
+}
+
+// Decode an uploaded base64 image into a temp file; caller unlinks.
+static bool b64_image_to_temp(const std::string& b64, std::string& out_path) {
+    std::string bytes;
+    if (!base64_decode(b64, bytes) || bytes.empty()) return false;
+    static std::atomic<int> seq{0};
+    out_path = "/tmp/onebit_img_" + std::to_string(getpid()) + "_" +
+               std::to_string(seq++) + ".png";
+    std::ofstream f(out_path, std::ios::binary);
+    f.write(bytes.data(), (std::streamsize)bytes.size());
+    f.close();
+    return true;
+}
+
 // ─── Global config ────────────────────────────────────────────────
 static std::string g_models_dir = "./models";
 static int g_port = 8089;
@@ -59,6 +100,8 @@ struct DiffusionModelEntry {
     std::string id;
     std::string path;
     std::string vae_path;
+    std::string t5xxl_path;
+    std::string clip_vision_path;
     std::string description;
 };
 
@@ -113,15 +156,23 @@ static void discover_models(const std::string& dir) {
                 model.description = "SD1.x / default";
             }
             
-            // Look for companion VAE
-            std::string vae_path_str = path.string();
-            auto dot = vae_path_str.find_last_of('.');
-            if (dot != std::string::npos) {
-                vae_path_str = vae_path_str.substr(0, dot) + ".vae" + ext;
-                if (fs::exists(vae_path_str)) {
-                    model.vae_path = vae_path_str;
+            // Look for companion files: <stem>.vae, <stem>.t5, <stem>.clip_vision
+            // (Wan video needs .t5 = umt5-xxl; i2v also needs .clip_vision).
+            // Companions may use a different container than the model, so
+            // probe the common extensions.
+            auto dot = path.string().find_last_of('.');
+            std::string base = dot == std::string::npos ? path.string()
+                            : path.string().substr(0, dot);
+            auto companion = [&](const char* tag) {
+                for (const char* e : {".safetensors", ".gguf", ".ckpt", ".pth"}) {
+                    std::string p = base + "." + tag + e;
+                    if (fs::exists(p)) return p;
                 }
-            }
+                return std::string();
+            };
+            model.vae_path = companion("vae");
+            model.t5xxl_path = companion("t5");
+            model.clip_vision_path = companion("clip_vision");
             
             g_models.push_back(model);
             
@@ -179,7 +230,8 @@ static bool ensure_model_loaded(const std::string& model_id) {
     
     if (!g_engine) g_engine = std::make_unique<DiffusionEngine>();
     printf("Loading model: %s (backend=%s)\n", model_id.c_str(), g_backend_str.c_str());
-    if (!g_engine->load_model(found->path, found->vae_path)) {
+    if (!g_engine->load_model(found->path, found->vae_path,
+                              found->t5xxl_path, found->clip_vision_path)) {
         fprintf(stderr, "Failed to load model '%s'\n", model_id.c_str());
         return false;
     }
@@ -270,6 +322,232 @@ static void handle_image_generation(const httplib::Request& req, httplib::Respon
     }
 }
 
+static void handle_image_edits(const httplib::Request& req, httplib::Response& res) {
+    try {
+        json body = json::parse(req.body);
+        
+        std::string model_id = body.value("model", g_models.empty() ? "" : g_models[0].id);
+        std::string prompt = body.value("prompt", "");
+        std::string negative_prompt = body.value("negative_prompt", "");
+        int width = body.value("width", 512);
+        int height = body.value("height", 512);
+        int steps = body.value("steps", 20);
+        float cfg_scale = body.value("cfg_scale", 7.0f);
+        int seed = body.value("seed", -1);
+        float strength = body.value("strength", 0.75f);
+        
+        std::vector<std::string> lora_paths;
+        std::vector<float> lora_strengths;
+        if (body.contains("lora_paths")) {
+            for (auto& lp : body["lora_paths"]) lora_paths.push_back(lp);
+            for (auto& ls : body["lora_strengths"]) lora_strengths.push_back(ls);
+        }
+        
+        // Init image: server path, or base64 PNG uploaded by the client.
+        std::string init_path = body.value("init_image", "");
+        std::string temp_file;
+        if (init_path.empty() && body.contains("init_image_b64")) {
+            if (!b64_image_to_temp(body["init_image_b64"].get<std::string>(), temp_file)) {
+                json err = {{"error", "failed to decode init_image_b64"}};
+                res.status = 400;
+                res.set_content(err.dump(), "application/json");
+                return;
+            }
+            init_path = temp_file;
+        }
+        if (init_path.empty()) {
+            json err = {{"error", "init_image or init_image_b64 is required"}};
+            res.status = 400;
+            res.set_content(err.dump(), "application/json");
+            return;
+        }
+        
+        // Optional mask (inpainting): path or base64.
+        std::string mask_path = body.value("mask_image", "");
+        std::string temp_mask;
+        if (mask_path.empty() && body.contains("mask_image_b64")) {
+            if (!b64_image_to_temp(body["mask_image_b64"].get<std::string>(), temp_mask)) {
+                json err = {{"error", "failed to decode mask_image_b64"}};
+                res.status = 400;
+                res.set_content(err.dump(), "application/json");
+                return;
+            }
+            mask_path = temp_mask;
+        }
+        
+        if (prompt.empty()) {
+            json err = {{"error", "prompt is required"}};
+            res.status = 400;
+            res.set_content(err.dump(), "application/json");
+            return;
+        }
+        
+        if (!ensure_model_loaded(model_id)) {
+            json err = {{"error", "Failed to load model: " + model_id}};
+            res.status = 500;
+            res.set_content(err.dump(), "application/json");
+            return;
+        }
+        
+        DiffusionParams params;
+        params.prompt = prompt;
+        params.negative_prompt = negative_prompt;
+        params.width = width;
+        params.height = height;
+        params.steps = steps;
+        params.cfg_scale = cfg_scale;
+        params.seed = seed;
+        params.strength = strength;
+        params.init_image_path = init_path;
+        params.mask_image_path = mask_path;
+        params.lora_paths = lora_paths;
+        params.lora_weights = lora_strengths;
+        
+        auto result = g_engine->img2img(params);
+        
+        if (!temp_file.empty()) std::remove(temp_file.c_str());
+        if (!temp_mask.empty()) std::remove(temp_mask.c_str());
+        
+        if (result.data.empty()) {
+            json err = {{"error", "Generation failed (null result)"}};
+            res.status = 500;
+            res.set_content(err.dump(), "application/json");
+            return;
+        }
+        
+        std::string b64 = base64_encode(result.data.data(), result.data.size());
+        json resp = {
+            {"created", std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count()},
+            {"data", json::array({
+                {
+                    {"b64_json", b64},
+                    {"seed", result.seed_used},
+                    {"width", result.width},
+                    {"height", result.height},
+                    {"mime_type", result.mime_type},
+                }
+            })}
+        };
+        
+        res.set_content(resp.dump(), "application/json");
+        
+    } catch (const std::exception& e) {
+        json err = {{"error", std::string("Internal error: ") + e.what()}};
+        res.status = 500;
+        res.set_content(err.dump(), "application/json");
+    }
+}
+
+static void handle_video_generation(const httplib::Request& req, httplib::Response& res) {
+    try {
+        json body = json::parse(req.body);
+        
+        std::string model_id = body.value("model", g_models.empty() ? "" : g_models[0].id);
+        std::string prompt = body.value("prompt", "");
+        std::string negative_prompt = body.value("negative_prompt", "");
+        int width = body.value("width", 832);
+        int height = body.value("height", 480);
+        int steps = body.value("steps", 20);
+        float cfg_scale = body.value("cfg_scale", 7.0f);
+        int seed = body.value("seed", -1);
+        int frames = body.value("frames", 81);
+        int fps = body.value("fps", 16);
+        std::string output_format = body.value("output_format", "avi");
+        float strength = body.value("strength", 0.75f);
+        
+        // Optional first-frame image (image-to-video): path or base64.
+        std::string init_path = body.value("init_image", "");
+        std::string temp_file;
+        if (init_path.empty() && body.contains("init_image_b64")) {
+            if (!b64_image_to_temp(body["init_image_b64"].get<std::string>(), temp_file)) {
+                json err = {{"error", "failed to decode init_image_b64"}};
+                res.status = 400;
+                res.set_content(err.dump(), "application/json");
+                return;
+            }
+            init_path = temp_file;
+        }
+        
+        // Optional LoRA
+        std::vector<std::string> lora_paths;
+        std::vector<float> lora_strengths;
+        if (body.contains("lora_paths")) {
+            for (auto& lp : body["lora_paths"]) lora_paths.push_back(lp);
+            for (auto& ls : body["lora_strengths"]) lora_strengths.push_back(ls);
+        }
+        
+        if (prompt.empty()) {
+            json err = {{"error", "prompt is required"}};
+            res.status = 400;
+            res.set_content(err.dump(), "application/json");
+            return;
+        }
+        
+        if (!ensure_model_loaded(model_id)) {
+            json err = {{"error", "Failed to load model: " + model_id}};
+            res.status = 500;
+            res.set_content(err.dump(), "application/json");
+            return;
+        }
+        
+        DiffusionParams params;
+        params.prompt = prompt;
+        params.negative_prompt = negative_prompt;
+        params.width = width;
+        params.height = height;
+        params.steps = steps;
+        params.cfg_scale = cfg_scale;
+        params.seed = seed;
+        params.video_frames = frames;
+        params.video_fps = fps;
+        params.video_output_format = output_format;
+        params.init_image_path = init_path;
+        params.strength = strength;
+        params.lora_paths = lora_paths;
+        params.lora_weights = lora_strengths;
+        
+        // Image-to-video when a first frame is supplied, text-to-video otherwise.
+        auto result = init_path.empty() ? g_engine->txt2vid(params)
+                                        : g_engine->img2vid(params);
+        
+        if (!temp_file.empty()) std::remove(temp_file.c_str());
+        
+        if (result.data.empty()) {
+            json err = {{"error", "Video generation failed"}};
+            res.status = 500;
+            res.set_content(err.dump(), "application/json");
+            return;
+        }
+        
+        // Build OpenAI-compatible response
+        std::string b64 = base64_encode(result.data.data(), result.data.size());
+        json resp = {
+            {"created", std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count()},
+            {"data", json::array({
+                {
+                    {"b64_json", b64},
+                    {"seed", result.seed_used},
+                    {"width", result.width},
+                    {"height", result.height},
+                    {"frames", result.frames},
+                    {"fps", fps},
+                    {"output_format", output_format},
+                    {"mime_type", result.mime_type},
+                }
+            })}
+        };
+        
+        res.set_content(resp.dump(), "application/json");
+        
+    } catch (const std::exception& e) {
+        json err = {{"error", std::string("Internal error: ") + e.what()}};
+        res.status = 500;
+        res.set_content(err.dump(), "application/json");
+    }
+}
+
 // ─── Main ─────────────────────────────────────────────────────────
 
 static void print_usage(const char* prog) {
@@ -313,6 +591,8 @@ int main(int argc, char** argv) {
     svr.Get("/health", handle_health);
     svr.Get("/v1/models", handle_list_models);
     svr.Post("/v1/images/generations", handle_image_generation);
+    svr.Post("/v1/images/edits", handle_image_edits);
+    svr.Post("/v1/video/generations", handle_video_generation);
     
     // Error handler
     svr.set_exception_handler([](const httplib::Request& req, httplib::Response& res, std::exception_ptr ep) {
@@ -326,6 +606,8 @@ int main(int argc, char** argv) {
     printf("    GET  /health\n");
     printf("    GET  /v1/models\n");
     printf("    POST /v1/images/generations\n");
+    printf("    POST /v1/images/edits\n");
+    printf("    POST /v1/video/generations\n");
     
     svr.listen("0.0.0.0", g_port);
     


### PR DESCRIPTION
### **User description**
## Summary

Wire video generation end-to-end: text-to-video **and** image-to-video (Wan, LTX, Hunyuan) through the existing `image_server` (stable-diffusion.cpp bridge), with browser-previewable WebM output, plus the ComfyUI node to drive it.

**Verified end-to-end on hardware** (Wan 2.1 T2V 1.3B, 512×512, 9f @ 8fps, 10 steps, seed 42):
- CPU: 8m48s
- ROCm (Strix Halo gfx1151 via TheRock SDK): 2m38s (~5-6× sampling)
- Output validated with `file`/`ffprobe`: real WebM (VP8)

## Changes

- **`src/diffusion_bridge.cpp` / `include/diffusion_bridge.h`**
  - `txt2vid()`/`img2vid()` via sd.cpp `generate_video()`; container encode exactly like sd.cpp's own server (WebM/WebP when the submodule build has `SD_USE_WEBM/WEBP`, else MJPG AVI); mime **sniffed from actual bytes** so a `webm` request in a non-webm build can't be mislabeled
  - `img2img()` now loads init image + mask (was a TODO)
  - Bug fix: `cfg_scale` was being written to `strength` (silently dropped); now routed to `sample_params.guidance.txt_cfg`
  - `load_model()` accepts `t5xxl_path`/`clip_vision_path` (Wan requires the umt5-xxl text encoder)

- **`tools/image_server.cpp`**
  - `POST /v1/video/generations` — text-to-video, or image-to-video via `init_image`/`init_image_b64` + `strength` (was advertised in the header comment but didn't exist)
  - `POST /v1/images/edits` — img2img with init image + optional mask, path or base64 upload
  - Model discovery finds companions `<stem>.vae` / `.t5` / `.clip_vision` across common containers

- **`integrations/comfyui/`** — new `OneBP_Video_Generate` node (WebM default, optional first-frame `IMAGE` input for i2v); `OneBP_Image_Generate` gains `init_image` + `strength`

- **`CMakeLists.txt`** — compiles `media_io.cpp`+`log.cpp` into the bridge; prefers `build-rocm` (SD_HIPBLAS, TheRock gfx1151) → `build-webm` → `build`; links `ggml-hip` + HIP runtime (versioned `.so` paths, rpath); WebM/WebP auto-detected from the submodule build

- **`tests/vid_encoder_check.cpp`** — runnable check: 3 synthetic frames → valid RIFF/AVI/MJPG container; WebM request degrades to AVI without `SD_USE_WEBM` (asserts both modes)

## Model files

Wan checkpoints live in `models/diffusion/` (gitignored): `wan2.1_t2v_1.3B_fp16.safetensors` + `<stem>.vae.safetensors` + `<stem>.t5.gguf` (umt5-xxl Q8). Run: `./build/image_server -w models/diffusion -p 8089`.

## Notes

- `img2vid` first-frame loading uses sd.cpp's `load_sd_image_from_file` (stbi)
- Submodule build dirs (`build-rocm`/`build-webm`) are untracked; `CMakeLists` auto-selects what's present


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Wire txt2vid/img2vid via sd.cpp generate_video with WebM/MJPG encode
  - mime sniffed from bytes; cfg_scale fixed to guidance.txt_cfg

- Add image_server endpoints for video generation and img2img edits
  - base64 init_image/mask upload, optional companion model discovery (.t5/.clip_vision)

- Add ComfyUI OneBP_Video_Generate node plus img2img in Image Generate
  - WebM/AVI output saved to ComfyUI output directory

- Extend CMake (ROCm/webm build deps) and add encoder conformance test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Comfy["ComfyUI video/image nodes"] -- "HTTP JSON (b64)" --> API["image_server endpoints /v1/video/generations | /v1/images/edits"]
  API -- "txt2img/img2img/txt2vid/img2vid" --> Bridge["DiffusionEngine bridge"]
  Bridge -- "generate_video()" --> Enc["media_io container encode"]
  Enc -- "WebM / MJPG AVI bytes" --> Resp["b64 response, sniffed mime"]
  Resp -- "saved to output dir" --> Out["ComfyUI output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>diffusion_bridge.cpp</strong><dd><code>Wire video generation and img2img with mask support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1452/files#diff-3586495a963bfc4b6f22cefaaca96ddfaccc545f3b31002212798c7c84061875">+143/-12</a></td>

</tr>

<tr>
  <td><strong>diffusion_bridge.h</strong><dd><code>Add companion encoder params and video pipeline declaration</code></dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1452/files#diff-7ca8123fab887ccbae47a131d3b0fe986db2938aa120399b6ad7b84fdba7b363">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>image_server.cpp</strong><dd><code>Add video generations and images edits endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1452/files#diff-819b10b14c02f14a044fd996123a1357bedc67e2eb7b9754233df2505ce69b7b">+291/-9</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Add OneBP video node and img2img support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1452/files#diff-c28ee83e701f076fac517c7f6a2e455b6e8f1fcd3b5f502b69a8d9226463d906">+115/-2</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Document new video and img2img nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1452/files#diff-4140dfcf8bddc0f4a05fda37642cf9da4ac50d445d9b0b53af0dd4bad49a00eb">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>vid_encoder_check.cpp</strong><dd><code>New conformance test for AVI/MJPG/WebM encoding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1452/files#diff-b082bd7efc7b7175d752bdc5091842a34e76deeca3f0edb9ca2c107d7e9e865f">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CMakeLists.txt</strong><dd><code>Add ROCm, webm compile, and media_io sources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1452/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+63/-11</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>AGENTS.md</strong><dd><code>Refresh GitNexus index statistics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1452/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

