### PR TITLE
ci(gh-ops): set GH_TOKEN; degrade run-list fetch

### DIFF
--- a/.github/workflows/gh-ops.yml
+++ b/.github/workflows/gh-ops.yml
@@ -29,6 +29,8 @@ jobs:
   gh-health:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: gh version
         run: gh --version | head -1
@@ -82,7 +84,8 @@ jobs:
           {
             echo "## Failed runs on main (last 7d)"
             ROWS=$(gh run list --branch main --status failure --limit 20 --json databaseId,workflowName,headBranch,createdAt,url \
-              --jq '.[] | "| [\(.workflowName)](\(.url)) | \(.createdAt) |"')
+              --jq '.[] | "| [\(.workflowName)](\(.url)) | \(.createdAt) |"') 2>/dev/null \
+              || { echo "::warning::gh run list failed — skipping"; ROWS=''; }
             if [ -n "$ROWS" ]; then printf '%s\n' "$ROWS"; else echo "None."; fi
           } >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
First dispatch failed: gh exit 4 — gh does not read GITHUB_TOKEN automatically in Actions. Alert steps' `|| echo '[]'` fallbacks masked it (all zeros); the run-list step had no fallback and failed loudly.

- Job-level `GH_TOKEN: ${{ github.token }}` (repo convention per traffic-alert.yml)
- Run-list fetch degrades to a warning instead of failing the job