### PR TITLE
fix(npu): embed_tokens offset + NPU_DUMP_HIDDEN + qwen36_full_ref + column-unlock docs

### DIFF
--- a/docs/research/npu/AMD-XDNA-COLUMN-UNLOCK-KNOWLEDGE-DUMP.md
+++ b/docs/research/npu/AMD-XDNA-COLUMN-UNLOCK-KNOWLEDGE-DUMP.md
@@ -670,3 +670,39 @@ Neither path is a natural continuation of the v5/v5a/v5b/v5c work — patching d
 Secure Boot has been re-enabled on the test box (it was only disabled to permit loading the unsigned out-of-tree `amdxdna` driver module during testing — unrelated to the PSP signature question, but no longer needed with this line of attack closed). System verified back to a clean stock baseline: in-tree signed driver, stock firmware, no errors.
 
 If this is picked up again, scope it explicitly as one of the two options above rather than another firmware-byte-patch variant — variant 6, 7, 8 of the same offset-guessing approach will hit the same wall as v5 through v5c.
+
+## Appendix: Deep-dive findings (2026-08-04) — research formally closed
+
+All prior work assumed the Strix Halo NPU had 40 physical AIE columns that were software-locked to 8. This is **incorrect**. The following findings close the 40-column unlock effort entirely.
+
+### Finding 1: The Strix Halo NPU has exactly 8 physical columns (6×8 topology)
+
+`xrt-smi examine` reports **Topology: 6x8** — 6 rows (4 compute + 1 mem + 1 shim) × 8 columns = 48 tiles total, producing ~50 TOPS. This matches AMD's published documentation (4×8 compute tiles). **There are no hidden columns to unlock.** The "40 columns" assumption likely arose from confusing the iGPU's 40 Compute Units with the NPU's column count.
+
+### Finding 2: The serialization-gate patch was never tested on hardware
+
+`npu_patched.sbin` (created 2026-06-29) has installation instructions but no test results in `PATCH_README.md`. The knowledge dump's description as "already-successful serialization-gate patch" referred to the *disassembly method* being proven, not the patch itself being loaded and tested. Binary analysis confirms `npu_patched.sbin` changed the first 16 header bytes (container GUID from `eb67de11...` to `f609a687...`) and NOP'd 7 branches — but no log anywhere shows it was loaded on the NPU without PSP rejection.
+
+### Finding 3: All firmware patches fail PSP RSA-2048 validation equally
+
+The PS1p container's last 256 bytes are a raw RSA-2048 signature (mean=128.6, stdev=73.4 — indistinguishable from random data). All firmware variants (stock, v5b, v5c, npu_patched) have **identical** RSA signatures and header hashes — the patches never update them. The PSP validates this signature using AMD's fused on-die key. **Any byte change to the payload invalidates the signature.** The v5 patches failed because of signature mismatch, not any column-specific logic.
+
+### Finding 4: The v5 patches changed 37 bytes total
+
+- Offset `0x31E0` (code): comparison constant 8→0x28 (1 byte)
+- Offset `0x31E4-0x31E7` (code): branch NOP (4 bytes)
+- 32 sub_payload entries: data table values 8→0x28
+
+### Finding 5: The first 16 bytes are NOT a SHA256 hash
+
+The PATCH_README claimed `npu_patched.sbin` had an "updated SHA256 header hash" but no SHA256 computation of any obvious region matches either the stock or patched first-16-byte values. These bytes are likely a firmware container GUID or version identifier, not a computable hash.
+
+### Finding 6: The `aie2_error_worker` has a 32-column bitmap limit
+
+`aie2_error_backtrack()` uses `u32 err_col = 0; /* assume AIE has less than 32 columns */` which can only represent 32 columns. For any future hardware with >31 columns, this needs widening to `u64` or `DECLARE_BITMAP`. (Moot for current Strix Halo with 8 columns.)
+
+### Conclusion
+
+The 40-column unlock effort is **formally closed**. The NPU has 8 physical columns and there is no software mechanism to increase this count. The PSP's RSA-2048 signature validation prevents any firmware modification without AMD's private signing key, and even if that were available, there would be no additional columns to unlock.
+
+The focus should shift to maximizing 8-column throughput via multi-context parallelism, temporal sharing, and driver-side optimization.

