### PR TITLE
docs: record batch decode numbers (-B 8: 135 ms/tok, 7.4 tok/s)

### DIFF
--- a/docs/wiki/performance.md
+++ b/docs/wiki/performance.md
@@ -59,7 +59,7 @@ This is a device-level number, not a model-inference tok/s figure.
 | SmolLM2-135M Q4_K_M | **662 tok/s** | GGML-Vulkan | Peak end-to-end decode |
 | SmolLM2-360M Q4_K_M | **389 tok/s** | GGML-Vulkan | |
 | SmolLM2-1.7B Q4_K_M | **167 tok/s** | GGML-Vulkan | |
-| Qwen3-0.6B (native NPU engine) | **2.3 tok/s (435 ms/tok)** | XDNA 2 (32 cores, v27) | Measured 2026-08-05 — bit-identical token stream vs v26; prefill 475 ms/9 tok. See `site/benchmarks.json` |
+| Qwen3-0.6B (native NPU engine) | **2.3 tok/s (435 ms/tok); 7.4 tok/s @ -B 8** | XDNA 2 (32 cores, v27) | Measured 2026-08-05 — bit-identical token stream vs v26; prefill 475 ms/9 tok. Multi-sequence batch decode (-B N) is strictly causal per-sequence. See `site/benchmarks.json` |
 | Qwen3-0.6B Q4_K_M | **373 tok/s** | GGML-Vulkan | |
 | Qwen2.5-VL-3B Q4_K_M | **100 tok/s** | GGML-Vulkan | |
 | Qwen3.5-4B Q4_K_M | **65 tok/s** | GGML-Vulkan | |

