### PR TITLE
fix: NPU device path probe handles flat /dev/accelN layout (#1517)

### DIFF
--- a/src/backend_factory.cpp
+++ b/src/backend_factory.cpp
@@ -17,13 +17,20 @@
 // Any /dev/accel/accelN node present — the index isn't stable across driver
 // resets (the XDNA driver has been observed renumbering accel0 -> accel1
 // after an IOMMU page fault / device reset), so don't hardcode accel0.
+// The node lives at /dev/accel/accelN (amdxdna >= 0.6) or flat /dev/accelN
+// on older drivers — probe both (issue #1517).
 static bool any_accel_device_present() {
     DIR* d = opendir("/dev/accel");
+    if (!d) d = opendir("/dev");
     if (!d) return false;
     bool found = false;
     struct dirent* e;
     while ((e = readdir(d)) != nullptr) {
-        if (strncmp(e->d_name, "accel", 5) == 0) { found = true; break; }
+        // 'accel' + digit — scanning /dev directly also sees the "accel"
+        // directory entry itself, which must not count as a device.
+        if (strncmp(e->d_name, "accel", 5) == 0 && e->d_name[5] >= '0' && e->d_name[5] <= '9') {
+            found = true; break;
+        }
     }
     closedir(d);
     return found;

--- a/src/backend_fused_npu.cpp
+++ b/src/backend_fused_npu.cpp
@@ -1,6 +1,7 @@
 // backend_fused_npu.cpp — NPU FFN caller (pure C++, not HIP).
 // Compiled as CXX to avoid HIP compiler context conflicts with XRT.
 #include "backend_fused_npu.h"
+#include "npu_device_path.h"
 #include "../engine/fusion/zero_copy/npu_gemm_kernel.h"
 #include <cmath>
 #include <vector>
@@ -17,7 +18,7 @@ struct NpuState {
 };
 
 NpuState* npu_state_create(const char* xclbin_dir, int H, int IM, int NC) {
-    int npu_fd = open("/dev/accel/accel0", O_RDONLY);
+    int npu_fd = open(npu_device_path(), O_RDONLY);
     if (npu_fd < 0) return nullptr;
     close(npu_fd);
 

--- a/src/backend_npu_flm.cpp
+++ b/src/backend_npu_flm.cpp
@@ -13,6 +13,7 @@
 // Part of the unified zaya_server binary.
 
 #include "backend.h"
+#include "npu_device_path.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -154,9 +155,10 @@ public:
             return false;
         }
 
-        // Detect NPU hardware
-        if (access("/dev/accel/accel0", F_OK) != 0) {
-            fprintf(stderr, "NPU: no /dev/accel/accel0 — XDNA 2 not available\n");
+        // Detect NPU hardware (node layout varies: /dev/accel/accelN or
+        // flat /dev/accelN — issue #1517)
+        if (!npu_device_present()) {
+            fprintf(stderr, "NPU: no %s — XDNA 2 not available\n", npu_device_path());
             return false;
         }
 

--- a/src/npu_device_path.h
+++ b/src/npu_device_path.h
@@ -1,0 +1,17 @@
+#pragma once
+// XDNA2 NPU device-node layout varies by driver/kernel: amdxdna >= 0.6
+// (Strix Halo) keeps nodes at /dev/accel/accelN; older or flat layouts put
+// accelN directly under /dev. Probe both instead of hardcoding one path
+// (issue #1517 — health checks reported "NPU not available" on hosts with
+// the flat layout).
+#include <unistd.h>
+
+static inline const char* npu_device_path() {
+    if (access("/dev/accel/accel0", F_OK) == 0) return "/dev/accel/accel0";
+    if (access("/dev/accel0", F_OK) == 0) return "/dev/accel0";
+    return "/dev/accel/accel0";  // default (used in error messages)
+}
+
+static inline bool npu_device_present() {
+    return access(npu_device_path(), F_OK) == 0;
+}


### PR DESCRIPTION
Fixes #1517.

The XDNA2 node layout **varies by driver**: amdxdna ≥ 0.6 (Strix Halo) keeps nodes at `/dev/accel/accelN`; older/flat layouts put `accelN` directly under `/dev`. Verified live on this host: **`/dev/accel/accel0` exists and is correct** (major 261, amdxdna loaded) — so a blind swap to `/dev/accel0` would have broken the working host. The fix probes both.

- **new `src/npu_device_path.h`** — `npu_device_path()` / `npu_device_present()` checking both layouts
- **backend_factory.cpp** — `any_accel_device_present()` falls back to scanning `/dev` for `accelN` (digit check so the `accel` directory entry itself doesn't count)
- **backend_fused_npu.cpp** / **backend_npu_flm.cpp** — use the probe (error message now prints the resolved path)

Verified: probe → `/dev/accel/accel0 present=1` on this host; `onebin` builds clean.