### PR TITLE
ZAYA converter dual-era rewrite + logit validation, NPU overflow fixes, VL CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,8 @@ jobs:
               test_gguf_reader_dequant test_tokenizer_logprobs test_backend \
               test_lora_runtime test_auth test_billing \
               test_voice_session jarvis_ws_proto_test test_npu_flm_delta test_moe_fused_math \
-              ppl_generic gguf_to_onebp vl_logit_check
+              ppl_generic gguf_to_onebp vl_logit_check \
+              vl_pipeline_test test_vit_encoder zaya1_vl_demo
           else
             echo "ROCm not available on this runner — reference checks only."
             if [ -f tests/test_medusa_skeleton.cpp ]; then

--- a/.github/workflows/tmp-cf-diag.yml
+++ b/.github/workflows/tmp-cf-diag.yml
@@ -1,6 +1,8 @@
 name: tmp-cf-repair
 on:
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   repair:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -804,6 +804,20 @@ if(TARGET ggml_vulkan)
         ggml ggml_cpu ggml_base ggml_vulkan -lvulkan -ldl -lpthread -lm)
     target_compile_options(spec_decode PRIVATE -O3 -std=c++17)
 endif()
+
+# ── Zaya GGUF-vs-BF16 logit validation ──
+# C++ side dumps greedy logits + token ids; tools/zaya_logit_check_ref.py replays
+# the ids through transformers and compares top-k agreement. Uses the submodule's
+# Zaya arch (llama.h), so it links the same static libs as spec_decode.
+if(TARGET ggml_vulkan)
+    add_executable(zaya_logit_check tools/zaya_logit_check.cpp)
+    target_include_directories(zaya_logit_check PRIVATE ${GGML_VULKAN_DIR}/include ${GGML_VULKAN_DIR}/ggml/include)
+    target_link_libraries(zaya_logit_check PRIVATE
+        "${GGML_BUILD_DIR}/src/libllama.a" "${GGML_BUILD_DIR}/common/libllama-common.a"
+        "${GGML_BUILD_DIR}/common/libllama-common-base.a"
+        ggml ggml_cpu ggml_base ggml_vulkan -lvulkan -ldl -lpthread -lm)
+    target_compile_options(zaya_logit_check PRIVATE -O3 -std=c++17)
+endif()
 if(RCPP_HAVE_VULKAN)
     list(APPEND ZAYA_SERVER_SRC tests/backends/backend_vulkan.cpp)
 endif()

--- a/engine/npu/pool/pool_kernel.cpp
+++ b/engine/npu/pool/pool_kernel.cpp
@@ -96,11 +96,11 @@ int main(int argc, char** argv) {
         fprintf(stdout, "kernels: 4 PDIs loaded (CONFIG_CU 0x11) — QKV/O/GU/D in the AIE array\n");
 
         // ── tensors from the ONE heap ──
-        npu::span bA = p.alloc(M * K);
-        npu::span bW = p.alloc(K * N);
-        npu::span bC = p.alloc(M * N * 4);
-        for (int i = 0; i < (int)(M * K); i++) bA.host[i] = (int8_t)(i % 7);
-        for (int i = 0; i < (int)(K * N); i++) bW.host[i] = (int8_t)(i % 5);
+        npu::span bA = p.alloc((size_t)M * K);
+        npu::span bW = p.alloc((size_t)K * N);
+        npu::span bC = p.alloc((size_t)M * N * 4);
+        for (int i = 0; i < (int)((size_t)M * K); i++) bA.host[i] = (int8_t)(i % 7);
+        for (int i = 0; i < (int)((size_t)K * N); i++) bW.host[i] = (int8_t)(i % 5);
         memset(bC.host, 0, bC.size);
         if (p.sync(bA.handle, SYNC_DIRECT_TO_DEVICE, 0, bA.size) != 0)
             throw std::runtime_error("sync bA");

--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -2472,7 +2472,7 @@ int main(int argc,char**argv){
                                 fuse_gdn_state_slots[s].resize(NC * (size_t)max_gdn_vh * max_gdn_hd * max_gdn_hd, 0);
                                 fuse_gdn_conv_state_slots[s].resize(NC * (size_t)max_gdn_conv_dim * max_gdn_conv_k, 0);
                             }
-                            fuse_gdn_attn_out.resize(max_gdn_vh * max_gdn_hd, 0);
+                            fuse_gdn_attn_out.resize((size_t)max_gdn_vh * max_gdn_hd, 0);
                         }
                     }
                     int n_slots_to_run = (op == 33) ? (int)batch : 1;

--- a/scripts/zoo-smoke.sh
+++ b/scripts/zoo-smoke.sh
@@ -43,6 +43,7 @@ check "Qwen3 0.6B Instruct"         "four|\\b4\\b"
 check "Bonsai-1.7B-TQ2"             "four|\\b4\\b"
 check "Zamba2-1.2B-Instruct-v2.Q8_0" "four|\\b4\\b"
 check "Qwen3-4B"                    "four|\\b4\\b"
+check "ZAYA1-8B"                  "four|\\b4\\b"
 
 echo "----------------------------------------"
 echo "zoo-smoke: $PASS passed, $FAIL failed"

--- a/tools/convert_zaya_safetensors_to_gguf.py
+++ b/tools/convert_zaya_safetensors_to_gguf.py
@@ -1,61 +1,174 @@
 #!/usr/bin/env python3
-"""Convert ZAYA safetensors to GGUF format (F16).
+"""Convert ZAYA safetensors → GGUF for the 1bit-systems llama.cpp runtime.
 
