### PR TITLE
docs(hackathon): demo script validated benchmark numbers

### DIFF
--- a/hackathon/demo-script.md
+++ b/hackathon/demo-script.md
@@ -1,4 +1,4 @@
-> **📜 Hackathon submission** — This document was created for the AMD Radeon Hackathon 2026-07 and reflects the project state at that time (July 2026). Numbers like "97 tok/s" NPU and FastFlowLM references are historical — see the [README](../README.md) and [current benchmarks](../docs/wiki/performance.md) for up-to-date data.
+> **📜 Hackathon submission** — This document was created for the AMD Radeon Hackathon 2026-07 and reflects the project state at that time (August 2026). All figures are validated measurements from `site/benchmarks.json` / `benchmarks/` — see the [README](../README.md) and [current benchmarks](../docs/wiki/performance.md) for up-to-date data.
 >
 # Demo Video Script — 1bit.systems
 ## AMD AI DevMaster Hackathon — Track 2 Submission
@@ -49,16 +49,16 @@ Show token routing log — tokens dispatched to GPU, then NPU, then GPU again.
 
 **Visual**: Terminal showing benchmark runs:
 ```
-Benchmark: Q1 GEMV (GPU 1-bit) — 417 tok/s
-Benchmark: Fused TQ2 (GPU ternary) — 415 tok/s
-Benchmark: NPU v12 (XDNA 2) — 97 tok/s
-Benchmark: BlackMamba 1.5B (Mamba1 HIP) — 79.8 tok/s
+Benchmark: Q1 GEMV (GPU 1-bit) — 433 tok/s
+Benchmark: Fused TQ2 (GPU ternary) — 420 tok/s
+Benchmark: Qwen3.6-35B-A3B NPU (XDNA 2, FLM) — 11.66 tok/s
+Benchmark: BlackMamba 1.5B (Mamba1 HIP) — 79.4 tok/s
 ```
 
 Show a comparison chart or table.
 
 **Narration**:
-> "Performance. Our fused Q1 GEMV kernel hits 417 tokens per second on the Radeon GPU. The NPU runs at 97 tok/s with Q4NX. And the BlackMamba 1.5 billion parameter model runs at nearly 80 tok/s — faster than most humans can read. All on a laptop."
+> "Performance. Our fused Q1 GEMV kernel hits 433 tokens per second on the Radeon GPU. The XDNA 2 NPU drives a 35-billion-parameter Qwen model at 11.66 tokens per second — with prefill 8 to 24 percent faster than AMD's own published numbers. BlackMamba 1.5B runs at nearly 80 tok/s on the GPU. All on a laptop."
 
 ### Scene 6: Private Agent Capabilities (2:45–3:15)
 


### PR DESCRIPTION
### **User description**
Refreshes the Track 2 demo script with validated measurements from `site/benchmarks.json` (all match the data file):

- Q1 GEMV: 417 → **433** tok/s
- Fused TQ2: 415 → **420** tok/s
- NPU: stale "97 tok/s (v12)" → **Qwen3.6-35B-A3B 11.66 tok/s** (FLM, measured)
- BlackMamba 1.5B: 79.8 → **79.4** tok/s

Also updates the banner note (August 2026, figures validated).


___

### **PR Type**
Documentation


___

### **Description**
- Refreshed demo script with validated benchmarks from `site/benchmarks.json`

- Replaced stale NPU v12 figure with Qwen3.6-35B-A3B 11.66 tok/s (FLM)

- Updated Q1 GEMV to 433, fused TQ2 to 420, BlackMamba to 79.4 tok/s

- Revised banner and narration to reference August 2026 validated data


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["site/benchmarks.json"] -- "validated figures" --> B["hackathon/demo-script.md"]
  B -- "updates" --> C["Scene 5: Performance Numbers"]
  B -- "updates" --> D["Banner note & narration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>demo-script.md</strong><dd><code>Update demo script benchmark figures from benchmarks.json</code></dd></summary>
<hr>

hackathon/demo-script.md

<ul><li>Replaced stale NPU "97 tok/s (v12)" with measured Qwen3.6-35B-A3B <br>11.66 tok/s (FLM)<br> <li> Updated Q1 GEMV from 417 to 433 tok/s and fused TQ2 from 415 to 420 <br>tok/s<br> <li> Updated BlackMamba 1.5B from 79.8 to 79.4 tok/s<br> <li> Refreshed banner note to August 2026 and added prefill speedup <br>commentary to narration</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1489/files#diff-7ec5dea31ff37558f53830ac6b474c49810c7ba35f3be27c99a594df35b1bc8e">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

