### PR TITLE
fix(npu): #1484 — non-MoE segfault at layer 0 (hardcoded attn dims → cfg)

### DIFF
--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -985,7 +985,7 @@ int main(int argc,char**argv){
     // the Qwen3.6-35B-A3B values. find_tensor_info returns shape[0]; for the
     // 3D I8 tensors the dequantized row count is shape[0] * (in_features/256).
     std::vector<int> gdn_vh(NC, 32), gdn_hd(NC, 128), gdn_conv_k(NC, 4), gdn_conv_dim(NC, 8192);
-    std::vector<int> std_nh(NC, 16), std_nkv(NC, 2), std_hd(NC, 256);
+    std::vector<int> std_nh(NC, cfg.NH), std_nkv(NC, cfg.NKV), std_hd(NC, cfg.HD);
     std::vector<float> rope_theta_per_layer(NC, cfg.rope_theta);
     std::vector<float> partial_rotary_factor(NC, 0.25f);
     if (cfg.has_moe) {


### PR DESCRIPTION
### **User description**
## Problem

Fixes #1484 — every non-MoE model segfaults at layer 0. The full-attention dims defaults were hardcoded to `NH=16, NKV=2, HD=256` (the Qwen3.6-35B-A3B values). For models with different geometry (e.g. Qwen3-0.6B: NH=16, NKV=8, HD=128), `QOUT=NH*HD` and `KVOUT=NKV*HD` oversize the dequant, reading past the weight BO → crash at layer 0.

## Fix

```cpp
- std::vector<int> std_nh(NC, 16), std_nkv(NC, 2), std_hd(NC, 256);
+ std::vector<int> std_nh(NC, cfg.NH), std_nkv(NC, cfg.NKV), std_hd(NC, cfg.HD);
```

Fallback dims now come from the parsed Q4NX header (cfg.NH/NKV/HD). The per-layer probe still overrides per-layer for MoE models.

Verified: `cmake --build build --target npu_engine_universal` clean.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace hardcoded attention-dim defaults with cfg-derived values

- Fixes layer-0 segfault for every non-MoE model

- Prevents dequant/pack from reading/writing past weight buffer

- MoE per-layer probe behavior remains unchanged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded NH=16 NKV=2 HD=256"] --> B["Wrong QOUT/KVOUT sizing"]
  B --> C["OOB dequant/pack access"]
  C --> D["Segfault at layer 0"]
  E["cfg.NH / cfg.NKV / cfg.HD"] --> F["Correct per-layer dims"]
  F --> G["Safe buffer access"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>npu_engine_universal.cpp</strong><dd><code>Derive attention dims from cfg to fix non-MoE crash</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/npu_engine_universal.cpp

<ul><li>Default std_nh/std_nkv/std_hd now initialized from cfg.NH, cfg.NKV, <br>cfg.HD<br> <li> Fallback dims match the parsed Q4NX model geometry instead of <br>Qwen3.6-35B-A3B values<br> <li> Per-layer tensor probe for MoE models still overrides values where <br>needed</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1488/files#diff-63677a636d5ff19712cf034cc1e2c15a96b194137caee54d8bd6883b0b76a10b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

