### PR TITLE
feat(build): one ELF only — remove the 7 redundant standalone server binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,15 +93,17 @@ jobs:
             # Build the server AND every test_* target so a dropped source or a
             # compile break fails CI (issue #236).
             # Also build all new C++ tools to catch compile errors.
-            ninja -C build zaya_server \
+            # zaya_server/onebitd/onebit/unified_router/vision_server are no
+            # longer separate targets — their sources compile into onebin/1bit
+            # only (see CMakeLists.txt). Build onebin instead of listing them.
+            ninja -C build onebin \
               test_medusa_skeleton test_standalone_nock test_prim_and_attn \
               test_ternary_gemm_smallm test_sherry_gemv test_bonsai_gemv \
               test_zaya_moe_gemv test_cca_attn test_wmma_i8_gemv \
               test_bonsai_e2e test_sherry_e2e test_block_scaled_ternary \
               test_gguf_reader_dequant test_tokenizer_logprobs test_backend \
               test_lora_runtime test_auth test_billing \
-              onebitd onebit onebin unified_router ppl_generic gguf_to_onebp \
-              vision_server vl_logit_check
+              ppl_generic gguf_to_onebp vl_logit_check
           else
             echo "ROCm not available on this runner — reference checks only."
             if [ -f tests/test_medusa_skeleton.cpp ]; then

--- a/.github/workflows/end-to-end-smoke.yml
+++ b/.github/workflows/end-to-end-smoke.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           source env.sh
           cmake -B build -G Ninja
-          cmake --build build --target unified_server vision_server -j$(nproc)
+          cmake --build build --target onebin -j$(nproc)
 
       - name: Download test model
         # Model files are git-ignored (symlinked to HF cache locally).
@@ -54,23 +54,23 @@ jobs:
         # unconditionally in Cleanup below.
         run: |
           sudo systemctl stop 1bit-systems.service || true
-          # Also kill stray manual servers (vision_server etc.) that can
+          # Also kill stray manual servers (`1bit vision` etc.) that can
           # squat on 8099 and answer health checks with the wrong schema.
-          pkill -f "[v]ision_server.*8099" || true
+          pkill -f "1bit [v]ision.*8099" || true
           # -9 fallback: a wedged instance can survive SIGTERM and squat on 8099
           # with the wrong health schema (issue #1257 incident class).
-          pkill -9 -f "[v]ision_server.*8099" || true
-          # Stray unified_server instances from manual runs/dev agents on this
+          pkill -9 -f "1bit [v]ision.*8099" || true
+          # Stray `1bit unified` instances from manual runs/dev agents on this
           # shared box answer health with the right schema but die mid-test
           # (curl 56), or hold the port so our server can't bind.
-          pkill -f "[u]nified_server.*8099" || true
-          pkill -9 -f "[u]nified_server.*8099" || true
+          pkill -f "1bit [u]nified.*8099" || true
+          pkill -9 -f "1bit [u]nified.*8099" || true
           sleep 2
 
       - name: Start server
         run: |
           rm -f /tmp/unified_server.lock
-          ./build/unified_server --port 8099 --weights models/ \
+          ./build/1bit unified --port 8099 --weights models/ \
             --gen-timeout-ms 10000 --quick &>/tmp/smoke_server.log &
           echo "pid=$!"
           # Wait for startup (GPU init can take ~90s on Strix Halo)
@@ -186,9 +186,9 @@ jobs:
             exit 0
           fi
           # Free the GPU for the VL stack.
-          pkill -f "unified_server.*8099" 2>/dev/null || true
+          pkill -f "1bit unified.*8099" 2>/dev/null || true
           sleep 2
-          ./build/vision_server --port 8099 --mmproj "$VIT" --model "$MM" \
+          ./build/1bit vision --port 8099 --mmproj "$VIT" --model "$MM" \
             &>/tmp/smoke_vision_server.log &
           echo "pid=$!"
           for i in $(seq 1 60); do
@@ -213,11 +213,11 @@ jobs:
           assert 'data' in d and len(d['data']) > 0, 'no models listed'
           print('OK: vision_server models endpoint:', d['data'][0].get('id'))
           "
-          pkill -f "vision_server.*8099" 2>/dev/null || true
+          pkill -f "1bit vision.*8099" 2>/dev/null || true
       - name: Cleanup
         if: always()
         run: |
-          pkill -f "unified_server.*8099" 2>/dev/null || true
-          pkill -f "[v]ision_server.*8099" 2>/dev/null || true
+          pkill -f "1bit unified.*8099" 2>/dev/null || true
+          pkill -f "1bit [v]ision.*8099" 2>/dev/null || true
           rm -f /tmp/unified_server.lock
           sudo systemctl start 1bit-systems.service || true

--- a/.github/workflows/end-to-end-smoke.yml
+++ b/.github/workflows/end-to-end-smoke.yml
@@ -82,6 +82,16 @@ jobs:
             fi
           done
 
+      - name: Show server log + kernel messages (diagnostic)
+        if: always()
+        run: |
+          echo "=== /tmp/smoke_server.log (last 150 lines) ==="
+          tail -150 /tmp/smoke_server.log 2>/dev/null || echo "(no log file)"
+          echo "=== dmesg (last 60 lines, may need sudo) ==="
+          sudo dmesg 2>/dev/null | tail -60 || dmesg 2>/dev/null | tail -60 || echo "(dmesg unavailable)"
+          echo "=== coredumpctl list (recent) ==="
+          coredumpctl list --no-pager 2>/dev/null | tail -10 || echo "(coredumpctl unavailable)"
+
       - name: Dump server model info
         run: |
           echo "=== Active backend ==="

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,35 +80,20 @@ jobs:
             -DCMAKE_PREFIX_PATH="$ROCM_PATH" \
             -DCMAKE_CXX_FLAGS="-I$ROCM_PATH/include" \
             -DCMAKE_HIP_FLAGS="--rocm-path=$ROCM_PATH"
-          # Build the core library, inference servers, and all new C++ tools
+          # Build the core library and the single onebin/1bit ELF (every
+          # server + CLI dispatched by subcommand — no separate binaries).
           ninja -C build \
             rocm_cpp \
-            zaya_server \
-            onebitd \
-            onebit \
             onebin \
-            unified_router \
-            unified_server \
-            zaya_agent \
             bitnet_tui
 
       - name: Package
         run: |
           mkdir -p dist/bin dist/lib
