### PR TITLE
Make VitisAI ONNX NPU backend an explicit opt-in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,7 +538,9 @@ endif()
 # VART backend is always compiled — uses __has_include guards for the stub fallback
 list(APPEND BACKEND_MANAGER_SOURCES src/backend_vart.cpp)
 
-# ONNX NPU backend — always compiled, uses __has_include guard
+# ONNX NPU backend — always compiled, uses __has_include guard. Only does
+# anything when -DONNX_VITISAI_NPU=ON (see that option, below); otherwise
+# HAS_ORT is unset and this compiles to a self-disabling stub.
 list(APPEND BACKEND_MANAGER_SOURCES src/backend_onnx.cpp)
 
 add_library(backend_manager STATIC ${BACKEND_MANAGER_SOURCES})
@@ -632,12 +634,28 @@ if(RCPP_HAVE_VART)
     target_include_directories(backend_manager PRIVATE ${VART_INCLUDE_DIR})
     target_link_libraries(backend_manager PRIVATE ${VART_RUNNER_LIB} ${VART_DPU_RUNNER_LIB} ${XIR_LIB})
 endif()
-# ONNX Runtime + VitisAI EP for NPU backend
-# ponytail: link only the base ORT lib; VitisAI EP provider .so is loaded at
-# runtime by ORT's AppendExecutionProvider (must match ORT version exactly)
-if(onnxruntime_FOUND)
+# ONNX Runtime is an optional third-party SDK, shared by the codec decoder
+# (further below) and, opt-in only, the VitisAI NPU backend here. Located
+# once, up front, so both consumers see the same onnxruntime_FOUND result.
+set(ONNXRUNTIME_ROOT_DIR "" CACHE PATH "ONNX Runtime install root")
+find_package(onnxruntime QUIET HINTS "${ONNXRUNTIME_ROOT_DIR}")
+
+# ONNX Runtime + VitisAI EP for NPU backend — OPT-IN ONLY, off by default.
+# AMD's VitisAI execution provider embeds its own Python runtime (flexml) and
+# needs libpython3.12 on LD_LIBRARY_PATH at runtime (ponytail: only the base
+# ORT lib is linked here; the VitisAI EP provider .so itself is loaded at
+# runtime by ORT's AppendExecutionProvider, must match ORT version exactly).
+# That Python dependency has no place in a build that ships "zero Python in
+# the runtime" by default, so this requires an explicit -DONNX_VITISAI_NPU=ON
+# in addition to onnxruntime being found. A plain `cmake -B build` never
+# links onnxruntime here; backend_onnx.cpp self-disables via its HAS_ORT guard.
+option(ONNX_VITISAI_NPU "Build the AMD VitisAI ONNX NPU backend (requires ONNX Runtime + AMD's VitisAI EP, which embeds a Python runtime — opt-in, off by default)" OFF)
+if(ONNX_VITISAI_NPU AND onnxruntime_FOUND)
+    message(STATUS "backend_onnx: ONNX_VITISAI_NPU=ON and ONNX Runtime found — building VitisAI NPU backend (pulls in AMD's Python-embedding EP at runtime)")
     target_include_directories(backend_manager PRIVATE ${ONNXRUNTIME_INCLUDE_DIRS})
     target_link_libraries(backend_manager PRIVATE onnxruntime::onnxruntime)
+elseif(ONNX_VITISAI_NPU AND NOT onnxruntime_FOUND)
+    message(WARNING "backend_onnx: ONNX_VITISAI_NPU=ON but ONNX Runtime not found (set ONNXRUNTIME_ROOT_DIR) — backend will self-disable")
 endif()
 target_compile_options(backend_manager PRIVATE -O3 -march=native -Wall -Wno-unused-result -std=c++23)
 # NOTE: no -ffast-math here (deliberately) — it implies -ffinite-math-only and
@@ -1403,9 +1421,8 @@ endif()
 # embedding a second BackendManager; own port 8080.
 # ── Optional: ONNX Runtime for codec decoder (voice cloning TTS) ──
 # The codec decoder compiles without it — decode() returns empty PCM.
-# Set ONNXRUNTIME_ROOT_DIR to help find_package locate the SDK.
-set(ONNXRUNTIME_ROOT_DIR "" CACHE PATH "ONNX Runtime install root")
-find_package(onnxruntime QUIET HINTS "${ONNXRUNTIME_ROOT_DIR}")
+# ONNX Runtime itself and ONNXRUNTIME_ROOT_DIR are located once, earlier,
+# alongside the (separately opt-in) VitisAI NPU backend — see that comment.
 if(onnxruntime_FOUND)
     message(STATUS "codec: ONNX Runtime FOUND — building codec decoder with real inference")
     add_definitions(-DUSE_ONNXRUNTIME)

