### PR TITLE
fix(npu): correct embed_tokens offset lookup for Qwen3.6

### DIFF
--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -534,8 +534,15 @@ int main(int argc,char**argv){
     int fd=open(mp,O_RDONLY);struct stat st;fstat(fd,&st);
     uint8_t*md=(uint8_t*)mmap(NULL,st.st_size,PROT_READ,MAP_PRIVATE,fd,0);close(fd);
     uint64_t hsz;memcpy(&hsz,md,8);uint64_t df=8+hsz;
-    auto i8p=[&](uint64_t o){return md+df+o;};auto emb=(const uint16_t*)(md+df);
+    auto i8p=[&](uint64_t o){return md+df+o;};
     const char*js=(const char*)(md+8);size_t jl=hsz;
+    // Embeddings by JSON offset, NOT data-start-by-assumption — the first
+    // data tensor is layer 0's ssm_a (offset 0); embed_tokens sits at 7680
+    // for this model. Reading from md+df gave misaligned garbage embeddings
+    // and collapsed hidden states (found via the #1471 full-model reference).
+    uint64_t emb_off = jo(js, jl, "model.embed_tokens.weight");
+    if (!emb_off && key_exists(js, jl, "model.embed_tokens.weight")) emb_off = 0;  // legitimately first
+    auto emb=(const uint16_t*)(i8p(emb_off));
 
     // Pre-convert embeddings f32 (v12 optimization)
     fprintf(stderr,"Pre-convert emb f32...\n");auto te=std::chrono::steady_clock::now();
@@ -2225,6 +2232,12 @@ int main(int argc,char**argv){
         }
         // Residual add: use saved pre-FFN values
         for(int pi=0;pi<npt;pi++)for(int i=0;i<H;i++)h_b[pi*H+i]=sb_data[pi*H+i]+dw_b[pi*H+i];
+        // #1471 bisect: NPU_DUMP_HIDDEN=<path> dumps h_b[0] (first prompt
+        // position) after every layer, appended (40 x H floats).
+        if (const char* dh = getenv("NPU_DUMP_HIDDEN")) {
+            FILE* df = fopen(dh, "ab");
+            if (df) { fwrite(h_b.data(), 4, H, df); fclose(df); }
+        }
         fprintf(stderr,"\n");fflush(stderr);
     }sp+=npt;memcpy(h_data.data(),&h_b[(npt-1)*H],H*4);
     printf("Prefill: %.0fms (%.0f ms/tok)\n\n",std::chrono::duration<double,std::milli>(std::chrono::steady_clock::now()-t0).count(),std::chrono::duration<double,std::milli>(std::chrono::steady_clock::now()-t0).count()/npt);


### PR DESCRIPTION
### **User description**
## Summary

For Qwen3.6-35B-A3B, `embed_tokens.weight` is at `data_offsets=[7680, ...]`, NOT at offset 0. The first tensor at offset 0 is `ssm_a`. The previous code hardcoded `emb = md+df` (data section start), which read garbage embeddings and produced collapsed hidden states.

## Fix

Look up `model.embed_tokens.weight` in the JSON header via `jo()`, with a fallback for models where `embed_tokens` IS at offset 0.

Also adds `NPU_DUMP_HIDDEN=<path>` env var for per-layer hidden state inspection (useful for #1471 oracle comparison).

## Test

- Built and ran on Strix Halo NPU (6×8 topology)
- Qwen3.6-35B-A3B: `jo()` correctly returns 7680 for `embed_tokens`
- Qwen3-0.6B: `jo()` returns 0 (embed_tokens IS the first tensor) — same behavior as before
- Engine processes all 40 layers of weight loading successfully


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix embed_tokens offset lookup via JSON metadata

- Add NPU_DUMP_HIDDEN env for per-layer hidden dumps

- Prevent garbage embeddings and collapsed hidden states

- Keep fallback when embed_tokens is first tensor


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JSON header"] -- "jo() lookup" --> B["embed_tokens offset"]
  B -- "7680 or 0 fallback" --> C["emb pointer"]
  D["Layer loop"] -- "NPU_DUMP_HIDDEN" --> E["Append h_b dump"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>npu_engine_universal.cpp</strong><dd><code>Correct embed offset and add hidden dump</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/npu_engine_universal.cpp

<ul><li>Resolve <code>model.embed_tokens.weight</code> offset from JSON via <code>jo()</code><br> <li> Fall back to offset 0 when embeddings are legitimately first<br> <li> Add <code>NPU_DUMP_HIDDEN=<path></code> to append first-position hidden state per layer<br> <li> Fixes garbage embeddings and collapsed hidden states for Qwen3.6</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1477/files#diff-63677a636d5ff19712cf034cc1e2c15a96b194137caee54d8bd6883b0b76a10b">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

