### PR TITLE
fix(convert): gguf_to_onebp emits valid Zaya MoE Q4NX (#1522)

### DIFF
--- a/include/onebp_format.h
+++ b/include/onebp_format.h
@@ -92,6 +92,7 @@ enum OnebpQuant : uint32_t {
     ONEBP_F32  = 5,   // Float32 (no quant)
     ONEBP_TQ2NZ= 6,   // No-zero 2-bit S40 {-4,-1,+1,+4} (ROCmFPX-FP2-style)
     ONEBP_TQ2NZ_E4M3 = 7, // TQ2NZ with 1-byte UE4M3 scales (2.25 bpw)
+    ONEBP_TQ2BS = 8,      // Block-scaled ternary, per-16 FP8 E4M3 scales (5 B/block)
 };
 
 // ─── Scale types ───────────────────────────────────────────────────

--- a/src/gguf_reader.cpp
+++ b/src/gguf_reader.cpp
@@ -644,7 +644,7 @@ bool GgufReader::get_tensor_raw(const std::string& name, int block_size, int blo
     if (it == tensors_.end() || !f_ || block_size <= 0 || block_bytes <= 0) return false;
     const GgufTensorInfo& ti = it->second;
     if (out_numel) *out_numel = ti.numel;
-    constexpr uint64_t MAX_TENSOR_ELEMENTS = 1ULL << 30;  // fixes #1320: guard sentinel-numel
+    constexpr uint64_t MAX_TENSOR_ELEMENTS = 1ULL << 31;  // fixes #1320: guard sentinel-numel; 2^31 elems = 8.6 GB f32 ceiling (74B embeddings are 1.07G elems, #1522)
     if (ti.numel > MAX_TENSOR_ELEMENTS) return false;
     uint64_t n_blocks = (ti.numel + block_size - 1) / block_size;
     out.resize(n_blocks * (uint64_t)block_bytes);
@@ -656,7 +656,7 @@ bool GgufReader::get_tensor_f32(const std::string& name, std::vector<float>& out
     auto it = tensors_.find(name);
     if (it == tensors_.end() || !f_) return false;
     const GgufTensorInfo& ti = it->second;
-    static constexpr uint64_t MAX_TENSOR_ELEMENTS = 1ULL << 30;
+    static constexpr uint64_t MAX_TENSOR_ELEMENTS = 1ULL << 31;
     if (ti.numel > MAX_TENSOR_ELEMENTS) return false;
     out.resize(ti.numel);
     if (out_n) *out_n = ti.numel;

--- a/tools/gguf_to_onebp.cpp
+++ b/tools/gguf_to_onebp.cpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <cstring>
 #include "onebp_format.h"
+#include "block_scaled_ternary.h"
 #include <signal.h>
 #include "gguf_reader.h"
 
@@ -81,6 +82,7 @@ int main(int argc, char** argv) {
         if (strcmp(argv[ai], "--tq2") == 0)       quant = ONEBP_TQ2;
         else if (strcmp(argv[ai], "--tq2nz") == 0) quant = ONEBP_TQ2NZ;
         else if (strcmp(argv[ai], "--tq2nz-e4m3") == 0) quant = ONEBP_TQ2NZ_E4M3;
+        else if (strcmp(argv[ai], "--tq2bs") == 0) quant = ONEBP_TQ2BS;
         else if (strcmp(argv[ai], "--tq1") == 0)  quant = ONEBP_TQ1;
         else if (strcmp(argv[ai], "--q4nx") == 0) quant = ONEBP_Q4NX;
         else if (strcmp(argv[ai], "--imatrix") == 0 && ai + 1 < argc) imatrix_path = argv[++ai];
@@ -94,6 +96,7 @@ int main(int argc, char** argv) {
     const char* quant_name = (quant == ONEBP_TQ2) ? "TQ2 (ternary 2-bit)" :
                              (quant == ONEBP_TQ2NZ) ? "TQ2NZ (no-zero 2-bit S40)" :
                              (quant == ONEBP_TQ2NZ_E4M3) ? "TQ2NZ-E4M3 (no-zero 2-bit, UE4M3 scales)" :
+                             (quant == ONEBP_TQ2BS) ? "TQ2BS (block-scaled ternary, FP8 scales)" :
                              (quant == ONEBP_TQ1) ? "TQ1 (ternary 1.58-bit)" :
                              "Q4NX (4-bit)";
     GgufReader reader;
@@ -142,6 +145,7 @@ int main(int argc, char** argv) {
     // Detect by checking whether shape[0] or shape[2] is consistent across
     // gate/down/up MoE tensors.
     bool moe_shape_colmajor = false;  // row-major [experts, rows, cols] by default
+    uint32_t meta_num_experts = 0;    // <arch>.expert_count metadata, authoritative
     {
         int s0_first = 0, s2_first = 0;
         int s0_count = 0, s2_count = 0;
@@ -154,7 +158,7 @@ int main(int argc, char** argv) {
             if (s0_first == 0) { s0_first = s0; s2_first = s2; }
             if (s0 == s0_first && s0 > 0) s0_count++;
             if (s2 == s2_first && s2 > 0) s2_count++;
-            if (tn.find("gate_exps") != std::string::npos) {
+            if (tn.find("gate_exps") != std::string::npos || tn.find("gate_up_exps") != std::string::npos) {
                 if (first_gate_s0 == 0) first_gate_s0 = s0;
             }
         }
@@ -164,6 +168,27 @@ int main(int argc, char** argv) {
         if (s2_count > s0_count && s2_count >= 2 &&
             (first_gate_s0 == 0 || s2_first < first_gate_s0)) {
             moe_shape_colmajor = true;
+        }
+
+        // Metadata expert count is authoritative and beats the shape heuristic:
+        // zaya stores expert tensors as [rows, cols, experts] (dims[2] = count),
+        // which ties the consistency vote 2:2 (both dims constant across
+        // tensors) and loses to row-major — the converter then reads 4096
+        // 'experts' and emits a ~242 GB fp32 garbage artifact (issue #1522).
+        // Qwen/Mixtral store [experts, rows, cols] (dims[0] = count).
+        if (!reader.get_u32(reader.architecture() + ".expert_count", meta_num_experts))
+            reader.get_u32("expert_count", meta_num_experts);
+        if (meta_num_experts > 0) {
+            for (auto& tn : reader.tensor_names()) {
+                auto* inf = reader.tensor_info(tn);
+                if (!inf || inf->shape.size() != 3) continue;
+                if (tn.find("exps.") == std::string::npos && tn.find("shexp") == std::string::npos) continue;
+                if ((int)inf->shape[2] == (int)meta_num_experts && (int)inf->shape[0] != (int)meta_num_experts)
+                    moe_shape_colmajor = true;   // zaya convention [rows, cols, experts]
+                else if ((int)inf->shape[0] == (int)meta_num_experts && (int)inf->shape[2] != (int)meta_num_experts)
+                    moe_shape_colmajor = false;  // qwen convention [experts, rows, cols]
+                break;
+            }
         }
     }
 
@@ -176,8 +201,19 @@ int main(int argc, char** argv) {
             if (inf && inf->shape.size() == 3) { is_moe = true; break; }
         }
         if (is_moe) {
-            // Infer intermediate_size and expert count from first MoE tensor
-            if (!hdr.intermediate_size || !hdr.num_experts) {
+            // Infer intermediate_size and expert count from metadata first
+            // (authoritative — beats the tensor-shape guess below, which
+            // cannot find zaya's ffn_gate_up_exps names, issue #1522).
+            if (!hdr.num_experts) hdr.num_experts = meta_num_experts;
+            if (!hdr.n_expert_used) {
+                uint32_t neu = 0;
+                if (!reader.get_u32(reader.architecture() + ".expert_used_count", neu))
+                    reader.get_u32("expert_used_count", neu);
+                hdr.n_expert_used = neu ? neu : 8;
+            }
+            // Fall back to the first MoE tensor's shape only when metadata
+            // is absent.
+            if (!hdr.num_experts || !hdr.intermediate_size) {
                 auto* exps = reader.tensor_info("blk.0.ffn_gate_exps.weight");
                 if (!exps) exps = reader.tensor_info("blk.0.ffn_down_exps.weight");
                 if (!exps) exps = reader.tensor_info("blk.0.ffn_up_exps.weight");
@@ -359,10 +395,22 @@ int main(int argc, char** argv) {
             data_off += tiled;
             if (tensors.size() <= 3) printf("  tensor %s: %dx%d tiled=%lu quant=%d\n", tn.c_str(), r, c, tiled, (int)tq);
         } else {
-            // ndim == 3: MoE expert-stacked tensor [num_experts, rows, cols]
+            // ndim == 3: expert-stacked tensor. Expert tensors (name contains
+            // 'exps.'/'shexp') follow the detected layout ([experts, rows,
+            // cols] row-major, [cols, rows, experts] colmajor, or zaya's
+            // [rows, cols, experts] — resolved via metadata expert count
+            // above, issue #1522). Non-expert 3D tensors (e.g. zaya's
+            // cca_conv_grp.weight [2, 128, n_qk]) are NOT expert stacks —
+            // always read row-major, matching the old behavior.
+            bool expert_tensor = (tn.find("exps.") != std::string::npos || tn.find("shexp") != std::string::npos);
             int ne, r, c;
-            if (moe_shape_colmajor) {
-                // column-major [cols, rows, experts]
+            if (!expert_tensor) {
+                ne = (int)inf->shape[0];
+                r  = (int)inf->shape[1];
+                c  = (int)inf->shape[2];
+            } else if (moe_shape_colmajor) {
+                // column-major [cols, rows, experts] (also zaya's [rows,
+                // cols, experts] read back as cols=shape[0], rows=shape[1])
                 ne = (int)inf->shape[2];  // experts
                 r  = (int)inf->shape[1];  // rows
                 c  = (int)inf->shape[0];  // cols
@@ -451,7 +499,14 @@ int main(int argc, char** argv) {
         if (inf) printf("%lu elements at offset %lu\n", inf->numel, inf->abs_offset);
         fflush(stdout);
         if (!reader.get_tensor_f32(ti.name, fw)) {
-            printf("SKIP (get_tensor_f32 failed)\n"); continue;
+            // A skipped tensor writes NOTHING while the index already reserved
+            // its tiled bytes — every subsequent offset desyncs and the whole
+            // file is silently garbage (issue #1522: token_embd 1.07G elems
+            // tripped the reader's size cap and produced a ~44 GB corrupt
+            // artifact). Never skip: abort so the failure is loud.
+            fprintf(stderr, "\nFATAL: get_tensor_f32 failed for %s — aborting (a skipped tensor would "
+                    "desync every subsequent offset)\n", ti.name.c_str());
+            return 1;
         }
         if (ti.ndim == 1) {
             // Raw, unquantized float32 — no tiling (norm weights, biases).
@@ -512,6 +567,24 @@ int main(int argc, char** argv) {
                                 qd[pos / 4] |= (uint8_t)(code << ((pos & 3) * 2));
                             }
                         }
+                    }
+                    fwrite(tdata.data(), 1, tdata.size(), fout);
+                    continue;
+                }
+                if (ti.tq == ONEBP_TQ2BS) {
+                    // ── TQ2BS: block-scaled ternary, per-16 blocks with FP8
+                    // E4M3 scale (5 B/block). Row-major within tile: 32 rows ×
+                    // 16 blocks × 5 B = 2560 B. Single quant from source —
+                    // avoids the TQ2→TQ2BS double-quant loss (see
+                    // tools/tq2_to_bst.cpp for the double-quant variant).
+                    std::vector<uint8_t> tdata((size_t)tr * (tc / 16) * BST_BLOCK_BYTES, 0);
+                    for (int rr = 0; rr < tr; rr++) {
+                        int ar = r0 + rr;
+                        if (ar >= R) break;  // partial last tile row → zero-pad
+                        int cw = std::min(tc, C - c0);
+                        uint8_t* blocks = tdata.data() + (size_t)rr * (tc / 16) * BST_BLOCK_BYTES;
+                        block_scaled_ternary_pack_row(
+                            fw.data() + expert_off + (size_t)ar * C + c0, blocks, cw);
                     }
                     fwrite(tdata.data(), 1, tdata.size(), fout);
                     continue;


### PR DESCRIPTION
Fixes #1522. Unblocks #1521 (native Zaya HIP engine validation).

## Root causes (found by running the converter against the real 74B GGUF)

**1. Shape-convention detection tied 2:2 and voted row-major.** Zaya stores expert tensors as [rows, cols, experts] (dims[2] = count); the heuristic only distinguishes Qwen/Mixtral [experts, rows, cols] from Laguna [cols, rows, experts]. Result: 4096 "experts" read, every expert tensor scrambled → the ~242 GB fp32 artifact. Fix: **zaya.expert_count metadata is authoritative** — matches dims[2] (not dims[0]) → zaya layout. Also taught the first_gate_s0 tie-break about gate_up_exps names, and the MoE header inference now prefers metadata (expert_used_count instead of the hardcoded 8).

**2. Silent skip desync.** token_embd.weight (262147×4096 = 1,073,754,112 elements) tripped gguf_reader's 1<<30 MAX_TENSOR_ELEMENTS guard → read failed → converter SKIPped it — but the index had already reserved its ~671 MB, so **every subsequent tensor's data shifted by 671 MB → the entire file was silently corrupt**. Fix: cap → 1<<31, and **any failed read now aborts the conversion** (a skipped tensor can never produce a valid file).

## Verification (real 74B, 45.76 GB Q4_K_M)
- Converted: ZAYA1-74B.1bp — **43.6 GiB Q4NX, 1923 tensors, 24 experts, header H=4096 L=120 NH=16 NKV=2 HD=128 IM=4096 V=262147 experts=24 used=1** (was: 242 GB fp32 garbage)
- Round-trip through the engine's own NpuOnebpModel dequant vs source GGUF: **Pearson r = 0.994–0.999** across experts 0/12/23 of layers 1/60/119, zero NaNs — exactly what two different 4-bit quantizations of identical weights should score
- Alternating-layer structure confirmed in the file (even layers have no experts)

**Next (documented in #1521):** the engine loader's tensor mapping (cdw ← ssm_conv1d, cgw ← cca_conv_grp 3D, gdw ← ffn_gate_inp, rout) — the strict #1537 loader will now abort loudly on the first mismatch instead of silently misreading.