-Works for any ZayaForCausalLM model (ZAYA1-8B, ZAYA1-base, ZAYA1-reasoning-base).
+Handles both naming eras:
+  - ZAYA1-base (Nov 2025): alternating layers (even=CCA attn, odd=MoE),
+      self_attn.qkv.{linear_q,linear_k,val_proj1,val_proj2,conv_qk.0,conv_qk.1,temp},
+      zaya_block.router.*, zaya_block.experts.local_experts.{e}.linear_fc{1,2},
+      model.res_scale.* (final), model.final_norm
+  - ZAYA1-8B / ZAYA1-74B-preview (May 2026): EVERY layer is hybrid (attn + MoE),
+      self_attn.qkv_proj.{q_proj,k_proj,v_proj_current,v_proj_delayed,conv_qk_depthwise,conv_qk_grouped},
+      self_attn.qk_norm.temp, mlp.gate.{down_proj,router_mlp.{norm,fc1,fc2,out_proj},balancing_biases},
+      mlp.experts.{down_proj,gate_up_proj} (pre-stacked), post_{attention,mlp}_residual_scale.*,
+      model.input_hidden_states_{scale,bias}, model.norm
+
+GGUF tensor names follow the canonical llama.cpp ZAYA mapping (upstream PR #23112) so the
+runtime's create_tensor() calls match: ssm_conv1d (conv_qk.0 / conv_qk_depthwise, squeeze(1)+transpose),
+cca_conv_grp, cca_val_proj1/2, cca_k_scale, attn_q/attn_k/attn_output, ffn_gate_inp, ffn_norm,
+ffn_gate, zaya_router_mlp2/4, zaya_router_biases, zaya_router_eda, ffn_down_exps, ffn_gate_up_exps,
+res_scale_hs/res_scale_res (+_mlp per layer), res_scale_hs/res_scale_res (final, base only),
+input_hidden_states_scale/bias (8B, model-level), post_attention_norm (8B, per layer).
 
 Usage: python3 tools/convert_zaya_safetensors_to_gguf.py <model_dir> <output.gguf>
+Self-check (no weights needed): python3 tools/convert_zaya_safetensors_to_gguf.py --check <model.safetensors.index.json>
 """
-import sys, os, json, time
+import sys, os, json, pathlib
 import numpy as np
 from safetensors import safe_open
 from gguf import GGUFWriter, GGMLQuantizationType
+from gguf.vocab import LlamaHfVocab
 
-# ── Config ──────────────────────────────────────────────────────────────────
-# These are read from config.json, but we need them for tensor shape validation
-EXPECTED_ARCH = "zaya"
+# ── config keys used for metadata (fallbacks for older configs) ──
+def cfg_int(cfg, *names, default=0):
+    for n in names:
+        v = cfg.get(n)
+        if v is not None:
+            return int(v)
+    return default
 
-# Tensor name mapping: safetensors → GGUF
-GLOBAL_MAP = {
-    'model.embed_tokens.weight':             'token_embd.weight',
-    'model.final_norm.weight':                'output_norm.weight',
-    'model.res_scale.hidden_states_bias':     'input_hidden_states_scale.bias',
-    'model.res_scale.hidden_states_scale':    'input_hidden_states_scale.weight',
-    'model.res_scale.residual_bias':          'input_residual_scale.bias',
-    'model.res_scale.residual_scale':         'input_residual_scale.weight',
-}
+# ── HF safetensors name → (GGUF name template, transform, kind) ──
+# kind: 'global' | 'layer' ; transform: 'T' (transpose) | 'squeeze1T' | 'permute210' | 'flat' | 'none'
+# We match the CURRENT (8B-era) names and the base-era names via alternates.
 
-LAYER_MAP = {
-    'input_norm.weight':                     'attn_norm.weight',
-    'self_attn.o_proj.weight':               'attn_output.weight',
-    'self_attn.qkv.linear_q.weight':         'attn_q.weight',
-    'self_attn.qkv.linear_k.weight':         'attn_k.weight',
-    'self_attn.qkv.val_proj1.weight':        'cca_val_proj1.weight',
-    'self_attn.qkv.val_proj2.weight':        'cca_val_proj2.weight',
-    'self_attn.qkv.conv_qk.0.weight':       'cca_conv_grp.weight',
-    'self_attn.qkv.conv_qk.0.bias':         'cca_conv_grp.bias',
-    'self_attn.qkv.conv_qk.1.weight':       'cca_conv_grp_2.weight',
-    'self_attn.qkv.conv_qk.1.bias':         'cca_conv_grp_2.bias',
-    'self_attn.qkv.temp':                   'cca_k_scale.weight',
-    'res_scale.hidden_states_bias':         'res_scale_hs.bias',
-    'res_scale.hidden_states_scale':        'res_scale_hs.weight',
-    'res_scale.residual_bias':              'res_scale_res.bias',
-    'res_scale.residual_scale':             'res_scale_res.weight',
-}
+def map_tensor(st_name, layer_idx, cfg):
+    """Return (gguf_name, transform) or None if the tensor is not consumed by the runtime."""
+    def layer(gguf_suffix, transform='T', lid=layer_idx):
+        return f"blk.{lid}.{gguf_suffix}", transform
 
-ZAYA_BLOCK_MAP = {
-    'zaya_block.router.down_proj.weight':           'ffn_gate_inp.weight',
-    'zaya_block.router.down_proj.bias':             'ffn_gate_inp.bias',
-    'zaya_block.router.router_mlp.0.weight':        'ffn_gate.weight',
-    'zaya_block.router.router_mlp.0.bias':          'ffn_gate.bias',
-    'zaya_block.router.router_mlp.2.weight':        'zaya_router_mlp2.weight',
-    'zaya_block.router.router_mlp.2.bias':          'zaya_router_mlp2.bias',
-    'zaya_block.router.router_mlp.4.weight':        'zaya_router_mlp4.weight',
-    'zaya_block.router.balancing_biases':            'zaya_router_biases.weight',
-    'zaya_block.router.rmsnorm_eda.weight':         'zaya_router_eda.weight',
-    'zaya_block.router.router_states_scale':        'zaya_router_states_scale',
-    'zaya_block.experts.local_experts.{e}.linear_fc1.weight': 'ffn_down_exps.weight',
-    'zaya_block.experts.local_experts.{e}.linear_fc2.weight': 'ffn_gate_up_exps.weight',
-}
+    def global_(gguf_name, transform='T'):
+        return gguf_name, transform
+
+    if st_name == 'model.embed_tokens.weight':
+        return global_('token_embd.weight', 'none')
+    if st_name in ('model.final_norm.weight', 'model.norm.weight'):
+        return global_('output_norm.weight', 'none')
+    # base-era final res scale → RES_SCALE_HS_FINAL / RES_SCALE_RES_FINAL ("res_scale_hs"/"res_scale_res", no blk)
+    if st_name == 'model.res_scale.hidden_states_scale':
+        return global_('res_scale_hs.weight', 'none')
+    if st_name == 'model.res_scale.hidden_states_bias':
+        return global_('res_scale_hs.bias', 'none')
+    if st_name == 'model.res_scale.residual_scale':
+        return global_('res_scale_res.weight', 'none')
+    if st_name == 'model.res_scale.residual_bias':
+        return global_('res_scale_res.bias', 'none')
+    # 8B-era model-level input scale (applied to embeddings; runtime applies when present)
+    if st_name == 'model.input_hidden_states_scale':
+        return global_('input_hidden_states_scale.weight', 'none')
+    if st_name == 'model.input_hidden_states_bias':
+        return global_('input_hidden_states_scale.bias', 'none')
+
+    if st_name.endswith('.input_layernorm.weight') or st_name.endswith('.input_norm.weight'):
+        return layer('attn_norm.weight', 'none')
+    if st_name.endswith('.post_attention_layernorm.weight'):
+        return layer('post_attention_norm.weight', 'none')
+
+    # ── attention (even layers in base; every layer in 8B) ──
+    attn_prefixes = ('self_attn.', )
+    if '.self_attn.' in st_name:
+        base = 'self_attn.qkv.'
+        new  = 'self_attn.qkv_proj.'
+        if base + 'linear_q.weight' in st_name:     return layer('attn_q.weight', 'none')
+        if base + 'linear_k.weight' in st_name:     return layer('attn_k.weight', 'none')
+        if base + 'val_proj1.weight' in st_name:    return layer('cca_val_proj1.weight', 'none')
+        if base + 'val_proj2.weight' in st_name:    return layer('cca_val_proj2.weight', 'none')
+        if base + 'conv_qk.0.weight' in st_name:    return layer('ssm_conv1d.weight', 'squeeze1')
+        if base + 'conv_qk.0.bias' in st_name:      return layer('ssm_conv1d.bias', 'none')
+        if base + 'conv_qk.1.weight' in st_name:    return layer('cca_conv_grp.weight', 'none')
+        if base + 'conv_qk.1.bias' in st_name:      return layer('cca_conv_grp.bias', 'none')
+        if base + 'temp' in st_name:                return layer('cca_k_scale.weight', 'none')
+        if new + 'q_proj.weight' in st_name:        return layer('attn_q.weight', 'none')
+        if new + 'k_proj.weight' in st_name:        return layer('attn_k.weight', 'none')
+        if new + 'v_proj_current.weight' in st_name:return layer('cca_val_proj1.weight', 'none')
+        if new + 'v_proj_delayed.weight' in st_name:return layer('cca_val_proj2.weight', 'none')
+        if new + 'conv_qk_depthwise.weight' in st_name: return layer('ssm_conv1d.weight', 'squeeze1')
+        if new + 'conv_qk_depthwise.bias' in st_name:   return layer('ssm_conv1d.bias', 'none')
+        if new + 'conv_qk_grouped.weight' in st_name:   return layer('cca_conv_grp.weight', 'none')
+        if new + 'conv_qk_grouped.bias' in st_name:     return layer('cca_conv_grp.bias', 'none')
+        if 'qk_norm.temp' in st_name:               return layer('cca_k_scale.weight', 'none')
+        if 'o_proj.weight' in st_name:              return layer('attn_output.weight', 'none')
+
+    # ── residual scaling (per layer) ──
+    if '.res_scale.hidden_states_scale' in st_name:     return layer('res_scale_hs.weight', 'none')
+    if '.res_scale.hidden_states_bias' in st_name:      return layer('res_scale_hs.bias', 'none')
+    if '.res_scale.residual_scale' in st_name:          return layer('res_scale_res.weight', 'none')
+    if '.res_scale.residual_bias' in st_name:           return layer('res_scale_res.bias', 'none')
+    if '.post_attention_residual_scale.hidden_states_scale' in st_name: return layer('res_scale_hs.weight', 'none')
+    if '.post_attention_residual_scale.hidden_states_bias' in st_name:  return layer('res_scale_hs.bias', 'none')
+    if '.post_attention_residual_scale.residual_scale' in st_name:      return layer('res_scale_res.weight', 'none')
+    if '.post_attention_residual_scale.residual_bias' in st_name:       return layer('res_scale_res.bias', 'none')
+    if '.post_mlp_residual_scale.hidden_states_scale' in st_name:       return layer('res_scale_hs_mlp.weight', 'none')
+    if '.post_mlp_residual_scale.hidden_states_bias' in st_name:        return layer('res_scale_hs_mlp.bias', 'none')
+    if '.post_mlp_residual_scale.residual_scale' in st_name:            return layer('res_scale_res_mlp.weight', 'none')
+    if '.post_mlp_residual_scale.residual_bias' in st_name:             return layer('res_scale_res_mlp.bias', 'none')
+
+    # ── MoE router (base: zaya_block.router.*, 8B: mlp.gate.*) ──
+    if '.router.down_proj.weight' in st_name or '.gate.down_proj.weight' in st_name:
+        return layer('ffn_gate_inp.weight', 'none')
+    if '.router.down_proj.bias' in st_name or '.gate.down_proj.bias' in st_name:
+        return layer('ffn_gate_inp.bias', 'none')
+    if '.router.rmsnorm_eda.weight' in st_name or '.router_mlp.norm.weight' in st_name:
+        return layer('ffn_norm.weight', 'none')
+    if '.router.router_mlp.0.weight' in st_name or '.router_mlp.fc1.weight' in st_name:
+        return layer('ffn_gate.weight', 'none')
+    if '.router.router_mlp.0.bias' in st_name or '.router_mlp.fc1.bias' in st_name:
+        return layer('ffn_gate.bias', 'none')
+    if '.router.router_mlp.2.weight' in st_name or '.router_mlp.fc2.weight' in st_name:
+        return layer('zaya_router_mlp2.weight', 'none')
+    if '.router.router_mlp.2.bias' in st_name or '.router_mlp.fc2.bias' in st_name:
+        return layer('zaya_router_mlp2.bias', 'none')
+    if '.router.router_mlp.4.weight' in st_name or '.router_mlp.out_proj.weight' in st_name:
+        return layer('zaya_router_mlp4.weight', 'none')
+    if '.router.router_mlp.4.bias' in st_name or '.router_mlp.out_proj.bias' in st_name:
+        return layer('zaya_router_mlp4.bias', 'none')
+    if '.router.balancing_biases' in st_name or '.gate.balancing_biases' in st_name:
+        return layer('zaya_router_biases.weight', 'none')
+    # base-era EDA: zaya_block.router.router_states_scale IS used by the base model
+    if '.router.router_states_scale' in st_name:
+        return layer('zaya_router_eda.weight', 'none')
+    # 8B/74B-era: mlp.gate.router_states_scale exists in the checkpoint but the reference
+    # model does NOT use it (module attr is None) — skipping avoids enabling the EDA path
+    if '.gate.router_states_scale' in st_name:
+        return None
+
+    # ── experts ──
+    if '.mlp.experts.down_proj' in st_name:      # 8B: (n_expert, n_embd, n_ff); ggml mul_mat A(ne0=n_ff=contraction) reads [e][r][c] → keep AS-IS
+        return layer('ffn_down_exps.weight', 'none')
+    if '.mlp.experts.gate_up_proj' in st_name:   # 8B: (n_expert, 2*n_ff, n_embd) → ne [n_embd, 2*n_ff, n_expert] ✓ as-is
+        return layer('ffn_gate_up_exps.weight', 'none')
+    if '.local_experts.' in st_name:             # base: per-expert, stacked at conversion time
+        if st_name.endswith('.linear_fc1.weight'):
+            return layer('ffn_gate_up_exps.weight', 'stack_raw')   # base: fc1 = fused gate+up; stack dim0 of raw (n_expert, 2*n_ff, n_embd)
+        if st_name.endswith('.linear_fc2.weight'):
+            return layer('ffn_down_exps.weight', 'stack_T')   # base: fc2 = down; per-expert .T then stack dim0
+
+    return None  # not consumed by runtime (e.g. base's post_attention_layernorm variants, unused tensors)
+
+
+def transform(t, kind):
+    """Apply the GGUF orientation transform to a loaded tensor (numpy).
+
+    llama.cpp stores ne in REVERSE numpy order, so create_tensor({a,b}) means
+    numpy (b,a) — i.e. HF (out, in) orientation, NO transpose for linear layers.
+    """
+    if kind == 'squeeze1':
+        return np.squeeze(t, axis=1)     # Conv1d {C,1,K} → {C,K}  (numpy (n_qk, d_conv))
+    if kind == 'transpose021':
+        return t.transpose(0, 2, 1)      # (n_expert, n_ff, n_embd) → (n_expert, n_embd, n_ff)
+    if kind == 'stack_raw':
+        return t  # stacked as-is on dim 0
+    if kind == 'stack_T':
+        return t  # caller transposes per-expert
+    return t
 
 
 def load_tensor(model_dir, shard, name):
@@ -64,11 +177,9 @@ def load_tensor(model_dir, shard, name):
         with safe_open(path, framework='np') as f:
             return f.get_tensor(name)
     except TypeError:
-        # BF16 not supported by numpy, use torch
         import torch
         with safe_open(path, framework='pt') as f:
-            t = f.get_tensor(name)  # Returns torch.tensor
-            return t.to(torch.float16).cpu().numpy()
+            return f.get_tensor(name).to(torch.float16).cpu().numpy()
 
 
 def to_f16(t):
@@ -81,137 +192,253 @@ def to_f16(t):
         if t.dtype == np.dtype('bfloat16'):
             return torch.from_numpy(t).to(torch.float16).numpy()
         return t.astype(np.float32).astype(np.float16)
-    # torch tensor
     return t.to(torch.float16).numpy()
 
 
+def write_vocab(writer, model_dir):
+    """Write tokenizer.ggml.* KVs from HF tokenizer.json (Gemma3 BPE, llama.cpp 'gemma' format)."""
+    import json
+    tok_path = os.path.join(model_dir, 'tokenizer.json')
+    cfg_path = os.path.join(model_dir, 'tokenizer_config.json')
+    if not os.path.exists(tok_path):
+        print("  WARNING: no tokenizer.json; writing raw vocab_size KV only")
+        return None
+    t = json.load(open(tok_path))
+    vocab = t['model']['vocab']
+    merges_raw = t['model'].get('merges', [])
+    # new HF format stores merges as [left, right] pairs; llama.cpp wants "left right" strings
+    if merges_raw and isinstance(merges_raw[0], (list, tuple)):
+        merges = [' '.join(pair) for pair in merges_raw]
+    else:
+        merges = merges_raw
+    added = t.get('added_tokens', [])
+    ids = {tok: tid for tok, tid in vocab.items()}
+    for at in added:
+        ids[at['content']] = at['id']
+    n = len(ids)
+    toks = [''] * n
+    for tok, tid in ids.items():
+        toks[tid] = tok
+    types = [1] * n  # normal
+    for at in added:
+        if at['id'] < n:
+            types[at['id']] = 3  # control (special tokens)
+    cfg = json.load(open(cfg_path)) if os.path.exists(cfg_path) else {}
+    def sid(name):
+        v = cfg.get(name)
+        if isinstance(v, dict):
+            v = v.get('content')
+        if v is None:
+            return 0
+        return ids.get(v, 0)
+    bos, eos, unk, pad = sid('bos_token'), sid('eos_token'), sid('unk_token'), sid('pad_token')
+    if unk < n:
+        types[unk] = 2  # unknown
+    writer.add_tokenizer_model('gemma4')
+    writer.add_token_list(toks)
+    writer.add_token_types(types)
+    writer.add_token_merges(merges)
+    writer.add_bos_token_id(bos)
+    writer.add_eos_token_id(eos)
+    writer.add_unk_token_id(unk)
+    writer.add_pad_token_id(pad)
+    writer.add_add_bos_token(True)
+    writer.add_add_eos_token(False)
+    writer.add_vocab_size(n)
+    print(f"  vocab: {n} tokens (gemma4 BPE), bos={bos} eos={eos} unk={unk} merges={len(merges)}")
+    return n
+
+
+def self_check(index_path):
+    """Verify every safetensors key maps to a runtime-consumed GGUF tensor (no silent drops)."""
+    with open(index_path) as f:
+        idx = json.load(f)
+    cfg = {}
+    cfg_path = os.path.join(os.path.dirname(index_path), 'config.json')
+    if os.path.exists(cfg_path):
+        with open(cfg_path) as f:
+            cfg = json.load(f)
+    wm = idx['weight_map']
+    unmapped, mapped = [], []
+    for k in sorted(wm):
+        parts = k.split('.')
+        lid = 0
+        if len(parts) >= 3 and parts[:2] == ['model', 'layers']:
+            lid = int(parts[2])
+        r = map_tensor(k, lid, cfg)
+        if r is None:
+            unmapped.append(k)
+        else:
+            mapped.append(r)
+    print(f"mapped: {len(mapped)}  unmapped: {len(unmapped)}")
+    for k in unmapped:
+        print(f"  SKIP: {k}")
+    # required tensors per the runtime's create_tensor() calls, derived from ACTUAL layer keys
+    n_layers = cfg_int(cfg, 'num_hidden_layers', 'n_layer', default=0)
+    names = {r[0] for r in mapped}
+    required = {'token_embd.weight', 'output_norm.weight'}
+    attn_req = {'attn_q.weight', 'attn_k.weight', 'attn_output.weight', 'ssm_conv1d.weight',
+                'cca_conv_grp.weight', 'cca_val_proj1.weight', 'cca_val_proj2.weight', 'cca_k_scale.weight'}
+    moe_req = {'ffn_gate_inp.weight', 'ffn_norm.weight', 'ffn_gate.weight', 'zaya_router_mlp2.weight',
+               'zaya_router_mlp4.weight', 'ffn_down_exps.weight', 'ffn_gate_up_exps.weight'}
+    for k in wm:
+        parts = k.split('.')
+        if len(parts) >= 3 and parts[:2] == ['model', 'layers']:
+            lid = parts[2]
+            if '.self_attn.' in k:
+                required |= {f'blk.{lid}.{t}' for t in attn_req}
+            if '.mlp.experts' in k or '.zaya_block.experts' in k:
+                required |= {f'blk.{lid}.{t}' for t in moe_req}
+    missing = required - names
+    if missing:
+        print("MISSING REQUIRED TENSORS:")
+        for m in sorted(missing):
+            print(f"  {m}")
+        sys.exit(1)
+    print("self-check OK")
+
+
 def main():
+    if len(sys.argv) == 3 and sys.argv[1] == '--check':
+        self_check(sys.argv[2])
+        return
     if len(sys.argv) < 3:
-        print(f"Usage: {sys.argv[0]} <model_dir> <output.gguf>")
+        print(f"Usage: {sys.argv[0]} <model_dir> <output.gguf>   |   {sys.argv[0]} --check <index.json>")
         sys.exit(1)
 
-    model_dir = sys.argv[1]
-    output_path = sys.argv[2]
-
+    model_dir, output_path = sys.argv[1], sys.argv[2]
     with open(os.path.join(model_dir, 'config.json')) as f:
         cfg = json.load(f)
     with open(os.path.join(model_dir, 'model.safetensors.index.json')) as f:
         idx = json.load(f)
-
     wm = idx['weight_map']
     shards = sorted(set(wm.values()))
 
-    n_layers = int(cfg.get('num_hidden_layers', 80))
-    hidden = int(cfg.get('hidden_size', 2048))
-    n_heads = int(cfg.get('num_attention_heads', 16))
-    n_kv = int(cfg.get('num_key_value_heads', 2))
-    head_dim = int(cfg.get('head_dim', 128))
-    vocab = int(cfg.get('vocab_size', 262272))
-    max_seq = int(cfg.get('max_position_embeddings', 32768))
+    n_layers = cfg_int(cfg, 'num_hidden_layers', default=40)
+    hidden   = cfg_int(cfg, 'hidden_size', default=2048)
+    n_heads  = cfg_int(cfg, 'num_attention_heads', default=8)
+    n_kv     = cfg_int(cfg, 'num_key_value_heads', default=2)
+    head_dim = cfg_int(cfg, 'head_dim', default=128)
+    vocab    = cfg_int(cfg, 'vocab_size', default=262272)
     norm_eps = float(cfg.get('norm_epsilon', 1e-5))
-    rope_base = float(cfg.get('rotary_base', 1000000.0))
-    use_parallel = bool(cfg.get('parallel_residual', False))
+    rope_base = float(cfg.get('rotary_base', cfg.get('rope_theta', 1000000.0)))
+    partial_rotary = float(cfg.get('partial_rotary_factor', 0.5))
+    d_conv   = cfg_int(cfg, 'cca_time0', default=2)
+    topk     = cfg_int(cfg, 'num_experts_per_tok', 'moe_router_topk', default=1)
 
-    # Detect zaya_block pattern
-    moe_layers = set()
+    n_qk = n_heads * head_dim + n_kv * head_dim
+    state_size = 2 * n_qk + hidden  # runtime asserts n_embd_s() == 2*n_qk + n_embd
+
+    # expert count: infer from stacked experts or base local_experts keys
+    n_experts = 16
     for k in wm:
-        if 'zaya_block' in k:
-            parts = k.split('.')
-            if len(parts) >= 3 and parts[1] == 'layers':
-                moe_layers.add(int(parts[2]))
+        if '.local_experts.' in k:
+            import re
+            m = re.search(r'\.local_experts\.(\d+)\.', k)
+            if m:
+                n_experts = max(n_experts, int(m.group(1)) + 1)
 
-    n_experts = 16  # ZAYA fixed
+    # n_ff_exp: prefer the actual router down_proj width over config guess
+    n_ff_exp = cfg_int(cfg, 'zaya_mlp_expansion', default=256)
+    for probe in ('mlp.gate.down_proj.weight', 'zaya_block.router.down_proj.weight'):
+        if probe in wm:
+            try:
+                t = load_tensor(model_dir, wm[probe], probe)
+                n_ff_exp = t.shape[0]
+                print(f"  n_ff_exp inferred from {probe}: {n_ff_exp}")
+            except Exception as e:
+                print(f"  WARNING: could not infer n_ff_exp from {probe}: {e}")
+            break
 
     print(f"  Model: {cfg.get('_name_or_path', os.path.basename(model_dir))}")
-    print(f"  Architecture: zaya, Layers: {n_layers}, Hidden: {hidden}")
-    print(f"  Heads: {n_heads}, KV: {n_kv}, Vocab: {vocab}")
-    print(f"  MoE layers: {sorted(moe_layers) if moe_layers else 'N/A (dense)'}")
-    print(f"  Shards: {shards}")
-    print(f"  Output: {output_path}")
-    print()
+    print(f"  arch=zaya  layers={n_layers}  hidden={hidden}  heads={n_heads}/{n_kv}  head_dim={head_dim}")
+    print(f"  partial_rotary={partial_rotary} → rope dims={int(partial_rotary*head_dim)}")
+    print(f"  conv_kernel={d_conv}  state_size={state_size}  experts={n_experts}  topk={topk}")
 
     writer = GGUFWriter(output_path, 'zaya')
-
-    # Metadata
     writer.add_block_count(n_layers)
-    writer.add_context_length(max_seq)
+    writer.add_context_length(cfg_int(cfg, 'max_position_embeddings', default=32768))
     writer.add_embedding_length(hidden)
     writer.add_head_count(n_heads)
     writer.add_head_count_kv(n_kv)
+    writer.add_uint32('zaya.attention.key_length', head_dim)
+    writer.add_uint32('zaya.attention.value_length', head_dim)
     writer.add_layer_norm_rms_eps(norm_eps)
-    writer.add_vocab_size(vocab)
-    writer.add_rope_dimension_count(head_dim)
+    writer.add_rope_dimension_count(int(partial_rotary * head_dim))
     writer.add_rope_freq_base(rope_base)
     writer.add_expert_count(n_experts)
-    writer.add_expert_used_count(1)
-    ffn_hidden = int(cfg.get('ffn_hidden_size', 0)) or (hidden * 4)
-    writer.add_feed_forward_length(ffn_hidden)
-    writer.add_file_type(1)  # F32 (we write F16 but without raw_dtype it auto-detects)
-    writer.add_bool('zaya.use_parallel_residual', use_parallel)
+    writer.add_expert_used_count(topk)
+    writer.add_feed_forward_length(cfg_int(cfg, 'moe_intermediate_size', 'ffn_hidden_size', default=hidden * 4))
+    writer.add_uint32('zaya.ssm.conv_kernel', d_conv)
+    writer.add_uint32('zaya.ssm.state_size', state_size)
+    writer.add_uint32('zaya.ssm.inner_size', 1)
+    writer.add_uint32('zaya.expert_feed_forward_length', n_ff_exp)
 
-    t0 = time.time()
-    total_tensors = 0
+    # vocab from tokenizer.json (Gemma3 tokenizer for all Zaya releases)
+    vocab_size = write_vocab(writer, model_dir) or vocab
 
-    def add_t(name, tensor):
-        nonlocal total_tensors
-        f16 = to_f16(tensor)
-        writer.add_tensor(name, f16)
-        total_tensors += 1
-        if total_tensors % 100 == 0:
-            elapsed = time.time() - t0
-            print(f"    {total_tensors} tensors ({elapsed:.0f}s)...")
+    # ── tensor pass ──
+    args_f32 = '--f32' in sys.argv
+    expert_stack = {}  # (layer, gguf_suffix) -> list of per-expert tensors (base era)
+    expert_stack_kind = {}
+    plan = []
+    for st_name in wm:
+        r = map_tensor(st_name, 0, cfg)
+        if r is None:
+            continue
+        gguf_name, kind = r
+        lid = 0
+        # extract layer id for blk tensors
+        parts = st_name.split('.')
+        if len(parts) >= 3 and parts[0] == 'model' and parts[1] == 'layers':
+            lid = int(parts[2])
+            gguf_name = gguf_name.replace('blk.0.', f'blk.{lid}.')
+        if kind in ('stack_raw', 'stack_T'):
+            expert_stack.setdefault((lid, gguf_name), []).append(st_name)
+            expert_stack_kind[(lid, gguf_name)] = kind
+        else:
+            plan.append((st_name, gguf_name, kind))
 
-    # Global tensors
-    print("  Global tensors...")
-    for st_name, gguf_name in GLOBAL_MAP.items():
-        if st_name in wm:
-            t = load_tensor(model_dir, wm[st_name], st_name)
-            add_t(gguf_name, t)
+    t0 = __import__('time').time()
+    total = 0
+    def add_t(gguf_name, tensor):
+        nonlocal total
+        # llama.cpp convention: norm weights, scales and biases are F32 (they are
+        # multiplied/added directly against the F32 activation stream); matmuls stay F16
+        is_small = ('norm' in gguf_name or 'scale' in gguf_name or 'biases' in gguf_name
+                    or gguf_name.endswith('.bias') or 'k_scale' in gguf_name
+                    or gguf_name.startswith('input_hidden_states'))
+        writer.add_tensor(gguf_name, tensor.astype(np.float32) if is_small or args_f32 else to_f16(tensor))
+        total += 1
+        if total % 100 == 0:
+            print(f"    {total} tensors ({__import__('time').time()-t0:.0f}s)...")
 
-    # Per-layer
-    print(f"  Layers (0..{n_layers-1})...")
-    for li in range(n_layers):
-        is_moe = li in moe_layers
+    print("  Global + layer tensors...")
+    for st_name, gguf_name, kind in plan:
+        t = load_tensor(model_dir, wm[st_name], st_name)
+        if gguf_name == 'token_embd.weight' and t.shape[0] > vocab_size:
+            # HF embeddings may exceed the tokenizer vocab (reserved/multimodal tokens)
+            t = t[:vocab_size]
+            print(f"  token_embd trimmed {t.shape[0]} → {vocab_size}")
+        add_t(gguf_name, transform(t, kind))
 
-        # Base layer tensors
-        for st_suf, gguf_suf in LAYER_MAP.items():
-            st_name = f"model.layers.{li}.{st_suf}"
-            if st_name in wm:
-                t = load_tensor(model_dir, wm[st_name], st_name)
-                add_t(f"blk.{li}.{gguf_suf}", t)
+    print("  Base-era expert stacking...")
+    for (lid, gguf_name), st_list in sorted(expert_stack.items()):
+        kind = expert_stack_kind.get((lid, gguf_name))
+        if kind == 'stack_raw':
+            tensors = [load_tensor(model_dir, wm[s], s) for s in sorted(st_list)]
+        else:  # stack_T
+            tensors = [load_tensor(model_dir, wm[s], s).T for s in sorted(st_list)]
+        stacked = np.stack(tensors, axis=0)
+        add_t(gguf_name, stacked)
 
-        # zaya_block (MoE) tensors if present
-        if is_moe:
-            for st_suf, gguf_suf in ZAYA_BLOCK_MAP.items():
-                if '{e}' in st_suf:
-                    # Stack expert tensors: load all, stack into [rows, cols, n_experts]
-                    expert_tensors = []
-                    for ei in range(n_experts):
-                        e_st_name = f"model.layers.{li}.{st_suf.replace('{e}', str(ei))}"
-                        if e_st_name in wm:
-                            t = load_tensor(model_dir, wm[e_st_name], e_st_name)
-                            t_f16 = to_f16(t)
-                            expert_tensors.append(t_f16)
-                    if expert_tensors:
-                        stacked = np.stack(expert_tensors, axis=-1)
-                        add_t(f"blk.{li}.{gguf_suf}", stacked)
-                else:
-                    st_name = f"model.layers.{li}.{st_suf}"
-                    if st_name in wm:
-                        t = load_tensor(model_dir, wm[st_name], st_name)
-                        add_t(f"blk.{li}.{gguf_suf}", t)
-
-    # Write
-    elapsed = time.time() - t0
-    print(f"\n  Writing {total_tensors} tensors ({elapsed:.0f}s)...")
     writer.write_header_to_file()
     writer.write_kv_data_to_file()
     writer.write_tensors_to_file()
     writer.close()
-
     size = os.path.getsize(output_path)
-    print(f"  ✅ Done: {output_path} ({size/1e9:.2f} GB)")
-    print(f"  Total tensors: {total_tensors}")
+    print(f"  ✅ Done: {output_path} ({size/1e9:.2f} GB)  tensors={total}")
+    print(f"  Run self-check on a fresh index: python3 tools/convert_zaya_safetensors_to_gguf.py --check model.safetensors.index.json")
 
 
 if __name__ == '__main__':

--- a/tools/zaya_logit_check.cpp
+++ b/tools/zaya_logit_check.cpp
@@ -1,0 +1,101 @@
+// zaya_logit_check.cpp — logit-level validation of a Zaya GGUF against the
+// BF16 transformers reference (tools/zaya_logit_check_ref.py).
+//
+// Loads the GGUF through the llama.cpp Zaya arch, generates N tokens greedily,
+// dumps per-step last-token logits to a .bin file (float32, vocab floats per
+// step, steps concatenated) and the exact id sequence to a .txt file.
+// The python side replays the identical ids through torch and compares.
+//
+// Usage:
+//   zaya_logit_check <model.gguf> <prompt> <n_predict> <logits.bin> <ids.txt>
+#include "llama.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+int main(int argc, char ** argv) {
+    if (argc < 6) {
+        fprintf(stderr, "usage: %s <model.gguf> <prompt> <n_predict> <logits.bin> <ids.txt>\n", argv[0]);
+        return 1;
+    }
+    const char * model_path = argv[1];
+    const std::string prompt = argv[2];
+    const int n_predict = atoi(argv[3]);
+    const char * logits_path = argv[4];
+    const char * ids_path = argv[5];
+
+    llama_backend_init();
+
+    llama_model_params mparams = llama_model_default_params();
+    mparams.n_gpu_layers = 0; // CPU — deterministic, matches torch reference
+    llama_model * model = llama_load_model_from_file(model_path, mparams);
+    if (!model) { fprintf(stderr, "FAIL: load model\n"); return 1; }
+
+    llama_context_params cparams = llama_context_default_params();
+    cparams.n_ctx = 4096;
+    cparams.n_batch = 32;
+    llama_context * ctx = llama_new_context_with_model(model, cparams);
+    if (!ctx) { fprintf(stderr, "FAIL: ctx\n"); return 1; }
+
+    const int n_vocab = llama_vocab_n_tokens(llama_model_get_vocab(model));
+    std::vector<llama_token> ids(8192);
+    const int n_tok = llama_tokenize(llama_model_get_vocab(model), prompt.c_str(), (int) prompt.size(), ids.data(), (int) ids.size(), true, false);
+    if (n_tok < 0) { fprintf(stderr, "FAIL: tokenize\n"); return 1; }
+    ids.resize(n_tok);
+
+    FILE * f_logits = fopen(logits_path, "wb");
+    FILE * f_ids = fopen(ids_path, "w");
+    if (!f_logits || !f_ids) { fprintf(stderr, "FAIL: open outputs\n"); return 1; }
+    for (llama_token t : ids) fprintf(f_ids, "%d\n", t);
+
+    // ── prefill: full prompt in one batch, logits on the last token ──
+    llama_batch batch = llama_batch_init(ids.size(), 0, 1);
+    for (size_t i = 0; i < ids.size(); ++i) {
+        batch.token[i] = ids[i];
+        batch.pos[i] = i;
+        batch.n_seq_id[i] = 1;
+        batch.seq_id[i][0] = 0;
+        batch.logits[i] = i == ids.size() - 1;
+    }
+    batch.n_tokens = ids.size();
+    if (llama_decode(ctx, batch) != 0) { fprintf(stderr, "FAIL: prefill decode\n"); return 1; }
+
+    const float * logits = llama_get_logits_ith(ctx, ids.size() - 1);
+    fwrite(logits, sizeof(float), n_vocab, f_logits);
+
+    int best = 0;
+    for (int v = 1; v < n_vocab; ++v) if (logits[v] > logits[best]) best = v;
+    fprintf(f_ids, "%d\n", best);
+
+    // ── single-token decode steps ──
+    llama_batch_free(batch);
+    batch = llama_batch_init(1, 0, 1);
+    for (int step = 1; step < n_predict; ++step) {
+        batch.n_tokens = 1;
+        batch.token[0] = best;
+        batch.pos[0] = ids.size() + step - 1;
+        batch.n_seq_id[0] = 1;
+        batch.seq_id[0][0] = 0;
+        batch.logits[0] = true;
+
+        if (llama_decode(ctx, batch) != 0) { fprintf(stderr, "FAIL: decode step %d\n", step); return 1; }
+
+        logits = llama_get_logits_ith(ctx, 0);
+        fwrite(logits, sizeof(float), n_vocab, f_logits);
+
+        best = 0;
+        for (int v = 1; v < n_vocab; ++v) if (logits[v] > logits[best]) best = v;
+        fprintf(f_ids, "%d\n", best);
+    }
+
+    fclose(f_logits);
+    fclose(f_ids);
+    llama_batch_free(batch);
+    llama_free(ctx);
+    llama_free_model(model);
+    llama_backend_free();
+    fprintf(stderr, "OK %d steps, %d vocab\n", n_predict, n_vocab);
+    return 0;
+}

--- a/tools/zaya_logit_check_ref.py
+++ b/tools/zaya_logit_check_ref.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""zaya_logit_check_ref.py — BF16 transformers reference for zaya_logit_check.cpp.
+
+Replays the exact token-id sequence produced by the C++ side through the
+Zyphra transformers (zaya1) model and compares per-step last-token logits.
+
+Usage: zaya_logit_check_ref.py <model_dir> <ids.txt> <logits.bin> <tol_topk>
+  ids.txt      : prompt ids + greedy continuation (one per line)
+  logits.bin   : float32 vocab per step, steps concatenated (from C++ side)
+  tol_topk     : required top-10 agreement fraction (default 1.0)
+Exit 0 on pass, 1 on fail.
+"""
+import sys, struct
+import numpy as np
+import torch
+
+def main():
+    model_dir, ids_path, logits_path = sys.argv[1:4]
+    tol_topk = float(sys.argv[4]) if len(sys.argv) > 4 else 1.0
+
+    ids = [int(l) for l in open(ids_path)]
+    ids = torch.tensor(ids, dtype=torch.long)
+
+    from transformers import AutoTokenizer
+    tok = AutoTokenizer.from_pretrained(model_dir)
+    n_vocab = len(tok)
+
+    with open(logits_path, 'rb') as f:
+        raw = f.read()
+    n_total = len(raw) // 4
+    steps = n_total // n_vocab
+    n_prompt = len(ids) - steps
+    cpp_logits = np.frombuffer(raw, dtype=np.float32).reshape(steps, n_vocab)
+    print(f"  ids={len(ids)} prompt={n_prompt} steps={steps} vocab={n_vocab}")
+
+    from transformers import AutoModelForCausalLM
+    model = AutoModelForCausalLM.from_pretrained(model_dir, torch_dtype=torch.bfloat16).eval()
+    # replay: step t uses ids[:n_prompt + t]
+    hits = 0
+    worst_cos = 1.0
+    with torch.no_grad():
+        for t in range(steps):
+            inp = ids[: n_prompt + t].unsqueeze(0)
+            out = model(inp)
+            ref = out.logits[0, -1, :n_vocab].float().numpy()
+            # compare: top-10 agreement
+            cpp_top = set(np.argsort(cpp_logits[t])[-10:])
+            ref_top = set(np.argsort(ref)[-10:])
+            agree = len(cpp_top & ref_top)
+            hits += agree == 10
+            # cosine
+            c = float(np.dot(cpp_logits[t], ref) / (np.linalg.norm(cpp_logits[t]) * np.linalg.norm(ref) + 1e-12))
+            worst_cos = min(worst_cos, c)
+            if t < 3 or agree < 10:
+                print(f"  step {t}: top10 agree {agree}/10 cos {c:.5f}")
+
+    frac = hits / steps
+    print(f"  top-10 agreement: {hits}/{steps} ({frac:.2%})  worst cos: {worst_cos:.5f}")
+    if frac >= tol_topk and worst_cos > 0.9:
+        print("PASS")
+        return 0
+    print("FAIL")
+    return 1
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/zuna_port.cpp
+++ b/tools/zuna_port.cpp
@@ -221,16 +221,16 @@ struct ZModel {
             snprintf(bf,sizeof(bf),"decoder.layers.%d.feed_forward.w2.weight",l); W->w2(bf,fn2,no,ni);
             snprintf(bf,sizeof(bf),"decoder.layers.%d.feed_forward.w3.weight",l); W->w2(bf,fn3,no,ni);
             snprintf(bf,sizeof(bf),"decoder.layers.%d.ffn_norm_post.norm.weight",l); W->w1(bf,fp,nn);
-            std::vector<f32> xnx(S*D), ynx(T*D), ca(S*D);
+            std::vector<f32> xnx((size_t)S*D), ynx((size_t)T*D), ca((size_t)S*D);
             adarnorm_rows(xnx.data(),h.data(),c,cxw.data(),cxb.data(),S,D,TD,eps);
             adarnorm_rows(ynx.data(),cross.data(),c,cyw.data(),cyb.data(),T,D,TD,eps);
             attention(xnx.data(),S,ynx.data(),T,D,H,HD,cq.data(),ck.data(),cv.data(),co.data(),cqn.data(),ckn.data(),freqs,tok_idx,tok_idx,ca.data());
             for(int s=0;s<S;s++){ f32* hh=h.data()+s*D; const f32* aa=ca.data()+s*D; std::vector<f32> post((size_t)D); rmsnorm(post.data(),aa,cpost.data(),D,eps); for(int j=0;j<D;j++) hh[j]+=post[j]; }
-            std::vector<f32> snx(S*D), sa(S*D);
+            std::vector<f32> snx((size_t)S*D), sa((size_t)S*D);
             adarnorm_rows(snx.data(),h.data(),c,sann.data(),sanb.data(),S,D,TD,eps);
             attention(snx.data(),S,snx.data(),S,D,H,HD,sq.data(),sk.data(),sv.data(),so.data(),sqn.data(),skn.data(),freqs,tok_idx,tok_idx,sa.data());
             for(int s=0;s<S;s++){ f32* hh=h.data()+s*D; const f32* aa=sa.data()+s*D; std::vector<f32> post((size_t)D); rmsnorm(post.data(),aa,sanp.data(),D,eps); for(int j=0;j<D;j++) hh[j]+=post[j]; }
-            std::vector<f32> fnx(S*D);
+            std::vector<f32> fnx((size_t)S*D);
             adarnorm_rows(fnx.data(),h.data(),c,fann.data(),fanb.data(),S,D,TD,eps);
             for(int s=0;s<S;s++){ const f32* x=fnx.data()+s*D; f32* hh=h.data()+s*D;
                 f32 g1[4096],g3[4096],mid[4096],ffb[4096];


### PR DESCRIPTION
Finishing the docs/journey-update-and-consistency-audit branch (already merged once as #1593; this adds the pending work batch on top):

1. **ZAYA GGUF converter rewrite** (`tools/convert_zaya_safetensors_to_gguf.py`): handles both naming eras (ZAYA1-base Nov 2025 alternating CCA/MoE; ZAYA1-8B/74B May 2026 every-layer hybrid), canonical llama.cpp PR #23112 tensor names, `--check` self-check that fails on silent drops / missing runtime tensors (fixes #1522 root causes).
2. **Logit validation**: `tools/zaya_logit_check.cpp` + `_ref.py` — greedy logits vs BF16 transformers reference, top-10 agreement, exit 0/1.
3. **Submodule bump**: llama.cpp bc8ce02c3 — Zaya 8B hybrid arch (input scale, post_attention_norm, hybrid detection, f16/f32 cast guards), debug scaffolding stripped.
4. **NPU overflow fixes**: size_t casts on tensor-dim products (pool_kernel, npu_engine_universal, zuna_port).
5. **CI**: VL pipeline tests on ROCm host build, ZAYA1-8B zoo smoke, tmp-cf-diag GITHUB_TOKEN read-only.

Converter self-check verified passing against ZAYA1-8B index.