### PR TITLE
docs: kernel profile — inner mmul loop is load-bound (28 loads / 12 vmac)

### DIFF
--- a/engine/npu/generators/README.md
+++ b/engine/npu/generators/README.md
@@ -188,3 +188,29 @@ depth 2 (batch=1); the k=64 build's depth-6 K-batching DMA pipelining is
 worth more than the halved K-iteration count.  Tile shape is L1-bound and
 effectively optimal for this kernel structure — further kernel work should
 target operand-feed efficiency inside the mmul loop, not tile dims.
+
+### Kernel profile (source + disassembly, 2026-08-05)
+
+The k-reduction loop of `matmul_vectorized_2x2_mmul` is:
+
+```
+for i in k/s:              // colA = k/s = 8 iterations for DIM_K=64
+    load A0, A1            // 2 vector loads
+    load B0, B1            // 2 vector loads
+    C00.mac(A0,B0) C01.mac(A0,B1) C10.mac(A1,B0) C11.mac(A1,B1)  // 4 vmac
+```
+
+**4 vector loads per 4 vmacs (1:1)**; the disassembly (.LBB0_2) shows the
+compiler double-buffering the loads (bm*1/bm*2 register pairs) but the four
+macs per step share A0/A1/B0/B1, so each step is one dependency group —
+the macs cannot start until all four loads land, and the next step's macs
+wait on this step's.  That is the concrete mechanism behind the ~750 GOP/s
+(≈20-30% of the core's mmul issue capacity): **insufficient independent
+macs to hide load/mac latency, not raw load count**.
+
+The fix direction is a wider n-expansion (2x4 instead of 2x2): load A0/A1
+once per k-step, load four B pairs, issue 8 macs — halves A traffic and,
+more importantly, doubles the independent macs the pipeline can overlap.
+That is a rewrite of the mmul loop in `mm_kernel_reference.cc` — the
+generator cannot fix it, and the tile-shape experiments (DIM_K=128)
+confirmed the L1 layout is already at its limit.


### PR DESCRIPTION
### **User description**
Kernel profile from source + disassembly — the concrete mechanism behind the ~750 GOP/s ceiling.

The k-reduction loop of `matmul_vectorized_2x2_mmul`:
```
for i in k/s:                 // 8 iterations for DIM_K=64
    load A0, A1               // 2 vector loads
    load B0, B1               // 2 vector loads
    C00.mac(A0,B0) C01.mac(A0,B1) C10.mac(A1,B0) C11.mac(A1,B1)  // 4 vmac
```
**4 loads per 4 vmacs (1:1)** — but all four macs share A0/A1/B0/B1, so each k-step is one dependency group: the macs can't start until all four loads land, and the next step's macs wait on this step's. The disassembly shows the compiler double-buffering the loads, yet the machine sustains only ~20-30% of the core's mmul issue capacity.

**Verdict: ILP-bound, not load-count-bound.** Each A load feeds only 2 macs; there aren't enough independent macs to hide load/mac latency.

**Fix direction:** widen the n-expansion (2×4 instead of 2×2) — one A load group feeding 8 macs doubles the independent work the pipeline can overlap. That's a `mm_kernel_reference.cc` rewrite; the generator can't fix it, and the DIM_K=128 experiment confirmed the L1 tile layout is already at its limit.


___

### **PR Type**
Documentation


___

### **Description**
- Add kernel profile for `matmul_vectorized_2x2_mmul` inner loop

- Document ILP-bound ~750 GOP/s ceiling from 4 loads per 4 vmacs

- Recommend wider 2x4 n-expansion requiring `mm_kernel_reference.cc` rewrite


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["2x2 mmul k-loop"] --> B["4 loads / 4 vmacs (1:1)"]
  B --> C["One dependency group per step"]
  C --> D["~750 GOP/s (ILP-bound)"]
  D --> E["Fix: 2x4 n-expansion"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document ILP-bound kernel profile and fix direction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/README.md

<ul><li>Adds kernel profile section summarizing source and disassembly <br>analysis<br> <li> Details 4 loads per 4 vmacs and the dependency-group ILP bottleneck<br> <li> Proposes wider 2x4 n-expansion to double independent macs<br> <li> Notes fix requires <code>mm_kernel_reference.cc</code> rewrite, not generator <br>changes</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1507/files#diff-e4ec6d73ff275dbf74b6851bf12c8fc0e8505b170aae72bf93abd98c9621c261">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

