### PR TITLE
ci(pr-agent): ai_timeout 600 for K3

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -45,3 +45,6 @@ custom_model_max_tokens = 128000
 # K3 allows ONLY temperature=1 (server-pinned). drop_params doesn't strip it
 # because litellm treats openai/* as temperature-capable. Send 1 explicitly.
 temperature = 1
+# K3 runs thinking=max by default; 120s default times out on real diffs
+# (litellm.Timeout in run 31629721723).
+ai_timeout = 600


### PR DESCRIPTION
### **User description**
K3 defaults to max thinking; the 120s default times out mid-review (litellm.Timeout, run 31629721723). 600s covers it.


___

### **PR Type**
Bug fix


___

### **Description**
- Set `ai_timeout = 600` in `.pr_agent.toml` config

- Prevents `litellm.Timeout` during K3 max-thinking reviews

- Adds comment citing failing run 31629721723


___

### Diagram Walkthrough


```mermaid
flowchart LR
  config[".pr_agent.toml"] -- "ai_timeout = 600" --> agent["PR Agent K3 review"]
  agent -- "avoids mid-review" --> timeout["litellm.Timeout"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pr_agent.toml</strong><dd><code>Raise PR agent AI timeout to 600 seconds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pr_agent.toml

<ul><li>Set <code>ai_timeout = 600</code>, replacing the 120s default<br> <li> Add comment explaining K3's server-pinned max-thinking causes timeouts<br> <li> Reference failed run 31629721723 (<code>litellm.Timeout</code>) as evidence</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1612/files#diff-356a4c0b1558da9e4be849aa64f19af78488ec6819f379e21ae93c53e750fbe7">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

