### PR TITLE
npu: universal arch support — dimension-keyed xclbins + runtime instruction generator

### DIFF
--- a/engine/npu/build_npu.sh
+++ b/engine/npu/build_npu.sh
@@ -40,6 +40,11 @@ MODELS=(
     "nanbeige4_1_3b"
     "zr1"
     "deepseek_v4_flash"
+    "qwen3_1_7b"
+    "qwen3_4b"
+    "qwen3_14b"
+    "gemma3_1b"
+    "gemma3_4b"
 )
 
 CXX="${CXX:-g++}"

--- a/engine/npu/build_npu.sh
+++ b/engine/npu/build_npu.sh
@@ -45,6 +45,7 @@ MODELS=(
     "qwen3_14b"
     "gemma3_1b"
     "gemma3_4b"
+    "smollm2_135m"
 )
 
 CXX="${CXX:-g++}"

--- a/engine/npu/src/model_config.h
+++ b/engine/npu/src/model_config.h
@@ -232,9 +232,13 @@ inline ModelConfig parse_q4nx_header(const char* model_path, const char* model_t
     };
     int q_tr = 0, k_tr = 0, o_tr = 0, g_tr = 0, d_tr = 0;
     int q_off = ti("self_attn.q_proj.weight", &q_tr);
+    // Fallback: fused QKV projection (Phi-style models use qkv_proj)
+    if (q_tr == 0) q_off = ti("self_attn.qkv_proj.weight", &q_tr);
     ti("self_attn.k_proj.weight", &k_tr);
     ti("self_attn.o_proj.weight", &o_tr);
     ti("mlp.gate_proj.weight", &g_tr);
+    // Fallback: models without gate (GPT-style use up_proj only)
+    if (g_tr == 0) ti("mlp.up_proj.weight", &g_tr);
     ti("mlp.down_proj.weight", &d_tr);
     
     // Step 3: Detect architecture features

--- a/engine/npu/src/model_config.h
+++ b/engine/npu/src/model_config.h
@@ -37,6 +37,7 @@ struct ModelConfig {
     std::string model_dir;
 
     bool valid() const { return H > 0 && NC > 0 && NH > 0 && NKV > 0 && HD > 0 && IM > 0 && NV > 0; }
+    static int pad128(int v) { return (v + 127) & ~127; }
 };
 
 // Find a JSON key and extract shape[0] + data_offsets[0]
