### PR TITLE
cleanup(zinc): delete dead load_model/generate stubs in ZincEngine (issue #1421)

### DIFF
--- a/engine/gpu/zinc_cpp/include/vulkan_wrapper.h
+++ b/engine/gpu/zinc_cpp/include/vulkan_wrapper.h
@@ -162,20 +162,12 @@ public:
     /// @param device_idx   GPU device index (-1 = auto-select)
     void init(const std::string& shader_dir, int device_idx = -1);
 
-    /// Load a GGUF model and upload weights to GPU.
-    bool load_model(const std::string& gguf_path);
-
     /// Destroy all resources.
     void destroy();
 
     // ── Inference ──
     /// Reset KV cache and position for a new sequence.
     void reset();
-
-    /// Generate one token from the model.
-    /// @param token_id  Input token ID
-    /// @return Next token ID, or -1 on failure
-    int generate(int token_id);
 
     // ── Accessors ──
     VkDevice device() const { return device_; }

--- a/engine/gpu/zinc_cpp/src/vulkan_wrapper.cpp
+++ b/engine/gpu/zinc_cpp/src/vulkan_wrapper.cpp
@@ -412,18 +412,7 @@ void ZincEngine::init(const std::string& shader_dir, int device_idx) {
     printf("ZINC: Vulkan initialized\n");
 }
 
-bool ZincEngine::load_model(const std::string& gguf_path) {
-    printf("ZINC: Loading model from %s\n", gguf_path.c_str());
-    // TODO: full GGUF parsing and weight upload
-    return true;
-}
-
 void ZincEngine::reset() { model_.current_pos = 0; }
-
-int ZincEngine::generate(int token_id) {
-    (void)token_id;
-    return -1; // placeholder — use InferenceEngine via backend_zinc.cpp
-}
 
 void ZincEngine::destroy() {
     if (device_) vkDeviceWaitIdle(device_);  // fix #776: drain before destroy


### PR DESCRIPTION
### **User description**
Fixes #1421 — `ZincEngine::load_model()` was a no-op that printed and returned `true` without loading anything (the TODO marker); `generate()` returned -1.

Investigation showed both are **dead code**:
- `backend_zinc.cpp` runs inference through `InferenceEngine` (`infer_->generate()` at line 194) — `ZincEngine` is only used for Vulkan infrastructure (device/queue/pipeline cache)
- The zinc demo CLI (`main.cpp`) loads via `ModelLoader`/`ModelGPU`, never `engine->load_model()`

So the stubs are deleted entirely (declaration + definition). Zero behavior change — verified by building `zinc_cpp` + `unified_server` clean (any stray caller would have broken the build).

Closes #1421.


___

### **PR Type**
Other


___

### **Description**
- Remove no-op `load_model` and placeholder `generate` from ZincEngine

- Inference handled by InferenceEngine via backend_zinc.cpp

- Stubs never called; zero behavior change

- Build verified: zinc_cpp and unified_server compile


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ZincEngine::load_model (no-op)"] -- "never called" --> D["Deleted"]
  B["ZincEngine::generate (placeholder)"] -- "never called" --> D
  C["InferenceEngine"] -- "actual inference" --> E["backend_zinc.cpp"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vulkan_wrapper.cpp</strong><dd><code>Delete dead load_model/generate implementations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/gpu/zinc_cpp/src/vulkan_wrapper.cpp

<ul><li>Removed <code>ZincEngine::load_model</code> no-op stub that returned <code>true</code> without <br>loading<br> <li> Removed <code>ZincEngine::generate</code> placeholder returning <code>-1</code><br> <li> No behavior change; inference runs via <code>InferenceEngine</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1456/files#diff-b6efe619151a0ffe0ade029053d634ba7804eebcc4e1e505ef45cf03f71fa54d">+0/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vulkan_wrapper.h</strong><dd><code>Remove stale ZincEngine API declarations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/gpu/zinc_cpp/include/vulkan_wrapper.h

<ul><li>Removed <code>load_model</code> declaration from <code>ZincEngine</code> public API<br> <li> Removed <code>generate</code> declaration from <code>ZincEngine</code> public API<br> <li> Aligns interface with implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1456/files#diff-5e6e9013789c6ed2759307087b80c610aadbefaa72d6ce8d7c1e972358cbadfb">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

