### PR TITLE
fix(npu): #1483 — non-MoE GDN siblings load (NH/NKV/HD + IM fallback)

### DIFF
--- a/engine/npu/src/model_config.h
+++ b/engine/npu/src/model_config.h
@@ -104,6 +104,35 @@ static bool key_exists(const char* js, size_t jl, const char* key) {
     return false;
 }
 
+// Parse shape[N] from a tensor entry: returns the dim-th element (0-based),
+// or 0 if absent. Handles 1D/2D/3D shapes (e.g. 3D I8 tiles [rows, cols, bytes]).
+static int get_shape_dim(const char* js, size_t jl, const char* key, int dim) {
+    size_t kl = strlen(key);
+    const char* p = js;
+    const char* e = js + jl;
+    while (p < e) {
+        auto q = (const char*)memmem(p, e - p, key, kl);
+        if (!q) return 0;
+        if ((q == js || *(q-1) == '"') && *(q + kl) == '"') {
+            auto shape_loc = strstr(q, "\"shape\"");
+            if (shape_loc) {
+                auto bracket = strchr(shape_loc, '[');
+                if (bracket) {
+                    const char* c = bracket + 1;
+                    for (int i = 0; i <= dim; i++) {
+                        while (*c == ' ' || *c == ',') c++;
+                        if (i == dim) return (int)strtoul(c, nullptr, 10);
+                        while (*c && *c != ',') c++;
+                    }
+                }
+            }
+            return 0;
+        }
+        p = q + kl;
+    }
+    return 0;
+}
+
 static int get_shape_dim1(const char* js, size_t jl, const char* key) {
     size_t kl = strlen(key);
     const char* p = js;
@@ -190,20 +219,33 @@ inline ModelConfig parse_q4nx_header(const char* model_path, const char* model_t
     }
     
     // Step 2: Read I8 tile row counts for each weight
+    // Dense naming: model.layers.N.* ; Qwen3.5/3.6 (GDN/MoE) naming: model.layer.N.*
+    auto ti = [&](const char* base, int* tr) -> int {
+        char key[256];
+        snprintf(key, sizeof(key), "model.layers.0.%s", base);
+        int off = find_tensor_info(js, jl, key, tr);
+        if (*tr == 0) {
+            snprintf(key, sizeof(key), "model.layer.0.%s", base);
+            off = find_tensor_info(js, jl, key, tr);
+        }
+        return off;
+    };
     int q_tr = 0, k_tr = 0, o_tr = 0, g_tr = 0, d_tr = 0;
-    int q_off = 0;
-    q_off = find_tensor_info(js, jl, "model.layers.0.self_attn.q_proj.weight", &q_tr);
-    find_tensor_info(js, jl, "model.layers.0.self_attn.k_proj.weight", &k_tr);
-    find_tensor_info(js, jl, "model.layers.0.self_attn.o_proj.weight", &o_tr);
-    find_tensor_info(js, jl, "model.layers.0.mlp.gate_proj.weight", &g_tr);
-    find_tensor_info(js, jl, "model.layers.0.mlp.down_proj.weight", &d_tr);
+    int q_off = ti("self_attn.q_proj.weight", &q_tr);
+    ti("self_attn.k_proj.weight", &k_tr);
+    ti("self_attn.o_proj.weight", &o_tr);
+    ti("mlp.gate_proj.weight", &g_tr);
+    ti("mlp.down_proj.weight", &d_tr);
     
     // Step 3: Detect architecture features
     int qn_hd = 0;
     cfg.has_q_norm = (find_tensor_info(js, jl, "model.layers.0.self_attn.q_norm.weight", &qn_hd) > 0);
+    if (!cfg.has_q_norm)
+        cfg.has_q_norm = (find_tensor_info(js, jl, "model.layer.0.self_attn.q_norm.weight", &qn_hd) > 0);
     if (cfg.has_q_norm && qn_hd > 0) cfg.HD = qn_hd;  // q_norm shape = [HD]
     
-    cfg.has_k_norm = key_exists(js, jl, "model.layers.0.self_attn.k_norm.weight");
+    cfg.has_k_norm = key_exists(js, jl, "model.layers.0.self_attn.k_norm.weight") ||
+                     key_exists(js, jl, "model.layer.0.self_attn.k_norm.weight");
     cfg.has_rope_freqs_file = key_exists(js, jl, "rope_freqs.weight");
     cfg.has_lm_head = key_exists(js, jl, "lm_head.weight");
     
@@ -271,6 +313,34 @@ inline ModelConfig parse_q4nx_header(const char* model_path, const char* model_t
     // down_proj in_features=IM, out_features=H
     // tile_rows_d = ceil(H/32) * ceil(IM/256)
     
+    // Step 5b: GDN fused-QKV dims fallback (Qwen3.5/3.6 class, non-MoE siblings)
+    // linear_attn.qkv_proj rows are Q8_0 8704 B (512 B bf16 scales + 8192 int8)
+    // or INT4 5120 B (values == bytes). Convention: HD=128, GQA=2 →
+    // NKV = T/(4*HD), NH = T/(2*HD).
+    auto derive_gdn_dims = [&]() -> bool {
+        int qkv_tr = 0;
+        find_tensor_info(js, jl, "model.layer.0.linear_attn.qkv_proj.weight", &qkv_tr);
+        if (qkv_tr == 0)
+            find_tensor_info(js, jl, "model.layers.0.linear_attn.qkv_proj.weight", &qkv_tr);
+        if (qkv_tr <= 0) return false;
+        cfg.has_gated_delta_net = true;
+        int row_bytes = get_shape_dim(js, jl, "model.layer.0.linear_attn.qkv_proj.weight", 2);
+        if (row_bytes == 0)
+            row_bytes = get_shape_dim(js, jl, "model.layers.0.linear_attn.qkv_proj.weight", 2);
+        int T = (row_bytes == 8704) ? 8192 : (row_bytes > 0 ? row_bytes : 8192);
+        cfg.HD = 128;
+        cfg.NKV = T / 128 / 4;   // 16 for T=8192
+        cfg.NH = T / 128 / 2;    // 32 for T=8192
+        cfg.GQA = cfg.NH / cfg.NKV;
+        cfg.WQH = cfg.NH / cfg.AW;
+        cfg.WKVH = cfg.NKV / cfg.AW;
+        cfg.qkv_k_offset = cfg.NH * cfg.HD;
+        cfg.qkv_v_offset = cfg.NH * cfg.HD + cfg.NKV * cfg.HD;
+        cfg.qkv_total = T;
+        return true;
+    };
+    if ((cfg.NH == 0 || cfg.HD == 0) && !cfg.has_moe) derive_gdn_dims();
+
     // Step 6: Compute derived values
     if (cfg.NH > 0 && cfg.NKV > 0) cfg.GQA = cfg.NH / cfg.NKV;
     cfg.WQH = cfg.NH / cfg.AW;
@@ -329,18 +399,8 @@ inline ModelConfig parse_q4nx_header(const char* model_path, const char* model_t
             // values_per_row = 8192 = qkv_total (NH*HD + 2*NKV*HD), and the
             // row count = in_features = H (already parsed). Qwen3.5/3.6 use
             // HD=128, GQA=2 (NH=2*NKV): NKV = T/4, NH = T/2, T = qkv_total/128.
-            if (cfg.has_gated_delta_net && cfg.NH == 0 && cfg.HD == 0) {
-                int qkv_total = 8192;  // 8704 - 512 scales
-                cfg.HD = 128;
-                cfg.NKV = qkv_total / 128 / 4;  // 8192/128/4 = 16
-                cfg.NH = qkv_total / 128 / 2;   // 8192/128/2 = 32
-                cfg.GQA = cfg.NH / cfg.NKV;
-                cfg.WQH = cfg.NH / cfg.AW;
-                cfg.WKVH = cfg.NKV / cfg.AW;
-                cfg.qkv_k_offset = cfg.NH * cfg.HD;
-                cfg.qkv_v_offset = cfg.NH * cfg.HD + cfg.NKV * cfg.HD;
-                cfg.qkv_total = qkv_total;
-            }
+            if (cfg.has_gated_delta_net && cfg.NH == 0 && cfg.HD == 0)
+                derive_gdn_dims();
             if (cfg.IM == 0) cfg.IM = cfg.IM_EXP;  // MoE FFN uses per-expert IM
             fprintf(stderr, "[ModelConfig] MoE: experts=%d top_k=%d im_exp=%d shared=%d gdn=%d\n",
                     cfg.N_EXPERTS, cfg.TOP_K, cfg.IM_EXP, cfg.N_SHARED, (int)cfg.has_gated_delta_net);

--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -988,7 +988,7 @@ int main(int argc,char**argv){
     std::vector<int> std_nh(NC, 16), std_nkv(NC, 2), std_hd(NC, 256);
     std::vector<float> rope_theta_per_layer(NC, cfg.rope_theta);
     std::vector<float> partial_rotary_factor(NC, 0.25f);
-    if (cfg.has_moe) {
+    if (cfg.has_moe || cfg.has_gated_delta_net) {
         // Per-layer detection: probe every layer individually so heterogeneous
         // models (e.g. DS V4 Flash layers 0-1 sliding-window vs. CSA/HCA rest)
         // get accurate dims rather than inheriting from the first matching layer.


### PR DESCRIPTION
### **User description**
Fixes #1483 — non-MoE GDN hybrid siblings fail to load.

**Root cause:** `parse_q4nx_header` derived NH/NKV/HD only from `self_attn.q_proj`/`k_proj` and IM from `gate_proj`, all under `model.layers.N.` naming. Qwen3.6-family GDN models have none of those: fused `linear_attn.qkv_proj` and `model.layer.N.` naming (no 's'). Config came back invalid → "ERR: invalid model config".

**Changes:**
- `get_shape_dim()` helper — parse any shape index (3D I8 tiles `[rows, cols, bytes]`)
- `derive_gdn_dims()` — NH/NKV/HD from `linear_attn.qkv_proj` row width (Q8_0 8704 B → 8192 values, INT4 5120 B → 5120; HD=128, GQA=2 convention, same as the existing MoE fallback). Shared by the MoE path and new non-MoE path.
- Step 2 probes (q/k/o/gate/down) fall back to `model.layer.N.` naming
- q_norm/k_norm detection falls back to `model.layer.N.` naming
- Engine per-layer dim probe now runs for `has_gated_delta_net` too — non-MoE GDN hybrids get tensor-derived per-layer GDN geometry instead of the hardcoded Qwen3.6-35B defaults (32/128/4/8192)

**Verified:** `dump_model_dims` on a synthetic non-MoE GDN header → `NH=32 NKV=16 HD=128 IM=3072 GQA=2 gdn=1 qkv_total=8192` (valid); dense Qwen3-0.6B → unchanged. `npu_engine_universal` builds clean.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix non-MoE GDN siblings failing to load

- Add `derive_gdn_dims()` fallback deriving NH/NKV/HD from qkv-proj width

- Probe weights with `model.layer.0.*` naming fallback

- Enable per-layer GDN dims probe for gated delta nets


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["parse_q4nx_header"] --> B["get_shape_dim()"]
  B --> C["derive_gdn_dims()"]
  C --> D["NH/NKV/HD/GQA/qkv offsets"]
  E["model.layer.* naming fallback"] --> A
  F["npu_engine_universal per-layer probe"] --> D
  D --> G["valid model config"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model_config.h</strong><dd><code>qkv-proj dims fallback and layer naming probes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/model_config.h

<ul><li>Added <code>get_shape_dim()</code> to read arbitrary tensor shape indices<br> <li> Added <code>derive_gdn_dims()</code> fallback for fused <code>linear_attn.qkv_proj</code><br> <li> Added <code>model.layer.0.*</code> naming fallback for q/k/o/gate/down probes<br> <li> Refactored MoE GDN path to share the new dims helper</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1491/files#diff-fe25e1ee20193e1c932bb4b783dae069223b5e63866b82a8d1b0834efd1f7ffc">+79/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>npu_engine_universal.cpp</strong><dd><code>Enable per-layer GDN probes for dense hybrids</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/npu_engine_universal.cpp

<ul><li>Extended per-layer GDN dimension detection to non-MoE models<br> <li> Gated on <code>cfg.has_gated_delta_net</code> in addition to <code>has_moe</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1491/files#diff-63677a636d5ff19712cf034cc1e2c15a96b194137caee54d8bd6883b0b76a10b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