--- a/src/backend_onnx.cpp
+++ b/src/backend_onnx.cpp
@@ -1,5 +1,15 @@
 // backend_onnx.cpp — ONNX Runtime + VitisAI EP backend for Strix Halo NPU.
 //
+// NOT part of the engine's "zero Python in the runtime" pure-C++ story. This
+// backend wraps AMD's own VitisAI execution provider, a vendor .so that
+// embeds a Python runtime (flexml) internally — that dependency lives inside
+// AMD's binary, not in code we own, so it can't be rewritten away. It's an
+// optional, off-by-default comparison path against the project's real,
+// reverse-engineered pure-C++ NPU backend (backend_npu.cpp / backend_npu_flm.cpp).
+// Requires an explicit -DONNX_VITISAI_NPU=ON at configure time (see
+// CMakeLists.txt); a plain `cmake -B build` never links ONNX Runtime here and
+// this file compiles to a self-disabling stub via the HAS_ORT guard below.
+//
 // Runs a GGUF-exported LLM ONNX graph (see tools/gguf_to_onnx.py) on the
 // XDNA 2 NPU via AMD's VitisAI execution provider. Pinned format (issue
 // #1468, hardware-verified 2026-08-05):


### PR DESCRIPTION
### **User description**
## Summary
- `backend_onnx.cpp` wraps AMD's own VitisAI execution provider, a vendor `.so` that embeds a Python runtime (flexml) and needs `libpython3.12` on `LD_LIBRARY_PATH`. That dependency lives inside AMD's binary and can't be rewritten away — it's not our code.
- Found a real bug while checking this: `onnxruntime_FOUND` was being checked ~770 lines *before* the `find_package(onnxruntime...)` call that sets it, so the guard was always false regardless of whether the SDK was actually present — silently dead rather than deliberate.
- Moved the ONNX Runtime lookup earlier, decoupled it from the unrelated codec/TTS feature's own (non-Python) ONNX Runtime use, and gated this backend behind a new `-DONNX_VITISAI_NPU=ON` flag, off by default.
- Updated the header comment in `backend_onnx.cpp` to state plainly this backend is not part of the "zero Python in the runtime" pure-C++ engine — it's an optional comparison path against the project's real reverse-engineered NPU backend (`backend_npu.cpp` / `backend_npu_flm.cpp`).

## Test plan
- [x] `cmake -B build` (no flag) on a real ROCm/XRT toolchain — configures clean, no onnxruntime linked, no VitisAI messages
- [x] `cmake -B build -DONNX_VITISAI_NPU=ON` without ONNX Runtime SDK present — correctly warns and self-disables rather than silently no-op'ing
- [ ] Full build + link with `-DONNX_VITISAI_NPU=ON` and ONNX Runtime SDK actually installed (not available in this environment)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Rebrand site from 1bit.systems to 1bit MONSTER
  - New landing page: sidebar layout, lime/black palette
  - Rename domain, repo links, design tokens site-wide

