### PR TITLE
site(eeg-medical): add live sync stats panel + stats.json fetch

### DIFF
--- a/site/eeg-medical/index.html
+++ b/site/eeg-medical/index.html
@@ -132,7 +132,13 @@ footer{border-top:1px solid var(--border);margin-top:20px;padding:40px 32px;}
 <span class="eyebrow">Data Access</span>
 <h2 style="margin:16px 0 8px;">Temple University Hospital EEG Corpus.</h2>
 <p class="lead">The TUH EEG Corpus requires a data access request directly from Temple University. Once access is granted: place EDF files under <code>data/tuh_raw/</code>, run <code>scripts/preprocess_tuh.py</code>, and the output lands in <code>data/tuh_processed/</code> as ZUNA-compatible pairs, ready for fine-tuning.</p>
-<div class="disclaimer">This is a research pipeline, not a diagnostic tool. Outputs have not been validated for clinical decision-making and should not be used to diagnose or treat patients.</div>
+<div class="stats" id="sync-stats" style="margin-top:28px;">
+<div class="stat"><span class="lbl">Recordings synced</span><span class="val" id="stat-synced">—</span></div>
+<div class="stat"><span class="lbl">Data synced</span><span class="val" id="stat-gb">—</span></div>
+<div class="stat"><span class="lbl">% of corpus</span><span class="val" id="stat-pct">—</span></div>
+<div class="stat"><span class="lbl">Last sync</span><span class="val" id="stat-lastsync" style="font-size:16px;">—</span></div>
+</div>
+<div class="disclaimer">This is a research pipeline, not a diagnostic tool. Outputs have not been validated for clinical decision-making and should not be used to diagnose or treat patients. The sync stats above are aggregate pipeline progress metrics only — no raw EEG data, file listings, or patient information is published here, per Temple University's data use agreement.</div>
 </section>
 
 <section id="quickstart" class="block">
@@ -167,6 +173,25 @@ Built on <a href="https://huggingface.co/Zyphra/ZUNA1.1" target="_blank" rel="no
 —bong-water-water-bong · "free for research and commercial use, no closed-source profiteering"
 </div>
 </footer>
+
+<script>
+fetch('./stats.json?_=' + Date.now())
+  .then(function(r){ return r.ok ? r.json() : null; })
+  .then(function(d){
+    if(!d) return;
+    function set(id, v){ var el = document.getElementById(id); if(el && v !== undefined && v !== null) el.textContent = v; }
+    if(typeof d.recordings_synced === 'number') set('stat-synced', d.recordings_synced.toLocaleString());
+    if(typeof d.gb_synced === 'number') set('stat-gb', d.gb_synced.toLocaleString() + ' GB');
+    if(typeof d.recordings_synced === 'number' && typeof d.total_available === 'number' && d.total_available > 0){
+      set('stat-pct', Math.round((d.recordings_synced / d.total_available) * 100) + '%');
+    }
+    if(d.last_sync_utc){
+      var dt = new Date(d.last_sync_utc);
+      if(!isNaN(dt.getTime())) set('stat-lastsync', dt.toLocaleDateString(undefined, {year:'numeric', month:'short', day:'numeric'}));
+    }
+  })
+  .catch(function(){});
+</script>
 
 </body>
 </html>

--- a/site/eeg-medical/scripts/update_stats.sh
+++ b/site/eeg-medical/scripts/update_stats.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# update_stats.sh
+#
+# Reference script: run this periodically (e.g. via cron) on the machine
+# that rsyncs the TUH EEG Corpus, AFTER each sync completes. It writes
+# aggregate, non-identifying counts to stats.json and pushes it, which
+# triggers an automatic Cloudflare Pages redeploy of eeg-medical.1bit.systems.
+#
+# IMPORTANT: this script must never copy, list, or publish any raw EEG
+# files, filenames, or patient/subject metadata — only aggregate counts.
+# This is required by Temple University's TUH EEG data use agreement,
+# which prohibits redistributing the corpus itself.
+#
+# Recommended: run this at most a few times per day. Every push triggers
+# this repo's full CI suite (C++ build, CodeQL, etc.), so avoid pushing
+# on every rsync run if that happens frequently.
+
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-$HOME/1bit-systems}"
+DATA_DIR="${DATA_DIR:-/data/tuh_raw}"
+TOTAL_AVAILABLE="${TOTAL_AVAILABLE:-26846}"
+STATS_FILE="$REPO_DIR/site/eeg-medical/stats.json"
+
+cd "$REPO_DIR"
+git fetch origin main
+git checkout main
+git pull --ff-only
+
+RECORDINGS=$(find "$DATA_DIR" -type f -name '*.edf' 2>/dev/null | wc -l | tr -d ' ')
+GB=$(du -sBG "$DATA_DIR" 2>/dev/null | cut -f1 | tr -d 'G' || echo 0)
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+cat > "$STATS_FILE" <<EOF
+{
+  "recordings_synced": $RECORDINGS,
+  "total_available": $TOTAL_AVAILABLE,
+  "gb_synced": $GB,
+  "last_sync_utc": "$NOW"
+}
+EOF
+
+git add "$STATS_FILE"
+if git diff --cached --quiet; then
+  echo "No change in stats, skipping commit."
+  exit 0
+fi
+
+git commit -m "chore(eeg-medical): update sync stats ($RECORDINGS recordings, $NOW)"
+git push origin main

--- a/site/eeg-medical/stats.json
+++ b/site/eeg-medical/stats.json
@@ -1,0 +1,6 @@
+{
+  "recordings_synced": 0,
+  "total_available": 26846,
+  "gb_synced": 0,
+  "last_sync_utc": null
+}


### PR DESCRIPTION
Adds a sync-stats block to the Data Access section that fetches ./stats.json and displays recordings synced, data synced, % of corpus, and last sync date. Updates the disclaimer to clarify these are aggregate pipeline metrics only, consistent with Temple's no-redistribution data use terms.

## Description

<!-- What does this PR do? -->

## Type of Change

- [ ] NPU Engine (`[npu]`)
- [ ] GPU Engine (`[gpu]`)
- [ ] Packaging (`[packaging]`)
- [ ] Documentation (`[docs]`)
- [ ] CI/CD (`[ci]`)
- [ ] Site (`[site]`)

## Performance Impact (if engine change)

- Before: `XXX ms/tok` / `YYY tok/s`
- After: `XXX ms/tok` / `YYY tok/s`
- Delta: `±XX%`

## Verification

- [ ] Built and ran locally
- [ ] Benchmarks pass (if applicable)
- [ ] No regressions in existing model support

## Related Issues

Closes #(issue)

---
*By submitting this PR, I confirm that any benchmark numbers or status
changes accurately reflect real on-device measurements, or are explicitly
marked `unvalidated` per the repo's process policy (see #54).*
