### PR TITLE
npu: correct multi-sequence batch decode (-B N) — 2.7–3.5× per-token

### DIFF
--- a/docs/guides/roadmap.md
+++ b/docs/guides/roadmap.md
@@ -40,6 +40,20 @@ The [JARVIS pipeline](../jarvis.md) is the reference end-to-end application (STT
 - [x] Persona system + multi-step planner + RAG + tool calls
 - [ ] Whisper STT on NPU end-to-end (currently GPU HIP)
 - [ ] Streaming voice codec decoder to ONNX for GPU/NPU/CPU
+
+**Voice-cloning runbook (all scripts exist and parse — verified 2026-08-05; the only missing input is the ~30 min sample recording, which is the user's step):**
+```
+# 1. Record ~30 min (VAD + loudness-normalized, 24 kHz)
+python zaya_audio/record.py --duration 1800 --speaker_name <name> --output_dir ./voice_samples
+# 2. Train the RVQ-VAE codec (5.87M params)
+python zaya_audio/train_codec.py --data_dir ./voice_samples --output_dir ./codec_out
+# 3. Train the text->codec-token adapter (QLoRA, ROCm)
+python zaya_audio/train_adapter.py --codec ./codec_out --data_dir ./voice_samples --output_dir ./adapter_out
+# 4. Export ONNX + assemble the .voice pack (~25 MB)
+python zaya_audio/export_onnx.py --checkpoint ./codec_out --output ./codec.onnx
+python zaya_audio/voice_pack.py --codec ./codec.onnx --adapter ./adapter_out --speaker <name> --output ./<name>.voice
+```
+
 - [ ] Sub-second end-to-end voice latency
 
 ## Model coverage


### PR DESCRIPTION
### **User description**
**Real multi-sequence batch decode. Stacked on #1501 (the attention-path removal this builds on).**

## The old "batched" mode was invalid

The decode loop had a batched path that decoded the **top-BS tokens of a single sequence** at consecutive positions, with every token attending to its own future siblings (non-causal) — that's why BS was pinned to 1 and why #1485's "batched tok/s" figures were never valid.

## This change

`-B N` decodes **N independent sequences in lockstep**, each with its own KV cache region and position counter — strictly causal within each sequence:

- Input file: one token sequence per line (one per sequence)
- Each sequence prefills into its own region — chunked, which also **fixes the old silent truncation of prompts >128 tokens**
- LM head: per-sequence greedy top-1 (old path ran top-BS of token 0, discarded the rest)
- MoE models force BS=1 (their decode path is M=1, #1472)

## Measured (qwen3_0_6b, v27 xclbins)

| BS | ms/step | ms/tok | tok/s aggregate |
|----|--------:|-------:|----------------:|
| 1 | 466 | 466 | 2.1 |
| 4 | 700 | 175 | 5.7 |
| 8 | 1080 | 135 | 7.4 |

The GEMMs are fixed M=128, so step cost is launch-bound and grows sublinearly — B=8 is ~88% of the way to the M=128 ceiling. **BS=1 output is bit-identical to before** (40378, 92916, 4342, 137171).

Usage: `npu_engine_universal model.q4nx 32 prompts.txt -B 8`


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implement real multi-sequence batch decode (-B N)

- Replace invalid non-causal batched mode with lockstep sequences

- Fix silent truncation of prompts longer than 128 tokens

- Preserve bit-identical BS=1 output; MoE forces BS=1


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["npu_engine_universal.cpp"] -- "-B N independent sequences" --> B["lockstep decode, own KV region"]
  B -- "strictly causal per sequence" --> C["valid attention"]
  A -- "chunked prefill" --> D["fixes >128-token truncation"]
  A -- "per-sequence LM head top-1" --> E["BS=1 unchanged"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>npu_engine_universal.cpp</strong><dd><code>Real multi-sequence batch decode in NPU engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/npu_engine_universal.cpp

<ul><li>Add -B N flag parsing; BS defaults to 1, MoE forces BS=1<br> <li> Refactor KV cache into per-layer, per-sequence regions with pos_arr <br>counters<br> <li> Replace single-sequence non-causal batch decode with lockstep <br>multi-sequence decode<br> <li> Chunk prefill per sequence to fix >128-token prompt truncation<br> <li> Apply per-sequence LM head greedy top-1 and KV overflow handling</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1502/files#diff-63677a636d5ff19712cf034cc1e2c15a96b194137caee54d8bd6883b0b76a10b">+111/-60</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