- Make VitisAI ONNX NPU backend explicit opt-in
  - New `-DONNX_VITISAI_NPU=ON` flag, off by default
  - Fix dead `onnxruntime_FOUND` guard ordering bug


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR"] --> B["Site rebrand to 1bit MONSTER"]
  A --> C["VitisAI ONNX backend opt-in"]
  B --> D["New landing page + lime palette"]
  B --> E["1bit.monster links + assets"]
  C --> F["ONNX_VITISAI_NPU flag, off by default"]
  C --> G["Fixed dead onnxruntime_FOUND guard"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>backend_onnx.cpp</strong><dd><code>Header comment documents opt-in Python-embedded backend</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-d1dca14f0f517dd84bfa34c7872dc024899e8a0ec4545bbe05cecabdc155f0f5">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Rename domain and repo references to 1bit MONSTER</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>index.html</strong><dd><code>Rebuild landing page with sidebar, lime palette, benchmarks</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+329/-184</a></td>

</tr>

<tr>
  <td><strong>index.html</strong><dd><code>Retheme palette and rename 1bit.systems to 1bit.monster</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-aef9cf1e2772f3835b32360da3eb558ecc9624843d3a91fe6a2c7e64b7a2c5e6">+57/-57</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>what-reviews-didnt-tell-you-ryzen-ai-halo.html</strong><dd><code>Retheme palette and update branding references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-33666bd438f8dff80a15eadbd8d0e19f17e0a796b83f6fbf0ca813302c9b9667">+31/-31</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dspark-speculative-decoding-572-tok-per-second.html</strong><dd><code>Retheme palette and update branding references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-080bbdf872a341a5367774de2dad8eaf9dca6974312ff34d9d36a0d2c432ba21">+19/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>one-binary-all-formats.html</strong><dd><code>Retheme palette and update branding references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-e936f801da069c71f616aafdb5f6b7f1acc36763efe31a7ab5f851b604df0016">+19/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CMakeLists.txt</strong><dd><code>Gate VitisAI ONNX backend behind opt-in flag, fix guard ordering</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+25/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>style.css</strong><dd><code>Retheme design tokens to black/lime palette</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-08df6bd53d0500786b030d721fd84df69869f591a6179a4b9a5f212d225e1d42">+80/-80</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>docs.css</strong><dd><code>Retheme docs design tokens to black/lime palette</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-5bccb68f4efb6ee1392622a350d45bf1ad639cac290cb35eadc8381a670dc7e4">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>install.sh</strong><dd><code>Update domain references in installer script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-ffcb6c2d4a13dd819ac914f6a0dcd6a0614ad9b48a95fe269695a86c9aaab20f">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.html</strong><dd><code>Retheme blog index and rename branding references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-563d98875998ed4bc31f9a54011326fb27225b009aafccf0a0692ab7503d4c08">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.html</strong><dd><code>Retheme store page and rename branding references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-ad5a8e808f64df07a540c3b2b55574aeec05f10211cc8a2b22be2ae5e909b84f">+24/-24</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.html</strong><dd><code>Retheme JARVIS page and rename branding references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-7b7b22aacf4e1f3898589e83e8c623ff773e8ba44c83648351904890cdbbcc4b">+21/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.html</strong><dd><code>Retheme demo page and rename branding references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-38dd12c17eb7ef18b281d534217e525bd85c188b79c8c629e7652e9c6d133371">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.html</strong><dd><code>Retheme docs pages and rename branding references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-c087a70d2d06711c8fd6f521557e1658738872b9566de6d16ad84bbad7ad46af">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>404.html</strong><dd><code>Retheme 404 page and rename branding references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-8cbce8d617d964ddab39632760ab6337f1b8e3c5584de59ef68c68f07ba8624d">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>robots.txt</strong><dd><code>Update sitemap URL to 1bit.monster</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-1ee750f25f70fe5d5aca67d58f8f70c35c3f10fa770f06d9feece2e8534ca7fa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>site.webmanifest</strong><dd><code>Update app name and domain references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-9ee2135d112b96f536692e5f5139f231a0d659125b8b56c6cc98161fddf248ab">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sitemap.xml</strong><dd><code>Update URLs to 1bit.monster domain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-6cab76c79002bb69ec6454698949f95c9f256c19f66edfebe1560f74319b8b67">+26/-26</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>45 files</summary><table>
<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-669d2a51f46a925c4e680583bb9a7fc173b8ca2f52d991e8986ab52c20321064">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>_headers</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-aa425049fdeab4ea6b94f164b358a4e51856cde1b52f7f4fba83a9b01146f1c3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>_redirects</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-efc21b966b8f947f5cd9c1cc0d6769c79bc4c3766826802dca8011b140ba40c1">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>agent.sh</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-2203ba060a658d345e283254e4373ff465aa8dc3a30cb9934fc1aa8da32b834a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-429c0cf7939c79413a3c15d49c7ebbd0fa6b7260586ae95f1f79b97bccd9e273">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NOTICE</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-29a94a3ca17bb2f3a7028ec6d674045abfe6a8a398d836d87bdbf12b4e03fb41">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>copy-code.css</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-0511c6698098bc2d13e07a424f146e7892aad1654a6d73c8c0203d5722372241">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>benchmarks.json</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-b552bfdecddd4c2f7fc7b8159f7a579cb78a692ce62528256ca28e5380c9e732">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flm-37-models-extracted.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-e89ffb946cd41c00e3b1ba21b409e32b752bf09a09ddb94bd071244f04fad287">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>fused-layer-engine-one-xclbin-per-layer.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-9ee4ad3785008837098f2bc4da138e3c728a4b6e39602261010667eedf3a4ca8">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>npu-132x-more-efficient-than-gpu.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-e3abd4d9ca7752e3197f0c1f2b450a7752f50e932d9e106c93c5a4b278f9d1b3">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>npu-benchmarks-55-tflops.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-48633baa16c8818e6e23048939f3853a6fa9d1e1165a945fcff74417eed4c1a1">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>npu-optimization-sprint-72x-speedup.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-316530ebf5273f358860ea2bb55d22e6936080931d3bfe34a784c3f8c004dd37">+13/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>one-binary-to-rule-them-all.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-2ccaaca934be8e17ea50cc7e3913912694c9f5af471306bb79516ec1b5d432b4">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>qwen35b-a3b-fully-on-npu.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-2e127e261b9e6fbbf102be97e2ac1da879fe536efa75dc763dc1fa6479de54bb">+21/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>reverse-engineered-amd-npu-4-days.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-3f3b722b1186b4a988719c25904ce85c89298c1898d5bdde7bb656c492b44d6c">+22/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>three-bugs-broke-97-tok-per-second.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-6ef28e03b8b74f5aeb234fac9fd1411f920a2341b559b12a2f5aa4cc0e3427b7">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>token-router.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-81720ef222ba3604a8ecf2ca3747f4438bdf7197831ec72f4d27f52d47ee9037">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>unsloth-for-amd.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-e4f23b09ab00c72ea1870b8619780d852cee7b81a399b0c1ee6b026886e7421a">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>zyphra-family-complete.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-8a04eb5ce666df2659e2d1add5f961f9dbc59eca86a253313a23897b5e40d41f">+23/-23</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-fe9a7c7a8b953caa17ecc651f126fe2400df02aeccb2c97bb9e7a8f24c7ff65c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app.js</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-9c9073e406d447950ad1a3f7793e90f0fa8367234607c812159d3276f24fb0aa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-6f181e6a7c5e18501b976efbf6fa5133257c632c53dffa75d3c085d6aaaf5a44">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>style.css</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-06663100422fd7375edb42148b8c489ce2e39d07511dff970d8bcb8958d46652">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>audio.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-f03c69976f349d56fb5d84ae11a5ff1c251a92c112cb999f9c3becb344a949a6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gpu.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-969502744371e268bfb675f072aa23fc0fe8185b524b2c431f0ecc5796a8f870">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>text.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-89dc8359ffaa0a1f3ed1b2a630f3129d054f1b64be9e59123e071c2e932d7d7b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vision.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-b437030619823f25eeb999fc4121dfbd5181f0d0888aba8129c471acf0d42c6d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-20795814a2916546e2d472f903f85ca5e701d19ab70eb2f67f8340d7af69b46b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>architecture.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-5d35d20ee1ffd360f1d4f0ccd067a3f73e14c5ca8b1ae9a17e0c3ef6a9a94742">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>benchmarks.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-c34e0bc95991a8a99bd906e57ad1c47f38c21ea4cbafad91a9db73a8d0dd5839">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>changelog.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-7733d671701591e660f1b74c07e52984d66eea9c26a8fec9e784bd5d9089ec8a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>contributing.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-04a89b519e594acd96d9b529fe217c23451de2b065b129e3eb01d732bef7f065">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>faq.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-f0816253088afddc29152facf1bc6280e8b186ee3aa92ba468bc13f4f9235621">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>install.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-1687e1d5278cf9ea6b1270464838fd3de7455ce5dcc0d702e9c380c8d72e5b57">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-74ad9b9954d9539c35549198e20ddc26474ce5342cb3ba8477d61a935efd158b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>quickstart.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-516f5a8eca39bca612693a0cc5c18220bcbe41f2cd201bfc701c56f0d9a7dd46">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>troubleshooting.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-29cecf346b51ce563dee52e8b0d6f24edbdf73c2334c94ba1c379c46aea89032">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>why.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-946b9828ac98c6ab2e1d9b04060cc9b842132169fb048e03442839e3b55aec56">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>[[path]].js</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-fd77f8889d710dd05dbeed205cf658e4bc62f70d84a4e33494b2990fcad21ca6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>live.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-e5c4cf175b868b38982fdb1b2ca7e26514b7ab6209be6519c692c5f9cc773b89">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mobile.sh</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-0e709a55a5409567bb82c44b2877df70210d615a04d9a9e50aad51c548e09ad9">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>numbers.json</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-ae47c5374645db1ea2408362085c7a2a5c4c466f4cb7c4f6115a316007aadf79">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-01de49c0f2f694d54e5d545bae67742491c3958e3705c904a15781d6c8ac2958">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>success.html</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1641/files#diff-94f71345545a05e98cf97cc8a1f10974b39895bc23360312fdba2fc03399e123">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

