### PR TITLE
feat(npu): TQ2 GEMV Phase 3 step 3 — ping-pong L1 buffers + DDR bytes/token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,8 @@ engine/npu/xclbins/v26_backup/
 
 # ASan build dir
 build-asan/
+
+# ── AIE/Vitis sim artifacts ──
+.Xil/
+x86simulator_output/
+Work/

--- a/engine/npu/kernel/mm_ternary_tq2_aie2.cc
+++ b/engine/npu/kernel/mm_ternary_tq2_aie2.cc
@@ -58,7 +58,7 @@ extern "C" {
 // pB: N × K/4 bytes packed codes
 // pS: N × 2 bf16 scales
 // pC: M×N bf16 output
-void ternary_tq2_gemv_aie2(int8_t *pA, uint8_t *pB, bfloat16 *pS, bfloat16 *pC) {
+void ternary_tq2_gemv_aie2(const int8_t *pA, const uint8_t *pB, const bfloat16 *pS, bfloat16 *pC) {
     event0();
 
     // ── tile-major activation tiles: a_tiles[mb][kb], 4×8 int8 contiguous ──

--- a/engine/npu/kernel/tq2_aiesim/README.md
+++ b/engine/npu/kernel/tq2_aiesim/README.md
@@ -1,0 +1,18 @@
+# tq2_aiesim — TQ2 ternary kernel x86sim harness
+
+Single-tile ADF graph running `../mm_ternary_tq2_aie2.cc` on the VEK280
+platform in x86sim. `./run.sh` builds, simulates, and checks vs golden.
+
+Status 2026-08-14: harness works at the plumbing level (A=0 → C=0 PASS —
+graph wiring, kernel compile, and aiecc link are all sound), but x86sim's
+AIE-ML `aie::mmul<4,8,8>` emulation misreads the B operand (single-k probes
+return the wrong columns; same class as the STQ sibling's documented
+`mac_4x8_8x8` bug that reads only 4 of 64 B bytes). Numerics are verified
+by the host mirror test (`../test_tq2_gemv_ref.cc`, max abs err 0.000023
+PASS); ground truth for the real kernel binary is AM020 or the physical
+board (VE2802 not in aiecompiler's hw device DB in 2026.1 — aiesimulator
+unavailable). Keep this harness for the board bring-up flow: swap
+`--target=x86sim` for `--target=hw` once the eval kit arrives.
+
+The data generator (`gen_data.cpp`) uses the same seed-42 vectors as the
+host mirror test, so golden output and the host reference agree bit-for-bit.

--- a/engine/npu/kernel/tq2_aiesim/gen_data.cpp
+++ b/engine/npu/kernel/tq2_aiesim/gen_data.cpp
@@ -1,0 +1,103 @@
+// gen_data.cpp — generate PLIO data files + golden output for the TQ2 sim.
+// Same encode as test_tq2_gemv_ref.cc (seed 42 → identical vectors).
+//
+//   ./gen_data          writes data/in{A,B,S}.txt + golden.txt (LSB-first words)
+//   ./gen_data msb      same, but bytes packed MSB-first per 32-bit word
+//   ./gen_data check    compares outC.txt (sim) vs golden.txt
+//
+// PLIO 32-bit hex format: one 8-hex-digit word per line.
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+constexpr int M = 32, K = 64, N = 128;
+constexpr int GROUP = 32, NGROUPS = 2;
+constexpr int BYTES_PER_ROW = K / 4;  // 16 (4 × 2-bit codes per byte)
+
+static bool g_msb = false;
+static void write_words(const char *path, const uint8_t *buf, size_t nbytes) {
+    FILE *f = fopen(path, "w");
+    for (size_t i = 0; i < nbytes; i += 4) {
+        uint32_t w = 0;
+        for (int j = 0; j < 4 && i + j < nbytes; j++)
+            w |= (uint32_t)buf[i + j] << (8 * (g_msb ? 3 - j : j));
+        fprintf(f, "%08x\n", w);
+    }
+    fclose(f);
+}
+
+static float bf16_to_float(uint16_t b) { uint32_t u = (uint32_t)b << 16; float f; memcpy(&f, &u, 4); return f; }
+static uint16_t float_to_bf16(float f) { uint32_t u; memcpy(&u, &f, 4); return (uint16_t)(u >> 16); }
+
+int main(int argc, char **argv) {
+    if (argc > 1 && std::string(argv[1]) == "check") {
+        // outC.txt lines: "0xLLLL 0xHHHH" (two bf16 halves, low first)
+        FILE *fg = fopen("golden.txt", "r"), *fo = fopen("outC.txt", "r");
+        if (!fg || !fo) { printf("missing golden.txt or outC.txt\n"); return 1; }
+        std::vector<uint16_t> out;
+        char t1[16], t2[16];
+        while (fscanf(fo, "%15s %15s", t1, t2) == 2) {
+            out.push_back((uint16_t)strtol(t1, nullptr, 16));
+            out.push_back((uint16_t)strtol(t2, nullptr, 16));
+        }
+        double maxerr = 0; int idx = 0; float g;
+        while (fscanf(fg, "%f", &g) == 1 && idx < M * N && idx < (int)out.size()) {
+            maxerr = std::max(maxerr, std::abs((double)g - bf16_to_float(out[idx])));
+            idx++;
+        }
+        printf("compared %d values, max abs error: %.6f\n", idx, maxerr);
+        bool ok = idx == M * N && maxerr < 0.1;
+        printf("%s\n", ok ? "PASS" : "FAIL");
+        return ok ? 0 : 1;
+    }
+
+    g_msb = argc > 1 && std::string(argv[1]) == "msb";
+    srand(42);
+    std::vector<int8_t> A(M * K), W(N * K);
+    std::vector<uint8_t> B(N * BYTES_PER_ROW);
+    std::vector<uint16_t> Sb(N * NGROUPS);
+    std::vector<float> S(N * NGROUPS);
+    for (auto &v : A) v = (int8_t)(rand() % 21 - 10);
+    for (int i = 0; i < N * NGROUPS; i++) {
+        S[i] = (float)(rand() % 100) / 50.0f - 1.0f;
+        Sb[i] = float_to_bf16(S[i]);
+    }
+    for (int n = 0; n < N; n++) {
+        for (int k = 0; k < K; k++) {
+            int c = rand() & 3;              // code 0=-1, 1=0, 2=+1, 3=0
+            W[n * K + k] = c == 0 ? -1 : (c == 2 ? 1 : 0);
+        }
+        for (int i = 0; i < BYTES_PER_ROW; i++) {
+            uint8_t b = 0;
+            for (int p = 0; p < 4; p++) {
+                int c = (W[n * K + 4 * i + p] == -1) ? 0 : (W[n * K + 4 * i + p] == 1 ? 2 : 1);
+                b |= (uint8_t)c << (2 * p);
+            }
+            B[n * BYTES_PER_ROW + i] = b;
+        }
+    }
+
+    if (system("mkdir -p data") != 0) return 1;
+    write_words("data/inA.txt", (uint8_t *)A.data(), A.size());
+    write_words("data/inB.txt", B.data(), B.size());
+    write_words("data/inS.txt", (uint8_t *)Sb.data(), Sb.size() * 2);
+
+    // golden: C[m][n] = sum_k A[m][k] * S[n][k/GROUP] * W[n][k]
+    FILE *fg = fopen("golden.txt", "w");
+    for (int m = 0; m < M; m++)
+        for (int n = 0; n < N; n++) {
+            float sum = 0;
+            for (int k = 0; k < K; k++)
+                sum += (float)A[m * K + k] * S[n * NGROUPS + k / GROUP] * W[n * K + k];
+            fprintf(fg, "%.6f\n", sum);
+        }
+    fclose(fg);
+    printf("data written (A=%d B=%d S=%d, golden %d values)\n",
+           (int)A.size(), (int)B.size(), (int)S.size(), M * N);
+    return 0;
+}

--- a/engine/npu/kernel/tq2_aiesim/run.sh
+++ b/engine/npu/kernel/tq2_aiesim/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# run.sh — build + run the TQ2 kernel in x86sim, check against golden.
+# Needs: Vitis 2026.1 aietools on PATH, XILINXD_LICENSE_FILE set.
+# Usage: ./run.sh
+set -euo pipefail
+cd "$(dirname "$0")"
+V=${XILINX_VITIS:-/home/bcloud/Xilinx/2026.1/2026.1/Vitis}
+export PATH=$V/aietools/bin:$V/bin:$PATH
+export LD_LIBRARY_PATH=$V/aietools/lib/lnx64.o:$V/lib/lnx64.o:${LD_LIBRARY_PATH:-}
+g++ -O2 -o gen_data gen_data.cpp
+./gen_data
+aiecompiler --target=x86sim \
+  --platform=$V/base_platforms/xilinx_vek280_base_202610_1/xilinx_vek280_base_202610_1.xpfm \
+  --include=. --include=/home/bcloud/mlir-aie/aie_kernels tq2_main.cpp
+rm -rf x86simulator_output
+x86simulator --pkg-dir=Work
+cp x86simulator_output/outC.txt outC.txt
+./gen_data check

--- a/engine/npu/kernel/tq2_aiesim/tq2_graph.h
+++ b/engine/npu/kernel/tq2_aiesim/tq2_graph.h
@@ -1,0 +1,37 @@
+// tq2_graph.h — minimal ADF graph: single tile running the TQ2 GEMV kernel.
+// Windows (bytes): A = 32*64 int8, B = 128*16 packed TQ2, S = 128*2 bf16,
+// C = 32*128 bf16. PLIO data files are hex words (hex=true).
+#pragma once
+#include <adf.h>
+
+void tq2_gemv_adf(input_window_int8 *, input_window_uint8 *,
+                  input_window_uint16 *, output_window_uint16 *);
+
+constexpr int M = 32, K = 64, N = 128;
+constexpr int A_BYTES = M * K;        // 2048
+constexpr int B_BYTES = N * K / 4;    // 2048 (16 bytes/row, 2-bit codes)
+constexpr int S_BYTES = N * 2 * 2;    // 512
+constexpr int C_BYTES = M * N * 2;    // 8192
+
+class Tq2Graph : public adf::graph {
+public:
+    adf::input_plio inA, inB, inS;
+    adf::output_plio outC;
+    adf::kernel k;
+
+    Tq2Graph() {
+        k = adf::kernel::create(tq2_gemv_adf);
+        adf::source(k) = "tq2_kernel_adf.cc";
+        adf::runtime<adf::ratio>(k) = 0.9;
+
+        inA = adf::input_plio::create("inA", adf::plio_32_bits, "data/inA.txt", 0.0, true);
+        inB = adf::input_plio::create("inB", adf::plio_32_bits, "data/inB.txt", 0.0, true);
+        inS = adf::input_plio::create("inS", adf::plio_32_bits, "data/inS.txt", 0.0, true);
+        outC = adf::output_plio::create("outC", adf::plio_32_bits, "outC.txt", 0.0, true);
+
+        adf::connect<adf::window<A_BYTES>>(inA.out[0], k.in[0]);
+        adf::connect<adf::window<B_BYTES>>(inB.out[0], k.in[1]);
+        adf::connect<adf::window<S_BYTES>>(inS.out[0], k.in[2]);
+        adf::connect<adf::window<C_BYTES>>(k.out[0], outC.in[0]);
+    }
+};

--- a/engine/npu/kernel/tq2_aiesim/tq2_kernel_adf.cc
+++ b/engine/npu/kernel/tq2_aiesim/tq2_kernel_adf.cc
@@ -1,0 +1,11 @@
+// tq2_kernel_adf.cc — ADF window-port wrapper for the TQ2 kernel (sim only).
+// Includes the kernel .cc directly so aiecompiler sees a single TU; the
+// production extern "C" raw-pointer interface stays untouched.
+#include <adf.h>
+#include "../mm_ternary_tq2_aie2.cc"
+
+void tq2_gemv_adf(input_window_int8 *a, input_window_uint8 *b,
+                  input_window_uint16 *s, output_window_uint16 *c) {
+    ternary_tq2_gemv_aie2((const int8_t *)a->ptr, (const uint8_t *)b->ptr,
+                          (const bfloat16 *)s->ptr, (bfloat16 *)c->ptr);
+}

--- a/engine/npu/kernel/tq2_aiesim/tq2_main.cpp
+++ b/engine/npu/kernel/tq2_aiesim/tq2_main.cpp
@@ -1,0 +1,11 @@
+// tq2_main.cpp — aiesim/x86sim testbench: run the graph once.
+#include "tq2_graph.h"
+
+Tq2Graph g;
+
+int main() {
+    g.init();
+    g.run(1);
+    g.end();
+    return 0;
+}


### PR DESCRIPTION
### **User description**
## Phase 3 step 3: ping-pong L1 weight streaming + DDR bytes/token

Continues VEK280 TQ2 GEMV (AIE-ML). Steps 1–2 (port, mmul vectorization) merged (#1596, #1597).

### Kernel: ping-pong L1 buffers
`mm_ternary_tq2_aie2.cc` now unpacks weights into **two L1 buffer sets** — b_ping (scale group 0, k 0-31) and b_pong (group 1, k 32-63) — the double-buffer shape a streaming caller needs to overlap DMA of the next K-chunk with MAC of the current. Group 1's fill is a separate pass so the scalar unpack unit can run ahead of the vector unit.

### Host verification
`test_tq2_gemv_ref.cc` mirrors the ping-pong layout against a naive reference: **max abs err 0.000023 PASS**. Kernel compiles clean for aie2 target (llvm-aie clang, exit 0).

### DDR bytes/token (measured, not assumed)
Test now reports the traffic win at the demo shape (M32 K64 N128):
- TQ2 packed: 2560 B/token (2048 codes + 512 bf16 scales)
- INT8 baseline: 8192 B/token
- **3.2× cut**; scales amortize toward the full 4× at real K (Bonsai K=2048+)

### Status
ppl on Bonsai already measured (8.73, lossless vs Q1_0 — QUALITY.md). Remaining Phase 3: board-bound hardware run (VEK280 eval kit, 8-week lead).


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- HF-native safetensors loading across the CPU engine
  - `SafetensorsWeightReader`: dtype decode, sharded index support
  - `load_safetensors()`: HF tensor mapping, MoE conventions, Phi fusion

- Generation-exact arch fixes: Granite, Gemma3, Phi, RoPE
  - GGUF RoPE un-rotation, F64 GEMV accumulation, config-driven softcaps

- TQ2 AIE2 GEMV ping-pong L1 buffers, DDR bytes/token

- Ten-suite self-check harness plus generation-vs-torch gate


___

### Diagram Walkthrough


```mermaid
flowchart LR
  HF["HF safetensors checkpoints"] -- "SafetensorsWeightReader" --> BE["Generic CPU backend"]
  CFG["config.json parsing"] -- "softcaps, multipliers, local RoPE" --> BE
  GGUF["GGUF loader"] -- "RoPE un-rotation" --> BE
  BE -- "F64 GEMV + arch-exact math" --> OUT["torch-identical generation"]
  TQ2["TQ2 packed weights"] -- "ping-pong L1 unpack" --> AIE["aie::mmul AIE2 GEMV"]
  CHK["Self-check suite"] -- "validates" --> BE
  CHK -- "validates" --> AIE
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>backend_generic.cpp</strong><dd><code>HF-native safetensors loader plus arch-exact math corrections</code></dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-82c4d3084e1369da4c917a8935387c33afa514e729d6753dd0bb508a05a8da0e">+405/-44</a></td>

</tr>

<tr>
  <td><strong>safetensors_reader.cpp</strong><dd><code>Weight reader with dtype decode, sharded checkpoints, config parsing</code></dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-912fa13cfe16e633ae228f043bfed6a7164073b52c8fe238cd799c949adef147">+297/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>safetensors_reader.h</strong><dd><code>Declare SafetensorsWeightReader API for sharded weight loading</code></dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-23d144fcc3ce5525b40cb337573bc89dd6d3be4d73193b74683db17c5cef8342">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>common.h</strong><dd><code>ModelConfig gains multipliers, softcaps, local RoPE fields</code></dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-bc020f3ca1b410d9c45f1a3e744c2b506de509f4c7063cf7755272d69283cdb4">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mm_ternary_tq2_aie2.cc</strong><dd><code>Ping-pong L1 double buffers for weight streaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-303e2445b206f4ce8e71a8da042c8e7ad3bf4b92af7832288160a71be4c22c8f">+43/-16</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>model_discovery.cpp</strong><dd><code>UNKNOWN-arch loud refusal and safetensors arch dispatch</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-8e5a86a100d1f204ba46c30c372580243c8f23095dd10e80a94f7110a39cd378">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>q4nx_reader.cpp</strong><dd><code>Q4NX and 1BP architecture dispatch corrections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-1ab49a79619a58bc0cb98da4959e7fdd4191cf1a92dccf7e94b776079c79624f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>test_tq2_gemv_ref.cc</strong><dd><code>Mirror ping-pong layout, report DDR bytes/token</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-4f6108c412b912d96cfc01c5b621c64b3735236323ca12d1ff8556b487b685f1">+34/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>safetensors_weights_selfcheck.cpp</strong><dd><code>Synthetic fixture verifying per-dtype weight decoding</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-34b4ccd4286f168f2b813effa563a2a2c4f13513461658a6cf26fabe0c00196d">+109/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>sharded_reader_selfcheck.cpp</strong><dd><code>Two-shard checkpoint index resolution self-check fixture</code>&nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-9507bfeb536d49b2848f6974210a46f12f5efcb8994c3939adb4851095746e6e">+95/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>discovery_selfcheck.cpp</strong><dd><code>Model discovery arch mapping for pilot architectures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-80623932b40de2a627b43b09a2c4107abfdcb7c964cd5beede08c909fd4f4055">+121/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>router_selfcheck.cpp</strong><dd><code>Backend route selection regressions for pilot archs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-a86708258380df365267bd4b4b51522a36a66fa9ddaff29fa9453cf987beb246">+123/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>arch_mapping_selfcheck.cpp</strong><dd><code>Architecture string to enum mapping checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-54de151fcbd3498049ee4336d6ec9e996cf8243ce4a5a86a0e04ac0b8f1751fb">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>e2e_safetensors_selfcheck.cpp</strong><dd><code>End-to-end safetensors versus GGUF loader comparison</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-d4a351f57154b8f54442f20374431fc7740c4a4ddfa6a38c44eb0824ee5884b8">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>aie2p_bf16_rni_selfcheck.cpp</strong><dd><code>Hardware-measured AIE2P bf16 round-toward-negative-infinity </code><br><code>verification</code></dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-1a52b00f56e83c470575d3aee648a8f0eb304379930cf9e1d8ef0cf4be02c76d">+104/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>run_all.sh</strong><dd><code>Aggregate runner wiring ten self-check suites</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-60779953d5d72f0d8ef3aea52f86b0b365bbdb42457aae2e5955d6320e32eb2c">+57/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>run_gen.sh</strong><dd><code>Autoregressive generation gate compared bit-exact against torch</code></dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-04e512ce626e6bd4f8bfa8f55df528f6ee4bd2e518ec69aeba7de640d9375e7f">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>AIE2P-FACTS.md</strong><dd><code>Document measured AIE2P bf16 rounding and dispatch costs</code>&nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-8d0b584287d9c7f40e7f6ed75aa8849e74b0aa8ce7b55cb85b1b80dd6a01931d">+87/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>gemm_wmma.cu</strong><dd><code>Reference WMMA GEMM port from MAX recipes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-2d30d26d660fcdd80d78dcc5573d40c279e901ad49a6805fdad7c44467f89a5f">+106/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>final_i8_GU_K1024_N6144.xclbin</strong><dd><code>Pointer to FLM Qwen3 NPU xclbin binary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-69e6308154619031dd7fe3bf8ef926e5a93179af4d0fece39e587dec48ecfd76">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>20 files</summary><table>
<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dump_weights.cpp</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-1eb82d123f1514f0d9ea104334986746bebc74fe810d401d16063d11db4c6e1a">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>e2e_gen_check.py</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-5cf722e191c51b8133b2c86c9ae94d3bdf499396a5a8db638d9194030574aaed">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>e2e_gen_check_hf.py</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-e4dc81a77e63b1488bd3f4e60cef90a58534ad13efead3770bfd40916c03ea91">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>e2e_seq_gen.cpp</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-3b1202da71bc351b58c1d9967759c0c8b6f4834db40e65ae93443cb1128dcad0">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>e2e_torch_oracle.py</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-73c0bb2ff5b148adf45748a8b7d9cb1085fb4edfbcfee2f329e9a764a5aae2e5">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rotation_table_selfcheck.cpp</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-5d6c4acbe7e3f67e88ad9a775128baf264bd765c1e688cc58771b222bfdb5775">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>jarvis.md</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-57259c68aa337a3f14c40360c953180cc7988c44da773044043be77ff2f3bc75">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>npu_engine_i8ctx_inc.h</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-00a304de6fc1ff0480e37d4ed288e548ef48a8b2cdde7652034ce7a3815b864c">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>npu_engine_universal.cpp</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-63677a636d5ff19712cf034cc1e2c15a96b194137caee54d8bd6883b0b76a10b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>final_i8_D_K3072_N1024.xclbin</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-79676b6945019f9634dbbdb8720895754681657f267c4a42ea32d242c1dae007">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>final_i8_O_K1024_N1024.xclbin</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-e1c02078d73cd21bb4a85736482dcdff762328980c998de0ce4c26b392fd9c0d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>final_i8_QKV_K1024_N4096.xclbin</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-86e7372f42ae712d1f01a49f895c01eb9f7b3144f73c38a11411865061f7644a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-c4ef174f158101326082a2d6f70f7556174e517ee20d2fe473bca05615437409">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gemm_fp8_wmma.cu</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-6a65cda8154402a5ffeff202fa1bafa7207bf09e971dabd5243e432fa2b349ed">+134/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>gemm_wmma_lds.cu</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-e9a2ecac2afe794c6190c75dd989291a1c3b67d4583987a481df9f6faa09cb48">+130/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>gemv_dpp.cu</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-ecfae2aa4ad10e1e7005acc32ae298e6b83fa5b9d598e054afe69c1285304c45">+101/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>max_recipes_port_guide.md</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-3b3191b4510789a8cd7c364e1a38d998af7aa5380168c789a24c1585bf6d04ec">+98/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rmsnorm_dpp.cu</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-859afcb56d7e8f2a920939a06bf63ebbf8e6e85a855d6fabe65a6f3bc75d8861">+114/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>bitnet_model.h</strong></td>
  <td><a href="https://github.com/1bit-systems/1bit-systems/pull/1621/files#diff-12d8fec0ba47f1c901fbf55f16f798edaba0a693e7c892bfd9302e0b1a87318a">+39/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

