### PR TITLE
feat(onebin): fold gaia_core into the single 1bit ELF — no more second binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1337,6 +1337,23 @@ if(EMBED_LEMONADE)
     target_link_libraries(onebin PRIVATE lemonade-server-core)
     target_compile_definitions(onebin PRIVATE EMBED_LEMONADE=1)
 endif()
+# Gaia C++ agent loop (third_party/gaia) folded into the single ELF instead
+# of shipping gaia-bash as a second binary — see third_party/gaia/UPSTREAM.md
+# local patch #3 for the ONE_BIN_DISPATCH guard on agents/bash/main.cpp.
+if(EMBED_GAIA_CPP)
+    target_sources(onebin PRIVATE
+        third_party/gaia/agents/bash/main.cpp
+        third_party/gaia/agents/bash/bash_agent.cpp
+        third_party/gaia/agents/bash/bash_tools.cpp
+        third_party/gaia/agents/bash/api_server.cpp
+        third_party/gaia/agents/bash/mcp_server.cpp)
+    target_include_directories(onebin PRIVATE third_party/gaia/agents/bash)
+    target_link_libraries(onebin PRIVATE gaia::gaia_core)
+    if(OpenSSL_FOUND)
+        target_compile_definitions(onebin PRIVATE CPPHTTPLIB_OPENSSL_SUPPORT)
+        target_link_libraries(onebin PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+    endif()
+endif()
 target_compile_definitions(onebin PRIVATE
     ONE_BIN_DISPATCH=1
     ROCM_CPP_STATIC_HIP=1

--- a/third_party/gaia/UPSTREAM.md
+++ b/third_party/gaia/UPSTREAM.md
@@ -29,6 +29,11 @@ Vendored patches (re-apply after each sync, listed in `CMakeLists.txt`):
 2. **nlohmann_json**: when `find_package(nlohmann_json)` resolves to the
    top-level build's FetchContent copy (non-exportable), use include-dir-only
    instead of a PUBLIC link so `install(EXPORT)` stays valid.
+3. **onebin dispatch**: `agents/bash/main.cpp`'s `int main()` is guarded by
+   `#ifdef ONE_BIN_DISPATCH` to compile as `gaia_bash_main()` when its
+   sources are linked into the 1bit `onebin` ELF instead of the standalone
+   `gaia-bash` binary (see `tools/onebin.cpp` and the `EMBED_GAIA_CPP` block
+   in the top-level `CMakeLists.txt`).
 
 Included from the top-level `CMakeLists.txt`; options default OFF when built
 as a subproject (tests/examples). TUI (FTXUI) is disabled — engine has its own

--- a/third_party/gaia/agents/bash/main.cpp
+++ b/third_party/gaia/agents/bash/main.cpp
@@ -83,7 +83,11 @@ static int listSessions() {
 // main
 // ---------------------------------------------------------------------------
 
+#ifdef ONE_BIN_DISPATCH
+int gaia_bash_main(int argc, char* argv[]) {
+#else
 int main(int argc, char* argv[]) {
+#endif
     try {
         // Parse arguments
         std::string query;

--- a/tools/onebin.cpp
+++ b/tools/onebin.cpp
@@ -13,6 +13,7 @@
 //   lemonade          → unified_server --lemonade (Lemonade's full server)
 //   jarvis, voice     → jarvis_server (TTS/voice clone + chat server)
 //   vision, vl        → vision_server (vision-language server)
+//   gaia, gaia-bash   → gaia-bash (AMD Gaia C++ agent loop — tools/repl/session)
 //   onebitd, daemon   → onebitd (inference daemon)
 //   everything else   → onebit (agent CLI: chat, up, down, status, build,
 //                        config, auth, serve, pull, list, update)
@@ -29,6 +30,7 @@ int onebitd_main(int argc, char *argv[]);
 int onebit_main(int argc, char *argv[]);
 int jarvis_server_main(int argc, char** argv);
 int vision_server_main(int argc, char** argv);
+int gaia_bash_main(int argc, char** argv);
 
 static std::string prog_name(const char* argv0) {
     std::string p = argv0 ? argv0 : "1bit";
@@ -46,6 +48,7 @@ int main(int argc, char** argv) {
     if (prog == "onebitd")        return onebitd_main(argc, argv);
     if (prog == "jarvis_server")  return jarvis_server_main(argc, argv);
     if (prog == "vision_server")  return vision_server_main(argc, argv);
+    if (prog == "gaia-bash")      return gaia_bash_main(argc, argv);
     if (prog == "onebit" || prog == "1bit") {
         // fall through to subcommand dispatch below
     } else {
@@ -83,6 +86,9 @@ int main(int argc, char** argv) {
         }
         if (cmd == "vision" || cmd == "vl") {
             return vision_server_main(argc - 1, argv + 1);
+        }
+        if (cmd == "gaia" || cmd == "gaia-bash") {
+            return gaia_bash_main(argc - 1, argv + 1);
         }
         // Everything else falls through to the agent CLI (chat, up, down,
         // status, build, config, auth, serve, update, --help).


### PR DESCRIPTION
### **User description**
Closes the gap flagged while auditing why the repo had multiple standalone server binaries despite the "One Binary to rule them all" pitch: `gaia-bash` (vendored `amd/gaia` v0.22.0 C++ port, `third_party/gaia`) was already built via `EMBED_GAIA_CPP=ON` but only as its own standalone executable — a second binary next to `build/1bit`, same shape as the `unified_server`/`zaya_server` split.

## What changed
- `third_party/gaia`'s 5 bash-agent sources are now also compiled into the `onebin` target (gated on `EMBED_GAIA_CPP`, mirroring the `EMBED_LEMONADE` block right above it), linking `gaia::gaia_core`.
- `agents/bash/main.cpp`'s `int main()` is guarded with `#ifdef ONE_BIN_DISPATCH`, the same convention every other folded-in server uses (`zaya_server.cpp`, `unified_server.cpp`, `jarvis_server.cpp`, `vision_server.cpp`, `unified_router.cpp`) — compiles as `gaia_bash_main()` inside `onebin`, as `main()` when built standalone. This is a local patch on a vendored file, documented as patch #3 in `third_party/gaia/UPSTREAM.md` so re-vendoring from upstream doesn't silently drop it.
- New dispatch in `tools/onebin.cpp`: `1bit gaia` / `1bit gaia-bash` subcommands, plus the `gaia-bash` legacy argv[0] symlink name.

## Not in scope for this PR
This links `gaia_core` into the one ELF — it does **not** yet retire the hand-rolled agent code in `onebit.cpp`/`jarvis_server.cpp` that `gaia_core` could replace (the larger PLAN-GAIA.md migration). That's a separate, bigger piece of surgery to scope out on its own.

## Verification
- `cmake -B build` configures clean (`GAIA SSL: enabled`, no new warnings/errors from the added block).
- `cmake --build build --target onebin -j$(nproc)` — all 5 new sources compile and link with 0 errors (only pre-existing, unrelated warnings elsewhere).
- `./build/1bit gaia --help` dispatches correctly to the gaia-bash CLI help text.
- `build/1bit` grew 70MB → 71.1MB, consistent with real code being linked in (not a no-op).
- GitNexus `detect_changes()`: LOW risk, 0 downstream impact — purely additive dispatch branches, `main()` in `onebin.cpp` had 0 upstream callers per `impact()` before editing.


___

### **PR Type**
Enhancement


___

### **Description**
- Embed gaia-bash sources into onebin target

- Guard Gaia main as gaia_bash_main for dispatch

- Add gaia/gaia-bash entries to onebin dispatch

- Document vendored ONE_BIN_DISPATCH patch


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Gaia["gaia-bash sources"] -- "EMBED_GAIA_CPP" --> Onebin["onebin target"]
  Main["agents/bash/main.cpp"] -- "ONE_BIN_DISPATCH" --> GBM["gaia_bash_main"]
  Onebin -- "gaia / gaia-bash dispatch" --> GBM
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.cpp</strong><dd><code>Guard Gaia bash main for onebin dispatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/gaia/agents/bash/main.cpp

<ul><li>Guarded <code>main()</code> with <code>#ifdef ONE_BIN_DISPATCH</code><br> <li> Exposes <code>gaia_bash_main()</code> when built into onebin<br> <li> Preserves standalone <code>main()</code> entry otherwise</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1464/files#diff-d75142bd7aaa5b9327509aa087db42a560dd467d47602d17bd90b45a85520ab4">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>onebin.cpp</strong><dd><code>Add gaia and gaia-bash dispatch entries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/onebin.cpp

<ul><li>Declared <code>gaia_bash_main()</code> prototype<br> <li> Added <code>gaia-bash</code> argv[0] symlink dispatch<br> <li> Added <code>gaia</code> and <code>gaia-bash</code> subcommands<br> <li> Updated dispatch header comment</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1464/files#diff-9b80912c6324c3f6e4d3f349e8ee750818e431e508d1679cd23d181305c3828f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Embed Gaia bash sources into onebin target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CMakeLists.txt

<ul><li>Added <code>EMBED_GAIA_CPP</code> block for gaia-bash sources<br> <li> Compiled five bash-agent sources into onebin<br> <li> Linked <code>gaia::gaia_core</code> and OpenSSL when found<br> <li> Mirrored existing <code>EMBED_LEMONADE</code> pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1464/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UPSTREAM.md</strong><dd><code>Document Gaia onebin vendored patch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/gaia/UPSTREAM.md

<ul><li>Documented vendored patch #3 for ONE_BIN_DISPATCH<br> <li> Notes re-vendoring must re-apply the main guard</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1464/files#diff-366f374e78468bc3b1b0c9baae65b4ee36dda49edfa1d93fbd2034392bd12b35">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

