### PR TITLE
Switch Pages to Actions-based deployment (fixes stuck build)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### **User description**
## Summary
- `1bit.monster` has been 404ing because the legacy "Deploy from a branch" Pages build has been stuck in `building` status for hours with no progress and no error message. Confirmed no GitHub-wide Pages incident (githubstatus.com clean); manually retriggering the build via `POST .../pages/builds` twice didn't help.
- Adds `.github/workflows/pages.yml`: a standard Actions-based deploy (upload repo root as a static artifact via `actions/upload-pages-artifact`, publish via `actions/deploy-pages`). Repo-tracked content is only ~4MB, well within artifact limits.
- I've already flipped the repo's Pages source setting from "Deploy from a branch" to "GitHub Actions" via the API (`build_type: workflow`) — safe to do ahead of merge, it doesn't change what's served until a workflow actually deploys. Current status shows `errored` only because no Actions deployment has run yet.

## Test plan
- [ ] Once merged, confirm the `Deploy Pages` workflow run succeeds on push to `main`
- [ ] Confirm `https://1bit.monster/` serves content again (currently 404)
- [ ] Confirm the custom domain + HTTPS cert still show correctly under Settings → Pages after the switch


___

### **PR Type**
Bug fix


___

### **Description**
- Add Actions-based GitHub Pages deployment workflow

- Fix stuck legacy branch-deploy build causing site 404

- Publish repo root as a static artifact

- Trigger on `main` pushes and manual dispatch


___

### Diagram Walkthrough


```mermaid
flowchart LR
  push["Push to main"] --> checkout["Checkout repository"]
  checkout --> setup["Setup Pages"]
  setup --> upload["Upload static artifact (repo root)"]
  upload --> deploy["Deploy to GitHub Pages"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pages.yml</strong><dd><code>Add Actions-based GitHub Pages deployment workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pages.yml

<ul><li>Add new <code>Deploy Pages</code> workflow triggered on pushes to <code>main</code> and <br><code>workflow_dispatch</code><br> <li> Set minimal permissions (<code>contents: read</code>, <code>pages: write</code>, <code>id-token: </code><br><code>write</code>) and a <code>pages</code> concurrency group<br> <li> Checkout repo, run <code>actions/configure-pages</code>, and upload repo root via <br><code>actions/upload-pages-artifact</code><br> <li> Publish with <code>actions/deploy-pages</code> and expose the page URL via the <br><code>github-pages</code> environment</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1643/files#diff-267452bb53d388a7b14551d9fc53a797edc124dc9085ecc79f5339277a1e53b5">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

