### PR TITLE
ci(gh-ops): set GH_REPO for issue/label commands (no checkout)

### DIFF
--- a/.github/workflows/gh-ops.yml
+++ b/.github/workflows/gh-ops.yml
@@ -31,6 +31,7 @@ jobs:
     timeout-minutes: 10
     env:
       GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}  # no checkout; gh needs explicit repo
     steps:
       - name: gh version
         run: gh --version | head -1


### PR DESCRIPTION
The Totals step fails with 'failed to run git: fatal: not a git repository' because the job has no checkout and gh issue list/create need an explicit repo.

Verified failure on main run 31290123224: code-scanning pagination now works (CS_OPEN=1269) but the Totals step dies at gh issue list.

Fix: job-level GH_REPO env.