### PR TITLE
ci: cache the TheRock ROCm SDK install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           submodules: recursive
-      - name: Install build deps + TheRock ROCm
+      - name: Install build deps
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq cmake ninja-build build-essential python3 python3-venv \
@@ -42,6 +42,18 @@ jobs:
           # xrt headers at compile time (same dep release.yml installs).
           sudo apt-get install -y -qq libxrt-dev || \
             echo "::warning::libxrt-dev not available — fused NPU backends stubbed"
+      - name: Compute ROCm cache key (weekly — TheRock is a nightly index)
+        id: rocm-week
+        run: echo "week=$(date -u +%Y-W%V)" >> "$GITHUB_OUTPUT"
+      - name: Cache TheRock ROCm SDK
+        id: cache-rocm
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: /opt/rocm-therock
+          key: rocm-therock-${{ runner.os }}-${{ steps.rocm-week.outputs.week }}
+      - name: Install TheRock ROCm (nightly, native gfx1151)
+        if: steps.cache-rocm.outputs.cache-hit != 'true'
+        run: |
           # TheRock nightly ROCm only (native gfx1151). This repo never falls
           # back to apt ROCm 7.2.4 — if TheRock can't install, CI fails.
           sudo python3 -m venv /opt/rocm-therock


### PR DESCRIPTION
### **User description**
## Summary
The C++ CI job (25-min timeout) reinstalls the entire ROCm SDK from AMD's nightly pip index (`rocm[devel,libraries]` + `rocm-sdk init`) on every single push, before compiling anything. Cache `/opt/rocm-therock`, keyed weekly since it's an unpinned nightly index (a week-old cache is an acceptable staleness tradeoff for CI speed), and skip the install step on a cache hit.

Minimal, single-purpose change — didn't touch the rest of the pipeline (no ccache for the actual C++ compile, no dedup with the separate llama.cpp pre-build pass) per KISS.

## Test plan
- [ ] First run on this PR: cache miss, installs ROCm as before, populates the cache
- [ ] A re-run (or the next PR this week): cache hit, install step skipped, job finishes noticeably faster


___

### **PR Type**
Enhancement


___

### **Description**
- Cache TheRock ROCm SDK install in C++ CI

- Key cache weekly (unpinned nightly index)

- Skip ROCm pip install on cache hit

- Split build-deps and ROCm install steps


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["C++ CI job"] --> B["Install build deps"]
  B --> C["Compute weekly cache key"]
  C --> D{"Cache hit for /opt/rocm-therock?"}
  D -- "yes" --> F["Skip install, compile"]
  D -- "no" --> E["pip install TheRock ROCm nightly"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Cache TheRock ROCm SDK weekly in C++ CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Split monolithic <code>Install build deps + TheRock ROCm</code> step: apt deps stay <br>in <code>Install build deps</code><br> <li> Add <code>Compute ROCm cache key</code> step emitting a weekly <code>YYYY-Www</code> identifier <br>via <code>GITHUB_OUTPUT</code><br> <li> Add <code>actions/cache</code> step caching <code>/opt/rocm-therock</code> keyed by <br><code>rocm-therock-${{ runner.os }}-<week></code><br> <li> Gate the ROCm venv/pip install behind <code>if: </code><br><code>steps.cache-rocm.outputs.cache-hit != 'true'</code> so it only runs on cache <br>miss</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1645/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