-          # C++ CLI agent (replaces Rust onebit)
+          # One binary: every server + CLI (zaya, unified, router, jarvis,
+          # vision, gaia, onebitd, onebit) dispatched by subcommand.
           cp build/1bit dist/bin/
-          cp build/onebit dist/bin/
-          # C++ daemon (spawns inference backend as subprocess)
-          cp build/onebitd dist/bin/
-          # C++ content-aware routing proxy (replaces unified-router.py)
-          cp build/unified_router dist/bin/
-          # HIP/C++ inference engine + OpenAI-compatible server
-          cp build/zaya_server dist/bin/
-          cp build/zaya_agent dist/bin/ 2>/dev/null || true
-          cp build/unified_server dist/bin/ 2>/dev/null || true
-          # Content-aware routing proxy (Lemonade policy engine when embedded)
-          cp build/unified_router dist/bin/ 2>/dev/null || true
-          # TUI frontend
+          # TUI frontend (separate binary, not folded into onebin)
           cp build/bitnet_tui dist/bin/ 2>/dev/null || true
           # Shared HIP kernel library
           cp build/librocm_cpp.so dist/lib/
@@ -190,17 +175,13 @@ jobs:
             - **AppImage** (`.AppImage`) — `chmod +x`, run directly, no install needed
 
             ### Includes
-            - `1bit` — C++ NPU-native coding agent CLI (chat, up, down, status, build, config, serve)
-            - `onebitd` — C++ inference daemon (spawns zaya_server, proxies HTTP)
-            - `zaya_server` — C++ HIP inference engine + OpenAI-compatible server;
-              `--lemonade` runs the embedded Lemonade server core in-process
-            - `unified_server` — multi-backend server with the **embedded Lemonade
-              server core** (llama.cpp, FastFlowLM, whisper.cpp, stable-diffusion.cpp,
-              kokoro, ryzenai-llm, vllm backends + policy router); `--lemonade` runs
-              Lemonade's full server in-process
-            - `unified_router` — NPU+GPU routing proxy; decisions run through
-              Lemonade's policy engine (keyword classifier → GPU, default → NPU)
-            - `bitnet_tui` — C++ FTXUI terminal chat UI
+            - `1bit` — one ELF, every server + CLI, dispatched by subcommand:
+              - `1bit` (no args) — NPU-native coding agent CLI (chat, up, down, status, build, config, serve)
+              - `1bit zaya` — C++ HIP inference engine + OpenAI-compatible server; `--lemonade` runs the embedded Lemonade server core in-process
+              - `1bit unified` — multi-backend server with the **embedded Lemonade server core** (llama.cpp, FastFlowLM, whisper.cpp, stable-diffusion.cpp, kokoro, ryzenai-llm, vllm backends + policy router); `--lemonade` runs Lemonade's full server in-process
+              - `1bit router` — NPU+GPU routing proxy; decisions run through Lemonade's policy engine (keyword classifier → GPU, default → NPU)
+              - `1bit jarvis` / `1bit vision` / `1bit gaia` / `1bit onebitd` — agent server, vision-language server, Gaia C++ agent loop, inference daemon
+            - `bitnet_tui` — C++ FTXUI terminal chat UI (separate binary)
             - `librocm_cpp.so` — ternary GEMV/GEMM HIP kernels
             - install script, docs, license
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -739,24 +739,11 @@ if(ZINC_CPP_AVAILABLE)
 endif()
 # HIP backend: adapter (InferenceBackend) + canonical src (Backend + zaya_engine)
 list(APPEND ZAYA_SERVER_SRC tests/backends/backend_hip_adapter.cpp src/backend_hip.cpp src/zaya_engine.cpp)
-add_executable(zaya_server ${ZAYA_SERVER_SRC})
 set_source_files_properties(tests/zaya_server.cpp tests/backends/backend_hip_adapter.cpp src/backend_hip.cpp src/zaya_engine.cpp PROPERTIES LANGUAGE HIP)
-target_include_directories(zaya_server PRIVATE
-    ${CMAKE_SOURCE_DIR}/tests
-    ${CMAKE_SOURCE_DIR}/tests/backends
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/src
-    ${CMAKE_SOURCE_DIR}/kernels)
-target_compile_options(zaya_server PRIVATE $<$<COMPILE_LANGUAGE:HIP>:-O3 -Wno-unused-result>)
-target_link_libraries(zaya_server PRIVATE rocm_cpp hip::host hip::device httplib::httplib nlohmann_json::nlohmann_json)
-set_target_properties(zaya_server PROPERTIES HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
-install(TARGETS zaya_server RUNTIME DESTINATION bin)
-if(RCPP_HAVE_VULKAN)
-    target_link_libraries(zaya_server PRIVATE Vulkan::Vulkan)
-    if(VIDEO_LORA_VK_AVAILABLE)
-        target_link_libraries(zaya_server PRIVATE video_lora_vk)
-    endif()
-endif()
+# zaya_server is no longer a standalone add_executable target — its full
+# source list (ZAYA_SERVER_SRC, kept above) is compiled into onebin/1bit
+# only; run it via `1bit zaya` (see tools/onebin.cpp). No second binary,
+# no symlink — the standalone target was pure duplication of onebin.
 
 rocm_hip_target(test_wmma_i8_gemv tests/test_wmma_i8_gemv.cpp)
 rocm_hip_target(test_bonsai_e2e tests/test_bonsai_e2e.cpp)
@@ -970,9 +957,12 @@ else()
     message(STATUS "rocm-cpp: fused GPU+NPU backend disabled (XRT headers or AIEBU missing)")
 endif()
 
-# unified_server — CUDA/Metal come through backend_manager (PR #579 pattern),
-# so they don't appear in sources or link line here.
-add_executable(unified_server ${UNIFIED_SERVER_SOURCES})
+# unified_server sources (UNIFIED_SERVER_SOURCES, kept above) compile into
+# onebin/1bit only — run via `1bit unified` (see tools/onebin.cpp). No
+# standalone add_executable here: it was pure duplication of onebin, the
+# same problem the zaya_server split had.
+# CUDA/Metal come through backend_manager (PR #579 pattern), so they don't
+# appear in sources or link line here.
 set_source_files_properties(src/backend_hip.cpp PROPERTIES LANGUAGE HIP)
 set_source_files_properties(src/backend_hip_1bp.cpp PROPERTIES LANGUAGE HIP)
 set_source_files_properties(src/zaya_engine.cpp PROPERTIES LANGUAGE HIP)
@@ -983,26 +973,6 @@ set_source_files_properties(src/backend_npu_flm.cpp PROPERTIES LANGUAGE CXX)
 set_source_files_properties(src/unified_pool.cpp PROPERTIES LANGUAGE CXX)
 set_source_files_properties(src/backend_fused_npu.cpp PROPERTIES LANGUAGE CXX)
 set_source_files_properties(src/backend_fused.cpp PROPERTIES LANGUAGE HIP)
-target_include_directories(unified_server PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/kernels>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/engine/npu/src>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party/llama.cpp/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party/llama.cpp/ggml/include>
-    $<INSTALL_INTERFACE:include>)
-target_compile_options(unified_server PRIVATE
-    $<$<COMPILE_LANGUAGE:HIP>:-O3 -Wno-unused-result>
-    $<$<COMPILE_LANGUAGE:CXX>:-O3 -Wall -Wno-unused-result -std=c++23>)
-if(TARGET ggml_vulkan)
-    target_link_libraries(unified_server PRIVATE ggml_vulkan ggml ggml_cpu ggml_base)
-    # Also link llama.cpp lib for model loading
-    target_link_libraries(unified_server PRIVATE
-        "${GGML_BUILD_DIR}/src/libllama.a"
-        "${GGML_BUILD_DIR}/common/libllama-common.a"
-        "${GGML_BUILD_DIR}/common/libllama-common-base.a"
-        -lvulkan -ldl -lpthread -lm)
-endif()
 # FastFlowLM (flm) is now an official AMD/ROCm project, shipped prebuilt:
 #   - built into the TheRock dist (7.14 / 7.15a) at <therock-root>/bin/flm
 #   - as the fastflowlm .deb (github.com/FastFlowLM/FastFlowLM releases — the
@@ -1070,8 +1040,6 @@ if(EXISTS "${FLM_BUILD_DIR}/flm")
         COMMENT "Building FastFlowLM NPU engine"
         BYPRODUCTS ${FLM_BINARY}
     )
