### PR TITLE
fix(vision): per-head 2D RoPE (M-RoPE vision mode) for Qwen2-VL-style mmprojs — issue #1417

### DIFF
--- a/include/vision_encoder.h
+++ b/include/vision_encoder.h
@@ -111,6 +111,12 @@ struct VitConfig {
     bool use_bias    = true;     // whether attention/FFN use bias
     bool use_pre_ln  = false;    // whether there's a pre-LN layer before the transformer
 
+    // Qwen2-VL style: apply per-head 2D (M-RoPE vision-mode) rotation to Q/K at
+    // the patch grid position, instead of learned position embeddings. Set by
+    // load_from_gguf when the mmproj is Qwen2-VL-shaped (dual patch embed,
+    // no v.position_embd.weight). CLIP/SigLIP/Pixtral/MAGE keep false.
+    bool use_2d_rope = false;
+
     // Image normalization constants (for preprocessing)
     float mean[3] = {0.48145466f, 0.45782750f, 0.40821073f}; // CLIP default
     float std[3]  = {0.26862954f, 0.26130258f, 0.27577711f};

--- a/src/vision_encoder.cpp
+++ b/src/vision_encoder.cpp
@@ -154,6 +154,14 @@ bool VisionWeights::load_from_gguf(const std::string& gguf_path, const VitConfig
         pre_ln_b.resize(H, 0.0f);
     }
 
+    // Qwen2-VL-style ViT: dual patch-embed conv (v.patch_embd.weight.1) AND no
+    // learned position embeddings — M-RoPE replaces them (issue #1417). CLIP/
+    // SigLIP/Pixtral have single patch embed + pos_embd, so they stay off.
+    config.use_2d_rope = has_patch_embd1 && !has_pos_embd;
+    if (config.use_2d_rope) {
+        fprintf(stderr, "  [vit] Qwen2-VL-style: per-head 2D RoPE on Q/K (no learned pos_embd)\n");
+    }
+
     // Detect if FFN names are swapped (llama.cpp clip bug: ffn_down is really up, ffn_up is really down)
     // We detect by checking shapes: if v.blk.0.ffn_down.weight has shape [ff, H] instead of [H, ff],
     // it's the real up-projection and names are swapped.
@@ -517,7 +525,21 @@ std::vector<float> vit_forward(const VisionWeights& weights, const float* img,
             std::copy(k.begin(), k.end(), &qkv_buf[(size_t)t * 3 * H + H]);
             std::copy(v.begin(), v.end(), &qkv_buf[(size_t)t * 3 * H + 2*H]);
 
-            // TODO: 2D RoPE could be applied here per-head for Qwen2-VL style
+            // Per-head 2D RoPE (Qwen2-VL-style M-RoPE vision mode): rotate Q/K
+            // with the patch's grid (row, col) — first head_dim/4 frequency
+            // bands keyed to row, next head_dim/4 to col (issue #1417). CLS
+            // (t=0) stays at (0,0) → identity rotation.
+            if (cfg.use_2d_rope) {
+                int row = 0, col = 0;
+                int off = weights.has_cls_embd ? 1 : 0;
+                if (t >= off) { int p = t - off; row = p / pw; col = p % pw; }
+                for (int h = 0; h < NH; h++) {
+                    float* Qh = &qkv_buf[(size_t)t * 3 * H] + (size_t)h * HD;
+                    float* Kh = &qkv_buf[(size_t)t * 3 * H + H] + (size_t)h * HD;
+                    vit_rope2d_apply(Qh, HD, row, col, 10000.0f);
+                    vit_rope2d_apply(Kh, HD, row, col, 10000.0f);
+                }
+            }
         }
 
         // Bidirectional full attention


### PR DESCRIPTION
### **User description**
Fixes #1417 — the TODO at `src/vision_encoder.cpp:520` ("2D RoPE could be applied here per-head for Qwen2-VL style").

## What

The ViT stored Q/K/V per patch token and went straight to bidirectional attention — the per-head 2D RoPE was never applied. Qwen2-VL-style mmprojs have **no** learned position embeddings (M-RoPE replaces them), so their image attention had no spatial signal.

- `VitConfig.use_2d_rope` — new flag, **default false** (CLIP/SigLIP/Pixtral/MAGE behavior bit-identical)
- `load_from_gguf` auto-detects the Qwen2-VL shape: dual patch embed (`v.patch_embd.weight.1`) **and** no `v.position_embd.weight`
- `vit_forward` rotates Q/K per head with the patch grid `(row, col)`: first `head_dim/4` frequency bands keyed to row, next `head_dim/4` to col, "rotate-half" pairing — the exact math already validated in `tools/vision_qwen2vl_poc.cpp` (derived from ggml's `GGML_ROPE_TYPE_VISION`); CLS token stays at `(0,0)` → identity rotation

## Safety

- Gated by default → zero change for existing consumers (Pixtral, ZAYA, MAGE, vision_server CLIP-style)
- Detection is conservative: requires BOTH the dual patch embed AND absence of pos_embd
- Math is verbatim from the POC that was validated against the ggml reference
- Build verified (`vision_encoder` target); no local Qwen2-VL mmproj on this box to run `test_vit_encoder` against — the path activates only when such a file is loaded

Closes #1417.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `VitConfig::use_2d_rope` flag, default false.

- Auto-detect Qwen2-VL mmproj shape in `load_from_gguf`.

- Apply per-head 2D RoPE rotation to Q/K in `vit_forward`.

- Gated behavior keeps CLIP/SigLIP/Pixtral/MAGE unchanged.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["load_from_gguf: dual patch embed, no pos_embd"] --> B["use_2d_rope = true"]
  B --> C["vit_forward: per-head 2D RoPE on Q/K"]
  D["use_2d_rope = false (default)"] --> E["CLIP/SigLIP/Pixtral unchanged"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vision_encoder.h</strong><dd><code>Add use_2d_rope flag to VitConfig</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/vision_encoder.h

<ul><li>Add <code>VitConfig::use_2d_rope</code> boolean flag, defaulting to <code>false</code>.<br> <li> Documents Qwen2-VL-style per-head 2D RoPE behavior and when it is set.<br> <li> Clarifies that CLIP/SigLIP/Pixtral/MAGE keep the flag disabled.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1453/files#diff-d7e653080bfd0d0f6f204bd40039c5e6a94853254291714657de937302e3f04c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vision_encoder.cpp</strong><dd><code>Implement Qwen2-VL 2D RoPE in vision encoder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/vision_encoder.cpp

<ul><li>Auto-detect Qwen2-VL mmproj shape in <code>load_from_gguf</code> via dual patch <br>embed and missing <code>pos_embd</code>.<br> <li> Log a message when the Qwen2-VL-style 2D RoPE path is activated.<br> <li> Apply per-head 2D RoPE rotation to stored Q/K in <code>vit_forward</code> using <br>patch grid <code>(row, col)</code>.<br> <li> CLS token stays at <code>(0,0)</code>, producing identity rotation; removes the old <br>TODO.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1453/files#diff-59e3aed16a1e08ec103472299df5bc585aefbbde9249b5a68f037706adc0536e">+23/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