--- a/tools/qwen36_full_ref.py
+++ b/tools/qwen36_full_ref.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Full-model Qwen3.6-35B-A3B reference from the Q4NX weights (#1471).
+
+Runs the complete 40-layer forward (30 GDN + 10 full-attention, MoE FFN,
+RMSNorms, lm_head) in numpy, mirroring npu_engine_universal's CPU path
+exactly (moe_ffn_cpu + gdn_attn_step + std_attn_step + rn_c), and compares
+greedy decode tokens + per-layer hidden states against the engine's worker
+op=32 stream. The honest end-to-end gate: per-layer math was already
+bit-validated, this checks the wiring (embeddings, norms, splits, MoE).
+
+Usage:
+  python3 tools/qwen36_full_ref.py --prompt 151644,872,198,13048 --steps 4
+  # then compare against the engine's worker output for the same prompt.
+"""
+import argparse
+import json
+import mmap
+import struct
+import sys
+
+import numpy as np
+
+MODEL = "/home/bcloud/.config/flm/models/Qwen3.6-35B-A3B-NPU2/model.q4nx"
+H = 2048
+EPS = 1e-6
+GDN_VH, GDN_KH, GDN_HD = 32, 16, 128
+STD_NH, STD_NKV, STD_HD = 16, 2, 256
+CONV_DIM, CONV_K = 8192, 4
+KEY_DIM = GDN_KH * GDN_HD          # 2048
+VALUE_DIM = GDN_VH * GDN_HD        # 4096
+N_EXPERTS, TOP_K, IM_EXP = 256, 8, 512
+THETA, ROT_DIM = 1e7, 64
+
+
+class Q4nx:
+    def __init__(self, path):
+        self.f = open(path, "rb")
+        self.mm = mmap.mmap(self.f.fileno(), 0, access=mmap.ACCESS_READ)
+        hsz = struct.unpack("<Q", self.mm[:8])[0]
+        raw = self.mm[8:8 + hsz].decode("utf-8", "replace")
+        self.hdr = json.loads(raw[:raw.rindex("}") + 1])
+        self.df = 8 + hsz
+
+    def raw(self, key):
+        v = self.hdr[key]
+        o = v["data_offsets"]
+        return v, self.mm[self.df + o[0]: self.df + o[1]]
+
+    def bf16(self, key):
+        v, b = self.raw(key)
+        u = np.frombuffer(b, dtype=np.uint16).astype(np.uint32) << 16
+        return u.view(np.float32).astype(np.float64), v["shape"]
+
+    def bf16_1d(self, key):
+        return self.bf16(key)[0]
+
+    def f32(self, key):
+        v, b = self.raw(key)
+        return np.frombuffer(b, dtype=np.float32).astype(np.float64)
+
+    def router(self, key):
+        """stride-8 interleaved BF16 [H, N] (probe-validated layout)."""
+        v, b = self.raw(key)
+        u = np.frombuffer(b, dtype=np.uint16).astype(np.uint32) << 16
+        flat = u.view(np.float32).astype(np.float64)
+        n_in, n_out = v["shape"]
+        blk = n_out * (n_in // 8)
+        i = np.arange(n_in)[:, None]
+        j = np.arange(n_out)[None, :]
+        return flat[(i % 8) * blk + j * (n_in // 8) + i // 8]
+
+    def q8_0(self, key):
+        """Q8_0 (8704 B/row) -> [out_features, in_features] row-major."""
+        v, b = self.raw(key)
+        shp = v["shape"]
+        i8_rows = shp[0] * shp[1]
+        in_features = shp[1] * 256
+        TR, TC, RB = 32, 256, 8704
+        ntc = in_features // TC
+        ntr = i8_rows // ntc
+        out = np.zeros((ntr * TR, ntc * TC), dtype=np.float64)
+        buf = np.frombuffer(b, dtype=np.uint8)
+        for ir in range(i8_rows):
+            t = buf[ir * RB:(ir + 1) * RB]
+            sc = (t[:512].view(np.uint16).astype(np.uint32) << 16).view(np.float32).astype(np.float64)
+            vals = t[512:].view(np.int8).astype(np.float64).reshape(TR, TC)
+            tr_, tc_ = ir // ntc, ir % ntc
+            s = sc.reshape(TC // 32, TR).T
+            s = np.repeat(s, 32, axis=1)
+            out[tr_ * TR:(tr_ + 1) * TR, tc_ * TC:(tc_ + 1) * TC] = vals * s
+        return out
+
+    def q4nx_1bp(self, key, i8_rows, in_features):
+        """Q4NX 1BP: tile = 32x256, row-major bf16 scales/zps, int4 low-nibble-even."""
+        v, b = self.raw(key)
+        TR, TC, GS = 32, 256, 32
+        ntc = in_features // TC
+        ntr = i8_rows // ntc
+        RB = TR * GS * 2 + TR * GS * 2 + TR * TC // 2   # 5120
+        out = np.zeros((ntr * TR, ntc * TC), dtype=np.float64)
+        buf = np.frombuffer(b, dtype=np.uint8)
+        for ir in range(i8_rows):
+            t = buf[ir * RB:(ir + 1) * RB]
+            sc = (t[:TR * GS * 2].view(np.uint16).astype(np.uint32) << 16).view(np.float32).astype(np.float64)
+            zp = (t[TR * GS * 2:TR * GS * 4].view(np.uint16).astype(np.uint32) << 16).view(np.float32).astype(np.float64)
+            qd = t[TR * GS * 4:]
+            tr_, tc_ = ir // ntc, ir % ntc
+            for r in range(TR):
+                for g in range(GS):
+                    s, z = sc[r * GS + g], zp[r * GS + g]
+                    if not np.isfinite(s) or abs(s) > 100: s = 0
+                    if not np.isfinite(z) or abs(z) > 100: z = 0
+                    for i in range(GS):
+                        col = g * GS + i
+                        byte = qd[(r * TC + col) // 2]
+                        val = (byte >> 4) if (col & 1) else (byte & 0x0F)
+                        out[tr_ * TR + r, tc_ * TC + col] = val * s + z
+        return out
+
+
+def silu(x):
+    return x / (1.0 + np.exp(-x))
+
+
+def softplus(x):
+    return np.where(x > 20, x, np.log1p(np.exp(np.minimum(x, 20))))
+
+
+def rn_c(x, w):
+    """Engine rn_c: RMSNorm over H with weight, EPS=1e-6."""
+    return x / np.sqrt((x * x).mean() + EPS) * w
+
+
+def l2norm(x):
+    return x / np.sqrt((x * x).sum() + EPS)
+
+
+def rot64(x, pos):
+    """Partial rotary: first 64 of 256 dims, half-split within 64, theta 1e7."""
+    out = x.copy()
+    for d in range(32):
+        f = 1.0 / THETA ** (d / 32.0)
+        a = pos * f
+        c, s = np.cos(a), np.sin(a)
+        x1, x2 = x[d], x[d + 32]
+        out[d] = x1 * c - x2 * s
+        out[d + 32] = x2 * c + x1 * s
+    return out
+
+
+class FullModel:
+    def __init__(self, m: Q4nx):
+        self.m = m
+        self.nc = max(int(k.split(".")[2]) for k in m.hdr if k.startswith("model.layer.")) + 1
+        self.is_gdn = [f"model.layer.{l}.linear_attn.qkv_proj.weight" in m.hdr for l in range(self.nc)]
+        # norms + embeddings
+        self.in_n = [m.bf16_1d(f"model.layer.{l}.input_layernorm.weight") for l in range(self.nc)]
+        self.pa_n = [m.bf16_1d(f"model.layer.{l}.post_attention_layernorm.weight") for l in range(self.nc)]
+        self.fin = m.bf16_1d("model.norm.weight")
+        v, b = m.raw("model.embed_tokens.weight")
+        u = np.frombuffer(b, dtype=np.uint16).astype(np.uint32) << 16
+        self.emb = u.view(np.float32).astype(np.float64)  # [NV, H] plain
+        # lm_head: Q8_0, rows = shape[0]*(H/256) i8 rows -> [31040, 2048]
+        self.lm = m.q8_0("lm_head.weight")
+        self.lm_nv = self.lm.shape[0]
+        # per-layer MoE: router (interleaved), shared gate, expert offsets
+        self.router = [m.router(f"model.layer.{l}.moe_router.weight") for l in range(self.nc)]
+        self.shgate = [m.bf16_1d(f"model.layer.{l}.shared_expert_gate.weight") for l in range(self.nc)]
+        # GDN per-layer (dequant on demand, cached)
+        self.gdn = {}
+        # STD per-layer
+        self.std = {}
+
+    def gdn_weights(self, l):
+        if l in self.gdn:
+            return self.gdn[l]
+        p = f"model.layer.{l}.linear_attn."
+        w = {
+            "qkv": self.m.q8_0(p + "qkv_proj.weight"),
+            "out": self.m.q8_0(p + "ssm_out_proj.weight"),
+            "z": self.m.q8_0(f"model.layer.{l}.self_attn.gate_proj.weight"),
+            "alpha": self.m.bf16_1d(p + "ssm_alpha_proj.weight").reshape(H, GDN_VH),
+            "beta": self.m.bf16_1d(p + "ssm_beta_proj.weight").reshape(H, GDN_VH),
+            "conv": self.m.bf16_1d(p + "ssm_conv1d.weight").reshape(CONV_K, CONV_DIM),
+            "norm": self.m.bf16_1d(p + "ssm_norm.weight"),
+            "a": self.m.f32(p + "ssm_a"),
+            "dt": self.m.f32(p + "ssm_dt.bias"),
+        }
+        self.gdn[l] = w
+        return w
+
+    def std_weights(self, l):
+        if l in self.std:
+            return self.std[l]
+        p = f"model.layer.{l}.self_attn."
+        w = {
+            "q": self.m.q8_0(p + "q_proj.weight"),      # [8192, 2048] q+gate halves
+            "k": self.m.q8_0(p + "k_proj.weight"),      # [512, 2048]
+            "v": self.m.q8_0(p + "v_proj.weight"),      # [512, 2048]
+            "o": self.m.q8_0(p + "o_proj.weight"),      # [2048, 4096]
+            "qn": self.m.bf16_1d(p + "q_norm.weight"),
+            "kn": self.m.bf16_1d(p + "k_norm.weight"),
+        }
+        self.std[l] = w
+        return w
+
+    def gdn_layer(self, l, x, conv_state, delta_state):
+        """One GDN layer step (mirror of gdn_attn_step + O + residual handled by caller)."""
+        w = self.gdn_weights(l)
+        qkv = w["qkv"] @ x
+        # causal depthwise conv1d
+        conv_state = np.roll(conv_state, -1, axis=1)
+        conv_state[:, -1] = qkv
+        qkv = silu((conv_state * w["conv"].T).sum(axis=1))
+        q = qkv[:KEY_DIM].reshape(GDN_KH, GDN_HD)
+        k = qkv[KEY_DIM:2 * KEY_DIM].reshape(GDN_KH, GDN_HD)
+        v = qkv[2 * KEY_DIM:].reshape(GDN_VH, GDN_HD)
+        a = w["alpha"].T @ x
+        b = w["beta"].T @ x
+        beta = 1.0 / (1.0 + np.exp(-b))
+        g = w["a"] * softplus(a + w["dt"])
+        rep = GDN_VH // GDN_KH
+        q = l2norm(np.repeat(q, rep, axis=0))
+        k = l2norm(np.repeat(k, rep, axis=0))
+        eg = np.exp(g)[:, None, None]
+        delta_state = delta_state * eg
+        kv_mem = (delta_state * k[:, :, None]).sum(axis=1)
+        delta = (v - kv_mem) * beta[:, None]
+        delta_state = delta_state + k[:, :, None] * delta[:, None, :]
+        core = (delta_state * q[:, :, None]).sum(axis=1) / np.sqrt(GDN_HD)
+        z = w["z"] @ x
+        zz = z.reshape(GDN_VH, GDN_HD)
+        core = core / np.sqrt((core * core).mean(axis=1, keepdims=True) + EPS) * w["norm"]
+        core = core * silu(zz)
+        return w["out"] @ core.reshape(-1), conv_state, delta_state
+
+    def std_layer(self, l, x, kvc, pos):
+        """One full-attention layer step with KV cache (mirror of std_attn_step)."""
+        w = self.std_weights(l)
+        qkv = w["q"] @ x
+        qq = np.empty((STD_NH, STD_HD))
+        gate = np.empty((STD_NH, STD_HD))
+        for h in range(STD_NH):
+            qq[h] = qkv[h * 512:h * 512 + 256]
+            gate[h] = qkv[h * 512 + 256:h * 512 + 512]
+        kk = w["k"] @ x
+        vv = w["v"] @ x
+        for h in range(STD_NH):
+            qq[h] = qq[h] / np.sqrt((qq[h] * qq[h]).mean() + EPS) * w["qn"]
+            qq[h] = rot64(qq[h], pos)
+        for h in range(STD_NKV):
+            kh = kk[h * STD_HD:(h + 1) * STD_HD]
+            kh = kh / np.sqrt((kh * kh).mean() + EPS) * w["kn"]
+            kk[h * STD_HD:(h + 1) * STD_HD] = rot64(kh, pos)
+        kvc["k"].append(kk)
+        kvc["v"].append(vv)
+        attn = np.zeros((STD_NH, STD_HD))
+        for h in range(STD_NH):
+            kvh = h // (STD_NH // STD_NKV)
+            K = np.stack(kvc["k"])[:, kvh * STD_HD:(kvh + 1) * STD_HD]   # [t, 256]
+            V = np.stack(kvc["v"])[:, kvh * STD_HD:(kvh + 1) * STD_HD]
+            scores = K @ qq[h] / np.sqrt(STD_HD)                          # [t]
+            p = np.exp(scores - scores.max())
+            p /= p.sum()
+            attn[h] = p @ V
+        attn = attn * (1.0 / (1.0 + np.exp(-gate)))
+        return w["o"] @ attn.reshape(-1)
+
+    def moe_ffn(self, l, x):
+        """MoE FFN (mirror of moe_ffn_cpu): router → top-8 → dequant → SiLU → shared."""
+        p = f"model.layer.{l}.mlp."
+        rt = self.router[l]
+        logits = rt.T @ x
+        probs = np.exp(logits - logits.max())
+        probs /= probs.sum()
+        topk = np.argsort(-probs)[:TOP_K]
+        out = np.zeros(H)
+        for e in topk:
+            G = self._exp_deq(p + "gate_exps_proj.weight", e, H, "g")
+            U = self._exp_deq(p + "up_exps_proj.weight", e, H, "u")
+            D = self._exp_deq(p + "down_exps_proj.weight", e, IM_EXP, "d")
+            gu = silu(G @ x) * (U @ x)
+            out += probs[e] * (D @ gu)
+        # shared expert (Q8_0) + sigmoid gate
+        sg = np.dot(self.shgate[l], x)
+        sg_sig = 1.0 / (1.0 + np.exp(-sg))
+        SG = self.m.q8_0(p + "share_gate_exps_proj.weight")
+        SU = self.m.q8_0(p + "share_up_exps_proj.weight")
+        SD = self.m.q8_0(p + "share_down_exps_proj.weight")
+        sgu = silu(SG @ x) * (SU @ x)
+        out += sg_sig * (SD @ sgu)
+        return out
+
+    def _exp_deq(self, key, ex, in_f, which):
+        """Dequant ONE expert's slice from the Q4NX tensor (vectorized)."""
+        v, _ = self.m.raw(key)
+        # 256 experts always (router N_EXPERTS); i8 rows total = shape0*shape1,
+        # split evenly per expert (128 for gate/up/down at these dims).
+        tr_per = v["shape"][0] * v["shape"][1] // N_EXPERTS
+        TR, TC, GS = 32, 256, 32
+        GRPS = TC // GS            # 8 scale groups per tile row
+        RB = 5120                  # scales 2*TR*GRPS + zps 2*TR*GRPS + int4 TR*TC/2
+        ntc = in_f // TC
+        ntr = tr_per // ntc
+        out = np.zeros((ntr * TR, ntc * TC))
+        buf = np.frombuffer(self.m.mm[self.m.df + v["data_offsets"][0]: self.m.df + v["data_offsets"][1]], dtype=np.uint8)
+        for ir in range(tr_per):
+            t = buf[(ex * tr_per + ir) * RB:(ex * tr_per + ir + 1) * RB]
+            sc = (t[:TR * GRPS * 2].view(np.uint16).astype(np.uint32) << 16).view(np.float32).astype(np.float64).reshape(TR, GRPS)
+            zp = (t[TR * GRPS * 2:TR * GRPS * 4].view(np.uint16).astype(np.uint32) << 16).view(np.float32).astype(np.float64).reshape(TR, GRPS)
+            qd = t[TR * GRPS * 4:]
+            vals = np.empty(TR * TC)
+            vals[0::2] = qd & 0x0F
+            vals[1::2] = qd >> 4
+            vals = vals.reshape(TR, TC)
+            s = np.repeat(sc, 32, axis=1)
+            z = np.repeat(zp, 32, axis=1)
+            np.clip(s, -100, 100, out=s); np.clip(z, -100, 100, out=z)
+            out[(ir // ntc) * TR:(ir // ntc + 1) * TR,
+                (ir % ntc) * TC:(ir % ntc + 1) * TC] = vals * s + z
+        return out
+
+    def decode(self, prompt, steps):
+        """Greedy decode: returns (tokens, per-layer hidden states of last step)."""
+        tokens = list(prompt)
+        conv = {l: np.zeros((CONV_DIM, CONV_K)) for l in range(self.nc) if self.is_gdn[l]}
+        delta = {l: np.zeros((GDN_VH, GDN_HD, GDN_HD)) for l in range(self.nc) if self.is_gdn[l]}
+        kvc = {l: {"k": [], "v": []} for l in range(self.nc) if not self.is_gdn[l]}
+        outs = []
+        for step in range(len(prompt) + steps - 1):
+            tok = prompt[step] if step < len(prompt) else tokens[-1]
+            x = self.emb[tok].copy()
+            hiddens = []
+            for l in range(self.nc):
+                x = rn_c(x, self.in_n[l])
+                if self.is_gdn[l]:
+                    attn_out, conv[l], delta[l] = self.gdn_layer(l, x, conv[l], delta[l])
+                else:
+                    attn_out = self.std_layer(l, x, kvc[l], len(kvc[l]["k"]))
+                x = x + attn_out
+                x = rn_c(x, self.pa_n[l])
+                x = x + self.moe_ffn(l, x)
+                hiddens.append(x.copy())
+            logits = self.lm @ rn_c(x, self.fin)
+            tok = int(np.argmax(logits))
+            tokens.append(tok)
+            if step >= len(prompt) - 1:
+                outs.append((tok, hiddens))
+        return tokens, outs
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--prompt", default="151644,872,198,13048")
+    ap.add_argument("--steps", type=int, default=4)
+    ap.add_argument("--dump-hidden", help="save per-layer hidden states of the last step")
+    ap.add_argument("--dump-first", help="save per-layer hidden states of the FIRST prompt position")
+    args = ap.parse_args()
+    prompt = [int(t) for t in args.prompt.split(",")]
+    m = Q4nx(MODEL)
+    fm = FullModel(m)
+    tokens, outs = fm.decode(prompt, args.steps)
+    print("prompt:", prompt)
+    print("tokens:", tokens[len(prompt):])
+    if args.dump_hidden:
+        np.save(args.dump_hidden, np.array(outs[-1][1]))   # [NC, H]
+        print(f"saved last-step hidden states ({len(outs[-1][1])} x {H})")
+    if args.dump_first:
+        # per-layer hidden states at prompt position 0 (mirror the engine's
+        # prefill h_b[0] dump: 40 x H)
+        x = rn_c(fm.emb[prompt[0]].copy(), fm.in_n[0])
+        states = []
+        for l in range(fm.nc):
+            if fm.is_gdn[l]:
+                conv = np.zeros((CONV_DIM, CONV_K))
+                delta = np.zeros((GDN_VH, GDN_HD, GDN_HD))
+                attn_out, conv, delta = fm.gdn_layer(l, x, conv, delta)
+            else:
+                kvc = {"k": [], "v": []}
+                attn_out = fm.std_layer(l, x, kvc, 0)
+            x = x + attn_out
+            x = rn_c(x, fm.pa_n[l])
+            x = x + fm.moe_ffn(l, x)
+            states.append(x.copy())
+        np.save(args.dump_first, np.array(states))
+        print(f"saved first-position hidden states ({len(states)} x {H})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### **User description**
Closes: #1471 (wiring validation)

### Changes

- **fix(npu)**: correct embed_tokens offset lookup for Qwen3.6-35B-A3B — \`embed_tokens.weight\` is at \`data_offsets=7680\`, NOT at offset 0 (first tensor is \`ssm_a\`). Previous code assumed embeddings were always at the data section start, producing misaligned embeddings and collapsed hidden states. Fixed via JSON header lookup with fallback.
- **feat(debug)**: \`NPU_DUMP_HIDDEN=<path>\` env var appends the first-position hidden state \`h_b\` after each layer during prefill — useful for oracle comparison.
- **test(npu)**: \`tools/qwen36_full_ref.py\` — full 40-layer numpy reference (30 GDN + 10 full-attn, MoE FFN, RMSNorms, lm_head) that mirrors \`moe_ffn_cpu\` / \`gdn_attn_step\` / \`std_attn_step\` / \`rn_c\` exactly. End-to-end gate: per-layer math was already bit-validated in the probe tools; this checks the wiring (embeddings, norms, splits, MoE routing).
- **docs(npu)**: close 40-column unlock investigation — confirmed via \`xrt-smi examine\` (Topology: 6×8) that Strix Halo NPU has exactly 8 physical AIE columns; the "40 column unlock" was based on a false assumption. Also documented: serialization-gate patch was never tested, all firmware patches fail PSP RSA-2048 validation equally, and the first-16-byte header field is a GUID not a SHA256 hash.


___

### **PR Type**
Bug fix, Tests, Documentation, Enhancement


___

### **Description**
- Fix embed_tokens offset via JSON header lookup
  - Qwen3.6 embeddings at data_offsets=7680, not data start

- Add NPU_DUMP_HIDDEN per-layer hidden-state dump

- Add qwen36_full_ref.py: 40-layer numpy wiring reference
  - Mirrors moe_ffn_cpu/gdn_attn_step/std_attn_step/rn_c exactly
  - Greedy decode + per-layer hidden-state comparison (#1471)

- Docs close 40-column unlock: 8 physical columns
  - PSP RSA-2048 validation blocks all firmware patches
  - Serialization-gate patch was never tested on hardware


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["embed_tokens JSON offset fix"] --> B["qwen36_full_ref.py 40-layer numpy reference"]
  B --> C["Compare tokens and per-layer hidden states (#1471)"]
  D["NPU_DUMP_HIDDEN prefill dump"] --> C
  E["Column-unlock findings: 8 physical columns, RSA-2048 gate"] --> F["40-column unlock closed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>npu_engine_universal.cpp</strong><dd><code>Fix embed_tokens offset; add NPU_DUMP_HIDDEN dump</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/npu_engine_universal.cpp

<ul><li>Fix <code>embed_tokens.weight</code> offset lookup via JSON header <br><code>jo("model.embed_tokens.weight")</code> with fallback to 0 when the key exists <br>but is legitimately first<br> <li> Previously assumed embeddings at data start (<code>md+df</code>); for Qwen3.6 the <br>first data tensor is <code>ssm_a</code>, embeddings sit at <code>data_offsets=7680</code><br> <li> Add <code>NPU_DUMP_HIDDEN=<path></code> env var appending the first-position <code>h_b</code> hidden <br>state (H floats) after each prefill layer for #1471 bisect</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1478/files#diff-63677a636d5ff19712cf034cc1e2c15a96b194137caee54d8bd6883b0b76a10b">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>qwen36_full_ref.py</strong><dd><code>Add full 40-layer numpy reference for wiring validation</code>&nbsp; &nbsp; </dd></summary>
<hr>

tools/qwen36_full_ref.py

<ul><li>New full-model numpy reference running all 40 layers (30 GDN + 10 <br>full-attn + MoE FFN + RMSNorms + lm_head) from Q4NX weights<br> <li> Mirrors engine CPU path exactly: <code>moe_ffn_cpu</code>, <code>gdn_attn_step</code>, <br><code>std_attn_step</code>, <code>rn_c</code>, including Q8_0/Q4NX/bf16/router dequant layouts<br> <li> Greedy decode comparison plus per-layer hidden-state dumps <br>(<code>--dump-hidden</code>, <code>--dump-first</code>) to validate wiring against engine output</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1478/files#diff-3c2798ea505d5bdde7d76d474aed8d68dc9056c7e6988516f3d90f35d560c845">+390/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AMD-XDNA-COLUMN-UNLOCK-KNOWLEDGE-DUMP.md</strong><dd><code>Close 40-column unlock research with findings appendix</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/research/npu/AMD-XDNA-COLUMN-UNLOCK-KNOWLEDGE-DUMP.md

<ul><li>Add appendix "Deep-dive findings (2026-08-04) — research formally <br>closed"<br> <li> Confirmed Strix Halo NPU has exactly 8 physical AIE columns (6×8 <br>topology) via <code>xrt-smi examine</code><br> <li> Documented PSP RSA-2048 signature validation gating all firmware <br>patches, v5 patches changing 37 bytes, first-16-byte header being a <br>GUID, and the <code>aie2_error_worker</code> 32-column bitmap limit</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1478/files#diff-cd0fa37e9ffc448338645978c0466a967f45d175f8ec3811346342fb95dd8861">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

