### PR TITLE
Revert sidebar mark back to '1bm' text logo

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -36,7 +36,7 @@
 <div style="display: grid; grid-template-columns: 232px 1fr; min-height: 100vh; background: #0B0B0B; color: #EDEFEA; font-family: 'DM Mono', monospace;">
   <div style="border-right: 1px solid #232323; padding: 30px 24px; display: flex; flex-direction: column; gap: 26px;">
     <div style="display: flex; flex-direction: column; gap: 12px;">
-      <img src="https://avatars.githubusercontent.com/u/316940957?v=4" alt="1bit MONSTER" width="62" height="62" style="display: block; margin-bottom: 6px; border: 1px solid #232323;">
+      <span style="font-family: 'DM Serif Display', serif; font-size: 62px; line-height: .8; letter-spacing: -0.04em; color: #C6FF3D; display: block; margin-bottom: 6px;">1bm</span>
       <span style="font-family: 'DM Serif Display', serif; font-size: 27px; line-height: 1.05; color: #EDEFEA;">1bit<br>monster</span>
       <span style="font-size: 12px; line-height: 1.6; color: #FFD83D;"><span style="color: #EDEFEA;">bong-water-water-bong</span> "Sorry but not sorry."</span>
     </div>


### PR DESCRIPTION
### **User description**
Reverts the org-avatar swap from #1646 — user asked to put the '1bm' text mark back.


___

### **PR Type**
Enhancement


___

### **Description**
- Reverts sidebar org avatar back to text logo

- Swaps `<img>` for styled `1bm` text span

- Uses DM Serif Display, lime `#C6FF3D`, 62px


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Revert sidebar avatar to '1bm' text logo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/index.html

<ul><li>Removed GitHub org avatar <code><img></code> from the sidebar header<br> <li> Added a <code><span></code> rendering <code>1bm</code> in DM Serif Display at 62px in lime (<code>#C6FF3D</code>)<br> <li> Rest of the sidebar branding and layout left unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1647/files#diff-aef9cf1e2772f3835b32360da3eb558ecc9624843d3a91fe6a2c7e64b7a2c5e6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

