### PR TITLE
ci(pr-agent): temperature=1 for K3

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -42,3 +42,6 @@ ignore_pr_labels = []
 # Deepseek key expired -> silent failures. K3 note: temperature/top_p are
 # FIXED server-side; do not add sampling params here or requests 400.
 custom_model_max_tokens = 128000
+# K3 allows ONLY temperature=1 (server-pinned). drop_params doesn't strip it
+# because litellm treats openai/* as temperature-capable. Send 1 explicitly.
+temperature = 1


### PR DESCRIPTION
K3 accepts only temperature=1; litellm drop_params doesn't strip it for openai/* models. One-liner config. Test evidence: run 31627721290 reached K3, 400'd on temperature=0.2.