### PR TITLE
Fix tagline attribution order on the landing page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -38,7 +38,7 @@
     <div style="display: flex; flex-direction: column; gap: 12px;">
       <span style="font-family: 'DM Serif Display', serif; font-size: 62px; line-height: .8; letter-spacing: -0.04em; color: #C6FF3D; display: block; margin-bottom: 6px;">1bm</span>
       <span style="font-family: 'DM Serif Display', serif; font-size: 27px; line-height: 1.05; color: #EDEFEA;">1bit<br>monster</span>
-      <span style="font-size: 12px; line-height: 1.6; color: #FFD83D;"><span style="color: #EDEFEA;">bong-water-water-bong</span> "Sorry but not sorry."</span>
+      <span style="font-size: 12px; line-height: 1.6; color: #FFD83D;">"Sorry but not sorry." <span style="color: #EDEFEA;">— bong-water-water-bong</span></span>
     </div>
     <div style="display: flex; flex-direction: column; gap: 11px; font-size: 13px;">
       <a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/README.md" style="color: #B9BEB4;">docs</a>


### PR DESCRIPTION
### **User description**
Quote first, em dash, then name — not name then quote.


___

### **PR Type**
Bug fix


___

### **Description**
- Reorder tagline: quote before author name

- Add em dash preceding attribution name


___

### Diagram Walkthrough


```mermaid
flowchart LR
  before["Name then quote"] -- "reorder" --> after["Quote, em dash, then name"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Reorder tagline quote and attribution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/index.html

<ul><li>Reordered the tagline span: quote <code>"Sorry but not sorry."</code> now appears <br>first<br> <li> Added an em dash before the <code>bong-water-water-bong</code> attribution name</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1677/files#diff-aef9cf1e2772f3835b32360da3eb558ecc9624843d3a91fe6a2c7e64b7a2c5e6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