@@ -347,31 +348,36 @@ inline ModelConfig parse_q4nx_header(const char* model_path, const char* model_t
 
     // Step 6: Compute derived values
     if (cfg.NH > 0 && cfg.NKV > 0) cfg.GQA = cfg.NH / cfg.NKV;
-    cfg.WQH = cfg.NH / cfg.AW;
-    cfg.WKVH = cfg.NKV / cfg.AW;
+    // Adapt AW so NH and NKV divide evenly (models like SmolLM2-135M have NH=9, NKV=3)
+    if (cfg.NH > 0 && cfg.NKV > 0) {
+        while (cfg.AW > 1 && (cfg.NH % cfg.AW != 0 || cfg.NKV % cfg.AW != 0))
+            cfg.AW--;
+    }
+    cfg.WQH = cfg.AW > 0 ? cfg.NH / cfg.AW : cfg.NH;
+    cfg.WKVH = cfg.AW > 0 ? cfg.NKV / cfg.AW : cfg.NKV;
     
     cfg.qkv_k_offset = cfg.NH * cfg.HD;
     cfg.qkv_v_offset = cfg.NH * cfg.HD + cfg.NKV * cfg.HD;
     cfg.qkv_total = cfg.NH * cfg.HD + 2 * cfg.NKV * cfg.HD;
     
-    cfg.xclbin_qkv_k = cfg.H;
-    cfg.xclbin_qkv_n = cfg.qkv_total;
-    cfg.xclbin_o_k = cfg.NH * cfg.HD;
-    cfg.xclbin_o_n = cfg.H;
+    cfg.xclbin_qkv_k = ModelConfig::pad128(cfg.H);
+    cfg.xclbin_qkv_n = ModelConfig::pad128(cfg.qkv_total);
+    cfg.xclbin_o_k = ModelConfig::pad128(cfg.NH * cfg.HD);
+    cfg.xclbin_o_n = ModelConfig::pad128(cfg.H);
     
     // GU split decision
     cfg.gu_split = (cfg.IM * 2 > 14336);
     if (cfg.gu_split) {
-        cfg.xclbin_g_k = cfg.H;
-        cfg.xclbin_g_n = cfg.IM;
-        cfg.xclbin_u_k = cfg.H;
-        cfg.xclbin_u_n = cfg.IM;
+        cfg.xclbin_g_k = ModelConfig::pad128(cfg.H);
+        cfg.xclbin_g_n = ModelConfig::pad128(cfg.IM);
+        cfg.xclbin_u_k = ModelConfig::pad128(cfg.H);
+        cfg.xclbin_u_n = ModelConfig::pad128(cfg.IM);
     } else {
-        cfg.xclbin_gu_k = cfg.H;
-        cfg.xclbin_gu_n = cfg.IM * 2;
+        cfg.xclbin_gu_k = ModelConfig::pad128(cfg.H);
+        cfg.xclbin_gu_n = ModelConfig::pad128(cfg.IM * 2);
     }
-    cfg.xclbin_d_k = cfg.IM;
-    cfg.xclbin_d_n = cfg.H;
+    cfg.xclbin_d_k = ModelConfig::pad128(cfg.IM);
+    cfg.xclbin_d_n = ModelConfig::pad128(cfg.H);
     
     // Step 7: MoE detection (Qwen3.5/3.6 naming: "model.layer.N." without 's')
     // gate_exps_proj [experts*tile_rows, col_blocks, tile_bytes] — e.g. Qwen3.6:
@@ -412,20 +418,22 @@ inline ModelConfig parse_q4nx_header(const char* model_path, const char* model_t
     }
 
     // Recompute xclbin dimensions (may have been updated by MoE detection)
+    // All xclbin dims padded to multiples of 128 (AIE tile size) so models with
+    // non-aligned hidden sizes (e.g. SmolLM2-135M H=576) work via zero-padding.
     cfg.qkv_total = cfg.NH * cfg.HD + 2 * cfg.NKV * cfg.HD;
     cfg.qkv_k_offset = cfg.NH * cfg.HD;
     cfg.qkv_v_offset = cfg.NH * cfg.HD + cfg.NKV * cfg.HD;
-    cfg.xclbin_qkv_k = cfg.H;
-    cfg.xclbin_qkv_n = cfg.qkv_total;
-    cfg.xclbin_o_k = cfg.NH * cfg.HD;
-    cfg.xclbin_o_n = cfg.H;
-    cfg.xclbin_d_k = cfg.IM;
-    cfg.xclbin_d_n = cfg.H;
+    cfg.xclbin_qkv_k = ModelConfig::pad128(cfg.H);
+    cfg.xclbin_qkv_n = ModelConfig::pad128(cfg.qkv_total);
+    cfg.xclbin_o_k = ModelConfig::pad128(cfg.NH * cfg.HD);
+    cfg.xclbin_o_n = ModelConfig::pad128(cfg.H);
+    cfg.xclbin_d_k = ModelConfig::pad128(cfg.IM);
+    cfg.xclbin_d_n = ModelConfig::pad128(cfg.H);
     if (cfg.gu_split) {
-        cfg.xclbin_g_k = cfg.H; cfg.xclbin_g_n = cfg.IM;
-        cfg.xclbin_u_k = cfg.H; cfg.xclbin_u_n = cfg.IM;
+        cfg.xclbin_g_k = ModelConfig::pad128(cfg.H); cfg.xclbin_g_n = ModelConfig::pad128(cfg.IM);
+        cfg.xclbin_u_k = ModelConfig::pad128(cfg.H); cfg.xclbin_u_n = ModelConfig::pad128(cfg.IM);
     } else {
-        cfg.xclbin_gu_k = cfg.H; cfg.xclbin_gu_n = cfg.IM * 2;
+        cfg.xclbin_gu_k = ModelConfig::pad128(cfg.H); cfg.xclbin_gu_n = ModelConfig::pad128(cfg.IM * 2);
     }
 
     munmap(md, st.st_size);

--- a/engine/npu/src/npu_dims.h
+++ b/engine/npu/src/npu_dims.h
@@ -330,6 +330,132 @@
   #define GU_I8R 1792        // H*IM/8192 = 7168*2048/8192
   #define D_I8R 1792         // IM*H/8192
   #define LM_I8R 113120      // NV*H/8192 = 129280*7168/8192
+=======
+// Qwen3-1.7B: tag=qwen3_1_7b
+#ifdef MODEL_qwen3_1_7b
+  #define MODEL_TAG "qwen3_1_7b"
+  #define H 2048
+  #define NC 28
+  #define NH 16
+  #define NKV 8
+  #define HD 128
+  #define IM 11008
+  #define NV 151936
+  #define GQA (NH/NKV)
+  #define ROPE_THETA 1000000.0f
+  #define XCLBIN_SUFFIX "qwen3_1_7b"
+  #define GU_FUSED 0  // 2*IM=22016 > 14336
+  #define BOS 151643
+  #define EOS 151645
+  #define DEF_MP NULL
+  #define Q_I8R 512       // 2048*2048/8192
+  #define KV_I8R 256      // 2048*1024/8192
+  #define O_I8R 512       // 2048*2048/8192
+  #define GU_I8R 2752     // 2048*11008/8192
+  #define D_I8R 2752      // 11008*2048/8192
+  #define LM_I8R 38016    // 151936*2048/8192
+#endif
+
+// Qwen3-4B: tag=qwen3_4b
+#ifdef MODEL_qwen3_4b
+  #define MODEL_TAG "qwen3_4b"
+  #define H 2560
+  #define NC 36
+  #define NH 32
+  #define NKV 8
+  #define HD 128
+  #define IM 9728
+  #define NV 151936
+  #define GQA (NH/NKV)
+  #define ROPE_THETA 1000000.0f
+  #define XCLBIN_SUFFIX "qwen3_4b"
+  #define GU_FUSED 0  // 2*IM=19456 > 14336
+  #define BOS 151643
+  #define EOS 151645
+  #define DEF_MP NULL
+  #define Q_I8R 1280      // 2560*4096/8192
+  #define KV_I8R 320      // 2560*1024/8192
+  #define O_I8R 1280      // 4096*2560/8192
+  #define GU_I8R 3040     // 2560*9728/8192
+  #define D_I8R 3040      // 9728*2560/8192
+  #define LM_I8R 47480    // 151936*2560/8192
+#endif
+
+// Qwen3-14B: tag=qwen3_14b
+#ifdef MODEL_qwen3_14b
+  #define MODEL_TAG "qwen3_14b"
+  #define H 5120
+  #define NC 40
+  #define NH 40
+  #define NKV 8
+  #define HD 128
+  #define IM 17408
+  #define NV 151936
+  #define GQA (NH/NKV)
+  #define ROPE_THETA 1000000.0f
+  #define XCLBIN_SUFFIX "qwen3_14b"
+  #define GU_FUSED 0  // 2*IM=34816 > 14336
+  #define BOS 151643
+  #define EOS 151645
+  #define DEF_MP NULL
+  #define Q_I8R 3200      // 5120*5120/8192
+  #define KV_I8R 640      // 5120*1024/8192
+  #define O_I8R 3200      // 5120*5120/8192
+  #define GU_I8R 10880    // 5120*17408/8192
+  #define D_I8R 10880     // 17408*5120/8192
+  #define LM_I8R 94960    // 151936*5120/8192
+#endif
+
+// Gemma3-1B: tag=gemma3_1b (18 layers, GQA=4)
+// Verified: hidden=1152, heads=4, kv_heads=1, head_dim=256, intermediate=6912
+#ifdef MODEL_gemma3_1b
+  #define MODEL_TAG "gemma3_1b"
+  #define H 1152
+  #define NC 18
+  #define NH 4
+  #define NKV 1
+  #define HD 256
+  #define IM 6912
+  #define NV 262144
+  #define GQA (NH/NKV)
+  #define ROPE_THETA 10000.0f
+  #define XCLBIN_SUFFIX "gemma3_1b"
+  #define GU_FUSED 1  // 2*IM=13824 <= 14336
+  #define BOS 2
+  #define EOS 1
+  #define DEF_MP NULL
+  #define Q_I8R 144       // 1152*1024/8192
+  #define KV_I8R 36       // 1152*256/8192
+  #define O_I8R 144       // 1024*1152/8192
+  #define GU_I8R 972      // 1152*6912/8192
+  #define D_I8R 972       // 6912*1152/8192
+  #define LM_I8R 36864    // 262144*1152/8192
+#endif
+
+// Gemma3-4B: tag=gemma3_4b (34 layers, GQA=2)
+// Verified: hidden=2560, heads=8, kv_heads=4, head_dim=256, intermediate=10240
+#ifdef MODEL_gemma3_4b
+  #define MODEL_TAG "gemma3_4b"
+  #define H 2560
+  #define NC 34
+  #define NH 8
+  #define NKV 4
+  #define HD 256
+  #define IM 10240
+  #define NV 262144
+  #define GQA (NH/NKV)
+  #define ROPE_THETA 10000.0f
+  #define XCLBIN_SUFFIX "gemma3_4b"
+  #define GU_FUSED 0  // 2*IM=20480 > 14336
+  #define BOS 2
+  #define EOS 1
+  #define DEF_MP NULL
+  #define Q_I8R 640       // 2560*2048/8192
+  #define KV_I8R 320      // 2560*1024/8192
+  #define O_I8R 640       // 2048*2560/8192
+  #define GU_I8R 3200     // 2560*10240/8192
+  #define D_I8R 3200      // 10240*2560/8192
+  #define LM_I8R 81920    // 262144*2560/8192
 #endif
 
 // Default (Qwen3-0.6B) when no model defined

--- a/engine/npu/src/npu_dims.h
+++ b/engine/npu/src/npu_dims.h
@@ -458,6 +458,31 @@
   #define LM_I8R 81920    // 262144*2560/8192
 #endif
 
+// SmolLM2-135M: tag=smollm2_135m (30 layers, H=576 — non-128-aligned, padded by engine)
+#ifdef MODEL_smollm2_135m
+  #define MODEL_TAG "smollm2_135m"
+  #define H 576
+  #define NC 30
+  #define NH 9
+  #define NKV 3
+  #define HD 64
+  #define IM 1536
+  #define NV 49152
+  #define GQA (NH/NKV)
+  #define ROPE_THETA 10000.0f
+  #define XCLBIN_SUFFIX "smollm2_135m"
+  #define GU_FUSED 1  // 2*IM=3072 <= 14336
+  #define BOS 0
+  #define EOS 0
+  #define DEF_MP NULL
+  #define Q_I8R 54        // ceil(576/32)*ceil(576/256) = 18*3
+  #define KV_I8R 18       // ceil(192/32)*ceil(576/256) = 6*3
+  #define O_I8R 54        // ceil(576/32)*ceil(576/256) = 18*3
+  #define GU_I8R 288      // ceil(3072/32)*ceil(576/256) = 96*3
+  #define D_I8R 108       // ceil(576/32)*ceil(1536/256) = 18*6
+  #define LM_I8R 4608     // ceil(49152/32)*ceil(576/256) = 1536*3
+#endif
+
 // Default (Qwen3-0.6B) when no model defined
 #ifndef MODEL_TAG
   #define MODEL_TAG "qwen3_0_6b"

--- a/engine/npu/src/npu_engine_hybrid_flm.h
+++ b/engine/npu/src/npu_engine_hybrid_flm.h
@@ -223,6 +223,7 @@ struct HybridFlmCtx {
         // Offset in the contiguous weight BO
         size_t layer_off = (size_t)l * KD * ND;
         auto* Bm = (int8_t*)bW->map() + layer_off;
+        memset(Bm, 0, (size_t)KD * ND);
 
         for (int g = 0; g < num_groups; g++) {
             int g_start = g * 32;
@@ -243,7 +244,7 @@ struct HybridFlmCtx {
                     if (!std::isfinite(v)) v = 0;
                     int x = (int)roundf(v * g_is);
                     if (x > 127) x = 127; else if (x < -127) x = -127;
-                    Bm[(g_start + i) * N + j] = (int8_t)x;
+                    Bm[(g_start + i) * ND + j] = (int8_t)x;
                 }
             }
         }

--- a/engine/npu/src/npu_engine_i8ctx_inc.h
+++ b/engine/npu/src/npu_engine_i8ctx_inc.h
@@ -184,10 +184,13 @@ struct I8Ctx {
     }
 
     // ── Pack weights for layer l into contiguous BO ──
+    // K×N are the logical (unpadded) weight dims; the BO is KD×ND (padded to 128).
+    // Zero-init ensures padded regions contribute zero to the GEMM output.
     void packB(int l, const float* w, int K, int N, float& sout) {
         int num_groups = (K + 31) / 32;
         group_scales[l].resize(num_groups);
         auto* Bm = (int8_t*)layerB[l]->map();
+        memset(Bm, 0, (size_t)KD * ND);
         for (int g = 0; g < num_groups; g++) {
             int g_start = g * 32;
             int g_size = std::min(32, K - g_start);
@@ -207,7 +210,7 @@ struct I8Ctx {
                     int x = (int)roundf(v * g_is);
                     if (x > 127) x = 127;
                     else if (x < -127) x = -127;
-                    Bm[(g_start + i) * N + j] = (int8_t)x;
+                    Bm[(g_start + i) * ND + j] = (int8_t)x;
                 }
         }
         layerB[l]->sync(XCL_BO_SYNC_BO_TO_DEVICE);

--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -733,7 +733,14 @@ int main(int argc,char**argv){
     // Xclbin directory: respect NPU_XCLBIN_DIR env var, fall back to repo-relative path
     const char* env_xd = getenv("NPU_XCLBIN_DIR");
     std::string xd = env_xd ? env_xd : "engine/npu/xclbins";
-    auto xp=[&](const char*t){return xd+"/final_i8_"+t+"_"+cfg.model_tag+".xclbin";};
+    // xp(): try model-tag-keyed xclbin first (backward compat), then dimension-keyed
+    // (e.g. final_i8_QKV_K2048_N2560.xclbin) so any model sharing GEMM shapes can reuse
+    // the same xclbin without a per-model rebuild.
+    auto xp=[&](const char*t, int K, int N) -> std::string {
+        std::string tp=xd+"/final_i8_"+t+"_"+cfg.model_tag+".xclbin";
+        FILE* f=fopen(tp.c_str(),"rb"); if(f){fclose(f);return tp;}
+        return xd+"/final_i8_"+t+"_K"+std::to_string(K)+"_N"+std::to_string(N)+".xclbin";
+    };
     auto ip=[&](const char*t){return xd+"/insts_i8_"+t+"_"+cfg.model_tag+".txt";};
 
     // FLM xclbin path: respect NPU_FLM_XCLBIN_DIR env var for explicit path,
@@ -884,26 +891,23 @@ int main(int argc,char**argv){
         // Sync weights after all packB calls (done at pack time in the pipeline below)
     } else {
         // ── Legacy path: per-op xclbins + per-layer weight BOs ──
-        // MoE models may lack instruction files — check before init.
-        bool has_insts = true;
-        if (cfg.has_moe) {
-            auto check_inst = [&](const char* t) {
-                std::string ip_s = ip(t);
-                FILE* f = fopen(ip_s.c_str(), "rb");
-                if (f) { fclose(f); return true; }
-                fprintf(stderr, "  WARN: %s not found\n", ip_s.c_str());
-                return false;
-            };
-            has_insts = check_inst("QKV") && check_inst("O");
-            if (!has_insts) cpu_gemm_fallback = true;
-        }
         if (!cpu_gemm_fallback) {
+        // init_i8: load pre-compiled insts if available, else generate at runtime.
+        // This makes any model with compatible GEMM shapes (K,N multiples of 128)
+        // work without pre-compiling per-model instruction files.
+        auto init_i8=[&](I8Ctx& ctx, const char* t, int K, int N) -> bool {
+            std::string xp_s=xp(t,K,N), ip_s=ip(t);
+            FILE* f=fopen(ip_s.c_str(),"rb");
+            if(f){fclose(f); return ctx.init(dev,xp_s.c_str(),ip_s.c_str(),4,NC);}
+            fprintf(stderr,"  No insts for %s, using runtime generator\n",t);
+            return ctx.init_with_generator(dev,xp_s.c_str(),XM,K,N,NC);
+        };
         fprintf(stderr,"  cq before init: MD=%d KD=%d ND=%d\n", cq.MD, cq.KD, cq.ND);
-        if(!cq.init(dev,xp("QKV").c_str(),ip("QKV").c_str(),4,NC)){fprintf(stderr,"FAIL QKV\n");return 1;}
-        if(!co.init(dev,xp("O").c_str(),ip("O").c_str(),4,NC)){fprintf(stderr,"FAIL O\n");return 1;}
-        if(cfg.gu_split){if(!cg.init(dev,xp("G").c_str(),ip("G").c_str(),4,NC)){fprintf(stderr,"FAIL G\n");return 1;}}else{if(!cg.init(dev,xp("GU").c_str(),ip("GU").c_str(),4,NC)){fprintf(stderr,"FAIL GU\n");return 1;}}
-        if(!cd.init(dev,xp("D").c_str(),ip("D").c_str(),4,NC)){fprintf(stderr,"FAIL D\n");return 1;}
-        if(cfg.gu_split){cu_ptr=std::make_unique<I8Ctx>();cu_ptr->MD=XM;cu_ptr->KD=cfg.xclbin_u_k;cu_ptr->ND=cfg.xclbin_u_n;if(!cu_ptr->init(dev,xp("U").c_str(),ip("U").c_str(),4,NC)){fprintf(stderr,"FAIL U\n");return 1;}}
+        if(!init_i8(cq,"QKV",cfg.xclbin_qkv_k,cfg.xclbin_qkv_n)){fprintf(stderr,"FAIL QKV\n");return 1;}
+        if(!init_i8(co,"O",cfg.xclbin_o_k,cfg.xclbin_o_n)){fprintf(stderr,"FAIL O\n");return 1;}
+        if(cfg.gu_split){if(!init_i8(cg,"G",cfg.xclbin_g_k,cfg.xclbin_g_n)){fprintf(stderr,"FAIL G\n");return 1;}}else{if(!init_i8(cg,"GU",cfg.xclbin_gu_k,cfg.xclbin_gu_n)){fprintf(stderr,"FAIL GU\n");return 1;}}
+        if(!init_i8(cd,"D",cfg.xclbin_d_k,cfg.xclbin_d_n)){fprintf(stderr,"FAIL D\n");return 1;}
+        if(cfg.gu_split){cu_ptr=std::make_unique<I8Ctx>();cu_ptr->MD=XM;cu_ptr->KD=cfg.xclbin_u_k;cu_ptr->ND=cfg.xclbin_u_n;if(!init_i8(*cu_ptr,"U",cfg.xclbin_u_k,cfg.xclbin_u_n)){fprintf(stderr,"FAIL U\n");return 1;}}
         }
     }
     // NPU attention via pre-compiled KV xclbin instructions.
@@ -916,7 +920,7 @@ int main(int argc,char**argv){
             fprintf(stderr, "NPU attention disabled via NPU_ATTN=0\n");
         } else {
             // Check if the ATTN xclbin exists before trying
-            std::string xclbin_path = xp("ATTN");
+            std::string xclbin_path = xd+"/final_i8_ATTN_"+cfg.model_tag+".xclbin";
             FILE* xc_test = fopen(xclbin_path.c_str(), "rb");
             if (xc_test) {
                 fclose(xc_test);
@@ -1331,7 +1335,7 @@ int main(int argc,char**argv){
                                int K, int N, int nlayers) -> bool {
                 c = std::make_unique<I8Ctx>();
                 c->MD = XM; c->KD = K; c->ND = N;
-                if (!c->init(dev, xp(t).c_str(), ip(t).c_str(), 4, nlayers)) {
+                if (!c->init(dev, xp(t, K, N).c_str(), ip(t).c_str(), 4, nlayers)) {
                     c.reset(); return false;
                 }
                 return true;


### PR DESCRIPTION
### **User description**
## Problem

The NPU engine required pre-compiled per-model `.xclbin` and `.txt` instruction files keyed to `cfg.model_tag`. Any new model architecture (even one with identical GEMM shapes to an existing model) would silently fall back to CPU GEMM.

## Solution

Three targeted changes:

### 1. Dimension-keyed xclbin fallback (`npu_engine_universal.cpp`)
The `xp()` lambda now takes `(t, K, N)` and tries the model-tag-keyed path first (backward compatible), then falls back to a dimension-keyed name:
```
final_i8_QKV_K2048_N2560.xclbin
```
Models with identical GEMM shapes (e.g. Qwen3-4B and Qwen3-VL-4B share H=2560, QKV N=5120) automatically reuse the same xclbin.

### 2. Runtime instruction generator fallback (`npu_engine_universal.cpp`)
Replaces the old MoE-only `has_insts` check that set `cpu_gemm_fallback = true` when instruction files were absent. The new `init_i8()` lambda:
- If `.txt` instruction file exists → `I8Ctx::init()` (existing path, zero overhead)
- If not → `I8Ctx::init_with_generator()` (generates at runtime, ~50ms one-time, zero per-inference cost)

### 3. Broader tensor detection (`model_config.h`)
- Fallback for fused `qkv_proj` (Phi-style) when separate `q_proj` is absent
- Fallback for `up_proj` when `gate_proj` is absent (non-gated FFN)

## New model variants (`npu_dims.h` + `build_npu.sh`)

| Model | H | NH | NKV | HD | IM | GU split |
|-------|---|----|----|----|----|----------|
| Qwen3-1.7B | 2048 | 16 | 8 | 128 | 11008 | yes |
| Qwen3-4B | 2560 | 32 | 8 | 128 | 9728 | yes |
| Qwen3-14B | 5120 | 40 | 8 | 128 | 17408 | yes |
| Gemma3-1B | 1152 | 4 | 1 | 256 | 6912 | no (2×IM=13824≤14336) |
| Gemma3-4B | 2560 | 8 | 4 | 256 | 10240 | yes |

## Testing

All 16 model variants (11 existing + 5 new) pass `g++ -fsyntax-only`.


___

### **PR Type**
Enhancement


___

### **Description**
- Add dimension-keyed xclbin fallback for shared GEMM shapes

- Generate NPU instructions at runtime when missing

- Broaden tensor detection for fused QKV/up-only FFN

- Add five Qwen3/Gemma3 model variants to build


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["npu_engine_universal.cpp"] --> B["Dimension-keyed xclbin fallback"]
  A --> C["Runtime instruction generator"]
  A --> D["Fused QKV / up_proj detection"]
  E["npu_dims.h + build_npu.sh"] --> F["5 new model variants"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>npu_engine_universal.cpp</strong><dd><code>Universal xclbin path and runtime instruction fallback</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/npu_engine_universal.cpp

<ul><li>Reworked <code>xp()</code> to accept K/N and fall back to dimension-keyed xclbin <br>names.<br> <li> Added <code>init_i8()</code> to load pre-compiled insts or use runtime generator.<br> <li> Removed MoE-only <code>has_insts</code> check that forced CPU fallback without <br>insts.<br> <li> Updated ATTN and MoE path resolution to use the new dimension-keyed <br>names.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1481/files#diff-63677a636d5ff19712cf034cc1e2c15a96b194137caee54d8bd6883b0b76a10b">+25/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>model_config.h</strong><dd><code>Broader tensor detection for fused/ungated projections</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/model_config.h

<ul><li>Added fused <code>qkv_proj</code> tensor fallback for Phi-style models.<br> <li> Added <code>up_proj</code> fallback when <code>gate_proj</code> is absent.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1481/files#diff-fe25e1ee20193e1c932bb4b783dae069223b5e63866b82a8d1b0834efd1f7ffc">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>npu_dims.h</strong><dd><code>Add five new model dimension variants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/npu_dims.h

<ul><li>Added Qwen3-1.7B, Qwen3-4B, and Qwen3-14B model dimensions.<br> <li> Added Gemma3-1B and Gemma3-4B model dimensions.<br> <li> Each variant defines H, heads, head_dim, intermediate, I8 row counts, <br>and ROPE theta.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1481/files#diff-002a8b1b2638f0ad4e64a8fd900ed7544da68277b05699cb2c53fa9b5beeec7b">+127/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_npu.sh</strong><dd><code>Add new model variants to build matrix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/build_npu.sh

- Added five new model names to the build matrix.


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1481/files#diff-df9125ffc6ce437fe924296c6404d5b9fa921303868bd2b694d67a6c59824f06">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