-    add_dependencies(unified_server build_flm)
-    
     # ── hotpatch target: update FLM submodule to latest main + rebuild ──
     # Keeps npu_flm backend on the latest ROCm/FLM source.
     # Run: cmake --build build --target update_flm
@@ -1085,73 +1053,46 @@ if(EXISTS "${FLM_BUILD_DIR}/flm")
         # no BYPRODUCTS: build_flm already declares ${FLM_BINARY}, and a
         # second rule for the same output breaks the Ninja generator (issue #1284)
     )
-    add_dependencies(unified_server update_flm)
 else()
     message(STATUS "flm: FLM comes from TheRock or is unavailable — skipping submodule build targets")
 endif()
 
-target_compile_definitions(unified_server PRIVATE
-    ROCM_CPP_STATIC_HIP=1
-    ROCM_CPP_STATIC_NPU=1
-    FLM_BINARY_PATH="${FLM_BINARY}"
-    FLM_CONFIG_PATH="${FLM_CONFIG}"
-    FLM_XCLBIN_PATH="${FLM_XCLBINS}"
-)
-
 # ── Lemonade SDK embed ─────────────────────────────────────────────────────
-# unified_server embeds Lemonade's server core (vendored from
-# github.com/lemonade-sdk/lemonade, see third_party/lemonade/UPSTREAM.md):
-# all 14 Lemonade backends
-# (llamacpp, flm, whispercpp, sd-cpp, kokoro, ryzenai-llm, vllm, ...) and
-# its policy-based Router run in-process — `unified_server --lemonade` hands
-# off to the full Lemonade server. unified_router uses the same routing
-# engine for NPU/GPU decisions. OFF by default so plain builds are unchanged.
+# Lemonade's server core (vendored from github.com/lemonade-sdk/lemonade, see
+# third_party/lemonade/UPSTREAM.md): all 14 Lemonade backends (llamacpp, flm,
+# whispercpp, sd-cpp, kokoro, ryzenai-llm, vllm, ...) and its policy-based
+# Router, embedded in-process — `1bit unified --lemonade` hands off to the
+# full Lemonade server; unified_router uses the same routing engine for
+# NPU/GPU decisions. onebin links lemonade-server-core itself, further down.
 option(EMBED_LEMONADE "Embed the Lemonade SDK server core" ON)
 if(EMBED_LEMONADE)
     set(BUILD_WEB_APP OFF CACHE BOOL "" FORCE)
     set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
     add_subdirectory(third_party/lemonade EXCLUDE_FROM_ALL)
-    target_link_libraries(unified_server PRIVATE lemonade-server-core)
-    target_compile_definitions(unified_server PRIVATE EMBED_LEMONADE=1)
-    # The flagship single binary gets the full Lemonade core too:
-    # `zaya_server --lemonade` runs Lemonade's server in-process.
-    target_link_libraries(zaya_server PRIVATE lemonade-server-core)
-    target_compile_definitions(zaya_server PRIVATE EMBED_LEMONADE=1)
 endif()
 
 # ── Gaia C++ agent framework (AMD official) ────────────────────────────────
 # Vendored from amd/gaia v0.22.0 cpp/ tree (third_party/gaia/UPSTREAM.md):
 # gaia::gaia_core + gaia-bash coding agent. Replaces the hand-rolled agent
 # layer (onebit/jarvis) — the agent talks to the engine through the
-# Lemonade-compatible endpoint (zaya_server --lemonade serve, :13305).
+# Lemonade-compatible endpoint (`1bit unified --lemonade serve`, :13305).
 # TUI (FTXUI) off: engine has its own console; flip with -DGAIA_BUILD_TUI=ON.
+# gaia-bash's own standalone binary is off too — its sources are linked
+# into onebin instead (see EMBED_GAIA_CPP block further down); no second
+# binary, matching the zaya_server/unified_server fix above.
 option(EMBED_GAIA_CPP "Build the vendored Gaia C++ agent framework" ON)
 if(EMBED_GAIA_CPP)
     set(GAIA_BUILD_TUI OFF CACHE BOOL "" FORCE)
+    set(GAIA_BUILD_BASH_AGENT OFF CACHE BOOL "" FORCE)
     add_subdirectory(third_party/gaia)
 endif()
