### PR TITLE
fix(npu): make windows_npu_driver.h compile on Windows (#1504)

### DIFF
--- a/npu-infer/include/npu_utils/windows_npu_driver.h
+++ b/npu-infer/include/npu_utils/windows_npu_driver.h
@@ -79,6 +79,18 @@
 
 #include <cstdint>
 
+// Windows API headers MUST be included outside any namespace: winnt.h cascades
+// into the C++ stdlib headers (via x86intrin.h -> mm_malloc.h -> <stdlib.h>),
+// which break when parsed inside a user namespace (::abs/::div_t not declared).
+#if defined(_WIN32) || defined(__WINDOWS__)
+#include <windows.h>
+#include <winioctl.h>
+
+#include <cstring>
+#include <string>
+#include <vector>
+#endif
+
 namespace windows_npu {
 
 // -- 2. Control device ------------------------------------------------------
@@ -102,15 +114,6 @@ inline constexpr std::uint32_t ctl_code(std::uint32_t dev_type,
 }
 
 #if defined(_WIN32) || defined(__WINDOWS__)
-
-#include <windows.h>
-#include <winioctl.h>
-
-#include <cstring>
-#include <string>
-#include <vector>
-
-namespace windows_npu {
 
 // -- Control-plane driver wrapper (raw ioctl equivalent) --------------------
 class Driver {


### PR DESCRIPTION
Validated on real Windows (winboat VM) — the header never compiled on a Windows toolchain. Two bugs found and fixed:

1. `<windows.h>` was included inside `namespace windows_npu` — winnt.h cascades into C++ stdlib headers (x86intrin.h → mm_malloc.h → <stdlib.h>) which break inside a user namespace (::abs/::div_t undeclared).
2. The _WIN32 block re-opened the namespace, nesting `windows_npu::windows_npu`.

Verified:
- x86_64-w64-mingw32-g++ cross-build: clean
- Test binary on Windows (winboat): all 11 checks PASS
- Linux build: unchanged, all checks PASS