### PR TITLE
Deploy site/ to GitHub Pages via Actions, not the legacy whole-repo build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,3 +26,22 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy site --project-name=1bit-systems
+
+  deploy-github-pages:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4
+        with:
+          path: site
+      - id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4


### PR DESCRIPTION
### **User description**
## Summary
- GitHub Pages for this repo was `build_type=legacy`, source `branch:main path:/` — every push tried to Jekyll-build the entire ~341MB monorepo (`third_party/`, `mobile/`, `kernels/`, ...) as the site. That build's `Upload artifact` step has been failing (Pages status: `"errored"`), which is why `1bit.monster` 404s even though DNS/CNAME correctly points at GitHub Pages.
- The real site content lives in `site/` and was already deployed to Cloudflare Pages by this workflow, but nothing published it to GitHub Pages — which is what the domain's DNS actually points at.
- Adds a `deploy-github-pages` job that uploads `site/` as a Pages artifact via `actions/upload-pages-artifact` and publishes it via `actions/deploy-pages`, running alongside (not replacing) the existing Cloudflare deploy job.
- Flipped the repo's Pages `build_type` to `"workflow"` via the API (not part of this diff) so the legacy Jekyll-from-root build no longer runs.

## Test plan
- [x] Manually dispatched this workflow on this branch (`workflow_dispatch`) to publish `site/` to GitHub Pages immediately and confirm `1bit.monster` serves the rebranded page
- [ ] After merge, confirm a future push touching `site/**` deploys to both Cloudflare and GitHub Pages


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `deploy-github-pages` job publishing `site/` to GitHub Pages

- Fix `1bit.monster` 404 from failing legacy whole-repo Jekyll build

- New job runs alongside existing Cloudflare Pages deployment

- Pin all actions to SHAs with least-privilege permissions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Push["Push to main"] --> Workflow["deploy.yml"]
  Workflow --> Cloudflare["deploy: Cloudflare Pages"]
  Workflow --> GHJob["deploy-github-pages"]
  GHJob --> Upload["upload-pages-artifact path=site"]
  Upload --> Deploy["deploy-pages publishes site"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy.yml</strong><dd><code>Add GitHub Pages deployment job for site directory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy.yml

<ul><li>Add <code>deploy-github-pages</code> job running on <code>ubuntu-latest</code> with 10-minute <br>timeout<br> <li> Grant <code>pages: write</code> and <code>id-token: write</code> permissions with read-only <br>contents<br> <li> Use <code>configure-pages</code>, <code>upload-pages-artifact</code> (path <code>site</code>), and <br><code>deploy-pages</code>, all SHA-pinned<br> <li> Expose deployed URL via <code>github-pages</code> environment from <br><code>steps.deployment.outputs.page_url</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1642/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

