### PR TITLE
ci: mapping-form trigger for tmp-cf-diag

### DIFF
--- a/.github/workflows/tmp-cf-diag.yml
+++ b/.github/workflows/tmp-cf-diag.yml
@@ -1,5 +1,6 @@
 name: tmp-cf-diag
-on: workflow_dispatch
+on:
+  workflow_dispatch:
 jobs:
   inspect:
     runs-on: ubuntu-latest


### PR DESCRIPTION
dispatch registry rejects scalar 'on: workflow_dispatch'; use mapping form