### PR TITLE
npu: multi-row GEMM generator (v27) — 32 cores, 5.6× over v26

### DIFF
--- a/engine/npu/generators/n1_core_i8_v27.py
+++ b/engine/npu/generators/n1_core_i8_v27.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+#
+# INT8 MLIR generator v27 — multi-row (whole-array) GEMM.
+#
+# v26 used one AIE core row (8 of the 32 compute tiles on Strix Halo, whose
+# topology is 6x8: row 0 shim, row 1 mem, rows 2-5 compute).  v27 uses all
+# n_aie_rows core rows, so the output tile grid is covered by 32 cores instead
+# of 8, and the M dimension is split across rows instead of being iterated
+# sequentially by a single row.
+#
+# Two effects, both measured against the same xclbin harness:
+#   1. 4x the compute tiles.
+#   2. 8x less A DMA traffic.  v26 worked around issue #1207 (object_fifo_link
+#      DISTRIBUTES round-robin instead of broadcasting) by giving every column
+#      its own A path and re-sending the identical A tile once per column.
+#      Broadcast works correctly when the consumer is a *list of tiles* on the
+#      fifo itself (not a link), so v27 sends each A tile once per row.
+#
+# Decomposition (core (j,c) owns output tile (row_group*rows + j, col_group*cols + c)):
+#   A varies by row, broadcast across the 8 columns of that row.
+#   B varies by column, broadcast down the 4 rows of that column.
+#   C is per-(row,col), joined into one (rows*m, n) L2 buffer per column.
+#
+# The C join needs no extra DMA dimension: concatenating rows microtiled (m,n)
+# tiles is bit-identical to one microtiled (rows*m, n) tile.  For element (r,c)
+# with r = j*m + r', the single-tile offset ((r/8)*(n/8) + c/8)*64 expands to
+# j*m*n + ((r'/8)*(n/8) + c/8)*64, which is exactly the join offset j*m*n plus
+# the local offset.  So the C shim tap is v26's with m -> rows*m.
+#
+# Channel budget (why n_shim_A = min(rows, cols) matters):
+#   mem tile in column c<rows: S2MM = A in + B in + rows C in = 6 (limit 6),
+#                              MM2S = A out + B out + C out = 3.
+#   shim tile c<rows: MM2S = A + B = 2 (limit 2), S2MM = C = 1.
+#
+# Usage: python3 n1_core_i8_v27.py -M 128 -K 1024 -N 4096 -r 4 -c 8 > design.mlir
+import argparse
+import numpy as np
+from aie.extras.context import mlir_mod_ctx
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.helpers.dialects.scf import _for as range_
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-M", type=int, default=128)
+    parser.add_argument("-K", type=int, default=1024)
+    parser.add_argument("-N", type=int, default=4096)
+    parser.add_argument("-m", type=int, default=32)
+    parser.add_argument("-k", type=int, default=64)
+    parser.add_argument("-n", type=int, default=128)
+    parser.add_argument("-c", "--cols", type=int, default=8, help="n_aie_cols (must divide N//n)")
+    parser.add_argument("-r", "--rows", type=int, default=4, help="n_aie_rows (must divide M//m)")
+    parser.add_argument("-b", "--batch-size", type=int, default=5,
+                        help="K-tiles per DMA round (fifo depth = batch+1; 6 keeps BDs <= 16)")
+    args = parser.parse_args()
+    with mlir_mod_ctx() as ctx:
+        my_matmul(args.M, args.K, args.N, args.m, args.k, args.n,
+                  args.cols, args.rows, args.batch_size)
+        print(ctx.module)
+
+
+def my_matmul(M, K, N, m, k, n, n_aie_cols=8, n_aie_rows=4, BATCH_SIZE=5):
+    dtype_in = np.int8
+    dtype_out = np.int32
+
+    assert M % m == 0 and K % k == 0 and N % n == 0
+    assert (N // n) % n_aie_cols == 0, "N//n must be a multiple of n_aie_cols"
+    assert (M // m) % n_aie_rows == 0, "M//m must be a multiple of n_aie_rows"
+    assert n_aie_cols >= 2, (
+        f"n_aie_cols={n_aie_cols} is unsupported; minimum is 2 (issue #1208)."
+    )
+    # A is sourced from one shim/mem tile per row, so a row index must address a
+    # real column.  Strix Halo has 4 core rows and 8 columns, so this holds.
+    assert n_aie_rows <= n_aie_cols, "n_aie_rows must be <= n_aie_cols (A shim per row)"
+
+    @device(AIEDevice.npu2)
+    def device_body():
+        A_ty = np.ndarray[(m, k), np.dtype[dtype_in]]
+        B_ty = np.ndarray[(k, n), np.dtype[dtype_in]]
+        C_ty = np.ndarray[(m, n), np.dtype[dtype_out]]
+        C_l2_ty = np.ndarray[(n_aie_rows * m, n), np.dtype[dtype_out]]
+
+        kernel_o = "mm_32x64x128.o"
+        zero = external_func("zero_i32", inputs=[C_ty], link_with=kernel_o)
+        matmul = external_func("matmul_i8_i32", inputs=[A_ty, B_ty, C_ty], link_with=kernel_o)
+
+        tiles = [[tile(col, row) for col in range(n_aie_cols)] for row in range(2 + n_aie_rows)]
+        shim_tiles, mem_tiles = tiles[0], tiles[1]
+        core_tiles = tiles[2:]  # core_tiles[j][c] = tile(c, 2+j)
+
+        # A: one path per row, broadcast to every column of that row.
+        #
+        # The broadcast goes shim -> cores DIRECTLY, with no mem-tile hop.  A
+        # linked pair (shim -> mem -> {8 cores}) does NOT broadcast: it
+        # distributes round-robin, so each core sees only n_k/n_aie_cols of the
+        # K-tiles and accumulates ~1/8 of the dot product (issue #1207, and
+        # reproduced on v27's first hardware run).  A single fifo with several
+        # consumer tiles and no link is a true multicast.
+        A_c = [None] * n_aie_rows
+        for j in range(n_aie_rows):
+            A_c[j] = object_fifo(f"A_C{j}", shim_tiles[j],
+                                 [core_tiles[j][c] for c in range(n_aie_cols)],
+                                 BATCH_SIZE + 1, A_ty)
+
+        # B: one path per column, broadcast down every row of that column.
+        B_s = [None] * n_aie_cols
+        B_c = [None] * n_aie_cols
+        for c in range(n_aie_cols):
+            B_s[c] = object_fifo(f"B_S{c}", shim_tiles[c], mem_tiles[c], BATCH_SIZE + 1, B_ty)
+            B_c[c] = object_fifo(f"B_C{c}", mem_tiles[c],
+                                 [core_tiles[j][c] for j in range(n_aie_rows)],
+                                 BATCH_SIZE + 1, B_ty)
+            object_fifo_link(B_s[c], B_c[c])
+
+        # C: per-(row,col) L1->L2, joined into one (rows*m, n) L2 buffer per column.
+        C_c = [[None] * n_aie_cols for _ in range(n_aie_rows)]
+        C_s = [None] * n_aie_cols
+        for c in range(n_aie_cols):
+            for j in range(n_aie_rows):
+                C_c[j][c] = object_fifo(f"C_C{c}_{j}", core_tiles[j][c], mem_tiles[c], 1, C_ty)
+            C_s[c] = object_fifo(f"C_S{c}", mem_tiles[c], shim_tiles[c], 1, C_l2_ty)
+            object_fifo_link([C_c[j][c] for j in range(n_aie_rows)], C_s[c],
+                             [m * n * j for j in range(n_aie_rows)])
+
+        num_row_group = M // m // n_aie_rows
+        num_col_group = N // n // n_aie_cols
+        num_groups = num_row_group * num_col_group
+        n_k = K // k
+
+        for j in range(n_aie_rows):
+            for c in range(n_aie_cols):
+                @core(core_tiles[j][c], stack_size=0x2000)
+                def core_body():
+                    for _ in range_(0xFFFFFFFF):
+                        for _ in range_(num_groups):
+                            Cbuf = C_c[j][c].acquire(ObjectFifoPort.Produce, 1)
+                            zero(Cbuf)
+                            for _ in range_(n_k):
+                                Abuf = A_c[j].acquire(ObjectFifoPort.Consume, 1)
+                                Bbuf = B_c[c].acquire(ObjectFifoPort.Consume, 1)
+                                matmul(Abuf, Bbuf, Cbuf)
+                                A_c[j].release(ObjectFifoPort.Consume, 1)
+                                B_c[c].release(ObjectFifoPort.Consume, 1)
+                            C_c[j][c].release(ObjectFifoPort.Produce, 1)
+
+        @runtime_sequence(
+            np.ndarray[(M * K,), np.dtype[dtype_in]],
+            np.ndarray[(K * N,), np.dtype[dtype_in]],
+            np.ndarray[(M * N,), np.dtype[dtype_out]],
+        )
+        def seq(A, B, C):
+            # Microtile DMA taps (see v26 header for the layout derivation).
+            # A tile (row_tile, ki): sizes=[m/8, k/8, 8, 8] strides=[8K, 8, K, 1]
+            # B tile (ki, n_tile):   sizes=[k/8, n/8, 8, 8] strides=[8N, 8, N, 1]
+            # C strip (row_group, n_tile): the rows joined tiles form one
+            #   microtiled (rows*m, n) tile, so the tap is the v26 C tap with
+            #   m -> rows*m.
+            rm = n_aie_rows * m
+
+            for gi in range(num_groups):
+                row_group = gi // num_col_group
+                col_group = gi % num_col_group
+
+                for ki0 in range(0, n_k, BATCH_SIZE):
+                    ki_end = min(ki0 + BATCH_SIZE, n_k)
+                    at_list = []
+                    bt_list = []
+                    for ki in range(ki0, ki_end):
+                        for j in range(n_aie_rows):
+                            row_tile = row_group * n_aie_rows + j
+                            a_off = row_tile * m * K + ki * k
+                            at = shim_dma_single_bd_task(
+                                A_c[j], A,
+                                offset=a_off,
+                                sizes=[m // 8, k // 8, 8, 8],
+                                strides=[8 * K, 8, K, 1],
+                                issue_token=True)
+                            dma_start_task(at)
+                            at_list.append(at)
+
+                        for c in range(n_aie_cols):
+                            n_tile = col_group * n_aie_cols + c
+                            b_off = ki * k * N + n_tile * n
+                            bt = shim_dma_single_bd_task(
+                                B_s[c], B,
+                                offset=b_off,
+                                sizes=[k // 8, n // 8, 8, 8],
+                                strides=[8 * N, 8, N, 1],
+                                issue_token=True)
+                            dma_start_task(bt)
+                            bt_list.append(bt)
+
+                    dma_await_task(*at_list, *bt_list)
+                    dma_free_task(*at_list, *bt_list)
+
+                c_tasks = []
+                for c in range(n_aie_cols):
+                    n_tile = col_group * n_aie_cols + c
+                    c_off = row_group * rm * N + n_tile * n
+                    ct = shim_dma_single_bd_task(
+                        C_s[c], C,
+                        offset=c_off,
+                        sizes=[rm // 8, n // 8, 8, 8],
+                        strides=[8 * N, 8, N, 1],
+                        issue_token=True)
+                    dma_start_task(ct)
+                    c_tasks.append(ct)
+
+                dma_await_task(*c_tasks)
+                dma_free_task(*c_tasks)
+
+
+main()

--- a/engine/npu/tests/bench_gemm_analytical.cpp
+++ b/engine/npu/tests/bench_gemm_analytical.cpp
@@ -1,0 +1,122 @@
+// bench_gemm_analytical.cpp — analytical GEMM correctness + throughput for INT8 xclbins.
+//
+// A and B are filled with 1, so C[i][j] == K exactly, for any tile layout: a
+// permutation of ones is still ones.  That removes the microtile-order variable
+// and leaves only the dataflow, which is what multi-core designs get wrong.  A
+// core that received only part of the K-tiles reports C == K * (received/total),
+// so the ratio C/K names the bug directly.
+//
+// Usage: ./bench_gemm_analytical <xclbin> <insts.txt> M K N [iters]
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+#include <chrono>
+#include <algorithm>
+#include <xrt/xrt_device.h>
+#include <xrt/xrt_bo.h>
+#include <xrt/xrt_kernel.h>
+
+int main(int argc, char** argv) {
+  if (argc < 6) {
+    fprintf(stderr, "Usage: %s <xclbin> <insts.txt> M K N [iters]\n", argv[0]);
+    return 1;
+  }
+  const char* xclbin_path = argv[1];
+  const char* insts_path = argv[2];
+  int M = atoi(argv[3]), K = atoi(argv[4]), N = atoi(argv[5]);
+  int iters = argc > 6 ? atoi(argv[6]) : 20;
+
+  FILE* f = fopen(insts_path, "rb");
+  if (!f) { fprintf(stderr, "cannot open %s\n", insts_path); return 1; }
+  fseek(f, 0, SEEK_END); long sz = ftell(f); fseek(f, 0, SEEK_SET);
+  std::vector<uint32_t> ins(sz / 4);
+  if (fread(ins.data(), 4, ins.size(), f) != ins.size()) { fclose(f); return 1; }
+  fclose(f);
+
+  xrt::device dev(0);
+  FILE* xf = fopen(xclbin_path, "rb");
+  if (!xf) { fprintf(stderr, "cannot open %s\n", xclbin_path); return 1; }
+  fseek(xf, 0, SEEK_END); long xsz = ftell(xf); fseek(xf, 0, SEEK_SET);
+  std::vector<char> xbuf(xsz);
+  if (fread(xbuf.data(), 1, xsz, xf) != (size_t)xsz) { fclose(xf); return 1; }
+  fclose(xf);
+  xrt::xclbin xc{xbuf};
+  dev.register_xclbin(xc);
+  xrt::hw_context hw(dev, xc.get_uuid());
+  xrt::kernel k(hw, "MLIR_AIE");
+
+  auto bI = xrt::bo(dev, ins.size() * 4, XCL_BO_FLAGS_CACHEABLE, k.group_id(1));
+  auto bA = xrt::bo(dev, (size_t)M * K, XRT_BO_FLAGS_HOST_ONLY, k.group_id(3));
+  auto bB = xrt::bo(dev, (size_t)K * N, XRT_BO_FLAGS_HOST_ONLY, k.group_id(4));
+  auto bC = xrt::bo(dev, (size_t)M * N * 4, XRT_BO_FLAGS_HOST_ONLY, k.group_id(5));
+
+  memcpy(bI.map(), ins.data(), ins.size() * 4);
+  bI.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  int8_t* Am = (int8_t*)bA.map();
+  int8_t* Bm = (int8_t*)bB.map();
+  printf("Analytical GEMM  M=%d K=%d N=%d\n", M, K, N);
+
+  // Pass 0: all ones, so C == K everywhere.  Permutation-invariant, which
+  // isolates the dataflow: a core that saw only part of the K-tiles reports
+  // K * (received/total).
+  //
+  // Pass 1: A[i][:] = i%4+1 and B[:][j] = j%3+1, so C[i][j] = K*(i%4+1)*(j%3+1).
+  // Still constant along k (still layout-independent), but the value now
+  // depends on the output coordinate, which catches a tile that was computed
+  // correctly and then written to the wrong row or column.
+  long bad = 0;
+  for (int pass = 0; pass < 2; pass++) {
+    if (pass == 0) {
+      memset(Am, 1, (size_t)M * K);
+      memset(Bm, 1, (size_t)K * N);
+    } else {
+      for (long i = 0; i < M; i++) memset(Am + i * K, (int)((i % 4) + 1), K);
+      for (long r2 = 0; r2 < K; r2++)
+        for (long j = 0; j < N; j++) Bm[r2 * N + j] = (int8_t)((j % 3) + 1);
+    }
+    memset(bC.map(), 0, (size_t)M * N * 4);
+    bA.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    bB.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    bC.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+    auto r = k((unsigned)3, bI, (unsigned)ins.size(), bA, bB, bC);
+    r.wait();
+    bC.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+    const int32_t* C = (const int32_t*)bC.map();
+    long wrong = 0, zero = 0;
+    int32_t lo = C[0], hi = C[0];
+    for (long i = 0; i < M; i++)
+      for (long j = 0; j < N; j++) {
+        int32_t want = pass == 0 ? K
+                                 : (int32_t)K * (int32_t)((i % 4) + 1) * (int32_t)((j % 3) + 1);
+        int32_t got = C[i * N + j];
+        if (got != want) wrong++;
+        if (got == 0) zero++;
+        lo = std::min(lo, got); hi = std::max(hi, got);
+      }
+    printf("  pass %d (%s): min=%d max=%d  wrong=%ld/%ld  zero=%ld  %s\n",
+           pass, pass == 0 ? "all-ones/dataflow" : "coord-dep/placement",
+           lo, hi, wrong, (long)M * N, zero, wrong == 0 ? "PASS" : "FAIL");
+    if (pass == 0 && wrong && hi > 0 && K % hi == 0)
+      printf("    ratio K/max = %d  (a core accumulated 1/%d of the K-tiles)\n", K / hi, K / hi);
+    bad += wrong;
+  }
+  printf("%s\n", bad == 0 ? "PASS" : "FAIL");
+
+  if (bad == 0) {
+    for (int i = 0; i < 3; i++) { auto w = k((unsigned)3, bI, (unsigned)ins.size(), bA, bB, bC); w.wait(); }
+    auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < iters; i++) {
+      auto w = k((unsigned)3, bI, (unsigned)ins.size(), bA, bB, bC);
+      w.wait();
+    }
+    auto t1 = std::chrono::steady_clock::now();
+    double ms = std::chrono::duration<double, std::milli>(t1 - t0).count() / iters;
+    double gops = 2.0 * M * K * N / (ms * 1e-3) / 1e9;
+    printf("  %.3f ms/launch   %.1f GOP/s   (%d iters)\n", ms, gops, iters);
+  }
+  return bad ? 1 : 0;
+}


### PR DESCRIPTION
### **User description**
First real step on #1486. **5.6× on the four production GEMM shapes, validated on hardware.**

## The finding

#1486 concluded the gap to FLM-class throughput was "the single-core kernel, not the loop schedule" and pointed at multi-core `whole_array` as the path. That turned out to be nearly free: the topology is `6x8` (row 0 shim, row 1 mem, **rows 2–5 compute = 32 tiles**), and `n1_core_i8_v26.py` builds `tiles = [... for row in range(3)]` — it only ever used **row 2, i.e. 8 of 32 cores.**

v27 uses all four core rows.

## Decomposition

- **A** varies by row, broadcast across that row's 8 columns
- **B** varies by column, broadcast down that column's 4 rows
- **C** is per-(row,col), joined into one `(rows*m, n)` L2 buffer per column

The C join needs no extra DMA dimension: concatenating `rows` microtiled `(m,n)` tiles is *bit-identical* to one microtiled `(rows*m, n)` tile — for `r = j*m + r'`, the single-tile offset `((r/8)*(n/8) + c/8)*64` expands to exactly `j*m*n + ((r'/8)*(n/8) + c/8)*64`. So the C tap stays 4-dimensional with `m → rows*m` (a 5th dim wouldn't fit in a shim BD).

The A broadcast also drops v26's **8× A duplication** — v26 re-sent each A tile once per column as its #1207 workaround — which is why the win is larger than the 4× core ratio.

## Measured (Strix Halo, 20 iters, both correctness passes clean everywhere)

| op | shape | v26 ms | v26 GOP/s | v27 ms | v27 GOP/s | speedup |
|----|-------|-------:|----------:|-------:|----------:|--------:|
| QKV | 128×1024×4096 | 8.843 | 121.4 | **1.591** | **674.8** | 5.6× |
| O | 128×2048×1024 | 4.314 | 124.5 | **0.710** | **756.7** | 6.1× |
| GU | 128×1024×6144 | 13.205 | 122.0 | **2.493** | **646.2** | 5.3× |
| D | 128×3072×1024 | 6.492 | 124.0 | **1.072** | **751.2** | 6.1× |

Per layer: **32.85 ms → 5.87 ms**. The v26 column reproduces #1486's recorded baseline (120–126 GOP/s), so both columns are measured identically. Device utilization goes from ~0.24% of 51 TOPS to ~1.4%.

## Harness

`bench_gemm_analytical.cpp` runs two passes, both constant along k and therefore immune to microtile-order confusion:
1. **all-ones** — `C == K` everywhere; a core that saw only part of the K-tiles reports `K*(received/total)`, so the ratio names the bug
2. **coordinate-dependent** — `C[i][j] = K*(i%4+1)*(j%3+1)`; catches a tile computed correctly but written to the wrong row/column

⚠️ Worth flagging: the existing `engine/npu/tests/test_gemm_i32_vectorized.cpp` reports **FAIL with byte-identical output for every xclbin**, including known-good v26 — its shuffle/unshuffle logic is broken and it produces false negatives. It cost real time here before I built the control experiment. Should be fixed or removed separately.

## Not wired into production yet

An xclbin and its instruction stream must be a matched pair, and `init_with_generator` (the fallback when no insts file exists) still emits v26-topology instructions. Flipping `run_build.sh`/`build_xclbins.sh` over needs that generator updated plus a real-model correctness run — deliberately not in this PR.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- v27 generator uses all 32 AIE compute cores

- 5.6–6.1× faster than v26 on production shapes
  - QKV 128x1024x4096: 8.843 ms → 1.591 ms
  - O 128x2048x1024: 4.314 ms → 0.710 ms
  - GU 128x1024x6144: 13.205 ms → 2.493 ms
  - D 128x3072x1024: 6.492 ms → 1.072 ms

- A/B broadcast removes v26's 8× A duplication

- Analytical GEMM harness verifies dataflow and placement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["v26 single-row generator"] -- "8 of 32 tiles" --> B["v27 multi-row generator"]
  B -- "32 cores, A/B broadcast" --> C["5.6–6.1× speedup"]
  B -- "validates dataflow/placement" --> D["bench_gemm_analytical.cpp"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>n1_core_i8_v27.py</strong><dd><code>Multi-row GEMM generator using all 32 cores</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/n1_core_i8_v27.py

<ul><li>New multi-row GEMM generator spanning 4 core rows (32 tiles)<br> <li> Broadcasts A per row and B per column via multicast object_fifo<br> <li> Joins per-core C tiles into one (rows*m, n) L2 buffer per column<br> <li> Drops v26's 8× A duplication and asserts topology constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1497/files#diff-339e3d996353c1827d91495f21d76c0c099835533ed08f8afb24204d83fa92fc">+214/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bench_gemm_analytical.cpp</strong><dd><code>Analytical GEMM correctness and throughput harness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tests/bench_gemm_analytical.cpp

<ul><li>New analytical correctness and throughput harness for INT8 GEMM <br>xclbins<br> <li> All-ones pass isolates dataflow; C/K ratio exposes partial K <br>accumulation<br> <li> Coordinate-dependent second pass catches wrong row/column placement<br> <li> Reports ms/launch and GOP/s once both passes pass</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1497/files#diff-9805de4d71cb3567e6c2a2dc7098200941b83d92bdb7e8f468775787f72d9fa4">+122/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