--- a/engine/npu/generators/README.md
+++ b/engine/npu/generators/README.md
@@ -160,3 +160,31 @@ The fix script:
   See [#1076](https://github.com/1bit-systems/1bit-systems/issues/1076).
 - **BD count limit**: If you increase batch_size beyond 6, verify total BDs
   stay under 16 per tile. See the table above for the formula.
+
+## Building kernel variants (mm_32x64x128.o) — measured verdict
+
+The GEMM core kernel is `mm_32x64x128.o` (DIM_M=32, DIM_K=64, DIM_N=128,
+`matmul_i8_i32` / `zero_i32` exports, 8x8x8 vectorized mmul).  The original
+compile command was not recorded anywhere — this is the verified reproduction
+(2026-08-05), with clang++ from the working Peano
+(`~/mlir-aie/.venv/lib/python3.14/site-packages/llvm-aie/bin/clang++`):
+
+```
+clang++ mm_kernel_reference.cc -c -o mm_32x64x128.o \
+  -I ~/mlir-aie/third_party/aie_api/include -I ~/mlir-aie/aie_kernels/aie2p \
+  -std=c++20 -O2 -DNDEBUG -D__AIE_API_AIE_ADF_HPP__ \
+  --target=aie2p-none-unknown-elf \
+  -DDIM_M=32 -DDIM_K=64 -DDIM_N=128 -Di8_i32_ONLY
+```
+
+(The `npu2_40_toolchain` checkout's iron/aiecc are internally inconsistent —
+missing modules, stale binaries — do not route kernel builds through it.)
+
+**DIM_K=128 variant — measured, negative.** `mm_32x128x128.o` (same 8x8x8
+kernel, K=128 tiles) on the QKV shape: **1.943 ms / 552.6 GOP/s vs 1.591 ms /
+674.8 GOP/s** for DIM_K=64 (~18% regression), both correctness passes clean.
+Cause: the 16 KB B tile + 16 KB C tile pin core L1 at 64 KB, forcing fifo
+depth 2 (batch=1); the k=64 build's depth-6 K-batching DMA pipelining is
+worth more than the halved K-iteration count.  Tile shape is L1-bound and
+effectively optimal for this kernel structure — further kernel work should
+target operand-feed efficiency inside the mmul loop, not tile dims.

--- a/site/benchmarks.json
+++ b/site/benchmarks.json
@@ -247,14 +247,14 @@
    "notes": "Decode 11.66@1k → 8.82@32k; prefill 98.05@1k → 239.79@32k tok/s. 8 iters/ctx, performance mode, Strix Halo MAX+ 395. Prefill beats AMD official (Kraken Point) +8..24%; decode trails 7-15%. Official Q4_K_S weights (FastFlowLM/Qwen3.6-35B-A3B-NPU2). See benchmarks/RESULTS-qwen3.6-35b-a3b-npu-flm-2026-07-30.md"
   },
   "qwen3_0_6b_npu": {
-   "tok_s": 2.3,
+   "tok_s": 7.4,
    "status": "validated",
    "remeasured": "2026-08-05",
    "label": "Qwen3-0.6B Q4NX on native NPU engine (npu_engine_universal, v27 multi-core xclbins)",
    "table": "end_to_end",
    "display_name": "Qwen3-0.6B NPU (native)",
    "backend": "XDNA 2 (32 cores, v27)",
-   "notes": "Decode 435 ms/tok (2.3 tok/s), prefill 475 ms for 9 tok — measured 2026-08-05, bit-identical token stream vs v26. NPU attention default flipped to opt-in (was 55x slower than CPU)."
+   "notes": "Decode 435 ms/tok (B=1) → 135 ms/tok at -B 8 (7.4 tok/s aggregate, 8 independent sequences), prefill 475 ms/9 tok — measured 2026-08-05, bit-identical token stream vs v26. Multi-sequence batch decode is strictly causal (per-sequence KV); the old top-BS extension was never valid (#1485). NPU attention removed (fixed-seq kernel, 55x slower than CPU)."
   }
  },
  "table_kernel": [


### PR DESCRIPTION
### **User description**
Records the multi-sequence batch decode numbers from #1502 in the canonical data files:

- `site/benchmarks.json`: `qwen3_0_6b_npu` → **7.4 tok/s aggregate at `-B 8` (135 ms/tok)**, up from 2.3 tok/s (435 ms/tok) at B=1; notes updated (strictly causal per-sequence batching; the old top-BS extension was never valid per #1485; NPU attention kernel removed)
- `docs/wiki/performance.md`: end-to-end row reflects the batched number


___

### **PR Type**
Documentation


___

### **Description**
- Update benchmarks.json to 7.4 tok/s @ -B 8.

- Add causal batch-decode notes to performance wiki row.

- Document mm_32x64x128.o build command in generators README.

- Record DIM_K=128 measured 18% regression verdict.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["site/benchmarks.json"] --> B["qwen3_0_6b_npu: 7.4 tok/s @ -B 8"]
  C["docs/wiki/performance.md"] --> D["row updated with -B 8 aggregate"]
  E["engine/npu/generators/README.md"] --> F["kernel build recipe + DIM_K=128 verdict"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>benchmarks.json</strong><dd><code>Update NPU benchmark entry to -B 8 aggregate throughput</code>&nbsp; &nbsp; </dd></summary>
<hr>

site/benchmarks.json

<ul><li>Update qwen3_0_6b_npu tok_s from 2.3 to 7.4 (135 ms/tok at -B 8)<br> <li> Rewrite notes: strictly causal per-sequence batching; old top-BS <br>invalid (#1485)<br> <li> Clarify NPU attention kernel removed</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1506/files#diff-b552bfdecddd4c2f7fc7b8159f7a579cb78a692ce62528256ca28e5380c9e732">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>performance.md</strong><dd><code>Reflect batched NPU decode number in performance wiki</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/wiki/performance.md

<ul><li>Add 7.4 tok/s @ -B 8 aggregate to Qwen3-0.6B NPU row<br> <li> Note multi-sequence batch decode is strictly causal per sequence</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1506/files#diff-ac6822f734ec3ed3a30e3da33cbccf2a4ac0e3d60b550d30db8d022d4f3f9887">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add kernel build recipe and DIM_K=128 measured verdict</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/README.md

<ul><li>Record verified mm_32x64x128.o build command (Peano clang++)<br> <li> Add DIM_K=128 measured verdict: 1.943 ms / 552.6 GOP/s, ~18% <br>regression<br> <li> Explain L1-bound tile shape; recommend operand-feed kernel work</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1506/files#diff-e4ec6d73ff275dbf74b6851bf12c8fc0e8505b170aae72bf93abd98c9621c261">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