-target_link_libraries(unified_server PRIVATE
-    backend_manager vl_image vision_encoder dl
-    httplib::httplib
-    nlohmann_json::nlohmann_json
-    rocm_cpp hip::host hip::device hipblas)
-
-target_link_options(unified_server PRIVATE -rdynamic -luuid)
-set_target_properties(unified_server PROPERTIES HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
-if(ZINC_CPP_AVAILABLE)
-    target_link_libraries(unified_server PRIVATE zinc_cpp)
-    target_include_directories(unified_server PRIVATE engine/gpu/zinc_cpp/include)
-endif()
-
-add_custom_target(zaya_agent ALL
-    DEPENDS unified_server
-    COMMAND ${CMAKE_COMMAND} -E copy
-        "$<TARGET_FILE:unified_server>"
-        "${CMAKE_BINARY_DIR}/zaya_agent"
-    COMMENT "Creating zaya_agent -> unified_server copy")
-set_property(TARGET unified_server APPEND PROPERTY
-    LINK_OPTIONS "-Wl,-rpath,\$ORIGIN")
+# unified_server's remaining link/rpath config (backend_manager, hipblas,
+# ZINC, TheRock rpath) lives on the onebin target only now — see the onebin
+# block further down. No standalone unified_server executable, no
+# zaya_agent copy target, no symlinks: the source lists (kept above) are
+# compiled into onebin/1bit and nothing else.
 # TheRock SDK runtime lib path — find libhipblas.so.3 and add its dir to rpath
+# (consumed by onebin's own rpath block further down).
 find_library(THEROCK_HIPBLAS_LIB hipblas PATHS
     "${THEROCK_SDK_BASE}/lib"
     "/opt/rocm-therock/lib/python3.14/site-packages/_rocm_sdk_devel/lib"
@@ -1159,9 +1100,6 @@ find_library(THEROCK_HIPBLAS_LIB hipblas PATHS
     NO_DEFAULT_PATH)
 if(THEROCK_HIPBLAS_LIB)
     get_filename_component(THEROCK_LIB_DIR "${THEROCK_HIPBLAS_LIB}" DIRECTORY)
-    set_property(TARGET unified_server APPEND PROPERTY
-        LINK_OPTIONS "-Wl,-rpath,${THEROCK_LIB_DIR}")
-    message(STATUS "unified_server rpath: ${THEROCK_LIB_DIR}")
 endif()
 
 
@@ -1234,35 +1172,19 @@ target_link_libraries(vision_qwen2vl_poc PRIVATE backend_manager vl_image dl)
 # OpenAI-compatible /v1/chat/completions with image_url support.
 # Auto-detects GPU (HIP) and falls back to CPU for image preprocessing.
 # Requires a VL-capable text model + mmproj GGUF file.
-add_executable(vision_server tools/vision_server.cpp src/tokenizer.cpp)
+# No standalone add_executable — tools/vision_server.cpp compiles into
+# onebin/1bit only; run via `1bit vision`.
 
 # -- vl_logit_check : logit-level 1BP-vs-BF16 decoder validation -----------
 add_executable(vl_logit_check tools/vl_logit_check.cpp src/tokenizer.cpp)
 target_include_directories(vl_logit_check PRIVATE src/ include/ engine/npu/src)
 target_compile_options(vl_logit_check PRIVATE -O3 -Wall -Wno-unused-result -std=c++23)
 target_link_libraries(vl_logit_check PRIVATE backend_manager onebp_model dl)
-target_include_directories(vision_server PRIVATE src/ include/ engine/npu/src)
-target_compile_options(vision_server PRIVATE -O3 -Wall -Wno-unused-result -std=c++23)
-target_link_libraries(vision_server PRIVATE
-    backend_manager vl_image vision_encoder dl
-    httplib::httplib
-    nlohmann_json::nlohmann_json)
 
 # -- unified_router : NPU+GPU content-aware routing proxy -------------------
-# Pure C++ replacement for unified-router.py. Uses cpp-httplib as HTTP
-# server and client, nlohmann-json for JSON parsing. No Python needed.
-add_executable(unified_router tools/unified_router.cpp)
-target_include_directories(unified_router PRIVATE src/ include/)
-target_compile_options(unified_router PRIVATE -O3 -Wall -Wno-unused-result -std=c++23)
-target_link_libraries(unified_router PRIVATE
-    httplib::httplib
-    nlohmann_json::nlohmann_json)
-
-# Route through Lemonade's policy engine (lemonade-server-core) when embedded.
-if(EMBED_LEMONADE)
-    target_link_libraries(unified_router PRIVATE lemonade-server-core)
-    target_compile_definitions(unified_router PRIVATE EMBED_LEMONADE=1)
-endif()
+# Pure C++ replacement for unified-router.py. No standalone add_executable
+# — tools/unified_router.cpp compiles into onebin/1bit only; run via
+# `1bit router`. Its EMBED_LEMONADE linkage lives on the onebin target.
 
 # -- onebin : the single binary --------------------------------------------
 # Every entry point in one ELF: zaya_server + unified_server + unified_router
@@ -1296,6 +1218,7 @@ set(ONE_BIN_SOURCES
     tools/onebitd.cpp)
 add_executable(onebin ${ONE_BIN_SOURCES})
 set_target_properties(onebin PROPERTIES OUTPUT_NAME "1bit")
+install(TARGETS onebin RUNTIME DESTINATION bin)
 # Language props: union of zaya_server + unified_server
 set_source_files_properties(tests/zaya_server.cpp tests/backends/backend_hip_adapter.cpp
     src/backend_hip.cpp src/zaya_engine.cpp PROPERTIES LANGUAGE HIP)
@@ -1337,6 +1260,23 @@ if(EMBED_LEMONADE)
     target_link_libraries(onebin PRIVATE lemonade-server-core)
     target_compile_definitions(onebin PRIVATE EMBED_LEMONADE=1)
 endif()
+# Gaia C++ agent loop (third_party/gaia) folded into the single ELF instead
+# of shipping gaia-bash as a second binary — see third_party/gaia/UPSTREAM.md
+# local patch #3 for the ONE_BIN_DISPATCH guard on agents/bash/main.cpp.
+if(EMBED_GAIA_CPP)
+    target_sources(onebin PRIVATE
+        third_party/gaia/agents/bash/main.cpp
+        third_party/gaia/agents/bash/bash_agent.cpp
+        third_party/gaia/agents/bash/bash_tools.cpp
+        third_party/gaia/agents/bash/api_server.cpp
+        third_party/gaia/agents/bash/mcp_server.cpp)
+    target_include_directories(onebin PRIVATE third_party/gaia/agents/bash)
+    target_link_libraries(onebin PRIVATE gaia::gaia_core)
+    if(OpenSSL_FOUND)
+        target_compile_definitions(onebin PRIVATE CPPHTTPLIB_OPENSSL_SUPPORT)
+        target_link_libraries(onebin PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+    endif()
+endif()
 target_compile_definitions(onebin PRIVATE
     ONE_BIN_DISPATCH=1
     ROCM_CPP_STATIC_HIP=1
@@ -1359,11 +1299,8 @@ if(EXISTS "${FLM_BUILD_DIR}/flm")
 endif()
 
 # -- onebitd : 1bit inference daemon (spawns backend, proxies HTTP) --------
-# Pure C++ daemon — spawns backend, proxies HTTP.
-add_executable(onebitd tools/onebitd.cpp)
-target_include_directories(onebitd PRIVATE src/ include/)
-target_compile_options(onebitd PRIVATE -O3 -Wall -Wno-unused-result -std=c++23)
-target_link_libraries(onebitd PRIVATE httplib::httplib)
+# No standalone add_executable — tools/onebitd.cpp compiles into onebin/1bit
+# only; run via `1bit onebitd` / `1bit daemon`.
 
 # -- jarvis_server : local private AI agent server (RAG, tools, planner) ---
 # C++ port of the deleted jarvis/ Python package (recovered from git
@@ -1383,33 +1320,9 @@ else()
     message(STATUS "codec: ONNX Runtime NOT found — codec decoder will return empty PCM")
 endif()
 
-add_executable(jarvis_server
-    tools/jarvis_server.cpp
-    tools/jarvis/rag.cpp
-    tools/jarvis/tools.cpp
-    tools/jarvis/routing.cpp
-    tools/jarvis/planner.cpp
-    tools/jarvis/beacon.cpp
-    tools/jarvis/tts.cpp
-    tools/jarvis/audio_out.cpp
-    tools/jarvis/audio_stream.cpp
-    tools/jarvis/codec_tts.cpp
-    tools/jarvis/persona.cpp
-    tools/jarvis/vad.cpp
-    tools/jarvis/context.cpp
-    tools/jarvis/auth.cpp
-    tools/jarvis/usage.cpp
-    tools/jarvis/billing.cpp
-    src/codec_decoder.cpp)
-target_include_directories(jarvis_server PRIVATE tools/ src/)
-target_compile_options(jarvis_server PRIVATE -O3 -Wall -Wno-unused-result -std=c++23 -fopenmp)
-target_link_libraries(jarvis_server PRIVATE
-    httplib::httplib
-    nlohmann_json::nlohmann_json
-    whisper)
-if(onnxruntime_FOUND)
-    target_link_libraries(jarvis_server PRIVATE onnxruntime::onnxruntime)
-endif()
+# No standalone add_executable — jarvis_server.cpp + tools/jarvis/*.cpp +
+# src/codec_decoder.cpp (all listed in ONE_BIN_SOURCES above) compile into
+# onebin/1bit only; run via `1bit jarvis` / `1bit voice`.
 
 # -- zaya1_vl_demo : ZAYA1-VL-8B vision-language inference demo -------------
 add_executable(zaya1_vl_demo tools/zaya1_vl_demo.cpp)
@@ -1451,18 +1364,9 @@ target_link_libraries(vl_pipeline_test PRIVATE
 
 
 # -- onebit : NPU-native terminal coding agent CLI -------------------------
-# Pure C++ agent CLI. Single binary — chat, up, down,
-# status, build, config, auth, serve, update.
-add_executable(onebit tools/onebit.cpp)
-target_include_directories(onebit PRIVATE src/ include/)
-target_compile_options(onebit PRIVATE -O3 -Wall -Wno-unused-result -std=c++23)
-target_link_libraries(onebit PRIVATE
-    httplib::httplib
-    nlohmann_json::nlohmann_json)
-
-# Alias for the canonical binary name
-# NOTE: the single binary (onebin, OUTPUT_NAME "1bit") supersedes this copy
-# target — onebit's main() lives inside build/1bit now.
+# No standalone add_executable — tools/onebit.cpp compiles into onebin/1bit
+# only; onebit's main() lives inside build/1bit (OUTPUT_NAME "1bit"). Run
+# via `1bit` with no recognized subcommand, or `1bit chat`/`up`/`down`/etc.
 
 add_executable(bitnet_tui tools/bitnet_tui.cpp)
 target_link_libraries(bitnet_tui PRIVATE
@@ -1921,8 +1825,11 @@ if(USE_AUDIO_CPP)
             ${AUDIO_GGML_BASE_LIB}
             m pthread)
         
-        # Patch jarvis_server to use native audio.cpp TTS instead of Piper
-        target_link_libraries(jarvis_server PRIVATE audio_bridge)
+        # jarvis_server is no longer a standalone target (see onebin) —
+        # give onebin native audio.cpp TTS instead of Piper.
+        if(TARGET onebin)
+            target_link_libraries(onebin PRIVATE audio_bridge)
+        endif()
         
         message(STATUS "audio: audio.cpp integration enabled (${AUDIO_CPP_LIB})")
     else()

--- a/install.sh
+++ b/install.sh
@@ -33,8 +33,8 @@ if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
     echo "       sha256sum -c install.sh.sha256"
     echo ""
     echo "Installs 1bit inference engine for AMD Strix Halo (gfx1151)."
-    echo "Builds pure C++ end-to-end: zaya_server, onebit (CLI), onebitd (daemon),"
-    echo "unified_router (proxy), bitnet_tui (TUI) + librocm_cpp.so — no Rust, no Python."
+    echo "Builds pure C++ end-to-end: 1bit (single binary — zaya/unified/router/"
+    echo "jarvis/vision/gaia subcommands), bitnet_tui (TUI) + librocm_cpp.so — no Rust, no Python."
     exit 0
 fi
 
@@ -94,21 +94,17 @@ if [ "$SKIP_ROCM" = false ]; then
     log "Building C++ inference stack (server + CLI + daemon)..."
     cd "$DIR"
     cmake -B build ${CMAKE_GENERATOR:+-G Ninja} -DCMAKE_HIP_ARCHITECTURES=gfx1151 || { warn "cmake configure failed"; exit 1; }
-    cmake --build build --target zaya_server onebitd onebit onebin unified_router -j"$(nproc)" || { warn "cmake build failed"; exit 1; }
+    cmake --build build --target onebin -j"$(nproc)" || { warn "cmake build failed"; exit 1; }
     log "Build complete:"
-    log "  $DIR/build/zaya_server ($(stat -c%s "$DIR/build/zaya_server" 2>/dev/null || echo '?') bytes)"
-    log "  $DIR/build/onebitd      ($(stat -c%s "$DIR/build/onebitd" 2>/dev/null || echo '?') bytes)"
-    log "  $DIR/build/onebit       ($(stat -c%s "$DIR/build/onebit" 2>/dev/null || echo '?') bytes)"
-    log "  $DIR/build/1bit         → onebit"
-    log "  $DIR/build/unified_router"
+    log "  $DIR/build/1bit ($(stat -c%s "$DIR/build/1bit" 2>/dev/null || echo '?') bytes) — zaya/unified/router/jarvis/vision/gaia subcommands"
 else
     warn "--skip-rocm: kernel build skipped."
-    warn "Make sure librocm_cpp.so is on LD_LIBRARY_PATH before running zaya_server."
-    log "Checking for pre-built server binary..."
-    if [ -f "$DIR/build/zaya_server" ]; then
-        log "Found existing build: $DIR/build/zaya_server"
+    warn "Make sure librocm_cpp.so is on LD_LIBRARY_PATH before running 1bit."
+    log "Checking for pre-built binary..."
+    if [ -f "$DIR/build/1bit" ]; then
+        log "Found existing build: $DIR/build/1bit"
     else
-        warn "No pre-built server found at $DIR/build/zaya_server."
+        warn "No pre-built binary found at $DIR/build/1bit."
         warn "Run without --skip-rocm on a ROCm-equipped machine, or"
         warn "download a pre-built release from GitHub."
     fi
@@ -120,7 +116,7 @@ log "Done. Run:"
 log "  export HSA_OVERRIDE_GFX_VERSION=11.5.1"
 log "  export HSA_ENABLE_SDMA=0"
 log "  export LD_LIBRARY_PATH=$DIR/build:\$LD_LIBRARY_PATH"
-log "  $DIR/build/zaya_server"
+log "  $DIR/build/1bit zaya"
 log ""
 log "Then send requests:"
 log '  curl -X POST http://localhost:8088/completion \'

--- a/packaging/services/vision-server.service
+++ b/packaging/services/vision-server.service
@@ -7,7 +7,7 @@ After=network.target
 Type=simple
 User=1bit
 Group=render
-ExecStart=/opt/1bit-systems/build/vision_server \
+ExecStart=/opt/1bit-systems/build/1bit vision \
     --port 8099 \
     --model /opt/1bit-systems/models/Mage-VL-4B.1bp \
     --mmproj /opt/1bit-systems/models/Mage-ViT.1bp \

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -31,9 +31,9 @@ echo "" | tee -a "$LOGFILE"
 
 # ── Step 2: Build ──
 echo "=== 2. Build ===" | tee -a "$LOGFILE"
-echo "  cmake --build build --target zaya_server -j\$(nproc)" | tee -a "$LOGFILE"
-cmake --build build --target zaya_server -j"$(nproc)" 2>&1 | tail -3 | tee -a "$LOGFILE"
-echo "  Binary: $(ls -lh build/zaya_server | awk '{print $5}')" | tee -a "$LOGFILE"
+echo "  cmake --build build --target onebin -j\$(nproc)" | tee -a "$LOGFILE"
+cmake --build build --target onebin -j"$(nproc)" 2>&1 | tail -3 | tee -a "$LOGFILE"
+echo "  Binary: $(ls -lh build/1bit | awk '{print $5}')" | tee -a "$LOGFILE"
 echo "" | tee -a "$LOGFILE"
 
 # ── Step 3: Tests ──
@@ -93,8 +93,8 @@ echo "" | tee -a "$LOGFILE"
 
 # ── Step 7: Server health check ──
 echo "=== 7. HTTP API Server ===" | tee -a "$LOGFILE"
-echo "  Binary: build/zaya_server ($(ls -lh build/zaya_server | awk '{print $5}'))" | tee -a "$LOGFILE"
-echo "  Start: ./build/zaya_server --port 8088" | tee -a "$LOGFILE"
+echo "  Binary: build/1bit ($(ls -lh build/1bit | awk '{print $5}'))" | tee -a "$LOGFILE"
+echo "  Start: ./build/1bit zaya --port 8088" | tee -a "$LOGFILE"
 echo "  Send: curl http://localhost:8088/v1/models" | tee -a "$LOGFILE"
 echo "" | tee -a "$LOGFILE"
 

--- a/spec-decode/tests/run_zr1_zaya_demo.sh
+++ b/spec-decode/tests/run_zr1_zaya_demo.sh
@@ -11,12 +11,13 @@ echo "║  ZR1→Zaya Speculative Decode Demo           ║"
 echo "╚══════════════════════════════════════════════╝"
 echo ""
 
-# 1. Build zaya_server if needed
-SERVER_BIN="./build/zaya_server"
+# 1. Build onebin (1bit) if needed
+SERVER_BIN="./build/1bit"
+SERVER_SUBCMD="zaya"
 if [ ! -f "$SERVER_BIN" ]; then
-    echo "Building zaya_server..."
+    echo "Building onebin (1bit)..."
     cmake -B build -G Ninja 2>/dev/null || cmake -B build
-    cmake --build build --target zaya_server -j8
+    cmake --build build --target onebin -j8
     echo ""
 fi
 
@@ -53,13 +54,13 @@ sleep 1
 
 # 4. Start ZR1 draft server
 echo "Starting ZR1-1.5B draft server (port 8081)..."
-"$SERVER_BIN" --model "$ZR1_MODEL" --port 8081 &
+"$SERVER_BIN" "$SERVER_SUBCMD" --model "$ZR1_MODEL" --port 8081 &
 PID_ZR1=$!
 echo "  PID: $PID_ZR1"
 
 # 5. Start Zaya target server
 echo "Starting Zaya1-8B target server (port 8082)..."
-"$SERVER_BIN" --model "$ZAYA_MODEL" --port 8082 &
+"$SERVER_BIN" "$SERVER_SUBCMD" --model "$ZAYA_MODEL" --port 8082 &
 PID_ZAYA=$!
 echo "  PID: $PID_ZAYA"
 

--- a/tests/download_and_run.sh
+++ b/tests/download_and_run.sh
@@ -17,7 +17,8 @@ set -euo pipefail
 
 MODEL_URL="${MODEL_URL:-https://huggingface.co/Qwen/Qwen3-0.6B-GGUF/resolve/main/qwen3-0.6b-q4_k_m.gguf}"
 MODEL_FILE="${MODEL_FILE:-/tmp/qwen3-0.6b-q4_k_m.gguf}"
-SERVER_BIN="${SERVER_BIN:-./build/zaya_server}"
+SERVER_BIN="${SERVER_BIN:-./build/1bit}"
+SERVER_SUBCMD="${SERVER_SUBCMD:-zaya}"
 TIMEOUT_SECS=120
 CI_MODE=false
 QUICK=false
@@ -63,12 +64,12 @@ fi
 
 # 2. Build server if not present
 if [ ! -f "$SERVER_BIN" ]; then
-  echo "Building zaya_server..."
+  echo "Building onebin (1bit)..."
   if [ -d build ]; then
-    cmake --build build --target zaya_server -j8 2>&1 | tail -3
+    cmake --build build --target onebin -j8 2>&1 | tail -3
   else
     cmake -B build -G Ninja 2>&1 | tail -1
-    cmake --build build --target zaya_server -j8 2>&1 | tail -3
+    cmake --build build --target onebin -j8 2>&1 | tail -3
   fi
   if [ ! -f "$SERVER_BIN" ]; then
     echo "ERROR: build failed — $SERVER_BIN not found"
@@ -78,8 +79,8 @@ fi
 
 # 3. Check what interface the server supports
 echo "Checking server interface..."
-SERVER_HELP=$("$SERVER_BIN" --help 2>&1 || true)
-echo "  $SERVER_BIN $(echo "$SERVER_HELP" | head -1)"
+SERVER_HELP=$("$SERVER_BIN" "$SERVER_SUBCMD" --help 2>&1 || true)
+echo "  $SERVER_BIN $SERVER_SUBCMD $(echo "$SERVER_HELP" | head -1)"
 
 # Detect CLI interface: different builds use different arg names
 if echo "$SERVER_HELP" | grep -q -- "--model"; then
@@ -107,13 +108,13 @@ echo "  Port arg: ${PORT_ARG:-(default port)}"
 PORT=$((RANDOM + 10000))
 echo "Starting server on port $PORT..."
 if [ -n "$MODEL_ARG" ] && [ -n "$PORT_ARG" ]; then
-  "$SERVER_BIN" "$MODEL_ARG" "$MODEL_FILE" "$PORT_ARG" "$PORT" &
+  "$SERVER_BIN" "$SERVER_SUBCMD" "$MODEL_ARG" "$MODEL_FILE" "$PORT_ARG" "$PORT" &
 elif [ -n "$MODEL_ARG" ]; then
-  "$SERVER_BIN" "$MODEL_ARG" "$MODEL_FILE" &
+  "$SERVER_BIN" "$SERVER_SUBCMD" "$MODEL_ARG" "$MODEL_FILE" &
 elif [ -n "$PORT_ARG" ]; then
-  "$SERVER_BIN" "$MODEL_FILE" "$PORT_ARG" "$PORT" &
+  "$SERVER_BIN" "$SERVER_SUBCMD" "$MODEL_FILE" "$PORT_ARG" "$PORT" &
 else
-  "$SERVER_BIN" "$MODEL_FILE" &
+  "$SERVER_BIN" "$SERVER_SUBCMD" "$MODEL_FILE" &
 fi
 SERVER_PID=$!
 cleanup() { kill "$SERVER_PID" 2>/dev/null || true; }

--- a/third_party/gaia/UPSTREAM.md
+++ b/third_party/gaia/UPSTREAM.md
@@ -29,6 +29,11 @@ Vendored patches (re-apply after each sync, listed in `CMakeLists.txt`):
 2. **nlohmann_json**: when `find_package(nlohmann_json)` resolves to the
    top-level build's FetchContent copy (non-exportable), use include-dir-only
    instead of a PUBLIC link so `install(EXPORT)` stays valid.
+3. **onebin dispatch**: `agents/bash/main.cpp`'s `int main()` is guarded by
+   `#ifdef ONE_BIN_DISPATCH` to compile as `gaia_bash_main()` when its
+   sources are linked into the 1bit `onebin` ELF instead of the standalone
+   `gaia-bash` binary (see `tools/onebin.cpp` and the `EMBED_GAIA_CPP` block
+   in the top-level `CMakeLists.txt`).
 
 Included from the top-level `CMakeLists.txt`; options default OFF when built
 as a subproject (tests/examples). TUI (FTXUI) is disabled — engine has its own

--- a/third_party/gaia/agents/bash/main.cpp
+++ b/third_party/gaia/agents/bash/main.cpp
@@ -83,7 +83,11 @@ static int listSessions() {
 // main
 // ---------------------------------------------------------------------------
 
+#ifdef ONE_BIN_DISPATCH
+int gaia_bash_main(int argc, char* argv[]) {
+#else
 int main(int argc, char* argv[]) {
+#endif
     try {
         // Parse arguments
         std::string query;

--- a/tools/model_router.sh
+++ b/tools/model_router.sh
@@ -16,7 +16,7 @@ case "$MODEL" in
     # Start server if not running
     if ! curl -sf http://127.0.0.1:$PORT/ >/dev/null 2>&1; then
         echo "  Starting server..."
-        build/zaya_server $PORT &>/tmp/zaya_server.log &
+        build/1bit zaya $PORT &>/tmp/zaya_server.log &
         for i in $(seq 1 30); do
             sleep 2
             if curl -sf http://127.0.0.1:$PORT/ >/dev/null 2>&1; then

--- a/tools/onebin.cpp
+++ b/tools/onebin.cpp
@@ -13,6 +13,7 @@
 //   lemonade          → unified_server --lemonade (Lemonade's full server)
 //   jarvis, voice     → jarvis_server (TTS/voice clone + chat server)
 //   vision, vl        → vision_server (vision-language server)
+//   gaia, gaia-bash   → gaia-bash (AMD Gaia C++ agent loop — tools/repl/session)
 //   onebitd, daemon   → onebitd (inference daemon)
 //   everything else   → onebit (agent CLI: chat, up, down, status, build,
 //                        config, auth, serve, pull, list, update)
@@ -29,6 +30,7 @@ int onebitd_main(int argc, char *argv[]);
 int onebit_main(int argc, char *argv[]);
 int jarvis_server_main(int argc, char** argv);
 int vision_server_main(int argc, char** argv);
+int gaia_bash_main(int argc, char** argv);
 
 static std::string prog_name(const char* argv0) {
     std::string p = argv0 ? argv0 : "1bit";
@@ -46,6 +48,7 @@ int main(int argc, char** argv) {
     if (prog == "onebitd")        return onebitd_main(argc, argv);
     if (prog == "jarvis_server")  return jarvis_server_main(argc, argv);
     if (prog == "vision_server")  return vision_server_main(argc, argv);
+    if (prog == "gaia-bash")      return gaia_bash_main(argc, argv);
     if (prog == "onebit" || prog == "1bit") {
         // fall through to subcommand dispatch below
     } else {
@@ -83,6 +86,9 @@ int main(int argc, char** argv) {
         }
         if (cmd == "vision" || cmd == "vl") {
             return vision_server_main(argc - 1, argv + 1);
+        }
+        if (cmd == "gaia" || cmd == "gaia-bash") {
+            return gaia_bash_main(argc - 1, argv + 1);
         }
         // Everything else falls through to the agent CLI (chat, up, down,
         // status, build, config, auth, serve, update, --help).


### PR DESCRIPTION
### **User description**
Supersedes #1464 (includes its gaia_core-into-onebin change plus finishes the job — closing #1464 in favor of this one).

## The problem
`zaya_server`, `unified_server`, `unified_router`, `vision_server`, `jarvis_server`, `onebitd`, `onebit`, and `gaia-bash` each had two lives: a standalone `add_executable()` target **and** full inclusion in `ONE_BIN_SOURCES` for `onebin`/`1bit`. The standalone targets were pure duplication — same source, same object code, compiled and linked twice, producing a second (or eighth) binary next to `build/1bit`. `tools/onebin.cpp`'s "ONE BINARY, busybox-style" dispatch design was real, but the CMake build never actually stopped producing the legacy binaries it was meant to replace.

## The fix
No symlinks, no wrapper scripts — delete the redundant `add_executable()`/`install(TARGETS)` targets. Run everything via `1bit <subcommand>` (`zaya`/`unified`/`router`/`jarvis`/`vision`/`gaia`/`onebitd`, or bare `1bit` for the agent CLI) or the argv[0] dispatch `onebin.cpp` already had for the legacy names.

This was surgical, not wholesale: several removed targets shared infrastructure with `onebin` (the FLM submodule build/hotpatch custom targets, `EMBED_LEMONADE`'s `add_subdirectory`, `EMBED_GAIA_CPP`'s `add_subdirectory`, TheRock hipblas rpath detection) that `onebin` also depends on — that shared logic is kept; only target-specific `add_executable`/`target_*()` calls were removed. Two link-only casualties fixed by extending the existing "wire it up for onebin too" pattern already used for `fusion_zero_copy`: the `zaya_agent` copy-of-`unified_server` custom target is deleted outright (it was `${CMAKE_COMMAND} -E copy`, an actual file copy — more wasteful than a symlink), and `jarvis_server`'s `audio_bridge` (native TTS) link now targets `onebin` under the same `if(TARGET onebin)` guard. `gaia-bash`'s standalone binary is disabled via `GAIA_BUILD_BASH_AGENT OFF` (a vendored subproject option, not a file patch).

`install(TARGETS zaya_server ...)` → `install(TARGETS onebin ...)`.

## Verification
- `cmake -B build` configures clean — both incrementally (warm cache) and from a fresh worktree with zero cache.
- `cmake --build build -j$(nproc)` (full default target, not just `onebin`) builds clean end to end, 0 errors.
- Confirmed `build/{zaya_server,unified_server,vision_server,unified_router,onebitd,jarvis_server,onebit,gaia-bash,zaya_agent}` are no longer produced; only `build/1bit` (plus unrelated demo/test binaries) exists.
- Smoke-tested subcommand dispatch: `1bit {zaya,router,onebitd,gaia,vision,jarvis,unified} --help`/startup all reach the correct code path.
- Smoke-tested argv[0] dispatch via a throwaway symlink literally named `gaia-bash`.
- GitNexus `detect_changes()`: LOW risk, 0 downstream impact.

## Not in scope
Retiring the hand-rolled `onebit`/`jarvis` agent code that `gaia_core` could replace (the larger PLAN-GAIA.md migration) — this PR only makes the binary situation honest, it doesn't change what runs inside `1bit jarvis`/`1bit` yet.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove seven duplicate standalone server executables from build

- Fold gaia-bash sources into onebin via EMBED_GAIA_CPP

- Add gaia/gaia-bash subcommands and argv0 dispatch

- Move audio_bridge TTS to onebin and install 1bit


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Standalone["7 standalone server executables"] -- "removed" --> Onebin["onebin / 1bit"]
  Gaia["gaia-bash agents/bash sources"] -- "EMBED_GAIA_CPP" --> Onebin
  Onebin -- "subcommands / argv0" --> Dispatch["zaya, unified, router, gaia, ..."]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Remove duplicate server targets; embed gaia-bash in onebin</code></dd></summary>
<hr>

CMakeLists.txt

<ul><li>Removes standalone <code>add_executable()</code> targets for zaya, unified, router, <br>vision, jarvis, onebitd, and onebit<br> <li> Keeps shared source lists and compiles them into <code>onebin</code> only<br> <li> Adds an <code>EMBED_GAIA_CPP</code> block linking five gaia-bash sources and <br><code>gaia::gaia_core</code><br> <li> Moves <code>audio_bridge</code> TTS linkage and installation onto <code>onebin</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1465/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+63/-156</a></td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>onebin.cpp</strong><dd><code>Add gaia-bash dispatch to onebin binary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/onebin.cpp

<ul><li>Declares <code>gaia_bash_main()</code> and dispatches <code>gaia</code>/<code>gaia-bash</code> subcommands<br> <li> Adds the legacy <code>gaia-bash</code> argv[0] symlink route<br> <li> Updates the subcommand header documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1465/files#diff-9b80912c6324c3f6e4d3f349e8ee750818e431e508d1679cd23d181305c3828f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.cpp</strong><dd><code>Guard Gaia main for onebin dispatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/gaia/agents/bash/main.cpp

<ul><li>Wraps <code>main()</code> in <code>#ifdef ONE_BIN_DISPATCH</code><br> <li> Exposes <code>gaia_bash_main()</code> when compiled into <code>onebin</code><br> <li> Preserves standalone <code>main()</code> entry point otherwise</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1465/files#diff-d75142bd7aaa5b9327509aa087db42a560dd467d47602d17bd90b45a85520ab4">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UPSTREAM.md</strong><dd><code>Document Gaia onebin dispatch patch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/gaia/UPSTREAM.md

<ul><li>Documents vendored patch #3 for the <code>ONE_BIN_DISPATCH</code> main guard<br> <li> Notes that re-vendoring must re-apply the <code>gaia_bash_main</code> patch</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1465/files#diff-366f374e78468bc3b1b0c9baae65b4ee36dda49edfa1d93fbd2034392bd12b35">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

