### PR TITLE
ci(pr-agent): drop_params for K3

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -42,3 +42,7 @@ ignore_pr_labels = []
 # Deepseek key expired -> silent failures. K3 note: temperature/top_p are
 # FIXED server-side; do not add sampling params here or requests 400.
 custom_model_max_tokens = 128000
+
+[litellm]
+# K3 400s on sampling params (temperature is pinned server-side).
+drop_params = true


### PR DESCRIPTION
K3 pins temperature server-side ('only 1 is allowed'); pr-agent sends 0.2. litellm drop_params strips unsupported sampling params. Verified K3 reachable in run 31622074890 — this is the last blocker.