### PR TITLE
fix: backend init exceptions must not abort the server (NPU wedge)

### DIFF
--- a/engine/fusion/zero_copy/npu_gemm_kernel.h
+++ b/engine/fusion/zero_copy/npu_gemm_kernel.h
@@ -72,15 +72,18 @@ public:
             d.register_xclbin(*xc);
             hc = std::make_unique<xrt::hw_context>(d, xc->get_uuid());
             k = std::make_unique<xrt::kernel>(*hc, "MLIR_AIE");
+
+            // BO allocation does an mmap on the NPU device — on a wedged
+            // NPU (firmware timeout) this throws; the backend must degrade
+            // to GPU-only, never crash the host process.
+            bI = std::make_unique<xrt::bo>(d, ins.size() * 4, XCL_BO_FLAGS_CACHEABLE, k->group_id(1));
+            memcpy(bI->map(), ins.data(), ins.size() * 4);
+            bI->sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+            bA = std::make_unique<xrt::bo>(d, (size_t)MD * KD, XRT_BO_FLAGS_HOST_ONLY, k->group_id(3));
+            bB = std::make_unique<xrt::bo>(d, (size_t)KD * ND, XRT_BO_FLAGS_HOST_ONLY, k->group_id(4));
+            bC = std::make_unique<xrt::bo>(d, (size_t)MD * ND * 4, XRT_BO_FLAGS_HOST_ONLY, k->group_id(5));
         } catch (...) { return false; }
-
-        bI = std::make_unique<xrt::bo>(d, ins.size() * 4, XCL_BO_FLAGS_CACHEABLE, k->group_id(1));
-        memcpy(bI->map(), ins.data(), ins.size() * 4);
-        bI->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-
-        bA = std::make_unique<xrt::bo>(d, (size_t)MD * KD, XRT_BO_FLAGS_HOST_ONLY, k->group_id(3));
-        bB = std::make_unique<xrt::bo>(d, (size_t)KD * ND, XRT_BO_FLAGS_HOST_ONLY, k->group_id(4));
-        bC = std::make_unique<xrt::bo>(d, (size_t)MD * ND * 4, XRT_BO_FLAGS_HOST_ONLY, k->group_id(5));
         memset(bA->map(), 0, (size_t)MD * KD);
         memset(bC->map(), 0, (size_t)MD * ND * 4);
         Am = (int8_t*)bA->map(); Cm = (int32_t*)bC->map(); ok = true; return true;

--- a/src/backend_manager.cpp
+++ b/src/backend_manager.cpp
@@ -514,7 +514,17 @@ bool BackendManager::init_in_order(const ModelConfig& cfg, const std::string& we
         // never came up; still bounded so a hung init can't block forever
         // (issue #1282).
         if (init_fut.wait_for(std::chrono::seconds(120)) == std::future_status::ready) {
-            init_ok = init_fut.get();
+            // init() may THROW (wedged NPU/XRT, driver fault, OOM) — the
+            // exception is captured by the future and rethrown here. A
+            // broken backend must be skipped, never allowed to terminate
+            // the whole server (mirrors benchmark_all()'s handling below).
+            try {
+                init_ok = init_fut.get();
+            } catch (const std::exception& e) {
+                printf("  → ❌ (init threw: %s)\n", e.what());
+            } catch (...) {
+                printf("  → ❌ (init threw unknown exception)\n");
+            }
         } else {
             printf("  → ⏱️  init timed out (>120s) — skipping\n");
             destroy_instance(info);

--- a/src/runner/runner.cpp
+++ b/src/runner/runner.cpp
@@ -39,7 +39,16 @@ std::map<std::string, runner_cmd_t> cmd_map = {
 Runner::Runner(model_list& supported_models, ModelDownloader& downloader, program_args_t& args)
     : supported_models(supported_models), downloader(downloader), tag(args.model_tag), asr(args.asr), embed(args.embed), img_pre_resize(args.img_pre_resize), preemption(args.preemption) {
 
-    this->npu_device_inst = xrt::device(0);
+    // NPU device handle — optional: a wedged NPU (firmware timeout, issue
+    // #1536 class) makes xrt::device(0) throw, which in a constructor would
+    // abort the whole process even for models that never touch the NPU.
+    try {
+        this->npu_device_inst = xrt::device(0);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "Warning: NPU unavailable (%s) — continuing without NPU\n", e.what());
+    } catch (...) {
+        fprintf(stderr, "Warning: NPU unavailable — continuing without NPU\n");
+    }
 
     if (args.ctx_length != -1) {
         this->ctx_length = args.ctx_length >= 512 ? args.ctx_length : 512;

--- a/src/server/rest_handler.cpp
+++ b/src/server/rest_handler.cpp
@@ -325,7 +325,18 @@ static json convert_tool_responses_gemma4(json messages) {
 ///@return the rest handler
 RestHandler::RestHandler(model_list& models, ModelDownloader& downloader, program_args_t& args)
     : supported_models(models), downloader(downloader), default_model_tag(args.model_tag), current_model_tag(""), asr(args.asr), embed(args.embed), img_pre_resize(args.img_pre_resize), preemption(args.preemption){
-    this->npu_device_inst = xrt::device(0);
+    // NPU device handle — optional: a wedged NPU (firmware timeout, issue
+    // #1536 class) makes xrt::device(0) throw, which in a constructor would
+    // abort the whole process even for models that never touch the NPU.
+    // Leave it default-constructed (empty) on failure; NPU-dependent models
+    // fail per-model instead of taking the server down.
+    try {
+        this->npu_device_inst = xrt::device(0);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "Warning: NPU unavailable (%s) — continuing without NPU\n", e.what());
+    } catch (...) {
+        fprintf(stderr, "Warning: NPU unavailable — continuing without NPU\n");
+    }
 
     if (args.ctx_length != -1) {
         this->ctx_length = args.ctx_length >= 512 ? args.ctx_length : 512;


### PR DESCRIPTION
## Problem

The End-to-End Smoke Test has failed on **every PR** (15+ consecutive runs). Root cause chain:

1. The self-hosted runner's NPU (amdxdna) gets wedged (firmware timeouts — issue #1536 class)
2. During server startup, `BackendManager::init_in_order()` tries every backend; a backend touching XRT throws `xrt_core::system_error` (mmap EAGAIN)
3. `init_fut.get()` rethrows **unguarded** → `std::terminate` → abort → core dump → server never starts → smoke test fails

The benchmark path (`benchmark_all`) already documents and implements the intent — *"init()/benchmark() may THROW (missing Vulkan shader, driver fault, OOM) — a broken backend must be skipped, never allowed to std::terminate the whole server"* — but `init_in_order` forgot the try/catch.

## Fix

- **backend_manager.cpp**: catch exceptions from backend init in `init_in_order` — skip the broken backend, keep the server up (mirrors `benchmark_all`)
- **npu_gemm_kernel.h**: move `xrt::bo` allocations inside the existing try/catch — a wedged NPU degrades the fused backend to GPU-only instead of throwing
- **rest_handler.cpp / runner.cpp**: `xrt::device(0)` in constructors no longer aborts the process on a wedged NPU; leaves a default (empty) device and logs a warning

## Verification

Full smoke sequence (health, chat completion, completion, invalid JSON, timeout) passes on the self-hosted runner with the fixed binary:

- health: ok, active: ggml_vulkan
- chat: finish=stop, 32 chars
- completion: text generated
- invalid JSON: 400 handled
- timeout: finish=stop