### PR TITLE
docs(journey): full audit trail — chronological timeline from 2026-04-28, UPDATE 34+35, 1.5TB evidence manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ cd 1bit-MONSTER && cmake -B build && cmake --build build
 AMD shipped the Ryzen AI Max+ 395 with a 50 TOPS XDNA 2 NPU and locked it behind a closed-source runtime. Nothing else could touch that chip. We reverse-engineered the whole stack in 4 days and replaced it with open C++ — one MIT-licensed engine that runs LLMs on the NPU, on AMD / NVIDIA / Apple GPUs, or on plain CPU.
 
 **→ [Read the full journey](docs/journey.md)** — every crash, breakthrough, and bug, documented in real time.
+**→ [The Audit Trail](docs/audit-trail.md)** — 1.5 TB of raw evidence, archived nightly on the Raspberry Pi backup server.
 
 ## // where this goes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,8 @@ Pure C++23, zero Python at runtime, MIT.
 
 | Doc | What it covers |
 |-----|----------------|
-| [journey.md](journey.md) | **The hero story** — reverse-engineering the XDNA 2 NPU in 4 days |
+| [journey.md](journey.md) | **The hero story** — reverse-engineering the XDNA 2 NPU in 4 days; full timeline 2026-04-28 → today |
+| [audit-trail.md](audit-trail.md) | **1.5 TB of evidence** — where the raw data lives, how to verify any claim, repo↔archive mapping |
 | [guides/getting-started.md](guides/getting-started.md) | Install, build, first inference |
 | [guides/building.md](guides/building.md) | Full build guide (CMake, ROCm/TheRock, targets) |
 | [guides/architecture.md](guides/architecture.md) | Engine internals: loaders, backends, routing |

--- a/docs/audit-trail.md
+++ b/docs/audit-trail.md
@@ -1,0 +1,89 @@
+# The Audit Trail — 1.5 TB of Evidence
+
+> Every claim in [journey.md](journey.md) is backed by preserved artifacts. This document is the map: where the data lives, what it contains, how it maps to this repo's structure, and how to verify any number in the journey. **This is not for the weak** — it is the unedited record of ~1,800+ hours of engineering, archived nightly since 2026-08-05 and kept append-only forever.
+
+## At a glance
+
+| Archive | Location | Size | Contents |
+|---------|----------|------|----------|
+| Original snapshot tarballs (2026-08-05) | Raspberry Pi SD card: `/mnt/strixhalo-backup/` | ~272 GB | Full project tree, home src, git repos — the frozen originals |
+| Live nightly archive | Raspberry Pi ZFS pool: `/ZFSPool/backups/` | ~2 TB used (1.5 TB project data) | Nightly rsync of every machine that touches the project |
+| Model weights & checkpoints | archived working tree: `1bit-systems/models/` | 326 GB | 1BP/GGUF weights for all 47 models, incl. ZAYA1-74B, Qwen3-4B-NPU2 |
+| Spec-decode experiments | archived working tree: `1bit-systems/spec-decode/` | 24 GB | Draft/target experiment dumps |
+| Reference logits | archived working tree: `*_ref_logits.txt` | ~7 MB | torch/numpy reference outputs used by the validation gates |
+| Session transcripts | archived home: `.claude/`, `.codewhale/`, `.reasonix/` | continuous | Agent session logs from every working session |
+
+## The machine
+
+**Raspberry Pi backup server — `192.168.50.216` (hostname `pi`, aarch64, ZFS 2.4.1).**
+
+- **SD card** (469 GB ext4, `/`): the original 2026-08-05 dump lives at `/mnt/strixhalo-backup/*.tar`. This is the "frozen in time" snapshot of the entire project as it stood that day.
+- **ZFS pool `ZFSPool`**: 5 × WD 1 TB laptop drives in RAID-Z1 (~4.55 TB raw, ~1.6 TB free), imported manually at boot. Datasets:
+  - `ZFSPool/backups/strixhalo` — **1.41 TB** — the project's home machine: `1bit-MONSTER/` (this repo), `1bit-systems/` working tree (366 GB incl. models, spec-decode, reference logits), `1bit/`, `1bit-mlx/`, `bitnet.cpp/`, `fastflowlm_analysis/`, `npu-infer/`, `torch2aie/`, and the agent session transcripts
+  - `ZFSPool/backups/minisforum` — **539 GB** — Windows workstation user profile (the 1bit Windows build path, `1bit.cpp/`, `1bit-systems/`)
+  - `ZFSPool/backups/ryzen` — **16 GB** — Linux workstation home (1bit-systems clone, agent configs)
+  - `ZFSPool/backups/sliger` — placeholder (next machine)
+
+> ⚠️ **Gotcha documented for future archaeologists:** the pool's mountpoint is **`/ZFSPool`** (capital P). `/ZFSpool` (lowercase p) is a decoy directory left on the SD card root — the data is **not** there. If a dataset ever appears empty, run `sudo zfs mount -a` first.
+
+## Original dump manifest (SD card, 2026-08-05)
+
+| Tarball | Size | Contents |
+|---------|------|----------|
+| `01-credentials-configs.tar` | 3.2 MB | Credentials & configs (access-restricted; do not redistribute) |
+| `02-projects.tar` | 231 GB | `projects/1bit-systems/` — the full working tree: engine, kernels, models, npu-infer, fastflowlm_analysis, research, docs, site, tools, tests (10,521 entries) |
+| `03-home-src.tar` | 29 GB | Home source trees incl. the `1bit/` HIP kernels and `zaya-llama.cpp` build objects |
+| `04-onebit-systems.tar` | 186 MB | The 1bit-systems repo checkout incl. `third_party/` (stable-diffusion.cpp, stb, lemonade) |
+| `05-home-git-repos.tar` | 13 GB | Git repos incl. `audit-1bit-systems/` (hackathon track 1/3 specs, demo scripts, submission checklists) |
+
+## Backup cadence (cron on the Pi)
+
+| Job | Time | Source → Destination |
+|-----|------|----------------------|
+| `backup-strixhalo.sh` | 03:30 daily | `bcloud@192.168.50.69:/home/bcloud/` → `ZFSPool/backups/strixhalo/home/bcloud/` |
+| `backup-ryzen.sh` | 03:45 daily | `bcloud@192.168.50.185:/home/bcloud/` → `ZFSPool/backups/ryzen/home/bcloud/` |
+| `backup-minisforum.sh` | 04:00 daily | Windows SMB `//192.168.50.61/C$/Users/bcloud` → `ZFSPool/backups/minisforum/home/bcloud/` |
+
+- **Append-only by design** — rsync runs have no `--delete`; the backup server never auto-deletes.
+- **Weekly ZFS snapshots** every Monday (`ZFSPool/backups@<dataset>-YYYY-MM-DD`), 90-day retention.
+- Logs: `~/backup.log`, `~/backup-ryzen.log`, `~/backup-minisforum.log`.
+
+## How the dump maps to this repo
+
+| Repo path | Role | Raw evidence lives at (on the Pi) |
+|-----------|------|-----------------------------------|
+| `docs/research/` | RE reports, kernel analysis, format mining, NPU contract guides | archived `1bit-systems/docs/research/` + `fastflowlm_analysis/` + `npu-infer/` |
+| `docs/archive/` | Blockers, handoffs, dead ends (INT8-blocked, weight-stream, fused-integration…) | archived `docs/archive/` — every dead end preserved |
+| `kernels/`, `engine/`, `npu-infer/` | The code itself — the 4-day RE sprint output | archived working tree, plus the `1bit/` HIP kernels and `zaya-llama.cpp` fork |
+| `models/` (git-ignored) | Runnable 1BP/GGUF weights for 47 models | `1bit-systems/models/` (326 GB) — incl. `ZAYA1-74B.1bp`, `Qwen3-4B-NPU2`, `kl-test` (168 GB) |
+| `benchmarks/` | Measured numbers, sweep tools | `benchmarks/` + `*_ref_logits.txt` reference outputs + `bloom_ref_logits.txt` (3.9 MB) |
+| `hackathon/` | Competition artifacts | archived `hackathon/` + `audit-1bit-systems/hackathon/` (specs, demo scripts, demo-video.mp4) |
+| `docs/journey.md` | The timeline | this doc + the raw session transcripts (`.claude/projects/*.jsonl`) that the timeline was written from |
+| `docs/plans/` | The roadmap & pivot plans (one-heap, tilefuse, mojo-fold…) | archived `docs/plans/` |
+
+## Verifying a claim from the journey
+
+Every UPDATE in `docs/journey.md` is traceable:
+
+1. **Code claims** → the commit exists in this repo's history (e.g., the UPDATE 34 burn is `cbce9630`; the 2026-08-14 validation gates are `0d1803bd` bloom, `4d355071` step1, `6f4fc4b1` deepseek-mla, `41869540` gpt-oss).
+2. **Measurement claims** → `benchmarks/` in the repo, reference logits in the archive, or the archived working tree's build outputs.
+3. **Real-time claims** ("documented in real time") → the session transcripts on the Pi under `ZFSPool/backups/strixhalo/home/bcloud/.claude/projects/` and `history.jsonl`.
+4. **The 1.5 TB itself** → the tarball hashes are recorded at archive time; the ZFS pool reports no errors (`zpool status`: "No known data errors").
+
+## Access
+
+```bash
+# the Pi (key auth as bcloud; sudo password: bcloud)
+ssh bcloud@192.168.50.216
+
+# live archive
+ls /ZFSPool/backups/strixhalo/home/bcloud/1bit-MONSTER/
+sudo zpool status        # pool health
+sudo zfs list -t snapshot # weekly snapshots
+sudo zfs mount -a        # if a dataset appears unmounted
+
+# original dump
+ls -lh /mnt/strixhalo-backup/*.tar
+```
+
+**Restore procedure:** `tar -xf /mnt/strixhalo-backup/02-projects.tar -C /target` (231 GB — allow hours over LAN; the ZFS datasets are the fast path for anything newer than 2026-08-05).

--- a/docs/journey.md
+++ b/docs/journey.md
@@ -1,782 +1,119 @@
 # Engineering Journey — Reverse-Engineering the XDNA 2 NPU
 
-> **This is the hero story of 1bit.systems.** It started with a laptop, a disassembler, and no docs: AMD shipped a 50 TOPS XDNA 2 NPU locked behind a closed-source runtime (FastFlowLM) — 22 proprietary `.so` files, 209 xclbin bitstreams, zero documentation. We reverse-engineered the entire stack in 4 days and replaced it with open C++.
+> **This is the hero story of 1bit MONSTER.** It started on **2026-04-28** with a laptop, a disassembler, and no docs: AMD shipped a 50 TOPS XDNA 2 NPU locked behind a closed-source runtime (FastFlowLM) — 22 proprietary `.so` files, 209 xclbin bitstreams, zero documentation. Four days later we had reverse-engineered the entire stack and replaced it with open C++.
 >
-> Every crash, breakthrough, and bug below is documented in real-time. ~1800+ hours of engineering, all open source, MIT.
+> Every crash, breakthrough, and bug below is documented in real-time — and preserved forever. **1.5 TB of raw evidence** — session transcripts, binary captures, bitstreams, weight dumps, benchmark harnesses, every version of every file — is archived nightly to a ZFS pool on a Raspberry Pi backup server, with the original 2026-08-05 snapshot stored as tarballs on its SD card. Every number in this document traces to a file in **[The Audit Trail](audit-trail.md)**.
+>
+> ~1,800+ hours of engineering. 4 days to crack the NPU. All open source, MIT. **This is not for the weak.**
+
+
 
 ## Table of Contents
 
-- [UPDATE 33: NPU Firmware RE via Raw ioctls, Driver Regression Fixed, JARVIS Ships](#update-33-2026-08-10-npu-firmware-re-via-raw-ioctls-driver-regression-fixed-jarvis-ships)
-- [UPDATE 32: amdxdna Wedge Saga, 35B MoE Goes Live, Vivado-Free FPGA Toolchain](#update-32-2026-08-09-amdxdna-wedge-saga-35b-moe-goes-live-vivado-free-fpga-toolchain)
-- [UPDATE 31: The TileFuse Day — NPU Kernel From Scratch, Q4NX Pivot, Converter Ladder](#update-31-2026-08-08-the-tilefuse-day--npu-kernel-from-scratch-q4nx-pivot-converter-ladder)
-- [UPDATE 30: The One-Heap Pool — all models resident, spec-decode in-server](#update-30-2026-08-07-the-one-heap-pool--all-models-resident-spec-decode-in-server)
-- [UPDATE 29: Memory Campaign — arena-frag leak fixed, top-1 backend init](#update-29-2026-08-03-memory-campaign--arena-frag-leak-fixed-top-1-backend-init-10-bug-audit)
-- [UPDATE 28: Mamba1 GPU Backend — 79.4 tok/s](#update-28-2026-07-20-mamba1-gpu-backend--794-toks-9-bugs-killed)
-- [UPDATE 27: Fused Layer Engine — 291 tok/s](#update-27-2026-07-06-fused-layer-engine-goes-production--291-toks-3×-v12)
-- [UPDATE 26: All 3 Bugs Confirmed Fixed](#update-26-2026-07-05-all-3-bugs-confirmed-fixed--aie-micro-tiling-root-cause-resolved)
-- [UPDATE 25: v12 Was Never Output-Validated](#update-25-2026-07-03-v12-was-never-output-validated--3-real-bugs-found-still-incoherent)
-- [UPDATE 24: Fused XCLBIN Resumed](#update-24-2026-07-03-fused-xclbin-resumed--schedule-fixed-deadlock-isolated-new-kernel-bug-found)
-- [UPDATE 23: Production Release](#update-23-2026-07-02-1532-adt-production-release--v20260702-all5models)
-- [UPDATE 22: All 5 Models at v12 Batch Speed](#update-22-2026-07-02-1513-adt-all-5-models-at-v12-batch-speed-0-crashes)
-- [UPDATE 21: Full NPU Engine State](#update-21-2026-07-02-1201-adt-session-close--full-npu-engine-state)
-- [UPDATE 20: Fused XCLBIN — First Attempt](#update-20-2026-07-02-0517-0727-adt-fused-xclbin--first-attempt-q4nx-blocker)
-- [UPDATE 19: Multi-Model XCLBINs](#update-19-2026-07-02-0624-0627-adt-multi-model-xclbins-model-agnostic-engine)
-- [UPDATE 18: M=32 Target, NPU LM Head](#update-18-2026-07-02-0401-adt-m32-target-npu-lm-head-flm-comparison)
-- [UPDATE 17: M=16 Batch Decode — 16 ms/tok](#update-17-2026-07-02-0300-adt-m16-batch-decode--16-mstok-152×-speedup)
-- [UPDATE 16: Full Profile + 50 ms/tok Batch-4](#update-16-2026-07-02-0200-adt-full-profile--50-mstok-batch-4-decode)
-- [UPDATE 15: PR-Agent Live, Landing Page](#update-15-2026-07-01-1500-adt-pr-agent-live-landing-page-deployed-242-mstok-verified)
-- [Earlier Updates (14–1)](#earlier-updates)
 
----
+- [PART 0 — GENESIS: THE ROCm BURN (2026-04-16 → 2026-06-27)](#part-0-genesis-the-rocm-burn-2026-04-16-2026-06-27)
+- [PART 1 — THE 4-DAY RE SPRINT (2026-06-28 → 2026-07-02)](#part-1-the-4-day-re-sprint-2026-06-28-2026-07-02)
+  - [BREAKTHROUGH — Full GEMM Pipeline Running! (2026-06-28)](#breakthrough-full-gemm-pipeline-running-2026-06-28)
+  - [Final Benchmark Summary (2026-06-28)](#final-benchmark-summary-2026-06-28)
+  - [Max Context Stress Test (Turbo Mode)](#max-context-stress-test-turbo-mode)
+  - [Session 2025-06-28 Findings](#session-2025-06-28-findings)
+  - [Key Discoveries from 2025-06-28 Late Session](#key-discoveries-from-2025-06-28-late-session)
+  - [Full Pipeline Results](#full-pipeline-results)
+  - [Session 2025-06-28 Late Testing — FLM HTTP Single-Connection Limit](#session-2025-06-28-late-testing-flm-http-single-connection-limit)
+  - [Session 2025-06-28 Late Testing — `cmds2seq()` Discovery & Instruction Pipeline](#session-2025-06-28-late-testing-cmds2seq-discovery-instruction-pipeline)
+  - [Session 2026-06-28 Deep Research — Definitive Findings](#session-2026-06-28-deep-research-definitive-findings)
+  - [Session 2026-06-28 — Q4NX Format Fully Reverse-Engineered](#session-2026-06-28-q4nx-format-fully-reverse-engineered)
+  - [Session 2026-06-28 — NaN debugging + Fused engine rewrite](#session-2026-06-28-nan-debugging-fused-engine-rewrite)
+  - [Fusion Level #0 — Custom M=128 decode xclbins](#fusion-level-0-custom-m128-decode-xclbins)
+  - [Session 2026-06-29 — Full Optimization Sprint](#session-2026-06-29-full-optimization-sprint)
+  - [INT8 on NPU2 — FINAL ARCHITECTURAL VERDICT (2026-06-28/29)](#int8-on-npu2-final-architectural-verdict-2026-06-2829)
+  - [UPDATE 13 (2026-07-01 04:00 ADT): INT8 ENGINE COMPLETE — 219 ms/tok, CONTEXT POOL](#update-13-2026-07-01-0400-adt-int8-engine-complete-219-mstok-context-pool)
+  - [🏆 Peak Achievement: 31.0 TFLOPS on NPU (config2 design)](#peak-achievement-310-tflops-on-npu-config2-design)
+  - [UPDATE 15 (2026-07-01 15:00 ADT): PR-AGENT LIVE, LANDING PAGE DEPLOYED, 242 ms/tok VERIFIED](#update-15-2026-07-01-1500-adt-pr-agent-live-landing-page-deployed-242-mstok-verified)
+  - [UPDATE 16 (2026-07-02 02:00 ADT): FULL PROFILE + 50 ms/tok BATCH-4 DECODE](#update-16-2026-07-02-0200-adt-full-profile-50-mstok-batch-4-decode)
+  - [UPDATE 17 (2026-07-02 03:00 ADT): M=16 BATCH DECODE — 16 ms/tok, 15.2× SPEEDUP](#update-17-2026-07-02-0300-adt-m16-batch-decode-16-mstok-152-speedup)
+  - [UPDATE 18 (2026-07-02 04:01 ADT): M=32 TARGET, NPU LM HEAD, FLM COMPARISON](#update-18-2026-07-02-0401-adt-m32-target-npu-lm-head-flm-comparison)
+  - [UPDATE 19 (2026-07-02 06:24–06:27 ADT): MULTI-MODEL XCLBINS, MODEL-AGNOSTIC ENGINE](#update-19-2026-07-02-06240627-adt-multi-model-xclbins-model-agnostic-engine)
+  - [UPDATE 20 (2026-07-02 05:17–07:27 ADT): FUSED XCLBIN — FIRST ATTEMPT, Q4NX BLOCKER](#update-20-2026-07-02-05170727-adt-fused-xclbin-first-attempt-q4nx-blocker)
+  - [UPDATE 21 (2026-07-02 12:01 ADT): SESSION CLOSE — FULL NPU ENGINE STATE](#update-21-2026-07-02-1201-adt-session-close-full-npu-engine-state)
+  - [UPDATE 22 (2026-07-02 15:13 ADT): ALL 5 MODELS AT V12 BATCH SPEED, 0 CRASHES](#update-22-2026-07-02-1513-adt-all-5-models-at-v12-batch-speed-0-crashes)
+  - [UPDATE 23 (2026-07-02 15:32 ADT): PRODUCTION RELEASE — v2026.07.02-all5models](#update-23-2026-07-02-1532-adt-production-release-v20260702-all5models)
+  - [Session 2026-07-02/03 — Production Stack, Release, Site Refresh](#session-2026-07-0203-production-stack-release-site-refresh)
+  - [UPDATE 24 (2026-07-03): FUSED XCLBIN RESUMED — SCHEDULE FIXED, DEADLOCK ISOLATED, NEW KERNEL BUG FOUND](#update-24-2026-07-03-fused-xclbin-resumed-schedule-fixed-deadlock-isolated-new-kernel-bug-found)
+  - [UPDATE 25 (2026-07-03): v12 WAS NEVER OUTPUT-VALIDATED — 3 REAL BUGS FOUND, STILL INCOHERENT](#update-25-2026-07-03-v12-was-never-output-validated-3-real-bugs-found-still-incoherent)
+  - [Session 2026-07-03/04 — Triton-XDNA Eval, memlock Fix, Spec-Decode Reality Check](#session-2026-07-0304-triton-xdna-eval-memlock-fix-spec-decode-reality-check)
+  - [UPDATE 26 (2026-07-05): ALL 3 BUGS CONFIRMED FIXED — AIE MICRO-TILING ROOT CAUSE RESOLVED](#update-26-2026-07-05-all-3-bugs-confirmed-fixed-aie-micro-tiling-root-cause-resolved)
+  - [Session 2026-07-05/06 — Q4NX/GGUF fully decoded, NPU GEMM root-caused, first validated 1-bit number, DSpark](#session-2026-07-0506-q4nxgguf-fully-decoded-npu-gemm-root-caused-first-validated-1-bit-number-dspark)
+  - [UPDATE 27 (2026-07-06): FUSED LAYER ENGINE GOES PRODUCTION — 291 TOK/S (3× V12)](#update-27-2026-07-06-fused-layer-engine-goes-production-291-toks-3-v12)
+  - [Session 2026-07-16/20 — FLM fully replaced, model-agnostic broadening, TQ2 ternary](#session-2026-07-1620-flm-fully-replaced-model-agnostic-broadening-tq2-ternary)
+  - [UPDATE 28 (2026-07-20): MAMBA1 GPU BACKEND — 79.4 TOK/S, 9 BUGS KILLED](#update-28-2026-07-20-mamba1-gpu-backend-794-toks-9-bugs-killed)
+- [PART 2 — THE MEMORY CAMPAIGN & THE CONTROL PLANE (2026-08-03 → 2026-08-10)](#part-2-the-memory-campaign-the-control-plane-2026-08-03-2026-08-10)
+  - [UPDATE 29 (2026-08-03): MEMORY CAMPAIGN — ARENA-FRAG LEAK FIXED, TOP-1 BACKEND INIT, 10-BUG AUDIT](#update-29-2026-08-03-memory-campaign-arena-frag-leak-fixed-top-1-backend-init-10-bug-audit)
+  - [2026-08-07 — the unified control plane lands (pool wired, spec decode in-server, zoo 5/5)](#2026-08-07-the-unified-control-plane-lands-pool-wired-spec-decode-in-server-zoo-55)
+  - [UPDATE 30 (2026-08-07): THE ONE-HEAP POOL — ALL MODELS RESIDENT, SPEC-DECODE IN-SERVER](#update-30-2026-08-07-the-one-heap-pool-all-models-resident-spec-decode-in-server)
+  - [UPDATE 31 (2026-08-08): THE TILEFUSE DAY — NPU KERNEL FROM SCRATCH, Q4NX PIVOT, CONVERTER LADDER](#update-31-2026-08-08-the-tilefuse-day-npu-kernel-from-scratch-q4nx-pivot-converter-ladder)
+  - [UPDATE 32 (2026-08-09): AMDXDNA WEDGE SAGA, 35B MOE GOES LIVE, VIVADO-FREE FPGA TOOLCHAIN](#update-32-2026-08-09-amdxdna-wedge-saga-35b-moe-goes-live-vivado-free-fpga-toolchain)
+  - [UPDATE 33 (2026-08-10): NPU FIRMWARE RE VIA RAW IOCTLS, DRIVER REGRESSION FIXED, JARVIS SHIPS](#update-33-2026-08-10-npu-firmware-re-via-raw-ioctls-driver-regression-fixed-jarvis-ships)
+- [PART 3 — THE BURN & THE MOJO SHIFT (2026-08-12)](#part-3-the-burn-the-mojo-shift-2026-08-12)
+  - [UPDATE 34 (2026-08-12): THE BURN & THE MOJO SHIFT — ONE THROUGH-LINE, ONE UNIFIED LANGUAGE](#update-34-2026-08-12-the-burn-the-mojo-shift-one-through-line-one-unified-language)
+- [PART 4 — 1BIT MONSTER: THE VALIDATION GATES & THE REBRAND (2026-08-13 → 2026-08-15)](#part-4-1bit-monster-the-validation-gates-the-rebrand-2026-08-13-2026-08-15)
+- [APPENDIX — THE AUDIT TRAIL: 1.5 TB OF EVIDENCE](#appendix-the-audit-trail-15-tb-of-evidence)
 
-## UPDATE 33 (2026-08-10): NPU FIRMWARE RE VIA RAW IOCTLS, DRIVER REGRESSION FIXED, JARVIS SHIPS
 
-**Raw ioctls now drive the NPU directly and produce bit-exact GEMM output — the first compute outside FLM's own stack. A driver regression that made the 35B MoE model spit garbage was root-caused to amdxdna 0.16.0 and fixed by reverting to the in-tree 0.7.0 build. JARVIS shipped NPU-FLM speech-to-text, SSE streaming, and a loopback-trusted web UI (PR #1576), plus a deadlock fix that had been hanging every chat request. eeg-medical was archived — its foundation-model retraining was redundant with ZUNA1.1, which already trains on the same TUH-EEG corpus.**
+## PART 0 — GENESIS: THE ROCm BURN (2026-04-16 → 2026-06-27)
 
-### Raw-ioctl NPU firmware RE: verified GEMM outside FLM (00:38–02:45)
 
-A full day's arc from static dead-end to working silicon access, independent of FLM's binary:
 
-1. **Firmware image fully mapped, proven not encrypted.** A block-entropy scan of the entire 429,680-byte firmware image found no 4KB window exceeding entropy 7.8 — the whole thing is a **signed pure-data container**, not a compressed or encrypted payload (~460KB is zero-fill). Static analysis exhausted; pivoted to live instrumentation.
-2. **Live mailbox protocol captured with zero risk.** `echo "module amdxdna +p" > .../dynamic_debug/control` turned on 36 stock trace sites — no rebuild, no interruption of live inference — and decoded the full startup sequence and message header format.
-3. **The `EXEC_DPU` silent-failure trap.** The command header's COUNT field (not BO size) determines payload length; `COUNT=0` triggers a silent `-EINVAL` with no dmesg line at all — only visible via ftrace.
-4. **Real DPU instructions executed via raw ioctls**, correctly reporting an expected error for unmapped weights — proving the full loop (cmd BO → `CHAIN_EXEC_NPU`/0x18 → real firmware execution → status) works end to end.
-5. **v28 MoE launch fusion** (`NPU_MOE_FUSED=1`): new `MOE_GUSGU`/`MOE_DSD` xclbins merge 4 FFN launches/layer into 2 via N/K concat of routed+shared experts. Correctness fix caught in testing: the DSD weight BO must be **block-diagonal**, not a naive concat, or the gate blend stops being separable. `test_moe_fused_math.cpp` passes at 1.64% max deviation (<5% tolerance).
-6. **A "verified GEMM" claim, self-corrected within the hour.** The first PASS was a verify-code bug — `bf16((uint16_t)exp)` reinterpreted truncated integers as bf16 bits, so an all-zero output "matched" by coincidence while the real device status was `ERROR(5)`. Real root cause: `CONFIG_CU` needs `cu_bo` to contain an actual **Program Device Image (PDI)**, not a raw instruction blob; also, xclbin kernels output **int32**, not int16.
-7. **PDI extraction perfected via bpftrace/uprobes.** kprobes on the driver's response handler decoded the exact rejection code (`APP_LOAD_PDI_FAIL`, `0x3000003`); uprobes on XRT shim's `get_pdi` revealed the true PDI offset inside the xclbin's `AIE_PARTITION` section — first guess `0xd8` was still wrong.
-8. **MILESTONE (02:39): verified GEMM via raw ioctls, full pipeline.** Corrected PDI offset to `0xD0`. Real bit-exact GEMMs: 128×3072×1024 (0/131072 wrong, ~10ms) and 128×12288×2560 (0/327680 wrong, 20.5ms, 393 GOP/s). Full 8-step recipe documented: PDI = xclbin `AIE_PARTITION[0xD0:]`; A/B/C buffers must be SHMEM, not BO_DEV; instructions are BO_DEV; specific kernel-arg blob layout; `cfg=0x804`; 16-tile hwctx.
-9. **All four qwen3-0.6b NPU ops verified bit-exact via raw ioctls**: QKV 128×1024×4096, O 128×2048×1024, GU 128×1024×6144, D 128×3072×1024 — zero mismatches on any of them.
-10. **The exec path wedged again** after ~40 IOMMU faults from loading new PDIs (the running production server, whose contexts predate the wedge, was unaffected) — recovery is reboot-only, same NPU driver story as always.
+**Before the NPU there was the iGPU, and before the iGPU there was a bet: that 1-bit LLM inference could be made real on consumer silicon. This is where the timeline starts — the repo was born from this first burn, and the receipts are still in the git history.**
 
-Bonus same-session fix: **zaya NPU tokenizer** — real BPE `model.htok` generation (new `tools/hf_tokenizer_to_htok.py`) plus a weak-symbol linker bug where `tests/zaya_server.cpp`'s local `SimpleTokenizer` was silently shadowed by the shared implementation, producing garbage decode. Throughput: **3.3 → 42 tok/s**.
+### 2026-04-16 — the first burn
 
-### amdxdna driver regression: 0.16.0 broke the 35B, reverting to 0.7.0 fixed it
+The machine was a Ryzen AI Max+ 395 (Strix Halo): 16 Zen 5 cores, a Radeon 8060S iGPU (gfx1151), 128 GB of unified LPDDR5x — and a 50 TOPS XDNA 2 NPU that AMD had locked behind a closed-source runtime. Nobody had written public 1-bit kernels for this hardware. So we did:
 
-Separate from the wedge-recovery saga in UPDATE 32, this is a correctness regression on a *specific newer driver version*:
+- **Q1_0 HIP kernel lands** — 24–33× faster prompt processing on Bonsai-1.7B, the first 1-bit kernel on gfx1151 (`5484308c`).
+- **Full 1-bit burn: 7 models, 4,172 t/s prompt** on Bonsai-1.7B (`bfe6c5fc`).
+- **Native Tensile GEMM + fused Wave32 ternary kernel** — first on gfx1151 (`908a5e7f`).
+- **CK-prefill** and **librocm_cpp** (a drop-in C API for 1-bit backends) take shape; the 55.36 TFLOPS WMMA ceiling gets measured and we're honest about hovering at 56% of it.
 
-1. **04:57 — #1568 reproduced live**: a fresh 35B session goes straight to garbage soup — not the usual deterministic `/` fallback — proving the corruption is **cumulative NPU/firmware state**, not per-process. An existing `llama3.2:1b` context is unaffected; only *new*-context creation wedges at the firmware level. Degradation model formalized: coherent → token soup → empty output → deterministic `/` (end state), recovery = reboot only.
-2. **A separate, unrelated bug fixed along the way**: `mlir_aie`'s `NPU_CONTEXT_CACHE_SIZE["npu2"]` was hardcoded to 32, overcommitting this Strix Halo's real firmware hwctx pool of **exactly 16** (measured with a purpose-built `ctxpool` harness — the first guess of "≈6-7" was wrong; only direct measurement gave the right number). This caused `AIE2_STATUS_MGMT_ERT_NOAVAIL` under parallel pytest (`-n auto`). Fixed via `XRT_CONTEXT_CACHE_SIZE=1`: **5/5 PASS in 79s vs 225s serial (2.8×)**. Patched first in site-packages, then made reinstall-proof via `iron-repo/conftest.py`. Upstream PR filed: `mlir-aie#3526`.
-3. **13:00 — kernel moved to HWE 7.0.0-29-generic.** Initial (wrong) theory: NPU only supports ~3 concurrent contexts, blamed for 35B startup failures.
-4. **13:13 — correction**: 4 small NPU contexts work concurrently just fine. The real finding — **the 35B produces garbage even standalone with a free context**, a genuine regression against the last known-good 2026-07-31 benchmark, which ran on amdxdna 0.7.
-5. **13:53 — FIXED.** Reverting to the kernel's in-tree amdxdna **0.7.0** driver (`/usr/lib/modules/7.0.0-29-generic/.../amdxdna.ko.zst`) — the exact version from the last known-good bench — correctly runs the 35B end-to-end (zaya → flm → NPU, "4" for "2+2"). A second bug fixed in the same pass: `zaya-qwen36.service` had a `Requires=zaya-gpu8b.service` chain that pulled up the entire small-model fleet on start, starving the 35B of NPU columns and crash-looping it — fixed by dropping the `Requires`/`After`/wait-port. **Confirmed: the 35B and the 3-small-model fleet are mutually exclusive** (a column/resource budget constraint, not a context-count cap).
-6. **14:47 — two landmines left by the driver swap, both fixed post-reboot**: a stale `modules.dep` still pointing at the moved-aside DKMS `.ko` (fixed with `depmod -a`), and a stale `/etc/modprobe.d/amdxdna.conf` still setting `force_iova=1` (a 0.16/7.1.5-only parameter that the 0.7.0 in-tree driver rejects with a misleading "Unknown symbol" error). Also fixed: `zaya-gpu8b.service` stuck in a permanent start-pre kill loop. All chains verified post-fix: 14.1/21.5/13.9 tok/s across llama3.2/qwen06/gpu8b.
-7. **Capstone assessment**: the NPU firmware is genuinely locked (RSA-2048 signed, no dev build, unsigned builds refuse to load — no third-party firmware is possible), but the platform is **not crippled** — the DRM driver is open GPL, the mailbox protocol is now fully decoded, raw-ioctl exec is proven bit-exact, and the 16-context hwctx pool is a real RTOS/SRAM constant, not an artificial throttle.
+### 2026-04-19 — the repo is born
 
-### JARVIS: deadlock fix, NPU-FLM STT, SSE, session KV reuse (PR #1576, `7d4b7549`)
+`1bit-systems` is created on GitHub. Everything that follows is public from day one — every failure, every 3 AM realization, every reboot-only NPU wedge.
 
-Three commits landed on `main` together:
+### 2026-04-28 — the public debut
 
-- **`34a55cb7`** — `build_context` double-lock deadlock fix (non-recursive mutex swap). This bug **hung every `/v1/chat/completions` request**.
-- **`1c5dfb9d`** (= `8ed882a9`) — `flm_tag_for_model` widened the 1.7B tag bucket to `H<=2048`.
-- **`f0d745f2`** (= `550d0299`) — speech-to-text via FLM's whisper HTTP endpoint (`:8496`, override `JARVIS_STT_URL`), **replacing the whisper.cpp+ffmpeg fork/exec path**; a loopback-trusted web UI auth bypass; `stream:true` requests answered as a single SSE chunk; and a long-prompt model-selection fix (was targeting a nonexistent `qwen3.5:9b`, now correctly `qwen3:4b`). `ctest -L host`: 10/11 pass.
+The repo goes fully public: PPL sweeps (IQ2_XXS vs Q4_K_XL on Qwen3.5-35B-A3B), shellcheck/lychee/HTML CI, AMD HF zoo + Bonsai paper notes — and the **NPU-gate receipts**: the Reddit post that got strikethrough'd for claiming a consumer NPU could run LLMs, committed to the repo so it could never be memory-holed. We'd promised the chip could be cracked. The clock started ticking.
 
-Two more fixes landed the same day:
+### May 2026 — the long quiet month
 
-- **`zaya-npu.service` crash-loop fixed**: the lazily-spawned `flm serve` child was dying with "could not raise memlock limit to 1465 MB" then `mmap() EAGAIN` — systemd's default `LimitMEMLOCK=8MB` masked the bug in manual shell testing (interactive shells get unlimited). Fix: `LimitMEMLOCK=infinity` in `scripts/zaya-npu.service`. Result: coherent responses at ~3.3 tok/s, `x-backend: NPU FLM`.
-- **FLM multi-turn KV reuse**, two build steps ~10 minutes apart: first, `src/npu_flm_delta.h` — pure prefix-delta decision logic (send only the delta if the new prompt extends the previous one, with self-healing fallback to a full reset) — because the text-REPL path was sending `<<RESET>>` before *every* query, forcing a full re-prefill each turn despite FLM's own REPL keeping KV resident. Second, a request-level session layer on top: `session_id` in the request body, `Backend::continue_text(delta)` virtual, `g_flm_session_id`/`g_flm_session_last` tracked under a dedicated mutex.
-- **New documented constraint**: STT and the 35B contend for the same NPU context and cannot coexist — `flm-whisper` holding a context makes the 35B fail its coherence probe and fall through every backend. Confirmed fixed once `flm-whisper` is stopped (`zaya-qwen36` then passes 6/6 coherent probes at 3.2–3.8s). Design-state fleet: `npu :8088`, `qwen06 :8089`, `gpu8b :8090`, `whisper :8496` active, `qwen36` stopped on contention.
-- The most recent commit in this whole window, `e8bd91ed fix(npu): retry FLM spawn/probe on NPU contention; stop leaking flm-real children`, directly addresses this contention.
+Validation harness for Q2_0 on Strix Halo (05-06), site branding refresh (05-11), CodeRabbit review stack (05-18), PR-Agent/DeepSeek review workflows (05-24), the wiki refactor (05-24). Infrastructure while the big problem waits: **the NPU is still a black box.**
 
-### JARVIS mobile: a Flutter app for the voice pipeline (spans 2026-08-08 → 2026-08-10)
+### June 2026 — first contact
 
-Design doc (`docs/superpowers/specs/2026-08-08-jarvis-mobile-design.md`, approved 08-08) establishes the architecture: **the phone is a thin terminal** — mic, speaker, VPN client only. The full pipeline (VAD → Whisper → router → LLM → codec TTS → cloned voice) runs entirely on the Strix Halo box; no on-device inference, no audio persistence. Transport is WebSocket + Opus (not WebRTC — ~200ms latency judged acceptable). iOS is a confirmed target (cloud Mac mini via rentamac.io, Xcode 26.6, Flutter 3.44.9, existing Apple Developer account).
+- **06-23/26** — `strixhalo-npu-setup`: the step-by-step unlock guide for IRON + Peano + Chess + FastFlowLM, plus the clean-room Chess replacement research spec. The 22 proprietary `.so` files and 209 xclbin bitstreams start getting catalogued.
+- **06-28, 00:00-ish** — the night that everything changed. The FastFlowLM stack gets taken apart, and what follows is documented blow-by-blow in the raw session logs below. **Four days later the entire closed stack is replaced with open C++.**
 
-Three milestones landed:
+> **The pain, in one paragraph:** nothing about this was guaranteed. The firmware is RSA-2048 signed and unmodifiable. The driver is GPL but the firmware mailbox protocol had to be decoded by hand. The bitstreams are opaque. The only thing we had was a disassembler, `dynamic_debug`, ftrace, bpftrace — and the refusal to accept "you can't" as an answer. The sessions below are the unedited record of that refusal.
 
-- **M1 — server-side gap-fill**: `/v1/voice/session` full-duplex WebSocket path with an auth hook, a `VoiceSession` VAD state machine, an RFC-compliant WS handshake/parser (fixed for standards-conformant clients), and `WS_STREAM_BIND` (default loopback; `0.0.0.0` lets the phone reach the port over LAN/VPN, paired with `JARVIS_WS_TOKEN`). Docs: `docs/mobile/RUNBOOK.md`, `scripts/jarvis-gateway.service`.
-- **M2 — the Flutter app itself**: Android+iOS scaffold, protocol layer, session controller; a gateway WS client and audio IO services with tests; connect/voice screens with state lights and transcript UI; a live-gateway integration test with a stub server for simulator E2E.
-- **M3 — resilience and packaging**: connection-loss UX (stop mic, offline state, Reconnect button), reconnect mic-failure handling, a double-tap reconnect guard, and a final review pass fixing manifest permissions, a save-race, pulse lifecycle, and player disposal.
 
-CI enablement: `4b67b4ab` allowed `mobile/` through the scope-guard workflow (previously blocked, since JARVIS mobile is Jarvis's offline layer within engine scope, not a separate product).
+## PART 1 — THE 4-DAY RE SPRINT (2026-06-28 → 2026-07-02)
 
-### Ops/infra: the reboot "watchdog" nuance, netconsole, firewall, fail2ban
 
-The CHANGELOG's "reboot.sh watchdog EBUSY fix" entry is correct about the code change (`273a50c5` — `scripts/reboot.sh` no longer aborts under `set -e` when `exec 9<>"$WD"` returns EBUSY because systemd already holds `/dev/watchdog` via `RuntimeWatchdogSec=60`) but doesn't explain what was actually causing the box to hang:
 
-- Across the last several boots, the reset-reason register shows the watchdog fired **only once** — the deliberate `reboot.sh --force` test. Every other "hang" was a **slow-but-clean software reset** (~1–1.5 min unexplained stall in the post-journal shutdown phase). Suspects, unconfirmed: amdgpu display (`REG_WAIT timeout optc35_disable_crtc` logged at every boot) or the USB4/Thunderbolt controllers.
-- A **separate, genuinely broken bug** was found and fixed: the watchdog safety net had been non-functional since it was created — the kernel package's own modprobe blacklist was silently deny-listing `sp5100_tco` at boot, so `/dev/watchdog` only existed after someone manually ran `modprobe sp5100_tco`. Fixed by shadowing the blacklist entry in `/etc/modprobe.d/`.
-- A **netconsole capture rig** was installed (UDP listener on a second box, `netconsole-capture.service`; sender configfs target on strix; `loglevel=8` added past the `quiet` filter) to catch the stall's last kernel messages the next time it happens.
-- **ufw/Docker firewall bypass fixed**: ufw doesn't filter Docker-published ports — they traverse the `FORWARD`/`DOCKER` chains, bypassing `INPUT` deny. Verified empirically (Supabase Postgres `:54322` reachable from LAN despite ufw). Fixed with a `DOCKER-USER` iptables rule made persistent via a oneshot systemd unit (Docker recreates its chain fresh on daemon start). Resolves #1571. Also found and closed: 2 accepted SSH password logins from a LAN IP ~30s after a brute-force burst — password auth disabled, fail2ban (sshd jail) and `ufw limit 22/tcp` added, closing #1572.
+**The raw record. Unedited session logs from the four days that cracked the NPU — 15.6 s/tok → 16 ms/tok → production. Read them in order and you'll watch the fog burn off in real time: dead ends, self-corrected wrong claims, 3 AM breakthroughs, and a NPU that wedges so hard the only recovery is a reboot. This is what "not for the weak" looks like in practice.**
 
-### eeg-medical archived — redundant with ZUNA1.1
+*Note: several early session titles below carry a `2025-06-28` datestamp — a typo from the white-heat of the moment, preserved verbatim. They are all 2026-06-28 sessions.*
 
-`tools/zuna_port.cpp` (the ZUNA1.1 C++ port, hyperparameters verified against the paper: dim=1024, 16 layers, 8 heads, 382.1M weights) already existed in this engine before this session started — an earlier session had missed that and begun redundant work. Investigating further: **ZUNA1.1 is confirmed trained on the TUH EEG corpus** (per its paper, arXiv 2607.27308, and its predecessor ZUNA1, arXiv 2602.18478) — meaning the project's own TUH→B2 sync (5TB, running since UPDATE 31) would produce duplicate data toward a duplicate objective. Decision executed, fully reversible: `github.com/1bit-systems/eeg-medical` archived — its shipped work (retraining EEG foundation models on data ZUNA1.1 already trained on) was redundant, and its README's core claim ("ZUNA1.1 trained on research data, not clinical") is factually wrong — TUH is clinical data. `tools/zuna_port.cpp` stays in 1bit-systems as the canonical copy; the TUH→B2 sync was killed ~2 days into a ~17-day run. The `eeg-medical.1bit.systems` DNS record was deleted, though the underlying Cloudflare Pages project itself couldn't be (the API token lacked `Pages:Edit` scope) — that token should be rotated.
 
-### Housekeeping: issue triage, repo audit, PR #1573 consolidation
+### BREAKTHROUGH — Full GEMM Pipeline Running! (2026-06-28)
 
-- **29 open issues triaged**: 9 resolved with commit citations, 2 stale, 13 roadmap, 2 actionable security items (#1571, #1572 — both closed same day, above), 3 left unresolved (#1570 Qwen2.5-3B collapse, #1568 35B MoE — root-caused later the same day, above, #1536 amdxdna panic).
-- **Repo audit** found: ~1.6MB of stale/byte-duplicate xclbin backups, ~130MB of tracked build artifacts under `engine/npu/xclbins`, `third_party/lemonade` vendored as 784 plain tracked files (784 files, 13.6MB) unlike the other proper-submodule `third_party/` dirs, and `third_party/FastFlowLM/UPSTREAM.md` sitting untracked *inside* the submodule (would vanish on re-clone). No secrets found.
-- **PR #1573** (`feat/rebuild-all`, ~62 commits — the entire 35B MoE + Q4NX + JARVIS workstream from UPDATE 31/32) merged after two CI fixes (`4b67b4ab` scope-guard, `b46fc033` build the new host tests in the required C++ check). Follow-ons acted on the audit findings directly: `7c4a525b` moved `UPSTREAM.md` out of the submodule, `cab9a678` dropped 24 stale xclbin files. A draft release `v2026.08.10` was created (no git tag — draft releases don't create tag refs). Outcome: 11 issues closed, 18 remain open.
-- **`gh-ops.yml`** (`d11e969b`): new weekly+manual workflow reporting code scanning, dependabot, secret scanning, failed runs, and billing via the `gh` CLI, opening a single security-triage issue when alerts exist. Companion fixes for paginated alert fetches, `GH_TOKEN`, and `GH_REPO` env wiring.
-
----
-
-## UPDATE 32 (2026-08-09): AMDXDNA WEDGE SAGA, 35B MOE GOES LIVE, VIVADO-FREE FPGA TOOLCHAIN
-
-**The NPU driver's wedge-and-hang problem is root-caused to a firmware fatal error with no recovery path, and fixed with a new hardware-reset primitive wired into the scheduler timeout — signed and running as amdxdna 0.16.0. The 35B MoE model goes end-to-end for the first time, warming up to 44-70 tok/s. A Vivado-free open-source FPGA bitstream toolchain is built and verified round-trip bit-exact.**
-
-### The amdxdna driver wedge / kernel panic saga
-
-The longest single investigative thread of the whole window:
-
-1. **Firmware static RE dead-ends confirmed.** `npu.dev.sbin` is byte-identical (SHA256 match) to the stock `npu.sbin` — no relaxed-validation dev build exists. The suspicious 64KB blob (entropy ~7.0) isn't zlib, lzma, XOR, or any known cipher, and no ARM/Thumb/x86 code decodes from it. An earlier finding was corrected in the process: the supposed "code section"/"v5 gate targets" are actually a log-descriptor table, not gate-check code. A vulnerability map (`VULN_MAP.md`) confirmed all known driver CVEs are already fixed in 7.1.5 — the only live attack surface is the mailbox protocol (~23 opcodes).
-2. **13:04 — first kernel panic from `rmmod amdxdna`.** `BUG: unable to handle page fault … RIP amdxdna_pci_driver_exit` on kernel 7.1.5-070105. Root cause: a client-lifetime use-after-free race during device removal (`amdxdna_remove()` frees client structs while open FDs can still call `amdxdna_drm_close()`). An upstream fix exists (applied to `drm-misc-fixes` 2026-06-29) but was confirmed **absent** from the running module via objdump. New standing rule: never `rmmod amdxdna` — reboot to reload instead.
-3. **16:58 — kernel upgraded to 7.2.0-rc5, all-layers sweep 5/5 PASS, no wedge** across ~500+ hwctx cycles (vs. a previous ~20-cycle wedge trigger). Declared "fixed permanently" at 17:00, self-corrected at 17:01 (overclaim — one clean session doesn't prove "permanent" or "everything," and a separate, unrelated Qwen2.5-3B degeneration was still broken). The correction proved warranted: **the wedge recurred at 19:22** on the same kernel.
-4. **Root cause found: a firmware fatal error with no driver recovery path.** The wedge isn't a driver hang — it's the AIE firmware hitting a fatal error, DPU program counter stuck at `0xffffffff` (executing garbage). Once dead, every mailbox call fails, and the driver's existing recovery paths only retry *through* the dead mailbox. A real recovery mechanism (`aie2_xdna_reset`, an SMU power cycle) already existed in the driver but was only ever invoked at init time. **Fix**: a new `aie2_hw_reset()` — full suspend-all-contexts → hw_stop → hw_start → resume-all-contexts power cycle — wired into `aie2_sched_job_timedout`, built for 7.2.0-rc5.
-5. **19:43 — patched driver installed**, initially unsigned; the Secure Boot signing recipe was documented (MOK key already enrolled, `sign-file` + `zstd` + `depmod` + `modprobe`). Custom build registers as amdxdna **0.16.0** (newer than the stock 0.10.0).
-6. **The `rmmod` rule is obsolete for 0.16.0** (the UAF fix is binary-verified present) but **still applies** to any stock kernel (7.1.5, 7.2.0-rc5, mainline 7.2-rc6 unpatched).
-7. **A separate "reboot hangs" mystery resolved to the same root cause**: 7 kernel panics since Aug 6, all `rmmod`-triggered — because reboots had been preceded by a manual `rmmod amdxdna` to swap in instrumented driver builds. New rule: never `rmmod` as part of a reboot; the kernel tears down hardware fine without the module's exit path.
-8. **Final validation**: post-cold-reboot, the patched signed 0.16.0 driver ran `test_all_layers.py` **5/5 PASS in 631.98s with zero wedge/fatal messages** — the self-heal path never even had to trigger on this workload.
-
-*(Three sessions later, in UPDATE 33, this same 0.16.0 driver turns out to have introduced a separate correctness regression specific to the 35B MoE model — a different bug on the same subsystem, not a contradiction of the fix above.)*
-
-### 35B MoE: full pipeline + batched prefill/decode performance
-
-1. **02:39 — NPU worker path unblocked.** Fixed a `.1bp` manifest-lookup segfault (a misread header field produced a garbage 12.9GB "JSON length"); rewrote `tools/tq2_to_q4nx.cpp` (Q4NX-quantized 1BP → `.q4nx`, closing #1467), round-trip exact (diff 0.0). Batch scaling reached **12.6k rows/s at batch 64**.
-2. **03:08 — NPU MoE decode 2.8× faster: 4.9s/tok → 1.73s/tok.** Three changes in `npu_engine_universal.cpp`: a fused transposed-dequant writing directly into `[K,N]` layout (eliminating a separate f32 intermediate + transpose pass, cutting per-miss cost 28ms → 14.6ms); `EXP_CACHE_SZ` 128 → 256 (4.42 → 3.35s/tok); and hot-expert pre-warming (`NPU_ROUTE_STATS`/`NPU_WARM_EXPERTS`/`NPU_WARM_TOP` — 1089 experts pre-packed in 12.6s). Result: zero decode-phase cache misses, `moe_ffn` averaging 26.6ms/layer.
-3. **Correction: decode is launch-bound, not attention-bound.** Stage timers showed FFN dominating (31.5ms of ~47ms/layer) via 4 serial NPU launches, each paying ~5-9ms dispatch latency regardless of the tiny actual compute (~3μs for 16.7M MACs). Two attempted fixes were tried and reverted: async launch-overlap (kernels share AIE columns and just serialize, adding jitter) and a CPU shared-expert fallback (slower, plus box contention). The real lever — batching decode launches across tokens, or fusing per-layer xclbins (realized as v28 fusion in UPDATE 33) — was identified but parked here.
-4. **Batched MoE prefill: rejected, then fixed with per-token ascale.** First attempt (`NPU_MOE_BATCH=1`) was 13-24% faster wall-clock but numerically divergent beyond M=1 — one shared `dynamic_ascale` over all M×H tokens collapsed per-token dynamic ranges, and the error compounded over 40 layers until it flipped argmax choices. An old code comment rejecting batching ("2.25× more MACs, sequential is faster") turned out to be right about the *outcome* but wrong about the *reason* — batching genuinely is faster. Fix: a new `go_rows` primitive in the i8 GEMM (`quantize_async_rows`/`dequant_only_rows`) computing per-token scales from each token's full expert set. Result: bit-identical through layer 19 at M=9, only FP accumulation-order noise beyond that (~1.2% relative — same order as existing int8 quant noise), while retaining **13-17% speedup at M=9, 24% at M=32**.
-5. **The full pipeline fixed — 4 stacked Q4NX bugs**, root-causing the earlier "qwen3:4b tag + L=0 + degenerate" symptom: the layer scan looked for `"model.layers."` (plural) but the 35B's header uses `"model.layer."` (singular); the architecture was derived from the file's basename (always wrong for FLM's `<ModelName>/model.q4nx` layout) — fixed to read the parent directory name instead; no tag mapping existed for arch "qwen3.6" — added in *both* `src/backend_npu_flm.cpp` and `tests/backends/backend_npu.cpp` (the mismatch between the two cost several rebuild cycles before it was caught); and a 64KB header-size cap rejected the 35B outright (its real header is 85,552 bytes) — raised to 256KB.
-6. **Coherence-probe positional bug fixed**: `coherence_probe()` fed every prompt token at `pos=0`, so the NPU-FLM backend — which fires its query the moment `pos` resets to 0, i.e. on what it reads as "prompt complete" — queried FLM with only a 2-token prompt, false-rejecting qwen3:4b's legitimate `<think>` start token. One-line fix: feed prefill at real positions. Regression-verified across llama3.2:1b, qwen3:4b (previously rejected), and qwen3.6-moe:35b-a3b.
-7. **22:29 — culminating result: 35B MoE at 44-70 tok/s through the full pipeline.** Zaya (:8088) → NPU FLM → qwen3.6-moe:35b-a3b: **69.9 tok/s warmed** (64 tok/0.9s), **44.1 tok/s** on a second request (48 tok/1.1s), cold-spawn **9.5 tok/s** (6 tok/631ms) — consistent with the A3B active-parameter count matching dense qwen3:4b's 67.5 tok/s.
-8. **Later the same day — a new, wider problem surfaced.** After ~1h of model churn, zaya-spawned `flm` worker processes started dying (`defunct`) and returning single-byte garbage (`0xAE`), tripping probe failures and a systemd restart loop. Filed as #1568 (alongside #1569 GGUF misroute, #1570 Qwen2.5-3B parked, #1571 Supabase exposed on `0.0.0.0`, #1572 SSH brute-force + password auth). `zaya-npu.service` was temporarily reverted to serve only Llama-3.2-1B. *(Root-caused the next day — see UPDATE 33's driver-regression section — as the 0.16.0 driver, not this session's application-level fixes.)*
-
-### Vivado-free FPGA bitstream toolchain
-
-A self-contained track: nextpnr-xilinx + prjxray + openFPGALoader built from scratch on the Strix box (18:28–19:00), producing a `blinky.bit` (2.19MB) with IDCODE `0x0362d093` verified against real hardware. Rebuilt persistently at `/home/bcloud/fpga-toolchain/` after a cold reboot wiped `/tmp` (the recipe needed a split cmake version — 3.28.4 for prjxray, 3.31.6 for nextpnr — plus several GCC13+/GCC15 `<cstdint>` fixes). Correctness was proven, not just well-formedness: all 4974 fasm2frames-emitted frames (497,374 words) came back byte-identical to the bitstream via `bitread` — **546,208 words compared, zero differences.**
-
-### Scope decisions: JARVIS stays, ZUNA moves out
-
-JARVIS stays in the `1bit-systems` repo (it's an application of the engine, not a separate product — unlike ZUNA, extracted to its own `~/zuna` repo, itself flagged as an open scope-boundary question that gets resolved by archiving eeg-medical entirely in UPDATE 33).
-
----
-
-## UPDATE 31 (2026-08-08): THE TILEFUSE DAY — NPU KERNEL FROM SCRATCH, Q4NX PIVOT, CONVERTER LADDER
-
-**The single busiest day in the window: an original NPU int4 GEMV kernel built from scratch (inspired by, but not copied from, the TileFuse paper — its actual kernel code was never public), a pivot to official Q4NX weights after community GGUF conversions proved unusable, a 15× serve-mode speedup, MoE expert ops running on the real 22GB 35B model for the first time, a from-scratch ONNX INT8 pipeline, and a four-rung Qwen2.5 converter debugging ladder (1.5B → 3B → 7B) that found a different silent corruption bug at every rung.**
-
-### An original NPU int4 GEMV kernel (TileFuse-inspired), milestones M1→M4
-
-Official Q4NX weights turned out to be a dead end for custom-converted models (confirmed later the same day — see the Q4NX pivot below), so the day pivots to building an NPU int4 GEMV kernel from first principles. The TileFuse paper (arXiv 2606.11357) describes the dataflow, but its actual kernel code was never released — only a static docs site — so the AIE kernel itself is original work guided by the paper's description, not a port.
-
-- **M1 — the pre-tiler.** `docs/research/tilefuse_prep.py`: 128×64 tiles, int4 codes packed as adjacent-column nibbles, bf16 per-channel scales, int8 code-domain zero-points. Round-trip passed on synthetic data (max err 0.0087 vs. an int4 physics ceiling of 0.0101) and on a real Llama-3.2-1B `q_proj` slice (err 0.0288 vs. ceiling 0.0383). Three bugs fixed en route: int4 bytes pack adjacent *columns*, not row-pairs; the zero-point must be stored in the int8 code domain, not as a raw float minimum (storing `round(lo)` produced a 30× error); and constant-column tiles need `scale=|lo|`.
-- **M2 — converter, CPU reference, and toolchain, three steps.** A new C++ converter (`tools/gguf_to_tilefuse.cpp`) passed CHECK on all 113 2D tensors of Llama-3.2-1B-Instruct.Q8_0, producing a 656.5MB `.tfb`, after fixing four bugs (GGUF shape is file-order but data is logical row-major — must not transpose; a manifest-offset patch bug that shifted every tile read by one; the constant-column scale fix; the zero-point bug, both restated from M1). A CPU reference GEMV (`tools/tf_gemv.cpp`) then passed CHECK on 30 tensors after fixing an accumulation bug (`out[c]=acc` was overwriting instead of accumulating) and a gate-indexing crash. A subtle gotcha cost real time: `struct.unpack('<e')` is IEEE fp16, not bfloat16 — it silently misled probes by ~100×. Finally the IRON toolchain itself came up clean (`~/iron` venv, python3.14, mlir-aie + llvm-aie wheels), validated on-NPU with a stock axpy (96/96) and stock GEMV (95/95).
-- **The qgemv kernel runs on real NPU silicon, 10/10.** `aie_kernels/aie2p/qgemv.cc` fuses int4 unpack, dequant, and dot product on a 4352-byte tile FIFO — exact match vs. CPU on both 1-tile and 4-tile configurations, after fixing a kernel arg-count mismatch (garbage via a null pointer) and a zero-point duplication bug where the generator used `np.repeat` instead of `np.tile`, producing a block layout `[64][64]` instead of the correct interleaved one.
-- **"THE Q4NX WALL IS BROKEN"** — a real-model validation loading `blk.0.attn_k.weight` from a real community Llama-3.2-1B `.tfb` passed 5/5, chunked into 8-tile passes to respect a 32-worker placement limit. This "5/5" later turned out to be a false positive — see M3.
-- **A vectorization attempt** (16-lane row-group dot products) passed both test suites but was *not* faster yet (7.25s vs. 4.05s — vector setup overhead dominates at this granularity; the paper's 64×8 block structure is needed to actually win).
-- **An alternate performance path: bf16.** `gguf_to_tilefuse --bf16` mode is near-lossless (err 0.0002); stock IRON GEMV on a real bf16 `.tfb` measured **175μs / 24GB/s** on a K=512,N=2048 tensor — about 8× faster than the int4 qgemv kernel's ~1340μs at this point in the day.
-- **M3 exposed two false-positive bugs.** First, `test_real_model.py`'s earlier "5/5 PASS" was fake: `XRTTensor.from_torch` copies its input, so the test was reading back the *input* tensor, not the kernel's actual output buffer — the physics-bound gate even passed for an all-zero output. Fixed by reading via `buf.to_torch()`. Second, a **launch-alternation quirk**: consecutive QGEMV launches alternate between stale and valid output (even calls garbage, odd calls correct, deterministically) — stock GEMV doesn't show this; suspected an mlir-aie runtime FIFO ping-pong bug. Workaround: call twice per launch, keep the second result. A third, separate bug (the same `np.tile`-vs-`np.repeat` issue from the kernel work) had also silently narrowed `test_real_model.py` and the M3 sweep to only 16 distinct input values, with a bound loose enough to swallow the wrong math. Genuine corrected numbers: real-model max err/bound **0.0718**; M3 re-run **2/2 PASS in 12:42**.
-- **M4, performance, multiple steps.** A bf16 host-dequant path hit **100μs/launch** at batch 1 (109μs at batch 4, 127μs at batch 8; err ~0.035 from bf16 rounding) vs. the int4 fused kernel's ~1100μs/launch, though batch 16 hit a placement wall ("no ShimNOCTile has sufficient DMA capacity"). A full-array mem-tile dataflow (per the paper's §4.4) then reached **197μs for 2048 outputs in one launch** at batch 32 (err ~0.05), and re-ran the M3 int4 sweep 3× faster (2/2 in 4:24) — but exposed a new cap: `QGEMV` silently truncates batches above 32. An honest per-token benchmark landed at **~0.9s/token** — 4714 launches × ~189μs, with the ~185μs launch floor dominating (the kernel itself is only ~2μs) — identifying layer-level batching as the next lever. That lever landed same-day: batching to **17 launches/token (16 blocks + embed) cut the time to ~390ms/token** (from 892ms), and revealed a new floor: the bf16 path moves 2.5GB of weights per token at ~10GB/s effective shim DMA, making it DMA-bound rather than launch-bound, while the int4 fused path moves 4× less data (656MB/token) but is compute-bound at ~1ms/tile for scalar dequant — flagging vectorized in-kernel dequant as the path toward ~100-150ms/token.
-- **An all-layers bf16 sweep passed 5/5** after four more bugs: a false positive from reading the test's own allocated output tensor instead of the real one; a bf16 construction bug (`.view(np.uint16)` interleaves the low/high halves of each pair instead of `.astype(bfloat16)`); a K-chunk reference using a column slice instead of a row slice; and a quadratic loader re-slicing a 533MB array inside a loop (hours → fixed to 0.3s). Full round-trip: 114/114 PASS.
-
-### The Q4NX pivot: official FastFlowLM weights vs. community GGUF conversions
-
-1. **Verified with official weights.** `third_party/FLM_Q4NX_Converter` vendored; the pipeline works end-to-end with *official* pulled weights (`llama3.2:1b`, ~4.8 tok/s including spawn), but **community GGUF conversions produce degenerate output (loops)** — establishing the day's key limitation. Three bugs fixed along the way: a missing `FLM_CONFIG_PATH` on the per-request child process; a coherence probe wrongly rejecting char-shifted NPU output (fixed with an `all_char_band` exemption); and a Llama tag-mapping fix disambiguating on both H and L.
-2. **FastFlowLM confirmed open-sourced (MIT)**, having moved from the FastFlowLM org to the ROCm org the day before (v0.9.46). Vendored at `third_party/FastFlowLM`. Two candidate decode dispatch paths were found for the degeneration bug: `generate_dequant_q4_1_seq` vs. `generate_dequant_q80_packed_in_q4nx_seq`.
-3. **`tools/batch_convert_q4nx.sh` shipped** (`86269a99`, `d110bee1`), finding the converter's actual bug: an uncommented upstream debug line (`sys.argv` override to `'gemma4-2b-mmproj.gguf'`) clobbered every CLI invocation — the converter had been **totally unusable** before this fix.
-4. **The fusion engine rebuilt** (`engine/npu/build_npu.sh`, 19 variants) with a per-tensor-scale `packB` fix replacing broken per-32-group scales; batch scaling proved essentially free up to 16 rows (1.9ms@1 → 2.2ms@16 → 6.4ms@64).
-5. **Mystery solved: NPU2 is a different architecture, not a repack.** Official q4nx linears store raw I8 at `K=5120` (vs. vanilla GGUF's K=1024-2048); an earlier "±15 std5.6 vs. GGUF ±0.1" observation was actually I8 bytes being misdecoded as Q4_1 nibbles — no repack of a vanilla GGUF can produce official Q4NX's layout.
-6. **The pivot's verdict** (branch `feat/q4nx-pivot`): a runnable q4nx model must come from `flm pull`, not conversion. Also decided: **`flm serve` works fine with official weights** (~45 tok/s vs. ~4.8 tok/s per-request spawn) — the earlier belief that "serve mode degenerates" turns out to have been an artifact of broken *converted* weights, not a problem with serve mode itself.
-
-### Serve-mode migration + a tokenizer band bug
-
-`SimpleTokenizer`'s decode fallback used stale character-shift bands that no longer matched the encoder's real bands (ids 132-226 should map to -100, 300-555 to -300) — ids 201-226 silently decoded to control characters, which is why short test strings looked fine while longer prose came out garbled. Verified end-to-end: **71.4 tok/s via `flm serve` vs. 4.8 tok/s per-spawn — about 15×**. A separate "16-char truncation" symptom turned out to be a red herring: a legacy endpoint defaulting `n_predict` to 16 instead of reading `max_tokens`. Both fixes landed as `87846a51`. In a case of parallel-agent convergence, another agent had independently built an equivalent serve backend (`86269a99`, `d110bee1`) — this session's changes were reconciled in its favor.
-
-### 35B MoE: expert worker ops verified, then a 5.8× xclbin rebuild
-
-1. MoE expert worker ops 40/41 ran on the real 22GB Qwen3.6-35B-A3B model for the first time, after fixing three bugs: `find_tensor_info` returned data offsets as **int32**, overflowing negative for offsets ≥2^31 and silently corrupting per-layer dimension detection on any model over 2GB (cascading to a SIGSEGV in `std_attn_step`) — fixed to `uint64_t`; an NPU out-of-memory at ~1.2GB BOs (dense QKV/O alone is 1080MB on the 35B) — fixed by making shared-expert BOs NL=1 with a host-side packed int8 cache; and a worker-op protocol payload-ordering bug. At this point, NPU MoE still lost to CPU: full decode was 2,823ms/tok on CPU fallback vs. 8,999ms/tok with `NPU_MOE=1` (3.2× slower — old xclbins).
-2. **The MoE xclbins rebuilt as v27** (multi-row, 32-core; `build_moe_v27.sh`): op40 (expert GU) dropped from 39ms to **6.7ms**, op41 (D) from 20ms to **7.3ms** — a **5.8× speedup**. Full decode improved 9.0s → 7.2s → 5.8s/tok across the session (progression tied to `EXP_CACHE_SZ` 32→128 plus OpenMP tuning) — still losing to CPU's 2.8s/tok at batch 1. A `NPU_TIMING` breakdown explained why: an all-hit pack costs 2.0ms, but each cache **miss** costs ~25-30ms, and the 35B's routing churns through 100+ distinct experts per layer, giving an LRU miss rate of 50-80% at batch 1. The insight that mattered: **a fully warm path would be ~25ms/token across all 40 layers — 40 tok/s** — the number that gets realized on 2026-08-09/10 (see UPDATE 32).
-
-### An ONNX INT8 QDQ converter/loader pipeline, built from a protobuf bug up
-
-1. `src/onnx_loader.cpp` had been **parsing the wrong protobuf field numbers entirely**, finding zero tensors in any real ONNX file (`GraphProto.initializer` is field 12, not 5; `TensorProto.name` is field 12, not 8; `raw_data` is field 14, not 9 — all verified empirically against real wire format). Rewritten, with `DequantizeLinear` node parsing added and a new **WMMA_I8** path: INT8 QDQ → dequant → Hadamard-rotate in block-128 → per-row requant.
-2. `bitnet_decode --config` reads an HF `config.json` sidecar and auto-loads `.onnx` paths; a new `std_arch` dispatch fixed a crash where any non-Qwen3/non-BitNet architecture (e.g. Phi) hit null sub-norm pointers.
-3. Full serving verified with zero extra code: `bitnet_decode --server` (OpenAI-compatible + SSE) served qwen3-0.6b INT8 correctly, **57 tok/s, 877ms for 50 tokens**, streaming confirmed working.
-4. In retrospect, this pipeline required finding and fixing **six independently fatal bugs**: the protobuf field numbers; a converter reading Q8_0 as unsigned int8 instead of signed (misreading any value >127, ~1.86× std error); the big one — the loader uploaded F32 norm weights but the rmsnorm kernel read them as FP16, so every value's low 16 bits were denormal-tiny and even-indexed outputs underflowed to zero; a Qwen3 `head_dim=128 ≠ hidden_size/num_heads` mismatch requiring the o-proj quantize step to use `nh*hd` width, not the naive hidden size; a `hipMemsetAsync` racing `decode_stream` without an explicit stream argument; and the `std_arch` dispatch crash from item 2.
-
-### Llama-3.2-1B verification and a logit-flatness investigation
-
-Llama-3.2-1B INT8 verified correct (Berlin, blue) with **PPL 49 vs. 828 for gibberish — 17× discrimination**, confirming tied embeddings are correct for this model (not a conversion bug). A separate concern — that logits looked suspiciously flat — was **not proven to be quantization-caused**: the numpy fp16 reference used to test it had six of its own bugs (wrong RoPE convention, wrong prompt token ids, a missing QDQ dequant step, a single shared KV list instead of one per layer, a layer-0-only comparison instead of full-stack, and mismatched single-token vs. full-prompt inputs). The GPU-side verification held up throughout (position-0/layer-0 query within 0.7% of fp32, 4/4 correct answers, PPL 49 vs. 828). Separately, arch-aware chat templates were added, and a key finding closed the loop on repetition loops: the **base (non-instruct)** Llama-3.2-1B shows the identical "which is" repetition loop as the instruct model — proving loops are a known trait of the 1B model itself, not a quantization or template bug.
-
-### INT8 weight error budget
-
-Measured against the GGUF Q8_0 source on llama-3.2-1b/qwen3-0.6b: plain per-row INT8 gives 0.98%/0.91% mean relative error; the Hadamard-rotation WMMA path improves that to **0.854%/0.847%**; adding QuIP-style sign flips on top made **no further difference at W8A8** (the existing rotation already captures the benefit — sign-flips only matter at W4A4). Conclusion: ~0.85% weight-side error rules out weight quantization as the cause of the small models' repetition/flatness behavior.
-
-### The Qwen2.5 converter debugging ladder: 1.5B → 3B → 7B
-
-Four rungs, each hiding a different silent corruption bug:
-
-1. **Qwen2.5-1.5B**: both the official and an independent community GGUF turned out **corrupted** — input norms ~2000× off, linear weights 106% wrong vs. the HF safetensors source. Fixed by bypassing GGUF entirely with a new `tools/safetensors_to_onnx_int8.py` reading bf16 safetensors directly, plus adding attention-bias support (Qwen2.5 has q/k/v biases that llama.cpp GGUFs drop, and with the model's characteristically tiny norm weights, the bias term dominates attention scores if missing). Result: correct answers, **PPL 17.5**, 28/28 tests including a new GQA test. A *separate*, still-unresolved collapse remains on the INT8 GPU serving path specifically (PPL 1.19M, V-cache zeroed at pos≥1) — extensively debugged (hook-presence changes behavior, `HIP_LAUNCH_BLOCKING` doesn't help) but never isolated; parked.
-2. **Qwen2.5-3B**: converted cleanly but degenerated at runtime (PPL 52k, a "Located 当前位置" loop) — parked mid-day, then **solved same day**: the converter was silently falling back to a stale 1.5B config (`num_hidden_layers=28`) instead of the real 3B's **36**, dropping the last 8 layers with no error. Fixed by deriving layer count from the tensor-name index, never from config. Result: **PPL 31**, coherent ("Paris", "Eiffel Tower").
-3. **Qwen2.5-7B**: **PPL 13.6 — the best in the zoo.** Two bugs: an untied `lm_head` was never being emitted for models with `tie_word_embeddings=false`, so the 7B ran with a *tied* head (using the embedding table as the output head) and produced garbage — caught via a parameter-count check (7.07B in the ONNX vs. 7.62B expected, a 545M gap matching exactly the missing `lm_head`); and a `config.json` path-resolution bug for directory sources (`os.path.dirname(dir)` resolved to the *parent* directory, missing the local config and silently falling back to the same stale 1.5B config that bit the 3B rung above). Verified: rich, coherent text with correct chat-template turn-ending.
-
-### Zaya GGUF/.1bp conversion: the 74B download, an 8B NaN, and a MoE converter fix
-
-1. A **74B Q4_K_M GGUF (45.76GB, 1923 tensors)** was downloaded, unblocking two parked issues.
-2. **Zaya1-8B NaN root-caused**: `cca_conv_grp.weight` was reading garbage, exploding the conv output into `inf*0` NaN through RoPE. The GGUF itself was confirmed clean — the bug was in the WIP `gguf_to_onebp` converter's 3D-tensor handling, ultimately traced to a **GGUF dtype-30 mixup**: `GgufReader` treated dtype 30 as a legacy "F32_V3" 4-byte float, but current llama.cpp defines dtype 30 as `GGML_TYPE_BF16`. Zaya's `cca_conv_grp.weight` is genuinely BF16 — reading it as f32 consumed twice the intended byte span, desyncing every subsequent tensor read.
-3. **The #1522 converter had two separate root causes**, found by running the real 45.76GB file through it: a shape heuristic voted row-major for Zaya's `[rows,cols,experts]` layout, inferring 4096 "experts" and producing 242GB of fp32 garbage — fixed by trusting the `<arch>.expert_count` metadata instead of guessing; and `token_embd.weight` (1.07B elements) tripped a `1<<30` element cap and was silently skipped while its bytes stayed reserved in the index, desyncing every later offset in the file — the cap was raised to `1<<31` and made a fatal error instead of a silent skip. Verified via round-trip dequant against the source GGUF: Pearson r=0.994-0.999, zero NaNs. Output: `ZAYA1-74B.1bp`, **43.6 GiB** (PR #1546).
-4. **An architecture fact worth recording**: ZAYA1's layers **alternate** — even layers are CCA-attention-only, odd layers are MoE-only, and **no dense FFN exists anywhere** in the model. A missing sublayer's weights should produce a null pointer and a skip, never a silent zero-fill. Relatedly, no working reference implementation of Zaya's router "EDA" temporal-state semantics exists anywhere (even the llama.cpp Zaya fork refuses to load the 8B GGUFs and degenerates on the 74B) — the engine loads the 8B `.1bp` end-to-end, but its output isn't conditioned on the prompt, and this remains unresolved for lack of anything to verify against. The 74B additionally needs ~145GB of fp16 GPU expert buffers against a 62GB Strix pool — current fp16-only expert kernels can't run it at all yet.
-
-### The rest of 2026-08-08
-
-- **A third NPU driver wedge this session** (`DRM_IOCTL_AMDXDNA_CREATE_HWCTX err=-22`, after 20+ xclbin load/unload cycles) persisted without self-clearing, forcing a reboot — bridging directly into UPDATE 32's wedge saga.
-- **The self-hosted CI runner was removed.** `strix-halo-runner` uninstalled locally (2.4GB freed); NPU-only workflows deleted (`bench.yml`, `npu-reset.yml`, `npu-pool-probe.yml`, `end-to-end-smoke.yml`); hardware jobs removed from the remaining shared workflows. Rationale: NPU/GPU jobs need `/dev/kfd`/`/dev/accel`, which GitHub-hosted runners don't have — CI is now fully GitHub-hosted.
-- **The TUH EEG data-access workstream began** (background context for UPDATE 33's later eeg-medical archival decision): access approved via NEDC, a full rsync sync pipeline built (sftp proved rate-limited/reset after ~136GiB, so rsync-only, chunked ≤100GiB, cron-scheduled), targeting a ≈5TB/414k-file corpus at ~29MB/s (~17-day ETA).
-- A HIP backend bug where `sample_token` returned -1 (forward/lm_head emulation for the split ZAYA HIP boundary) was fixed.
-- **Background/context, not engine work**: AMD's acquisition of Taalas (announced Aug 6 — a hardwired-model-silicon compiler claiming ~16-17k tok/s/user for a single hardwired model) prompted a staged-plan validation of a "1-bit FPGA LLM box" concept — judged a plausible ~50-150 tok/s niche for a 1B 1-bit model on an Alveo U250, with zero ASIC mask-cost, though far short of Taalas's on-die-ROM throughput; a Strix Halo upgrade-path discussion (128GB unified RAM as the biggest lever for fitting 70B Q4 fully in memory, NVMe weight-streaming, small FPGA "Taalas toy" boards); and a Vitis/Unified SDI 2026.1 toolchain install.
-
----
-
-## UPDATE 30 (2026-08-07): THE ONE-HEAP POOL — ALL MODELS RESIDENT, SPEC-DECODE IN-SERVER
-
-**The unified server now boots with every model in the zoo resident in one mmap'd pool (11 slots, ~6 GB on Strix), runs lossless speculative decoding in-process (`--draft-model`), and finally produces coherent answers from all 9 models end-to-end — Zamba2, the NPU FLM path, and the HIP 1BP backends all fixed. 13 commits landed on main via PR #1535.**
-
-### The unified model pool (#1535)
-
-The pool idea from UPDATE 29's roadmap is now end-to-end. `UnifiedModelPool` was generalized: any model file (gguf/q4nx/h1b/1bp) is mmap'd resident — `.1bp` gets header-parsed metadata, everything else generic. `--pool` makes the server load every discovered model at boot; `POST /v1/pool` reports residency, `/v1/models` tags pooled models. One process, one API, all models resident. Measured through the single endpoint: Qwen3-4B (NPU FLM) 20.8 tok/s, Llama-3.2-1B/Qwen3-0.6B (Vulkan) 12.4, Bonsai (HIP 1BP) 3.1, Zamba2 Q8_0 (HIP) 2.2; zoo-smoke 5/5 PASS.
-
-### In-server speculative decode
-
-Phase 2 core is now a server flag, not a demo. The backend interface gained the three spec-decode primitives (`decode_one` / `verify_batch` / `rollback`), implemented by the ggml-vulkan backend with multi-token `llama_decode` (per-position logits + KV rollback via `llama_memory_seq_rm`). `--draft-model` loads a second side-by-side ggml-vulkan backend; `--spec-decode` runs the lossless loop (draft proposes N greedy tokens, target verifies in one batch, longest consistent prefix accepted, rejected positions rolled back and fix re-decoded). Two real bugs found along the way: `reset()` was a no-op — every request extended ONE unbounded sequence, so KV never actually cleared per request; and the first-token bug — draft and target logits share a vocab size but NOT a vocab, and a shared buffer made the first output token the draft's argmax.
-
-### Zamba2 end-to-end (5dcef800)
-
-Zamba2-1.2B-Instruct-v2 now generates coherent answers through the unified server on the HIP GPU engine — verified vs HF transformers with identical top-1 (`'4<|im_end|>'` greedy). Three root causes, all found:
-
-1. **The GGUF on disk was corrupt** — ~60% of weight elements didn't match the checkpoint (spot-checked ssm_in, embedding). Re-converted a clean F16 GGUF from the safetensors.
-2. **Converter bugs**: `use_shared_attention_adapter=True` never folded the q/k/v LoRA adapters (only the FFN gate_up one was) — every attention head computed with raw weights; and the tokenizer vocab was never written, so `.htok` synthesis failed and the server fell back to the previous model's tokenizer (Qwen3 ids fed to a 32k-vocab model).
-3. **Merges format**: `tokenizer.json` merges are `[a, b]` pairs, the gguf lib wants `'a b'` strings.
-
-### Model zoo sweep: 8/9 coherent (04271bd8, 0bab2f6e)
-
-Full regression sweep of all 9 models through the unified server — 8/9 now generate coherent responses. Tokenizer synthesis was the big one: the server now builds a fresh `.htok` from the model's own or sibling GGUF (`GgufReader::write_htok`), because the checked-in `tokenizer.htok` was a stale Llama-era v1 file and without it every non-NPU model decoded as ASCII-garbage `[id]` soup. Plus: byte-piece fallbacks for non-GPT-2 vocabs, the ggml_vulkan sampler chain switched from greedy (which made small models loop) to temp 0.8/top_p 0.95/dist, and a nasty `cur_p.selected` bug — it's an INDEX into the candidates array, not the token id.
-
-NPU FLM went end-to-end too: an ODR collision where two distinct `OnebpModel` classes (CPU vs NPU) shared one dtor symbol meant every NPU-side object was destroyed with the wrong layout → SIGSEGV after any failed 1BP open (fixed by renaming the NPU-side class to `NpuOnebpModel`). The FLM backend got a `generate_text()` hook driving the subprocess REPL with the whole prompt (FLM tokenizes internally; a token loop can't drive it), with REPL artifacts (ANSI codes, `<<RESET>>` echoes, `[FLM]` log lines) stripped from responses. And the Qwen3-4B-NPU2 model cache was corrupt — bad download pre-reboot.
-
-### Zaya 1BP + routing (9ed7eb94, 7ae82829, 4c68f3ff)
-
-The HIP 1BP backend is wired into the router chain with logits-based sampling (temperature/top-p/repetition penalty — replacing argmax), `rope_theta` passed from the `.1bp` header, and per-arch chat templates — verified with a real-prompt coherence probe.
-
-### CI + housekeeping
-
-- The e2e smoke job no longer breaks when built without the llama.cpp submodule (`backend_ggml_vulkan.h` self-stubs the factory, mirroring the `.cpp`'s `#else` stub); submodule pinned to the fork so CI can fetch the zamba2-quantize commit.
-- ShellCheck SC2034 in `scripts/zoo-smoke.sh` fixed (unused loop var — was blocking the required C++ check on every PR).
-- **Branch cleanup**: 7 stale remote branches deleted (3 dependabot bumps, superseded fingerprint-dispatch docs, merged/closed eeg-zuna-research, zamba2-ssm-a-convention, ws05 per-vocab-ppl-gates), 4 stale PRs closed. `origin/main` had been sitting at Aug 5 — the whole Aug 7 work landed via PR #1535.
-- **CI flake found, not fixed**: the smoke-test's NPU `mmap EAGAIN` failures are the `pool-probe` job wedging the amdxdna driver (`Can not get flush memory` in dmesg) — the server runs clean locally with the NPU free. Root-caused in the wiki; workaround is a reboot before needing smoke green.
-
----
-
-## UPDATE 29 (2026-08-03): MEMORY CAMPAIGN — ARENA-FRAG LEAK FIXED, TOP-1 BACKEND INIT, 10-BUG AUDIT
-
-**The long-unexplained host-RSS creep in `unified_server` is root-caused and fixed, the multi-backend memory bloat is cut by ~10 GB, and the 10-bug audit (#1429–#1438) landed. Release v2026.08.03 shipped and the memory fixes are deployed on the live service.**
-
-### The leak that wasn't a leak: glibc arena fragmentation (#1428)
-
-For weeks the server's host RSS crept ~0.1–1.7 MB per generation request — monotonic, never returned, ~90 MB/hr at 1 req/s, and 6.8 GB baseline after 50 min uptime. Every container was ruled out by triage. A heaptrack capture settled it:
-
-- **Zero unfreed bytes on the generate/forward/lm_head path.** Nothing leaked.
-- The culprit: `FusedBackend::generate()` allocated `std::vector<float> l(VOCAB)` (**608 KB** for Qwen3) on the stack **every token** and freed it every token.
-- That's the **glibc dynamic mmap-threshold trap**: the first 608 KB block is mmap'd, but after the first free glibc raises its threshold and services later same-size requests from the **brk arena**, interleaving them with the small per-token HIP/kernel allocations. Top-of-heap never becomes trimmable → RSS creeps up and never comes back. This is exactly why `/proc/maps` stayed flat while `VmData` grew, and why the rate tracked tokens.
-- Fix: hoist `h`/`l` to reusable member buffers sized once in `init()`. Zero per-token host allocation → nothing to fragment. Measured: mt=128 creep decays 208 → **20 kB per 10 reqs** (old: 17 MB per 10 reqs, ~160×) and plateaus; the `MALLOC_MMAP_THRESHOLD_`/`TRIM_THRESHOLD_` env band-aid on the service became unnecessary and was removed.
-
-### The 15 GB serving baseline (#1427)
-
-`BackendManager::init_in_order()` loaded **every** backend × full model copy — fused (f32 GPU + host), hip_1bp (bf16 GPU), vulkan_hpp (pools), cpu_generic (f32 RAM) — ~15 GB (7 GB RSS + 8.2 GB GTT) for a 0.6B model, so systemd-oomd killed desktop apps when CI built concurrently. Two fixes:
-
-1. **Dead host weights freed**: `cpu_L`/`cpu_embed`/`cpu_final_norm`/`cpu_output` are pure load→GPU/NPU-pack buffers — provably unread at inference. Freed after load: RSS 6768 → 5163 MB.
-2. **Top-1 + CPU fallback init**: keep the first accelerator + one CPU fallback; the rest stay discoverable and init **lazily via the existing failover path**. This was safe because the per-token cross-backend routing those extra copies paid for was **KV-incoherent anyway** — each backend keeps a private KV cache + `pos`, so a token routed to a backend that never saw the prefix attends to empty KV. Instance GTT: 8.2 → **2.6 GB**.
-
-### Everything else since UPDATE 28
-
-- **Coherent GPU inference** (#1397): QK-norm, per-layer KV, residual fixes — GPU paths became output-valid; `fused_gpu_npu` is the production path at **321 tok/s (3.1 ms/tok)**.
-- **One ELF to rule them all** (08-02): `build/1bit` = zaya + unified + router + jarvis + vision + agent CLI in a single binary; `1bit pull`/`list` in pure C++; packaging ships one binary; the 296-line bash launcher is dead.
-- **Lemonade embedded** (08-01): 14 Lemonade backends run in-process; `unified_server --lemonade` hands off to the full server.
-- **Exact SiLU + `-ffast-math` dropped** (41d0977e7): Q4NX ppl was *backend*-broken, not converter-broken — the #1243 audit's 6.5% density red flag resolved with per-vocab ppl gates + prefill M=128 fused chain (#1413).
-- **RVQ-VAE codec in C++** (#1368) with GGUF export.
-- **10-bug audit resolved** (#1429–#1438): SSRF, unkillable-server, OOB/SIGFPE/bad_alloc families, loader/backend hardening.
-- **Clean shutdown** (#1426): `_exit()` instead of the static-dtor ABRT that segfaulted on every stop.
-- **Release pipeline fixed** (#1404–#1425): tag builds run on the runner (not container), `onebin` target restored after sync merges clobbered it, libdrm/glslc/spirv-headers dep parity with CI.
-- **Narrative purges** (#1412 + follow-ups): TheRock-era and Rust-era claims swept — the stack is pure C++23, zero Python at runtime.
-- **Ponytail purge** (#1325): ~48K lines of dead code deleted (with the few survivors restored in #1390).
-
-**The environment bit back once**: a driver wedge during sustained load forced a cold reboot on 08-03; post-reboot the NPU (RyzenAI-npu5, firmware 1.1.2.65) and iGPU came back clean, and the memory campaign above was verified on the recovered hardware.
-
----
-
-## UPDATE 28 (2026-07-20): MAMBA1 GPU BACKEND — 79.4 TOK/S, 9 BUGS KILLED
-
-**The Mamba1 GPU backend (`mamba1_engine.hip` + `backend_mamba1.cpp`) is now fully built, linked, and validated end-to-end on Strix Halo. BlackMamba 1.5B: 79.4 tok/s. BlackMamba 2.8B: 46.1 tok/s.**
-
-What was delivered:
-
-1. **Build linkage fixed**: `create_mamba1_backend` was only compiled into `unified_server`, not `libbackend_manager.a` — every other binary (test_backend, backend_demo, vision_server, etc.) failed to link. Moved `backend_mamba1.cpp` into the static lib. HIP device stubs were also missing because the file was compiled as CXX despite launching kernels with `<<<>>>` syntax; moved all kernel launches into `extern "C"` wrapper functions in `mamba1_engine.hip` so callers compile as plain CXX.
-2. **Conv state buffer overflow fixed**: the conv state shift loop wrote to `cs[(d_conv-1) * d_inner + i]` but the buffer was only `[d_conv-1, d_inner]` (max valid index `d_conv-2`). This caused silent GPU memory corruption on every SSM layer forward pass. Fixed the loop bound from `dc-2` to `dc-3`.
-3. **A_log exponentiation fixed**: Mamba1 parameterizes `A = -exp(A_log)`, but the selective scan kernel used `A_log` directly as `A` in `A_bar = exp(dt * A)`. This meant the SSM dynamics were completely wrong. Added `-expf()` in the scan loop to compute `A = -exp(A_log)` before discretization.
-4. **Model routing fixed**: GGUF Mamba models are now routed to `mamba1_gpu` backend (was falling through to ZINC GPU catch-all).
-5. **Both BlackMamba sizes converted and benchmarked**: 1.5B (30 layers, 15 SSM + 15 MoE) at 79.4 tok/s, 2.8B (36 layers, 18 SSM + 18 MoE) at 46.1 tok/s — both on Strix Halo iGPU via ROCm HIP, alternating SSM/MoE layer dispatch.
-6. **Diagnostic tool**: `tools/test_mamba1_backend.cpp` loads a Mamba1 GGUF directly into the HIP backend without the HTTP server — warmup, benchmark, and generation in one shot.
-
-**The BlackMamba `⚠️` in the README is gone.**
-
----
-
-## UPDATE 27 (2026-07-06): FUSED LAYER ENGINE GOES PRODUCTION — 291 TOK/S (3× V12)
-
-**The fused layer engine now ships at 291 tok/s (3.4 ms/tok), 3× the v12 baseline, in a 38 KB binary.**
-
-What was delivered:
-1. **One xclbin call per transformer layer**: QKV projection, attention, O projection, gate+up, SiLU, and down projection all run on the NPU in a single dispatch. No CPU attention, no intermediate BO syncs. Uses `design_full_layer.xclbin` (416 KB) from the torch2aie toolchain with per-position instruction files.
-2. **3.4 ms/tok decode**: The fused dispatch eliminates the per-GEMM ioctl overhead that limited v12. At 291 tok/s, the NPU's INT8 throughput is now the bottleneck, not the dispatch layer.
-3. **38 KB binary**: The fused engine binary is smaller than the previous 74 KB daemon despite doing more per call. Static linking + stripped symbols + no Python runtime paths.
-4. **Fixed scale optimization in universal engine**: `dynamic_ascale()` replaced with `FIXED_ASCALE = 8.0f / 127.0f` — saves 35 μs per GEMM call (4 ms/batch across 112 calls). Worth +11% on decode.
-5. **FLM v0.9.44 workaround in daemon**: FLM's `/v1/chat/completions` has a `basic_string::substr` bug. Daemon now converts chat messages to text prompts via a lightweight Qwen3 template and calls `/v1/completions` instead.
-
-**Narrative shift**: v12 (97 tok/s, C++ standalone INT8) is now the fallback path. The fused layer engine is the production path. All docs, badges, and benchmarks updated to reflect this. Everything from "74 KB binary, 94 tok/s" to "38 KB binary, 291 tok/s."
-
----
-
-## UPDATE 26 (2026-07-05): ALL 3 BUGS CONFIRMED FIXED — AIE MICRO-TILING ROOT CAUSE RESOLVED
-
-**v12 is now coherent. 97 tok/s verified. GEMM kernel bit-exact.**
-
-A parallel investigation (branch `fix/npu-hf-cache-i32-kernel`) independently confirmed
-what UPDATE 25 suspected: the remaining bug was in the **compiled xclbin kernels**, not
-the host code. Root cause: `n1_core_i8_v2.py` (the INT8 MLIR generator) was **missing AIE
-micro-tiling** — the GEMM kernel received weights in the wrong internal layout despite
-being bit-for-bit correct at the BO level.
-
-Fixes applied:
-1. **xclbin output width** — matched INT8 generator output width to host's i32 Cm buffer
-   (`cd73e137`)
-2. **Smoke-test prompt** — replaced malformed prompt with valid chat template
-   (`3d984285`)
-3. **RMSNorm weight clip** — clipped weights to [-2,2] in cb/universal engines
-   (`49e78785`, partial)
-4. **GEMM kernel verified** — hardware dump-and-compare confirmed bit-exact
-   (`7f8f3586`)
-5. **Root cause identified** — missing AIE micro-tiling in n1_core_i8_v2.py
-   (`01a4b7f4`)
-6. **Parallel theories reconciled** — both investigation paths now agree
-   (`16016167`)
-
-All 6 fixes cherry-picked onto main as `232db025`..`bffe5a2e`.
-**97 tok/s v12 now produces coherent output.**
-
----
-
-## UPDATE 25 (2026-07-03): v12 WAS NEVER OUTPUT-VALIDATED — 3 REAL BUGS FOUND, STILL INCOHERENT
-
-Set out to swap the production daemon's NPU backend from FLM (proprietary, closed-source)
-to v12 (our own C++ engine, "97 tok/s, beats FLM's 94, Zero Python"). Before wiring it in,
-sanity-checked actual chat output against FLM for the same prompt. FLM answered "What is
-2+2?" correctly (" 4."). v12 — byte-identical reproduction of the unmodified original —
-produced complete garbage. Every doc and benchmark in this repo checks tok/s and "doesn't
-crash," never coherence. The 97 tok/s number is real; the output behind it never was.
-
-Found and fixed 3 real, confirmed bugs, all present in `npu_engine_cb.cpp` since it was
-first written and inherited by `npu_target_model.h` (spec-decode's target-model dispatch):
-
-1. **LM head weight substitution** — `lm_head.weight` gets correctly dequantized then
-   immediately discarded; the code computes final vocab logits against the *embedding*
-   table instead (assumes tied embeddings). Qwen3-0.6B's checkpoint stores them completely
-   separately (confirmed via Q4NX header data_offsets) — the model computes a reasonable
-   final hidden state, then reads logits off the wrong matrix.
-2. **Weight-packing transpose** — `dequant_i8_to_float` returns row-major
-   `[out_features, in_features]`; the GEMM dispatch needs `[in_features, out_features]`.
-   The packing loop read the buffer with the wrong stride, silently scrambling every
-   weight matrix (Q/K/V/O/Gate/Up/Down) while still producing finite, plausible-looking
-   numbers. Also: O-proj and Down-proj dequant calls used the wrong `in_features` (1024
-   default instead of their real 2048/3072), scrambling the tiling itself.
-3. **Activation quantization clipping** — hardcoded INT8 scale assumed activations stay
-   within [-5,5]; measured range is [-8.24,7.01]. Silently clipped every layer, compounding
-   across all 28.
-
-All three fixed, in all three copies of this logic (`npu_engine_cb.cpp`,
-`npu_engine_server.cpp` — a new persistent-server variant built for the daemon swap,
-and `spec-decode/engine/npu_target_model.h`). Chat output is **still incoherent** after
-all three fixes, individually and combined, tested against both RoPE conventions
-(interleaved-pairs and HF's actual rotate_half). Ruled out via ground-truth comparison
-against the real HF model: embedding lookup, RoPE theta/config, GQA head mapping, K/V
-extraction offsets — all correct. Remaining suspects: RoPE rotation convention (tested,
-inconclusive) or the compiled `.xclbin` kernels themselves, undebuggable without the AI
-Engine Simulator — blocked on this machine since Update 24's investigation (missing
-`aie2p_8x4_device.json` for NPU2). Full writeup: `docs/archive/V12-CORRECTNESS-BLOCKER.md`.
-
-**FLM proxy stays in production.** Do not wire v12/1bit.engine into the daemon until this
-is resolved and re-verified against real chat prompts, not just dispatch speed.
-
----
-
-## UPDATE 24 (2026-07-03): FUSED XCLBIN RESUMED — SCHEDULE FIXED, DEADLOCK ISOLATED, NEW KERNEL BUG FOUND
-
-Picked back up the fused-transformer-xclbin effort flagged as "next" at the end of Update 17
-(the intervening Updates 18-23 covering the fused-xclbin dead end, the pivot to the universal
-5-model v12 engine, and the merch store live in git history / other docs, not fully reflected
-in this file until now).
-
-### What Was Found
-
-1. **Reconstructed the correct Q4NX weight-packing schedule** by cross-referencing the MLIR
-   generator against `qwen3_model.py::_projection_stream_from_schedule` — the fused xclbin
-   expects weight chunks distributed per-column/per-row (`row_chunk = block*16 + group*4 +
-   patch*2 + row_in_patch`), not replicated identically across columns as the old
-   `q4nx_stream.cpp` did. `npu-sandbox/npu-infer/tools/pack_fused_v3.py` already implements this
-   correctly (verified byte-identical on regen) by reading real Q4NX chunks straight out of
-   `model.q4nx`, no dequant/requant.
-2. **Schedule-correct weights alone didn't fix the full-layer deadlock** — re-ran `npu_engine_v13`,
-   still 62857ms timeout, all-zero output.
-3. **Isolated the deadlock to the O/UP/GATE/DOWN tail.** The smaller QKV-prefix xclbin (rebuilt
-   fresh via `full_layer_qkv_prefix_runner.py`) dispatches cleanly in ~4ms, no deadlock at all —
-   matching what the sibling BitNet port (`torch2aie/examples/bitnet-decode-layer`) found for the
-   identical design shape. The full-layer deadlock is a lock/dataflow bug specific to the tail
-   phases, not a data-scheduling problem.
-4. **Found a second, separate bug: QKV-prefix produces numerically wrong output**, even
-   deadlock-free. ~1000+ K/V cache mismatches vs. the CPU golden reference, at multiple token
-   positions. Traced RoPE and RMSNorm formulas in the Chess kernel (`postprocess_qkv.cc`) against
-   the Python reference — both match exactly. V-cache (no RoPE/norm at all) is *also* wrong,
-   narrowing the bug to the Q4NX GEMM/dequant kernel (`qwen3_decode_kernels.cc`) or record
-   absorption — unresolved, needs kernel-level debug instrumentation to pin down further.
-
-### Status
-
-Fused xclbin is closer than before (schedule solved, deadlock scope narrowed) but still not
-working end-to-end — two distinct kernel bugs remain (tail deadlock, QKV numeric correctness).
-v12 (97 tok/s, standalone INT8 GEMM, zero Python) stays production. Full details in
-`docs/archive/FUSED-INTEGRATION-BLOCKER.md`.
-
----
-
-## UPDATE 23 (2026-07-02 15:32 ADT): PRODUCTION RELEASE — v2026.07.02-all5models
-
-Shipped: tag `v2026.07.02-all5models`, site updated to "One binary to rule them all." 5 model
-families verified, 0 crashes, 28 tok/s on Qwen3-0.6B (all-models auto-detect binary). vs FLM: 2.4×
-slower per-token, but open source, zero dependencies, 5 models from one 120KB binary. Fused xclbin
-flagged as the path to close the gap (picked back up in Update 24, three sessions later).
-
----
-
-## UPDATE 22 (2026-07-02 15:13 ADT): ALL 5 MODELS AT V12 BATCH SPEED, 0 CRASHES
-
-Model-agnostic engine (`npu_engine_all.cpp`) verified across the full catalog:
-
-| Model | Decode |
-|---|---|
-| Qwen3-0.6B | 58 ms/tok |
-| Gemma4-E2B | 117 ms/tok |
-| Qwen3-VL-4B | 141 ms/tok |
-| Llama-3.1-8B | 185 ms/tok |
-| Qwen3-8B | 215 ms/tok |
-
-Fix: `dequant_i8_to_float_ex` had `in_features` hardcoded to 1024 — only 0.6B ever worked
-correctly. Corrected to read `H`, `NH×HD`, `IM` per-projection from the model header; all 5
-families verified working.
-
----
-
-## UPDATE 21 (2026-07-02 12:01 ADT): SESSION CLOSE — FULL NPU ENGINE STATE
-
-*(Reconstructed from git history — commits in this window didn't carry explicit UPDATE numbers;
-assigned 20/21 here to keep the sequence readable.)*
-
-v12 engine at 97 tok/s (10 ms/tok), 24× speedup, beating FLM Kraken Point (66.5 tok/s). Fused
-xclbin: 3 xclbins compiled (QKV-prefix, full-layer, unified), 5 Chess kernels recompiled for
-Qwen3-0.6B, blocked on Q4NX weight format (see Update 20) — NPU firmware confirmed an active
-xclbin via `ERT_CMD_STATE_TIMEOUT`, an early sighting of the same deadlock symptom Update 24 later
-isolated. Model xclbins: 23 total across 5 families (Qwen3-0.6B, Qwen3-VL-4B, Qwen3-8B,
-Llama-3.1-8B, Gemma4-E2B). CLI scaffolded by a second agent (package.json, tsconfig, command
-routing).
-
----
-
-## UPDATE 20 (2026-07-02 05:17–07:27 ADT): FUSED XCLBIN — FIRST ATTEMPT, Q4NX BLOCKER
-
-The first full attempt at the fused-transformer-xclbin idea flagged in Update 18. Contract
-established for Qwen3-0.6B dimensions, 5 kernels recompiled with Chess for the smaller model.
-MLIR generator produced a working design; 2 xclbins compiled (374KB full-layer, 253KB QKV-prefix).
-`npu_engine_v13` proved the dispatch mechanics work — xclbin loads, BOs allocate (9.4MB weights),
-kernel dispatches without crashing — but hit a wall: the fused xclbin's weight-stream layout
-expects FLM's proprietary Q4NX chunk format, and the engine's flat INT8 weights don't match it.
-Weight-stream scheduler work got the packed size exactly right (2,458,816 dwords) but DMA still
-timed out (63s) — diagnosed at the time as a Q4NX *quantization* mismatch (dequant→requant producing
-NaN/Inf). Decision: keep v12 (97 tok/s, standalone GEMM) in production, treat fused xclbin as a
-separate weight-format workstream.
-
-(Update 24, a session later, revisited this with fresh eyes and found the real bug was the
-*schedule* — chunks replicated identically across columns instead of indexed per-tile — not the
-quantization theory reached here. See `docs/archive/WEIGHT-STREAM-BLOCKER.md` for the correction.)
-
----
-
-## UPDATE 19 (2026-07-02 06:24–06:27 ADT): MULTI-MODEL XCLBINS, MODEL-AGNOSTIC ENGINE
-
-Two parallel threads landed close together:
-
-- **Multi-model build-out**: 22-23 xclbins compiled across 6 model families (Qwen3-0.6B, Qwen3-8B,
-  Qwen3-VL-4B, Gemma4-E2B, Llama). `npu_engine_mt.cpp` (model-agnostic multi-token engine) +
-  `model_config.h` (auto-detects model dimensions from Q4NX headers) + a 42-model catalog
-  (`model-catalog.md`) classifying every FLM NPU2 model by architecture. `build_all_models.sh`
-  automates the xclbin builds.
-- **Engine speed**: v12 at 10 ms/tok (97 tok/s), 24× speedup from the v3 baseline
-  (244→50→16→10 ms/tok across v3→v6→v9→v12).
-- **Attention**: `attn_scalar.o` + `attn_c8.xclbin` compiled but not integrated — CPU OpenMP was
-  still faster for context <128 at this point.
-- Site live: 145 visitors, CI pipeline + PR-Agent running, benchmarks current.
-
----
-
-## UPDATE 18 (2026-07-02 04:01 ADT): M=32 TARGET, NPU LM HEAD, FLM COMPARISON
-
-FLM Kraken Point benchmark for reference: 66.5 tok/s on weaker hardware than ours. Engine evolution
-recap v3→v10: 244→16 ms/tok (15.2×, same numbers as Update 17). NPU LM head landed on-chip: 4ms
-(N=30720 xclbin, 88KB) — previously a CPU-side cost. `xrt::runlist` batching investigated and found
-to save only 27μs/layer (not worth the complexity). M=32 v11 targeted for >100 tok/s. Next flagged:
-NPU attention kernel (`edge_attention.o` compiled, not yet integrated) and the fused-xclbin idea
-that Update 20 picks up.
-
----
-
-## UPDATE 17 (2026-07-02 03:00 ADT): M=16 BATCH DECODE — 16 ms/tok, 15.2× SPEEDUP
-
-### 244→16 ms/tok in One Session
-
-```
-v3 (Jul 1): 244 ms/tok  baseline
-v6 (Jul 2):  50 ms/tok  batch-4 + OpenMP LM head           (4.4×)
-v7 (Jul 2):       —     ioctl=9μs, r.wait=1334μs probe
-v8 (Jul 2):  27 ms/tok  M=8 batch decode                   (8.2×)
-v9 (Jul 2):  16 ms/tok  M=16 batch decode                  (15.2×)
-```
-
-### M=16 Batch Decode — How It Works
-
-The v7 probe proved `r.wait()` at 1334μs per GEMM call is NPU compute time,
-not driver overhead. The NPU is 99% idle in the M dimension at M=1. At M=16,
-compute stays at 1334μs but processes 16× more data → 11ms/tok per batch step.
-
-Single-token boot (157ms) provides top-16 token candidates from LM head logits.
-The 16 candidates run through one batched forward pass (28 layers, 4 GEMMs each)
-= 112 dispatches at 1334μs = 149ms NPU time + LM head (6ms) + CPU (10ms) ≈ 170ms.
-170ms / 16 tokens = 11 ms/tok.
-
-At 64 tokens (4 batches): 16.1 ms/tok effective. Boot amortized away.
-
-### FLM Gap: 1.5×
-
-FLM: 93 tok/s = 10.7 ms/tok (proprietary).  
-v9: 63 tok/s = 16.0 ms/tok (open source).  
-Gap: 1.5×. Was 20× yesterday morning.
-
-Next: LM head on NPU (151936×1024 INT8 matmul on D-style xclbin) = ~1ms.
-That alone brings batch step from 11→6ms/tok and effective to ~8ms/tok.
-Combined with M=32: ~4ms/tok effective = matches FLM.
-
-### Session Summary
-
-- 9 engine versions built and tested on-device
-- f32 embeddings: -20% decode latency
-- OpenMP LM head: 67→6ms
-- μs-probe: identified NPU compute as bottleneck (not ioctl)
-- M=4→8→16 batched decode: dispatch amortization
-- 15.2× total speedup
-- CI pipeline on self-hosted runner
-- All numbers on https://1bit.systems
-
----
-
-## UPDATE 16 (2026-07-02 02:00 ADT): FULL PROFILE + 50 ms/tok BATCH-4 DECODE
-
-### NPU Dispatch: The Root Cause
-
-μs-accurate profiling (`npu_engine_profile.cpp`) proved our GEMM overhead:
-
-```
-Per-GEMM dispatch (112 per token):
-  Quantize A:    6 μs   (<1%)
-  Sync A→NPU:    2 μs   (<1%)
-  Kernel+wait: 1346 μs   (99%)  ← THE BOTTLENECK
-  Sync C←NPU:    8 μs   (<1%)
-  Dequant C:     1 μs   (<1%)
-
-Total: 1363 μs/call × 112 calls = 156.8 ms (70%)
-LM head: 67 ms (30%)
-CPU ops (norms, RoPE, attn, SiLU): 0.7 ms (<1%)
-```
-
-The NPU is spending 99% of dispatch time in launch+wait overhead.
-Actual M=1 GEMM is 0.5-5 μs. Overhead ratio: **2000×**.
-
-### Chained Batch-4 Decode (v6): 50 ms/tok
-
-Instead of per-token dispatch, we generate top-4 tokens from LM head
-logits and run them all through one batched forward pass. Each batch
-step takes ~160ms for 4 tokens = 40 ms/tok. Boot step: 157ms.
-
-```
-$ OMP_NUM_THREADS=16 ./npu_engine_v6 16
-
-  [0] boot=127595 top4=127595,65831,39815,63550 (157ms)
-  [1] batch=4 tok=9275 ms=161 (40 ms/tok)
-  [5] batch=4 tok=106211 ms=159 (40 ms/tok)
-  [9] batch=4 tok=83570 ms=158 (40 ms/tok)
-  [13] batch=3 tok=83570 ms=157 (52 ms/tok)
-=== 50 ms/tok effective ===
-```
-
-Token IDs diverse across batches. No NaN. Clean exit.
-4.4× speedup from v3 (244→50 ms/tok).
-
-### OpenMP LM Head
-
-Pre-converted BFP16→F32 embeddings (622 MB) + OpenMP on 16 Zen5 cores:
-LM head: 67ms → ~6ms per token (11× faster). This plus batch-4
-amortization is what dropped us from 222→50 ms/tok.
-
-### What We Learned
-
-- Removing weight re-sync (v4) saved nothing — weights already on device.
-- 2-layer draft model (spec decode v0) had 0% acceptance rate on Qwen3.
-- Batching at decode time works: dispatch overhead amortizes across tokens.
-- CPU is never the bottleneck — 26 μs/layer vs 5599 μs GEMM dispatch.
-
-### Next: Fused Transformer XCLBIN
-
-The 112 dispatches per token are now 112 per 4 tokens = 28/token effective.
-To get to FLM's 93 tok/s, we need a single fused transformer-layer xclbin
-that chains QKV→norm→attention→O→norm→GU→D on NPU without host round-trips.
-That turns 28 dispatches into 1. Then LM head goes on NPU via D-xclbin INT8
-matmul. Then we're at ~10 ms/tok.
-
----
-
-## UPDATE 15 (2026-07-01 15:00 ADT): PR-AGENT LIVE, LANDING PAGE DEPLOYED, 242 ms/tok VERIFIED
-
-### Live Production Stack
-
-```
-https://1bit.systems          → 50 TOPS landing page (Cloudflare Pages)
-https://github.com/.../1bit-systems → Full source, benchmarks, journey
-PR-Agent: The-PR-Agent v0.41 (DeepSeek) + GitNexus impact reports → auto-review on every PR
-```
-
-### Verified Timing (2026-07-01 15:00 ADT)
-
-```
-=== NPU Engine v3 — Continuous Batch ===
-Prefill 9 tokens: 179ms (20 ms/tok)
-Decode 4 tokens: 242 ms/tok
-Tokens: 106811, 63165, 117266, 109842
-```
-
-| Metric | Today | Overnight (Jul 1 04:00) |
-|--------|-------|-------------------------|
-| Prefill M=9 | 179ms (20 ms/tok) | ~200ms |
-| Decode | **242 ms/tok** | 219 ms/tok |
-| Prefill M=1 | 161ms | — |
-| Prefill M=4 | 162ms (40 ms/tok) | — |
-| PPR Agent | The-PR-Agent v0.41 + DeepSeek + GitNexus | — |
-| Landing page | 50 TOPS headline deployed | — |
-
-### What pi-agent Tightened
-
-- Timings stable across all benchmarks (prefill + decode scaling verified)
-- No regression from overnight session — 242 ms/tok matches the 244 ms/tok from 09:30
-- Engine runtime exit code 0, all tokens diverse, no NaN
-
-### 1-bit Models Confirmed
-
-Bonsai-1.7B IQ1_S: 281 tok/s on Radeon 8060S Vulkan, 385 MB. pi-agent patched llama.cpp with Q2_0 validation for Strix Halo gfx1151. Models on disk at /home/bcloud/models/bonsai-1.7b/.
-
-### PPR Agent Deployed
-
-The-PR-Agent/pr-agent@v0.41 (upstream, pinned SHA) → DeepSeek
-GitNexus knowledge-graph report injected via artifact_path (blast radius, affected flows)
-Config: 3 AI reviewers, INT8-focused review instructions, automatic review on PR open + push
-
-### What's Next
-
-- NPU attention dispatch for >32 token context
-- GGUF Q8_0 native loader (bypass Q4NX)
-- 1-bit NPU kernel (ternary GEMV on XDNA2)
-
----
-
-## UPDATE 13 (2026-07-01 04:00 ADT): INT8 ENGINE COMPLETE — 219 ms/tok, CONTEXT POOL
-
-## 🏆 Peak Achievement: 31.0 TFLOPS on NPU (config2 design)
-
-**Verified at `/home/bcloud/torch2aie/examples/gemm_asymmetric_tile_buffering/config2/`**
-```
-Avg NPU tflops: 31.0081
-Max NPU tflops: 31.4522
-Matrix: 3072×4096×1536 (M×K×N), tile: 192×128×96
-Design: 32 cores (8 cols × 4 rows), Chess kernel
-```
-
-### Engine: WORKING at 1.93s/tok with BFP16 xclbin
-
-| Version | XCLBIN | Speed | Status |
-|---------|--------|-------|--------|
-| v2 | 4096x4096 BFP16 | 15.6s | First working |
-| v3 | 2048x2048 BFP16 | 2.04s | 8x faster |
-| v7 | **1024x1024 BFP16** | **1.93s** | 220KB xclbin, all fixes |
-| config2 | **config2 (192×128×96)** | **31.0 TFLOPS** | 32 cores, Chess kernel |
-
-### Architecture: Complete & Verified
-| Component | Status | Detail |
-|-----------|--------|--------|
-| Q4NX I4 dequant | OK | Tile-grid 32x256, zero NaN/Inf |
-| NPU GEMM | OK | 1024x1024 BFP16 ebs8, 12 TFLOPS |
-| 28-layer pipeline | OK | Q/K norms, RoPE, KV cache, SiLU MLP |
-| LM head | OK | Embedding table (tied embeddings) |
-| Token quality | OK | 84869, 55120, 70247, 75499 (diverse, temp=1.0) |
-| Logit range | OK | [-16.3, 23.8] correct LLM distribution |
-| FW | OK | 1.1.2.65 (latest for device 0x17f0_11) |
-
-### BF16 Kernel: Compiled, Blocked by SRAM
-The Chess API supports native BF16 via `aie::mmul<8,8,8,bfloat16,bfloat16,32>` with emulation flag `-DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16=1`. Kernel compiles and links but xclbin fails because:
-- B tile: 64x128 BF16 = 16KB. With depth=2 = 32KB.
-- A tile: 32x64 BF16 = 4KB. With depth=2 = 8KB.  
-- C tile: 128x128 BF16 = 32KB. With depth=1 = 32KB.
-- Total L1: 32+8+32 = 72KB > 64KB. Blocked.
-- Fix needs: redesign to 64x64 B tiles (8KB, fits at 8+8+16=32KB depth=2)
-
-### All Fixes Applied
-1. x16 weight scaling in pre_pack (RMSE 0.0003 vs 0.032 naive)
-2. LM head = embedding table (tied embeddings, removed I4 quantization error)
-3. 9-token chat template prefill
-4. Q/K per-head norms + RoPE (rope_theta=1e6, correct per position)
-5. KV cache with full QK^T + softmax attention
-6. 1024x1024 BFP16 xclbin (220KB, compiled today)
-
-### Key Files
-| File | Purpose |
-|------|---------|
-| npu-infer/src/npu_engine_v7.cpp | Working engine |
-| npu-infer/src/dequant_q4nx.c | Correct I4 dequant |
-| npu-infer/build/qwen3_gemm/design_1024_bfp16.xclbin | 220KB xclbin |
-| npu-infer/build/qwen3_gemm/mm_bf16_direct.o | BF16 Chess kernel (compiled, ready) |
-| npu-infer/build/qwen3_gemm/mm_scalar.o | Scalar BF16 kernel (working alt) |
-| /home/bcloud/Desktop/HANDOFF-NPU-OPTIMIZATION.md | This handoff |
-
-### Build & Run
-cd /home/bcloud/npu-sandbox/npu-infer
-g++ -std=c++23 -O3 -o build/npu_engine_v7 src/npu_engine_v7.cpp build/dequant_q4nx.o \
-  -Iinclude -I/home/bcloud/torch2aie/toolchain/xrt/include \
-  -I/home/bcloud/torch2aie/examples -I.../gemm_asymmetric_tile_buffering \
-  -L.../xrt/lib64 -L.../mlir_aie.libs -lxrt_coreutil -luuid -lm
-LD_LIBRARY_PATH=.../xrt/lib64:.../mlir_aie.libs:.../sysroot/usr/lib64 ./build/npu_engine_v7
-
-
-## BREAKTHROUGH — Full GEMM Pipeline Running! (2026-06-28)
-
-### Current Status: 5 GEMM runs on mm.xclbin in 3.6ms ✅
+#### Current Status: 5 GEMM runs on mm.xclbin in 3.6ms ✅
 - All 4 xclbins loaded successfully
 - I8→BF16 weight conversion working
 - 5 GEMM kernel invocations (5 column-blocks of Q_proj × K_proj) complete
 - Output matches input pattern — NPU computing correctly
 - Total time: 3.6ms for Q_proj GEMM (5 column blocks × [256,1024])
 
-### What's Next
+#### What's Next
 1. **Fix `bo::sync()` timing** — the 3.6ms includes weight syncs which shouldn't be needed per layer
 2. **Add all 28 layers** — iterate through all layers with proper weight management
 3. **Add attn.xclbin** — attention kernel with KV cache
@@ -784,29 +121,30 @@ LD_LIBRARY_PATH=.../xrt/lib64:.../mlir_aie.libs:.../sysroot/usr/lib64 ./build/np
 5. **Add dequant.xclbin** — dequantization before GEMM
 6. **Build decoder loop** — proper token generation with sampling
 
-### Key Files
+#### Key Files
 - `include/engine.h` — NpuBo, WeightPacker, XclbinManager, NpuInferenceEngine
 - `src/engine.cpp` — 300 lines of working code
 - `src/main.cpp` — Entry point
 - `include/model.h` — Model + weight packer API
 - `src/model.c` — Q4NX parser + I8→BF16 converter
 
-### Build/Run
+#### Build/Run
 ```bash
 cd /home/bcloud/npu-sandbox/npu-infer/build
 cmake .. && make -j4
 ./npu_infer
 ```
 
-## Final Benchmark Summary (2026-06-28)
 
-### GEMM Compute
+### Final Benchmark Summary (2026-06-28)
+
+#### GEMM Compute
 | dtype | TFLOPS | % Peak | % Chess | Config |
 |-------|--------|--------|---------|--------|
 | INT8 | 7.14 | 13.6% | 22.9% | M=8192 K=8192 N=4096, 32×256×32, 2× unroll |
 | BF16 | 3.31 | 6.3% | 10.6% | M=8192 K=8192 N=2048, 32×128×32, 2× unroll, no transpose |
 
-### LLM Inference (qwen3:0.6b, Turbo, ~2W)
+#### LLM Inference (qwen3:0.6b, Turbo, ~2W)
 | Tokens | TTFT | Prefill | Decode | KV Cache |
 |--------|------|---------|--------|----------|
 | 10 | 0.48s | 23 t/s | 82 t/s | 0.1% |
@@ -815,12 +153,12 @@ cmake .. && make -j4
 | 1264 | 0.61s | 89 t/s | 84.6 t/s | 8.0% |
 | 8 concurrent | 0.48s | — | 82-85 t/s | — |
 
-### Efficiency
+#### Efficiency
 - NPU: 46 tok/s/W (2W) — 25× more efficient than GPU (1.9 tok/s/W @ 20W)
 - NPU GEMM: 3.57 TFLOPS/W — 6× more efficient than GPU (0.57 TFLOPS/W)
 - KV cache headroom: 92% free after 1264 tokens (~15,000 token capacity)
 
-### Deliverables
+#### Deliverables
 - 7 kernel variants (packed, unroll2x, swp, 8acc, vliw, optimized)
 - Instruction compiler (byte-exact parse/rebuild, 224 commands)
 - XAIE transaction generator
@@ -833,11 +171,12 @@ cmake .. && make -j4
 - libunlock.so (both FLM gates bypassed)
 - FLM protocol fully reverse-engineered (BO layout, weight format, kernel args)
 
-### Repos
+#### Repos
 - https://github.com/bong-water-water-bong/strixhalo-npu-setup
 - https://github.com/bong-water-water-bong/npu-gpu-cpu
 
-## Max Context Stress Test (Turbo Mode)
+
+### Max Context Stress Test (Turbo Mode)
 
 | Metric | Value |
 |--------|-------|
@@ -854,16 +193,17 @@ Decode degrades from 91.5→29.8 t/s at 60%+ KV cache — still usable.
 KV cache has room for ~6,000 more tokens within 16,384 ctx-len.
 Multi-turn conversation: KV cache persists correctly across requests.
 
-## Session 2025-06-28 Findings
 
-### Weight Format Breakthrough
+### Session 2025-06-28 Findings
+
+#### Weight Format Breakthrough
 Q4NX `dtype=I8` is MISLEADING. The data is ACTUALLY BF16 stored as pairs of bytes:
 - Every 2 consecutive I8 bytes form one BF16 value: `[lo_byte, hi_byte]` little-endian
 - Shape [256, 5120] I8 = [256, 2560] BF16 values
 - No per-group dequantization needed — read byte pairs directly as BF16
 - The per-group absmax scaling approach was incorrect (produced wrong weights)
 
-### Critical Issue: opcode=3 is IDENTITY
+#### Critical Issue: opcode=3 is IDENTITY
 - mm.xclbin with opcode=3 copies input BO to output BO unchanged
 - Weight BOs at idx=5 and idx=6 are COMPLETELY IGNORED
 - Tested with different weights at idx=5 and idx=6: no effect on output
@@ -875,14 +215,14 @@ Q4NX `dtype=I8` is MISLEADING. The data is ACTUALLY BF16 stored as pairs of byte
   3. The kernel needs BOs pinned to specific memory (SRAM vs HOST)
   4. The kernel uses a DIFFERENT set of arguments than what we provide
 
-### Current Engine State
+#### Current Engine State
 - Builds and runs: loads model, creates BOs, sends weights, runs all 28 layers
 - Output is deterministic but WRONG: tokens [919, 996, 185, 385, 495, 156, ...]
 - 16 tokens generated in ~3.5s (220ms/tok)
 - ~591 BOs (after BF16 fix, down from ~985 with per-group dequant)
 - Weight init time: ~190ms (vs ~2100ms with per-group dequant)
 
-### Next Steps / Options
+#### Next Steps / Options
 
 **Option A: Build npu_sequence framework from scratch**
 - Implement `npu_dma_memcpy_nd` equivalent using DRM ioctl BD creation
@@ -907,9 +247,10 @@ Q4NX `dtype=I8` is MISLEADING. The data is ACTUALLY BF16 stored as pairs of byte
 - Maybe use mmap on NPU tile memory directly
 - NPU has shared virtual memory feature
 
-## Key Discoveries from 2025-06-28 Late Session
 
-### Architecture: Weight DMA via libgemm instruction generation
+### Key Discoveries from 2025-06-28 Late Session
+
+#### Architecture: Weight DMA via libgemm instruction generation
 - **ALL 4 xclbins opcode=3 is IDENTITY** — none read from weight BOs directly
 - **Weight DMA is REQUIRED** — weights must be in AIE tile-local memory via DMA BD descriptors
 - **libgemm.so** can be `dlopen`'d independently (ZERO external deps beyond libstdc++)
@@ -922,7 +263,7 @@ Q4NX `dtype=I8` is MISLEADING. The data is ACTUALLY BF16 stored as pairs of byte
 - **Internal vectors**: offset 0x28 = pointer array (to command objects), offset 0x38 = real instruction words
 - **Instruction words generated for various GEMM shapes**: Q_proj (584 words), O_proj (704+912), gate/up (784+1548), down (1024+3600)
 
-### Critical Technical Details
+#### Critical Technical Details
 - **shim_tiles** is at 0x15960 in libgemm.so's `.rodata` (read-only, values [0,1,2,3,4,5,6,7])
 - **npu_sequence layout**:
   - 0x00: n_tile_rows (u32)
@@ -941,14 +282,14 @@ Q4NX `dtype=I8` is MISLEADING. The data is ACTUALLY BF16 stored as pairs of byte
   - attn_kv_tiles: [48,80,55,87, 32,64,39,71, 2,3,4,5,0,0,0,0]
   - shim_tiles: [0,1,2,3,4,5,6,7,0,0,0,0,0,0,0,0]
 
-### Generated Instruction Files
+#### Generated Instruction Files
 - `/tmp/gemm_Qproj_vec38.bin` — 16 bytes (containing 0x1ef1 header)
 - `/tmp/gemm_Oproj_vec38.bin` — 3648 bytes (912 u32 words)
 - `/tmp/gemm_gate_vec38.bin` — 6192 bytes
 - `/tmp/gemm_up_vec38.bin` — 6192 bytes
 - `/tmp/gemm_down_vec38.bin` — 14400 bytes
 
-### BREAKTHROUGH: libgemm.so instructions submitted to XRT kernel
+#### BREAKTHROUGH: libgemm.so instructions submitted to XRT kernel
 - **Wrote `test_libgemm9_final.cpp`**: calls `Gemm::generate_seq()` then submits vec@0x38 instructions as SRAM BO to XRT kernel
 - **ALL 5 GEMM configurations execute successfully** through kernel with opcode=0 (dynamic instruction mode)
 - **Execution times**: Qproj=3.15ms, Oproj=0.12ms, gate=0.10ms, up=0.08ms, down=0.08ms
@@ -961,7 +302,8 @@ Q4NX `dtype=I8` is MISLEADING. The data is ACTUALLY BF16 stored as pairs of byte
   - args 3-7: BOs (HOST group 65536)
 - **XRT sync bug**: `bo.sync(dir, 0, size)` treats sz=0 as flag meaning "use size from third param" — `sync(dir, 0, 4MB)` crashes but `sync(dir, sz, 0)` with non-zero sz works
 
-## Full Pipeline Results
+
+### Full Pipeline Results
 
 All 7 FLM pipeline functions successfully loaded and called:
 - `_send_rope_rms_weights` ✅
@@ -976,9 +318,10 @@ Output: 114,208 bytes (28,552 instructions). Kernel executes (ERT_CMD_STATE_COMP
 
 Full pipeline source: `npu-sandbox/xrt-direct/full_pipeline.cpp`
 
-## Session 2025-06-28 Late Testing — FLM HTTP Single-Connection Limit
 
-### Discovery: FLM's HTTP Server Crashes Under Concurrent Connections
+### Session 2025-06-28 Late Testing — FLM HTTP Single-Connection Limit
+
+#### Discovery: FLM's HTTP Server Crashes Under Concurrent Connections
 
 tested the unlock library strategy extensively and discovered a fatal limitation:
 
@@ -987,7 +330,7 @@ FLM can only handle ONE TCP connection at a time.
 Even with --socket 10 (10 I/O threads), concurrent connections CRASH FLM.
 ```
 
-### Test Results
+#### Test Results
 
 | Test | Result |
 |------|--------|
@@ -998,7 +341,7 @@ Even with --socket 10 (10 I/O threads), concurrent connections CRASH FLM.
 | `--socket 1` (single-threaded) | Still crashes on concurrent; logs "Connection limit reached (1)"
 | `--socket 16 --q-len 10` | Same crash behavior
 
-### Root Cause
+#### Root Cause
 FLM's HTTP server (based on standalone ASIO) has a hard limit of 1 active connection.
 The `--socket` parameter appears to set max concurrent I/O THREADS, not max connections.
 When a 2nd TCP connection arrives while the 1st is still being processed:
@@ -1006,7 +349,7 @@ When a 2nd TCP connection arrives while the 1st is still being processed:
 2. FLM crashes (SIGABRT or segfault)
 3. Process dies, all pending requests get `ConnectionResetError`
 
-### Implications
+#### Implications
 - **LD_PRELOAD unlock is a dead-end**: Even if both NPU gates are bypassed, FLM's HTTP server
   can't handle concurrent requests. The unlock worked (both mutex + g_npu_in_use bypassed)
   but FLM's global inference state (`current_messages`, model context, BO state) is not
@@ -1018,7 +361,7 @@ When a 2nd TCP connection arrives while the 1st is still being processed:
   Lazy resolution (resolve on first actual call, not in constructor) avoids this.
   Even a minimal pass-through LD_PRELOAD (no NPU logic, just dlsym + forward) crashes.
 
-### Viable Path Forward
+#### Viable Path Forward
 
 **Option 1: Proxy/Queue (#1 priority)**
 Build a lightweight proxy in front of FLM that:
@@ -1049,7 +392,7 @@ Continue the `npu-infer/` engine path. Current status:
 **Option 3: Enhanced unlock with https://github.com/nicedoc/singleton**
 Use a separate NPU driver/hack approach that doesn't go through FLM at all.
 
-### Updated Bottleneck Analysis
+#### Updated Bottleneck Analysis
 
 The original bottleneck analysis was partially wrong. FLM has TWO bottlenecks:
 
@@ -1065,9 +408,10 @@ Even unlocking both NPU gates doesn't help because the HTTP server itself can't 
 concurrent connections. FLM's true bottleneck is its **HTTP server architecture**, not
 just the NPU lock.
 
-## Session 2025-06-28 Late Testing — `cmds2seq()` Discovery & Instruction Pipeline
 
-### `cmds2seq()` WORKS from Independent `npu_sequence`
+### Session 2025-06-28 Late Testing — `cmds2seq()` Discovery & Instruction Pipeline
+
+#### `cmds2seq()` WORKS from Independent `npu_sequence`
 
 Prior handoff said `cmds2seq()` crashes on independently-created sequences. **This was incorrect** — it only crashes when `npu_sequence` internal vectors aren't properly initialized. With correct initialization (n_tile_rows=4, n_tile_cols=4, DDR base addresses set), `cmds2seq()` works from both `libmha.so` and correctly compiles commands to instructions.
 
@@ -1089,7 +433,7 @@ cmds2seq(&seq);
 // seq.vec@0x38 now has 3384-4412 instruction words with BD descriptors
 ```
 
-### Instruction Output After cmds2seq
+#### Instruction Output After cmds2seq
 
 | GEMM Shape | Instr Before | Instr After | BD Headers |
 |-----------|-------------|-------------|-----------|
@@ -1097,7 +441,7 @@ cmds2seq(&seq);
 | Oproj (1024,1024,256) | 912 words | 3384-4412 words | 10-14 BDs |
 | gate (256,1024,2048) | 1548 words | ? | ~20 BDs |
 
-### BD Descriptor Format (from analysis)
+#### BD Descriptor Format (from analysis)
 
 Decoded BD structure at word N:
 ```
@@ -1117,7 +461,7 @@ BD field meanings (determined from repeated patterns):
 - `0x00010000` + `0x00000003` at W[N+7,N+8]: Write DMA (DDR → tile)
 - `0x00004000` + `0x0000000f` at W[N+7,N+8]: Barrier/sync
 
-### Key Discovery: BD Addresses Reference Command Objects, NOT BO Addresses
+#### Key Discovery: BD Addresses Reference Command Objects, NOT BO Addresses
 
 The 48-bit addresses in the instruction BD descriptors (`0x7390..., 0x7832..., 0x764b...`) point to **command objects** (npu_write_cmd, npu_dma_block_cmd instances) in the seq's command vector (vec@0x28), NOT directly to BO data buffers.
 
@@ -1126,13 +470,13 @@ After `cmds2seq()`, the instruction stream contains:
 2. **DDR base addresses** (from seq.ddr_*_base) encoded as 32-bit offsets within specific BD fields
 3. **Control flags** for DMA direction, tile selection, synchronization
 
-### Architecture: Dual DMA Model
+#### Architecture: Dual DMA Model
 
 The instructions handle **activation DMA only** (moving activations between DDR BO and tile SRAM).
 Weight DMA is a SEPARATE step via `npu_sequence::npu_dma_memcpy_nd()`, which generates additional
 BD descriptors for transferring weights from weight BOs to tile-local SRAM.
 
-### Impact on npu-infer Engine
+#### Impact on npu-infer Engine
 
 The engine needs to:
 1. Create `npu_sequence` with correct tile params + DDR base addresses (= bo.address() & 0xFFFFFFFF)
@@ -1143,13 +487,13 @@ The engine needs to:
 6. Submit to XRT kernel with opcode=0
 7. The instructions handle all DMA internally — weight BOs at args 5,6 might not be needed
 
-### Open Questions
+#### Open Questions
 1. What is the exact `npu_dma_memcpy_nd()` signature? (defined in libgemm.so)
 2. How do the tile addresses map to physical AIE tiles?
 3. Can we skip weight DMA and pass weights via kernel args?
 4. What is the correct opcode for compute-only mode (without DMA instructions)?
 
-### Answer to Open Question #4 (from FLM strace)
+#### Answer to Open Question #4 (from FLM strace)
 FLM uses **opcode=3 with instr=0, ninstr=0** — meaning it uses the xclbin's pre-compiled AIE kernel.
 FLM does NOT use opcode=0 (dynamic instruction mode). This means:
 - Opcode=3 IS the "compute-only" mode where the AIE kernel handles everything
@@ -1163,13 +507,13 @@ FLM does NOT use opcode=0 (dynamic instruction mode). This means:
 The AIE kernel reads weights from tile SRAM, not from DDR BOs. The kernel args (BOs) tell it
 where in DDR to find the activation data, but weights must be pre-loaded to tile SRAM.
 
-### Next Priority
+#### Next Priority
 1. Find `npu_dma_memcpy_nd()` signature by searching libgemm.so symbols
 2. Build combined pipeline: generate_seq + dma_memcpy_nd + cmds2seq → instruction stream
 3. Test with opcode=0 and SRAM instr_bo containing both weight + activation DMA descriptors
 4. Or: find if there's a simpler weight submission API that doesn't need DMA descriptors
 
-### Session 2025-06-28 End — `cmds2seq` works, instructions don't produce GEMM, need runlist
+#### Session 2025-06-28 End — `cmds2seq` works, instructions don't produce GEMM, need runlist
 
 Summary of last session's findings:
 
@@ -1235,9 +579,10 @@ Build a comprehensive XRT capture (intercept library) that captures the ACTUAL B
 - A) Replicate the exact same BO setup and runlist pattern
 - B) Use FLM's own `npu_app_manager` with proper initialization to generate the full pipeline
 
-## Session 2026-06-28 Deep Research — Definitive Findings
 
-### npu_sequence Layout — DEFINITIVELY DETERMINED
+### Session 2026-06-28 Deep Research — Definitive Findings
+
+#### npu_sequence Layout — DEFINITIVELY DETERMINED
 
 Built probe (`/tmp/probe_seq_layout.cpp`) that dumps all vector states before/after `generate_seq` and `cmds2seq`. Results for Oproj (1024,1024,256):
 
@@ -1249,14 +594,14 @@ Built probe (`/tmp/probe_seq_layout.cpp`) that dumps all vector states before/af
 
 **`cmds2seq()` APPENDS to vec@0x38 and POPULATES vec@0x40 with proper IRON-format instructions including DDR_PATCH commands.** The correct instruction source for opcode=0 submission is **vec@0x40** (not vec@0x38 which contains raw BDs without DDR_PATCH metadata).
 
-### cmds2seq Call Verified Working
+#### cmds2seq Call Verified Working
 
 - `cmds2seq` is a **weak symbol** in `libgemm.so` at offset `0xdd20`
 - Also present in `libmha.so` (offset `0xdd20`) and `libqwen3_npu.so` (offset `0x59a70`)
 - Requires `RTLD_GLOBAL` + loading `libmha.so` and `libqwen3_npu.so` to resolve
 - Mangled name: `_ZN12npu_sequence8cmds2seqEv`
 
-### Opcode=0 + cmds2seq: STILL IDENTITY
+#### Opcode=0 + cmds2seq: STILL IDENTITY
 
 | Test | Instructions | DDR_PATCH | Opcode | Result |
 |------|-------------|-----------|--------|--------|
@@ -1267,7 +612,7 @@ Built probe (`/tmp/probe_seq_layout.cpp`) that dumps all vector states before/af
 
 **The mm.xclbin kernel produces identity output regardless of opcode or instruction format.** Even with the complete FLM pipeline (rope_rms → rms → dequant → send_x → move_weights → gen_seq → cmds2seq) generating 114KB of proper IRON instructions, the NPU copies input to output unchanged.
 
-### Key Test Binary Status
+#### Key Test Binary Status
 
 | Binary | Path | Status |
 |--------|------|--------|
@@ -1277,7 +622,7 @@ Built probe (`/tmp/probe_seq_layout.cpp`) that dumps all vector states before/af
 | capture_lib.so | `xrt-direct/capture_lib.so` | Intercepts XRT, captures logs |
 | npu_infer | `npu-infer/build/npu_infer` | Full engine, wrong output |
 
-### npu-infer Engine Critical Bugs Found
+#### npu-infer Engine Critical Bugs Found
 
 1. **Row-blocking bug**: Only first 256 rows of each weight tensor are packed — 75%+ of weights silently zero for tensors with >256 rows
 2. **No RMS normalization**: Pre-attention and pre-MLP RMS norm never applied
@@ -1287,7 +632,7 @@ Built probe (`/tmp/probe_seq_layout.cpp`) that dumps all vector states before/af
 6. **Missing implementation**: `run_mm_blocked()` declared in header but never defined
 7. **Single-kernel, not runlist**: Each weight block gets individual `run_gemm()` with `r.wait()` — no batching
 
-### torch2aie — Custom Kernel Compilation Path EXISTS
+#### torch2aie — Custom Kernel Compilation Path EXISTS
 
 The `/home/bcloud/torch2aie/` directory contains a complete AIE kernel development toolchain:
 - **Chess compiler** for AIE2P (`xchesscc_wrapper aie2p`)
@@ -1299,13 +644,13 @@ The `/home/bcloud/torch2aie/` directory contains a complete AIE kernel developme
 
 This is the path to creating custom xclbins with REAL compute kernels that read from weight BOs.
 
-### Root Cause Theory
+#### Root Cause Theory
 
 The mm.xclbin/attn.xclbin/layer.xclbin kernels are "weight-stationary" — they expect weights pre-loaded into AIE tile SRAM via a prior DMA step (FLM's weight DMA runlist batch). The GEMM compute step reads weights from tile SRAM, not from kernel argument BOs. Our instructions are correct for activation DMA but the compute kernel never executes because tile SRAM doesn't contain weights in the expected format/layout.
 
 **The pre-compiled xclbin is a black box.** Without modifying the xclbin itself (which requires the torch2aie toolchain), we can't make the existing kernels do GEMM.
 
-### Updated Priority — Two Viable Paths
+#### Updated Priority — Two Viable Paths
 
 **Path A: torch2aie custom xclbin** (Clean, but effort)
 1. Use the existing torch2aie pipeline to compile a new GEMM xclbin
@@ -1319,9 +664,9 @@ The mm.xclbin/attn.xclbin/layer.xclbin kernels are "weight-stationary" — they 
 3. Replicate FLM's complete weight-DMA-then-compute protocol
 4. This reveals what tile SRAM state the xclbin expects
 
-### ## Session 2026-06-28 Final — 40-Column NPU2 Compiler & Firmware Analysis
+#### ## Session 2026-06-28 Final — 40-Column NPU2 Compiler & Firmware Analysis
 
-### 40-Column Compiler Build — SUCCESSFUL
+#### 40-Column Compiler Build — SUCCESSFUL
 
 Modified MLIR-AIE source at `/home/bcloud/mlir-aie/`:
 1. `include/aie/Dialect/AIE/IR/AIETargetModel.h:823` — `return 8` → `return 40` (header-only, fully inlined)
@@ -1334,12 +679,12 @@ Modified MLIR-AIE source at `/home/bcloud/mlir-aie/`:
 - `NPU2().cols = 40`, `NPU2().rows = 6`, 160 compute tiles, 40 mem tiles, 40 shim tiles ✅
 - Virtualized variants (1-7 cols) still work via `npu2_1col`..`npu2_7col` ✅
 
-### 40-Column XCLBIN Compiled — 1.8MB, 160 cores
+#### 40-Column XCLBIN Compiled — 1.8MB, 160 cores
 - All 160 AIE core ELF files compiled via xchesscc
 - Partition JSON encodes `column_width: 40`, txn header encodes `numCols = 0x28 = 40`
 - xclbin passes xclbinutil validation, bootgen would accept it
 
-### Bug Fix: Partition Metadata Auto-Detection
+#### Bug Fix: Partition Metadata Auto-Detection
 **Problem:** Partition JSON and txn header both hardcoded `tm.columns() = 40`, causing ALL xclbins to report `column_width=40` (even 12-col designs used only 12 columns).
 
 **Fix (applied to rebuilt toolchain source):**
@@ -1347,7 +692,7 @@ Modified MLIR-AIE source at `/home/bcloud/mlir-aie/`:
 - `lib/Targets/AIETargetNPU.cpp:emit()` — same fix for txn header `numCols`
 - Both match the actual tile placements: 12-col design → `column_width=12`, etc.
 
-### Firmware Limit: 8 Columns HARDCODED
+#### Firmware Limit: 8 Columns HARDCODED
 - `DRM_IOCTL_AMDXDNA_CREATE_HWCTX` rejects `EINVAL` for any `column_width > 8`
 - Tested: 9, 10, 12, 16, 40 — **ALL rejected**
 - 8 columns works perfectly at 31.0 TFLOPS
@@ -1356,13 +701,13 @@ Modified MLIR-AIE source at `/home/bcloud/mlir-aie/`:
 - The `aie2_max_col` kernel driver parameter (`echo 40 > /sys/module/amdxdna/parameters/aie2_max_col`) does NOT override this — firmware validates independently
 - Older firmware `npu.sbin.1.0.0.166` (376KB) has **no column validation strings** — might accept >8 columns but likely lacks other features
 
-### Conclusion
+#### Conclusion
 **31.0 TFLOPS is the practical maximum** from the NPU without firmware modification.
 The MLIR-AIE compiler can be told about all 40 columns, firmware only allows 8-column-partitions.
 To unlock 50+ TFLOPS: reverse-engineer PSP firmware format, patch the column limit constant,
 reflash with valid hash/signature.
 
-### Firmware Deep-Dive (this session)
+#### Firmware Deep-Dive (this session)
 
 **Two firmware files, different purposes:**
 
@@ -1394,7 +739,7 @@ Kernel driver    → Firmware (npu_7.sbin) → AIE HW
 ```
 The kernel driver allows 40! The firmware rejects >8 at `CREATE_CONTEXT`.
 
-### Golden Artifacts
+#### Golden Artifacts
 
 | Artifact | Path | Purpose |
 |----------|------|---------|
@@ -1421,7 +766,7 @@ Files Created This Session
 | `/tmp/bo_capture_v*.so` → `src/xrt-direct/bo_capture.cpp` | **BREAKTHROUGH: DRM ioctl intercept library that dumps BO content during FLM inference** |
 | `/tmp/bo_dump/` → `xrt-direct/captured_bo_dump/` | **Captured actual BO content from FLM inference** — reveals full memory architecture |
 
-### BO Content Capture Results
+#### BO Content Capture Results
 
 **Architecture**: Built `bo_capture_v10.so` that intercepts DRM ioctls on `/dev/accel/accel0` at the `CREATE_BO`, `GET_BO_INFO`, `SYNC_BO`, and `EXEC_CMD` levels. Uses `mmap` on the device fd with `map_offset` from `GET_BO_INFO` to directly read BO content.
 
@@ -1465,9 +810,10 @@ Since we now have actual BO content dumps from FLM, we can either:
 - **Reverse-engineer the cmd buffer** — the 128MB BO content reveals the exact xclbin command format
 - **Wrap FLM's internal functions** — use `libqwen3_npu.so`'s `_move_weights()` to pack weights, then submit via our own XRT path
 
-## Session 2026-06-28 — Q4NX Format Fully Reverse-Engineered
 
-### Weight Format Breakthrough
+### Session 2026-06-28 — Q4NX Format Fully Reverse-Engineered
+
+#### Weight Format Breakthrough
 
 Q4NX `dtype=I8` is **MISLEADING**. The data is actually **INT4** (not INT8):
 
@@ -1487,16 +833,17 @@ The mapping from storage shape to logical shape is:
 - `I8_rows = logical_rows / 32 * 4` (each logical row of 32 I4 = 4 bytes)
 - `I8_cols = logical_cols / 32 * 20` (each group of 32 I4 = 20 bytes)
 
-### BF16 tensors
+#### BF16 tensors
 - Embedding, norms: stored as raw BF16 (little-endian uint16 pairs)
 - `bf16_to_float(v) = (float)((uint32_t)v << 16)`
 
-### Verified with existing npu-infer model.c
+#### Verified with existing npu-infer model.c
 The model.c code (lines 88-101) reads I8 data as BF16 byte pairs — this works correctly ONLY for tensors where the storage IS already BF16 (like norms). For I4-quantized tensors, the proper dequantization is needed.
 
-## Session 2026-06-28 — NaN debugging + Fused engine rewrite
 
-### Key Discoveries
+### Session 2026-06-28 — NaN debugging + Fused engine rewrite
+
+#### Key Discoveries
 
 1. **BOTH engines collapse to a single repeating token**: Old engine outputs 4739 repeating,
    fused engine outputs 55120. This is NOT a bug in the fused engine — it's a model quality
@@ -1513,14 +860,14 @@ The model.c code (lines 88-101) reads I8 data as BF16 byte pairs — this works 
    Current `engine.cpp` has `NpuInferenceEngine` (FLM-style) which is NOT the same as
    `CustomNpuEngine` that `main.cpp` expects. This means `make npu_infer` is broken.
 
-### What was built
+#### What was built
 
 - **Completely rewritten `npu_engine_fused.cpp`**: Clean, compact, 345ms/tok engine
   using original 1024×1024 xclbin with N-tiling for larger projections.
 - Fixed weight packing to use exact same layout as reference engine.
 - Engine runs all 28 layers with no NaN, generates tokens at 345ms/tok.
 
-### New xclbin path
+#### New xclbin path
 
 Fused engine now uses:
 ```
@@ -1529,21 +876,21 @@ INSTS:  /home/bcloud/npu-sandbox/npu-infer/build/qwen3_gemm/design_1024_bfp16.in
 ```
 (NOT the custom M=128 xclbins which produce NaN in 28-layer pipeline)
 
-### Files changed this session
+#### Files changed this session
 - `src/npu_engine_fused.cpp` — Major rewrite: single xclbin (1024×1024), N-tiled
 - `src/engine.cpp` — Minor: hnorm diagnostic added (reverted by git stash)
 - `src/npu_engine_fused.cpp` — Changed xclbin path to original design_1024_bfp16
 - `docs/fusion-level-0.md` — Created: detailed documentation
 - `Desktop/HANDOFF-NPU-OPTIMIZATION.md` — Updated status + fusion level #0
 
-### Next steps
+#### Next steps
 1. Restore CustomNpuEngine implementation (recover from git stash or object files)
 2. Or: rebuild fused engine with M=128 variants AND consistent BFP16 (pack at
    1024×1024 tile count for all variants → requires recomputing shuffle for variants)
 3. Temperature-based sampling to break token repetition
 4. Compare logits with PyTorch reference to validate NPU compute accuracy
 
-### Current Status
+#### Current Status
 - ✅ Q4NX format fully understood (I4 group quantization + BF16 byte-pair storage)
 - ✅ torch2aie toolchain verified working (19.5 TFLOPS config1 GEMM)
 - ✅ CPU inference engine architecture designed
@@ -1554,7 +901,8 @@ INSTS:  /home/bcloud/npu-sandbox/npu-infer/build/qwen3_gemm/design_1024_bfp16.in
    O (1024), D (3072 K-dims → K-tile clipped to 1024)
 - ⚠️ Output token differs from old engine (55120 vs 4739) due to N-tiling
 
-## Fusion Level #0 — Custom M=128 decode xclbins
+
+### Fusion Level #0 — Custom M=128 decode xclbins
 
 **Status: Complete** — 5 xclbins built and individually verified.
 
@@ -1563,7 +911,7 @@ original 1024×1024 xclbin and the M=128 variants.
 **Workaround:** `npu_engine_fused.cpp` now uses the original `design_1024_bfp16.xclbin`
 with N-tiling for projections with >1024 output dimensions.
 
-### Built XCLBINs (8-core, 1-row AIE design)
+#### Built XCLBINs (8-core, 1-row AIE design)
 | xclbin | Size | For |
 |--------|------|-----|
 | `final_128x1024x1024_128x64x128.xclbin` | 52KB | K, V proj (1×1024→1024) |
@@ -1572,7 +920,7 @@ with N-tiling for projections with >1024 output dimensions.
 | `final_128x2048x1024_128x64x128.xclbin` | 52KB | O proj (1×2048→1024) |
 | `final_128x3072x1024_128x64x128.xclbin` | 52KB | down proj (1×3072→1024) |
 
-### Key Files
+#### Key Files
 | File | Purpose |
 |------|---------|
 | `/home/bcloud/torch2aie/examples/gemm_asymmetric_tile_buffering/config1/n1_core_placed.py` | 8-core MLIR design source |
@@ -1580,9 +928,10 @@ with N-tiling for projections with >1024 output dimensions.
 | `/home/bcloud/npu-sandbox/npu-infer/build/npu_infer_fused` | Compiled binary (345ms/tok) |
 | `/home/bcloud/npu-sandbox/npu-infer/docs/fusion-level-0.md` | Detailed fusion doc |
 
-## Session 2026-06-29 — Full Optimization Sprint
 
-### 🏆 Final Engine: 210 ms/tok (3.2× faster than 668ms baseline)
+### Session 2026-06-29 — Full Optimization Sprint
+
+#### 🏆 Final Engine: 210 ms/tok (3.2× faster than 668ms baseline)
 
 Achieved through iterative optimizations on the torch2aie M=128 xclbin infrastructure:
 
@@ -1598,7 +947,7 @@ Achieved through iterative optimizations on the torch2aie M=128 xclbin infrastru
 | **-O3 -march=native -flto** | 210 ms | +2% | Compiler flags |
 | **Total** | **210 ms** | **3.2×** | — |
 
-### Engine Architecture
+#### Engine Architecture
 
 **6 xclbins loaded simultaneously:**
 
@@ -1631,13 +980,13 @@ Achieved through iterative optimizations on the torch2aie M=128 xclbin infrastru
 - Static arrays for RoPE cos/sin (no std::vector allocation)
 - Disk cache: packed weights saved to /tmp/npu_*.bin for ~2.5s init
 
-### Key Source File
+#### Key Source File
 
 **`/home/bcloud/npu-sandbox/npu-infer/src/npu_engine_fused.cpp`** — 310 lines, self-contained.
 - Build: `bash /home/bcloud/npu-sandbox/npu-infer/build/build_fused.sh`
 - Run: `bash /home/bcloud/npu-sandbox/npu-infer/build/run_fused.sh`
 
-### Performance Data
+#### Performance Data
 
 | Metric | Value |
 |--------|-------|
@@ -1649,7 +998,7 @@ Achieved through iterative optimizations on the torch2aie M=128 xclbin infrastru
 | Logit range | [22.6, -14.4] (correct LLM distribution) |
 | NaN count | 0 across 28 layers |
 
-### Built XCLBIN Inventory (config1/build/)
+#### Built XCLBIN Inventory (config1/build/)
 
 | xclbin | Size | Status |
 |--------|------|--------|
@@ -1669,7 +1018,7 @@ Achieved through iterative optimizations on the torch2aie M=128 xclbin infrastru
 | `final_256x1024x6144_128x64x128.xclbin` | 132KB | ✅ Built (multi-token GU, M=256) |
 | `final_256x3072x1024_128x64x128.xclbin` | 90KB | ✅ Built (multi-token D, M=256) |
 
-### Blocked Items
+#### Blocked Items
 
 | Item | Cause | Detail |
 |------|-------|--------|
@@ -1680,11 +1029,12 @@ Achieved through iterative optimizations on the torch2aie M=128 xclbin infrastru
 
 ---
 
-## INT8 on NPU2 — FINAL ARCHITECTURAL VERDICT (2026-06-28/29)
+
+### INT8 on NPU2 — FINAL ARCHITECTURAL VERDICT (2026-06-28/29)
 
 INT8 xclbins BUILD and RUN for all 5 matrix shapes, but produce **394% mean relative error** with random input data on the NPU2 8-core design. The root cause is architecturally unfixable within the MLIR-AIE ObjectFifo abstraction.
 
-### Root Cause: K-Slice Interleaving on Shared A Fifo
+#### Root Cause: K-Slice Interleaving on Shared A Fifo
 
 The BFP16 reference design (210ms/tok, 12 TFLOPS) uses:
 - 1 shim DMA channel for A data (shared across 8 cores via mem tile stream extractor)
@@ -1701,7 +1051,7 @@ For BFP16 (block floating point with 8-element shared exponents), adjacent K-blo
 
 For raw INT8, A values are independent across K → **394% mean relative error**.
 
-### Attempted Fixes — All Blocked
+#### Attempted Fixes — All Blocked
 
 | Approach | Result | Blocked By |
 |----------|--------|------------|
@@ -1712,7 +1062,7 @@ For raw INT8, A values are independent across K → **394% mean relative error**
 | DRAM-backed bf16copy (v21) | ✅ Builds, **4× correct value** | BFP16 w/ r=8,s=8 sub-viewing doesn't translate to INT8 |
 | Weight reordering | ❌ Mathematical impossibility | Σ A(K_sub) × B_reordered ≠ Σ A(all K) × B(original K) |
 
-### DRAM-Backed bf16copy Attempt (v21, 2026-06-29)
+#### DRAM-Backed bf16copy Attempt (v21, 2026-06-29)
 
 Exact copy of the BFP16 generator (`n1_core_i8_bf16copy.py`) with:
 - `m=128, mtk=512, depth=2` — A_L3L2 element = (128, 512) int8 = 64KB
@@ -1725,7 +1075,7 @@ Exact copy of the BFP16 generator (`n1_core_i8_bf16copy.py`) with:
 
 The fundamental conflict: **BFP16 dimensions produce the correct number of linked pool sub-views for 8 cores × 16 K-iterations = 128 acquires**. INT8 with r=1,s=1 dimensions only produces 16 sub-views (depth 2 × 8: max pool size for linked fifos).
 
-### Windows INT8 Answer
+#### Windows INT8 Answer
 The same NPU2 silicon on Windows uses AMD's proprietary XDNA driver (DirectML) with a fundamentally different dataflow architecture:
 - **M-parallel tiling** (row-parallel, NOT K-parallel) — each column gets different M-rows
 - **Software-managed BD chains** — time-multiplexes shim DMA across all columns without hardware lock-based fifos
@@ -1733,7 +1083,7 @@ The same NPU2 silicon on Windows uses AMD's proprietary XDNA driver (DirectML) w
 
 This bypasses MLIR-AIE's ObjectFifo resource constraints. The NPU2 hardware CAN do INT8 at ~50 TOPS — just not through the MLIR-AIE stack's abstraction.
 
-### Built XCLBIN Inventory (build/int8/)
+#### Built XCLBIN Inventory (build/int8/)
 
 | xclbin | Size | Status | All-1s | Random |
 |--------|------|--------|--------|--------|
@@ -1745,7 +1095,7 @@ This bypasses MLIR-AIE's ObjectFifo resource constraints. The NPU2 hardware CAN 
 | `final_i8_KV_v17.xclbin` | 54KB | ✅ Runs | same K-issue | ❌ 129K/131K errors |
 | `final_i8_KV_bf16copy.xclbin` | 49KB | ✅ Runs | **4× correct** | — |
 
-### Generator Files
+#### Generator Files
 
 | File | Purpose |
 |------|---------|
@@ -1755,7 +1105,7 @@ This bypasses MLIR-AIE's ObjectFifo resource constraints. The NPU2 hardware CAN 
 | `bf16_kernel_dev/n1_core_i8_bf16copy.py` | Exact BFP16 copy for INT8 (4× value) |
 | `build/int8/mm_128x64x128.o` | DIM_M=128 kernel (matmul_scalar_i8_i16) |
 
-### Recommendation
+#### Recommendation
 **Use BFP16 for the inference engine** (210ms/tok, 12 TFLOPS, correct results).
 
 INT8 on NPU2 via MLIR-AIE is architecturally blocked:
@@ -1768,7 +1118,7 @@ The xclbins are valid for K-invariant workloads (batchnorm at inference, uniform
 
 ---
 
-### Next Steps (for future sessions)
+#### Next Steps (for future sessions)
 
 1. **Fix multi-token kernel**: Recompile `mm_bfp_mixed.cc` with `g_counter` mod 2 instead of mod 4 → 2-token decode → ~110ms/2tok = 55ms/tok
 2. **Fix 2-layer batch engine**: Integrate N=8320/K=4096/K=6144 xclbins → ~170ms/tok
@@ -1776,7 +1126,7 @@ The xclbins are valid for K-invariant workloads (batchnorm at inference, uniform
 4. **2-layer batch + multi-token combined**: 2 tokens × 2 layers per batch → 28/2=14 batches → ~80ms/2tok = 40ms/tok
 
 
-### INT8 Engine Architecture
+#### INT8 Engine Architecture
 
 ```
 Engine pipeline (219 ms/tok, 4.6 tok/s):
@@ -1791,7 +1141,7 @@ Per-layer: RMS norm → QKV GEMM(514μs) → Q/K norm+RoPE → CPU softmax+atten
 Per-token: Final RMS norm → LM head(CPU: 155M MACs) → softmax sample → embed lookup
 ```
 
-### Speed History
+#### Speed History
 
 | Engine | ms/tok | tok/s | Key Change |
 |--------|--------|-------|------------|
@@ -1802,7 +1152,7 @@ Per-token: Final RMS norm → LM head(CPU: 155M MACs) → softmax sample → emb
 | BFP16 v8 (baseline) | 1,335 | 0.7 | — |
 | FLM proprietary | 11 | 93 | Reference (proprietary stack) |
 
-### Proven NPU GEMM Performance
+#### Proven NPU GEMM Performance
 
 | Projection | Shape | Latency | TFLOPS |
 |-----------|-------|---------|--------|
@@ -1811,7 +1161,7 @@ Per-token: Final RMS norm → LM head(CPU: 155M MACs) → softmax sample → emb
 | GU (fused) | 128×1024×6144 | 742 μs | 2.2 |
 | D | 128×3072×1024 | 326 μs | 2.5 |
 
-### Context Pool Architecture
+#### Context Pool Architecture
 
 Instead of the old sa() (ensure-alive swap) which destroyed and recreated
 the entire XRT state (xclbin registration, hw_context, kernel, BOs), the
@@ -1830,7 +1180,7 @@ struct I8Slot {
 };
 ```
 
-### Path to 50-100 ms/tok (10-20 tok/s)
+#### Path to 50-100 ms/tok (10-20 tok/s)
 
 | # | Optimization | Speedup | Est ms/tok | Effort |
 |---|-------------|---------|------------|--------|
@@ -1841,7 +1191,7 @@ struct I8Slot {
 | 5 | NPU edge attention (BF16) | 18% | ~85 | 3 days |
 | 6 | Fused QKV-attn-O xclbin | 10% | ~70 | 7 days |
 
-### Key Files
+#### Key Files
 
 | File | Purpose |
 |------|---------|
@@ -1852,7 +1202,7 @@ struct I8Slot {
 | `npu-infer/build/int8/insts_i8_*_v.txt` | Instruction sequences |
 | `npu-infer/build/chess_infer/attn_06b.xclbin` | NPU edge attention (421 μs, DPU kernel) |
 
-### Build Commands
+#### Build Commands
 
 ```bash
 # Rebuild xclbins (if generator changes)
@@ -1882,9 +1232,341 @@ sudo ./npu_engine_i8
 
 ---
 
-## Session 2026-07-02/03 — Production Stack, Release, Site Refresh
 
-### FLM Proxy Daemon (July 2)
+### UPDATE 13 (2026-07-01 04:00 ADT): INT8 ENGINE COMPLETE — 219 ms/tok, CONTEXT POOL
+
+
+### 🏆 Peak Achievement: 31.0 TFLOPS on NPU (config2 design)
+
+**Verified at `/home/bcloud/torch2aie/examples/gemm_asymmetric_tile_buffering/config2/`**
+```
+Avg NPU tflops: 31.0081
+Max NPU tflops: 31.4522
+Matrix: 3072×4096×1536 (M×K×N), tile: 192×128×96
+Design: 32 cores (8 cols × 4 rows), Chess kernel
+```
+
+#### Engine: WORKING at 1.93s/tok with BFP16 xclbin
+
+| Version | XCLBIN | Speed | Status |
+|---------|--------|-------|--------|
+| v2 | 4096x4096 BFP16 | 15.6s | First working |
+| v3 | 2048x2048 BFP16 | 2.04s | 8x faster |
+| v7 | **1024x1024 BFP16** | **1.93s** | 220KB xclbin, all fixes |
+| config2 | **config2 (192×128×96)** | **31.0 TFLOPS** | 32 cores, Chess kernel |
+
+#### Architecture: Complete & Verified
+| Component | Status | Detail |
+|-----------|--------|--------|
+| Q4NX I4 dequant | OK | Tile-grid 32x256, zero NaN/Inf |
+| NPU GEMM | OK | 1024x1024 BFP16 ebs8, 12 TFLOPS |
+| 28-layer pipeline | OK | Q/K norms, RoPE, KV cache, SiLU MLP |
+| LM head | OK | Embedding table (tied embeddings) |
+| Token quality | OK | 84869, 55120, 70247, 75499 (diverse, temp=1.0) |
+| Logit range | OK | [-16.3, 23.8] correct LLM distribution |
+| FW | OK | 1.1.2.65 (latest for device 0x17f0_11) |
+
+#### BF16 Kernel: Compiled, Blocked by SRAM
+The Chess API supports native BF16 via `aie::mmul<8,8,8,bfloat16,bfloat16,32>` with emulation flag `-DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16=1`. Kernel compiles and links but xclbin fails because:
+- B tile: 64x128 BF16 = 16KB. With depth=2 = 32KB.
+- A tile: 32x64 BF16 = 4KB. With depth=2 = 8KB.  
+- C tile: 128x128 BF16 = 32KB. With depth=1 = 32KB.
+- Total L1: 32+8+32 = 72KB > 64KB. Blocked.
+- Fix needs: redesign to 64x64 B tiles (8KB, fits at 8+8+16=32KB depth=2)
+
+#### All Fixes Applied
+1. x16 weight scaling in pre_pack (RMSE 0.0003 vs 0.032 naive)
+2. LM head = embedding table (tied embeddings, removed I4 quantization error)
+3. 9-token chat template prefill
+4. Q/K per-head norms + RoPE (rope_theta=1e6, correct per position)
+5. KV cache with full QK^T + softmax attention
+6. 1024x1024 BFP16 xclbin (220KB, compiled today)
+
+#### Key Files
+| File | Purpose |
+|------|---------|
+| npu-infer/src/npu_engine_v7.cpp | Working engine |
+| npu-infer/src/dequant_q4nx.c | Correct I4 dequant |
+| npu-infer/build/qwen3_gemm/design_1024_bfp16.xclbin | 220KB xclbin |
+| npu-infer/build/qwen3_gemm/mm_bf16_direct.o | BF16 Chess kernel (compiled, ready) |
+| npu-infer/build/qwen3_gemm/mm_scalar.o | Scalar BF16 kernel (working alt) |
+| /home/bcloud/Desktop/HANDOFF-NPU-OPTIMIZATION.md | This handoff |
+
+#### Build & Run
+cd /home/bcloud/npu-sandbox/npu-infer
+g++ -std=c++23 -O3 -o build/npu_engine_v7 src/npu_engine_v7.cpp build/dequant_q4nx.o \
+  -Iinclude -I/home/bcloud/torch2aie/toolchain/xrt/include \
+  -I/home/bcloud/torch2aie/examples -I.../gemm_asymmetric_tile_buffering \
+  -L.../xrt/lib64 -L.../mlir_aie.libs -lxrt_coreutil -luuid -lm
+LD_LIBRARY_PATH=.../xrt/lib64:.../mlir_aie.libs:.../sysroot/usr/lib64 ./build/npu_engine_v7
+
+
+### UPDATE 15 (2026-07-01 15:00 ADT): PR-AGENT LIVE, LANDING PAGE DEPLOYED, 242 ms/tok VERIFIED
+
+#### Live Production Stack
+
+```
+https://1bit.systems          → 50 TOPS landing page (Cloudflare Pages)
+https://github.com/.../1bit-systems → Full source, benchmarks, journey
+PR-Agent: The-PR-Agent v0.41 (DeepSeek) + GitNexus impact reports → auto-review on every PR
+```
+
+#### Verified Timing (2026-07-01 15:00 ADT)
+
+```
+=== NPU Engine v3 — Continuous Batch ===
+Prefill 9 tokens: 179ms (20 ms/tok)
+Decode 4 tokens: 242 ms/tok
+Tokens: 106811, 63165, 117266, 109842
+```
+
+| Metric | Today | Overnight (Jul 1 04:00) |
+|--------|-------|-------------------------|
+| Prefill M=9 | 179ms (20 ms/tok) | ~200ms |
+| Decode | **242 ms/tok** | 219 ms/tok |
+| Prefill M=1 | 161ms | — |
+| Prefill M=4 | 162ms (40 ms/tok) | — |
+| PPR Agent | The-PR-Agent v0.41 + DeepSeek + GitNexus | — |
+| Landing page | 50 TOPS headline deployed | — |
+
+#### What pi-agent Tightened
+
+- Timings stable across all benchmarks (prefill + decode scaling verified)
+- No regression from overnight session — 242 ms/tok matches the 244 ms/tok from 09:30
+- Engine runtime exit code 0, all tokens diverse, no NaN
+
+#### 1-bit Models Confirmed
+
+Bonsai-1.7B IQ1_S: 281 tok/s on Radeon 8060S Vulkan, 385 MB. pi-agent patched llama.cpp with Q2_0 validation for Strix Halo gfx1151. Models on disk at /home/bcloud/models/bonsai-1.7b/.
+
+#### PPR Agent Deployed
+
+The-PR-Agent/pr-agent@v0.41 (upstream, pinned SHA) → DeepSeek
+GitNexus knowledge-graph report injected via artifact_path (blast radius, affected flows)
+Config: 3 AI reviewers, INT8-focused review instructions, automatic review on PR open + push
+
+#### What's Next
+
+- NPU attention dispatch for >32 token context
+- GGUF Q8_0 native loader (bypass Q4NX)
+- 1-bit NPU kernel (ternary GEMV on XDNA2)
+
+---
+
+
+### UPDATE 16 (2026-07-02 02:00 ADT): FULL PROFILE + 50 ms/tok BATCH-4 DECODE
+
+#### NPU Dispatch: The Root Cause
+
+μs-accurate profiling (`npu_engine_profile.cpp`) proved our GEMM overhead:
+
+```
+Per-GEMM dispatch (112 per token):
+  Quantize A:    6 μs   (<1%)
+  Sync A→NPU:    2 μs   (<1%)
+  Kernel+wait: 1346 μs   (99%)  ← THE BOTTLENECK
+  Sync C←NPU:    8 μs   (<1%)
+  Dequant C:     1 μs   (<1%)
+
+Total: 1363 μs/call × 112 calls = 156.8 ms (70%)
+LM head: 67 ms (30%)
+CPU ops (norms, RoPE, attn, SiLU): 0.7 ms (<1%)
+```
+
+The NPU is spending 99% of dispatch time in launch+wait overhead.
+Actual M=1 GEMM is 0.5-5 μs. Overhead ratio: **2000×**.
+
+#### Chained Batch-4 Decode (v6): 50 ms/tok
+
+Instead of per-token dispatch, we generate top-4 tokens from LM head
+logits and run them all through one batched forward pass. Each batch
+step takes ~160ms for 4 tokens = 40 ms/tok. Boot step: 157ms.
+
+```
+$ OMP_NUM_THREADS=16 ./npu_engine_v6 16
+
+  [0] boot=127595 top4=127595,65831,39815,63550 (157ms)
+  [1] batch=4 tok=9275 ms=161 (40 ms/tok)
+  [5] batch=4 tok=106211 ms=159 (40 ms/tok)
+  [9] batch=4 tok=83570 ms=158 (40 ms/tok)
+  [13] batch=3 tok=83570 ms=157 (52 ms/tok)
+=== 50 ms/tok effective ===
+```
+
+Token IDs diverse across batches. No NaN. Clean exit.
+4.4× speedup from v3 (244→50 ms/tok).
+
+#### OpenMP LM Head
+
+Pre-converted BFP16→F32 embeddings (622 MB) + OpenMP on 16 Zen5 cores:
+LM head: 67ms → ~6ms per token (11× faster). This plus batch-4
+amortization is what dropped us from 222→50 ms/tok.
+
+#### What We Learned
+
+- Removing weight re-sync (v4) saved nothing — weights already on device.
+- 2-layer draft model (spec decode v0) had 0% acceptance rate on Qwen3.
+- Batching at decode time works: dispatch overhead amortizes across tokens.
+- CPU is never the bottleneck — 26 μs/layer vs 5599 μs GEMM dispatch.
+
+#### Next: Fused Transformer XCLBIN
+
+The 112 dispatches per token are now 112 per 4 tokens = 28/token effective.
+To get to FLM's 93 tok/s, we need a single fused transformer-layer xclbin
+that chains QKV→norm→attention→O→norm→GU→D on NPU without host round-trips.
+That turns 28 dispatches into 1. Then LM head goes on NPU via D-xclbin INT8
+matmul. Then we're at ~10 ms/tok.
+
+---
+
+
+### UPDATE 17 (2026-07-02 03:00 ADT): M=16 BATCH DECODE — 16 ms/tok, 15.2× SPEEDUP
+
+#### 244→16 ms/tok in One Session
+
+```
+v3 (Jul 1): 244 ms/tok  baseline
+v6 (Jul 2):  50 ms/tok  batch-4 + OpenMP LM head           (4.4×)
+v7 (Jul 2):       —     ioctl=9μs, r.wait=1334μs probe
+v8 (Jul 2):  27 ms/tok  M=8 batch decode                   (8.2×)
+v9 (Jul 2):  16 ms/tok  M=16 batch decode                  (15.2×)
+```
+
+#### M=16 Batch Decode — How It Works
+
+The v7 probe proved `r.wait()` at 1334μs per GEMM call is NPU compute time,
+not driver overhead. The NPU is 99% idle in the M dimension at M=1. At M=16,
+compute stays at 1334μs but processes 16× more data → 11ms/tok per batch step.
+
+Single-token boot (157ms) provides top-16 token candidates from LM head logits.
+The 16 candidates run through one batched forward pass (28 layers, 4 GEMMs each)
+= 112 dispatches at 1334μs = 149ms NPU time + LM head (6ms) + CPU (10ms) ≈ 170ms.
+170ms / 16 tokens = 11 ms/tok.
+
+At 64 tokens (4 batches): 16.1 ms/tok effective. Boot amortized away.
+
+#### FLM Gap: 1.5×
+
+FLM: 93 tok/s = 10.7 ms/tok (proprietary).  
+v9: 63 tok/s = 16.0 ms/tok (open source).  
+Gap: 1.5×. Was 20× yesterday morning.
+
+Next: LM head on NPU (151936×1024 INT8 matmul on D-style xclbin) = ~1ms.
+That alone brings batch step from 11→6ms/tok and effective to ~8ms/tok.
+Combined with M=32: ~4ms/tok effective = matches FLM.
+
+#### Session Summary
+
+- 9 engine versions built and tested on-device
+- f32 embeddings: -20% decode latency
+- OpenMP LM head: 67→6ms
+- μs-probe: identified NPU compute as bottleneck (not ioctl)
+- M=4→8→16 batched decode: dispatch amortization
+- 15.2× total speedup
+- CI pipeline on self-hosted runner
+- All numbers on https://1bit.systems
+
+---
+
+
+### UPDATE 18 (2026-07-02 04:01 ADT): M=32 TARGET, NPU LM HEAD, FLM COMPARISON
+
+FLM Kraken Point benchmark for reference: 66.5 tok/s on weaker hardware than ours. Engine evolution
+recap v3→v10: 244→16 ms/tok (15.2×, same numbers as Update 17). NPU LM head landed on-chip: 4ms
+(N=30720 xclbin, 88KB) — previously a CPU-side cost. `xrt::runlist` batching investigated and found
+to save only 27μs/layer (not worth the complexity). M=32 v11 targeted for >100 tok/s. Next flagged:
+NPU attention kernel (`edge_attention.o` compiled, not yet integrated) and the fused-xclbin idea
+that Update 20 picks up.
+
+---
+
+
+### UPDATE 19 (2026-07-02 06:24–06:27 ADT): MULTI-MODEL XCLBINS, MODEL-AGNOSTIC ENGINE
+
+Two parallel threads landed close together:
+
+- **Multi-model build-out**: 22-23 xclbins compiled across 6 model families (Qwen3-0.6B, Qwen3-8B,
+  Qwen3-VL-4B, Gemma4-E2B, Llama). `npu_engine_mt.cpp` (model-agnostic multi-token engine) +
+  `model_config.h` (auto-detects model dimensions from Q4NX headers) + a 42-model catalog
+  (`model-catalog.md`) classifying every FLM NPU2 model by architecture. `build_all_models.sh`
+  automates the xclbin builds.
+- **Engine speed**: v12 at 10 ms/tok (97 tok/s), 24× speedup from the v3 baseline
+  (244→50→16→10 ms/tok across v3→v6→v9→v12).
+- **Attention**: `attn_scalar.o` + `attn_c8.xclbin` compiled but not integrated — CPU OpenMP was
+  still faster for context <128 at this point.
+- Site live: 145 visitors, CI pipeline + PR-Agent running, benchmarks current.
+
+---
+
+
+### UPDATE 20 (2026-07-02 05:17–07:27 ADT): FUSED XCLBIN — FIRST ATTEMPT, Q4NX BLOCKER
+
+The first full attempt at the fused-transformer-xclbin idea flagged in Update 18. Contract
+established for Qwen3-0.6B dimensions, 5 kernels recompiled with Chess for the smaller model.
+MLIR generator produced a working design; 2 xclbins compiled (374KB full-layer, 253KB QKV-prefix).
+`npu_engine_v13` proved the dispatch mechanics work — xclbin loads, BOs allocate (9.4MB weights),
+kernel dispatches without crashing — but hit a wall: the fused xclbin's weight-stream layout
+expects FLM's proprietary Q4NX chunk format, and the engine's flat INT8 weights don't match it.
+Weight-stream scheduler work got the packed size exactly right (2,458,816 dwords) but DMA still
+timed out (63s) — diagnosed at the time as a Q4NX *quantization* mismatch (dequant→requant producing
+NaN/Inf). Decision: keep v12 (97 tok/s, standalone GEMM) in production, treat fused xclbin as a
+separate weight-format workstream.
+
+(Update 24, a session later, revisited this with fresh eyes and found the real bug was the
+*schedule* — chunks replicated identically across columns instead of indexed per-tile — not the
+quantization theory reached here. See `docs/archive/WEIGHT-STREAM-BLOCKER.md` for the correction.)
+
+---
+
+
+### UPDATE 21 (2026-07-02 12:01 ADT): SESSION CLOSE — FULL NPU ENGINE STATE
+
+*(Reconstructed from git history — commits in this window didn't carry explicit UPDATE numbers;
+assigned 20/21 here to keep the sequence readable.)*
+
+v12 engine at 97 tok/s (10 ms/tok), 24× speedup, beating FLM Kraken Point (66.5 tok/s). Fused
+xclbin: 3 xclbins compiled (QKV-prefix, full-layer, unified), 5 Chess kernels recompiled for
+Qwen3-0.6B, blocked on Q4NX weight format (see Update 20) — NPU firmware confirmed an active
+xclbin via `ERT_CMD_STATE_TIMEOUT`, an early sighting of the same deadlock symptom Update 24 later
+isolated. Model xclbins: 23 total across 5 families (Qwen3-0.6B, Qwen3-VL-4B, Qwen3-8B,
+Llama-3.1-8B, Gemma4-E2B). CLI scaffolded by a second agent (package.json, tsconfig, command
+routing).
+
+---
+
+
+### UPDATE 22 (2026-07-02 15:13 ADT): ALL 5 MODELS AT V12 BATCH SPEED, 0 CRASHES
+
+Model-agnostic engine (`npu_engine_all.cpp`) verified across the full catalog:
+
+| Model | Decode |
+|---|---|
+| Qwen3-0.6B | 58 ms/tok |
+| Gemma4-E2B | 117 ms/tok |
+| Qwen3-VL-4B | 141 ms/tok |
+| Llama-3.1-8B | 185 ms/tok |
+| Qwen3-8B | 215 ms/tok |
+
+Fix: `dequant_i8_to_float_ex` had `in_features` hardcoded to 1024 — only 0.6B ever worked
+correctly. Corrected to read `H`, `NH×HD`, `IM` per-projection from the model header; all 5
+families verified working.
+
+---
+
+
+### UPDATE 23 (2026-07-02 15:32 ADT): PRODUCTION RELEASE — v2026.07.02-all5models
+
+Shipped: tag `v2026.07.02-all5models`, site updated to "One binary to rule them all." 5 model
+families verified, 0 crashes, 28 tok/s on Qwen3-0.6B (all-models auto-detect binary). vs FLM: 2.4×
+slower per-token, but open source, zero dependencies, 5 models from one 120KB binary. Fused xclbin
+flagged as the path to close the gap (picked back up in Update 24, three sessions later).
+
+---
+
+
+### Session 2026-07-02/03 — Production Stack, Release, Site Refresh
+
+#### FLM Proxy Daemon (July 2)
 
 The C++ engine runs 5 models but at lower tok/s than FLM. Decision: proxy to FLM for production while the open-source engine catches up on the fused xclbin.
 
@@ -1899,11 +1581,11 @@ The C++ engine runs 5 models but at lower tok/s than FLM. Decision: proxy to FLM
 - `Restart=always` with 5s backoff
 - `LimitMEMLOCK=infinity` for NPU memory access
 
-### TypeScript Build Fix (July 2)
+#### TypeScript Build Fix (July 2)
 
 `npm run build` was broken — `bridge.ts` and `server.ts` imported `fastify` which wasn't installed. These were WIP TypeScript servers that tried to run the C++ engine directly; the Python daemon replaced them. Excluded from tsconfig, removed `fastify` from package.json. Build exits clean.
 
-### Benchmark Results — FLM Turbo (July 3)
+#### Benchmark Results — FLM Turbo (July 3)
 
 | Metric | pmode=performance | pmode=turbo |
 |--------|-------------------|-------------|
@@ -1914,14 +1596,14 @@ The C++ engine runs 5 models but at lower tok/s than FLM. Decision: proxy to FLM
 
 Turbo gain: marginal (+0.6% decode, -16ms TTFT). The 500ms TTFT is the NPU loading weights from DDR — no software knob fixes this. Only a fused xclbin can break through.
 
-### CPU + GPU Tuning
+#### CPU + GPU Tuning
 
 - CPU governor: powersave→performance (marginal TTFT improvement)
 - GPU perf level: auto (2900 MHz under load, 600 MHz idle)
 - GPU sclk seen at 2646-2900 MHz. No fan controls exposed on this APU — EC handles it.
 - No manual overclock available on NPU — clock gated by XDNA firmware.
 
-### Release Packaging (July 2-3)
+#### Release Packaging (July 2-3)
 
 Built and uploaded to GitHub Releases (`v2026.07.02`):
 | File | Size | Contents |
@@ -1931,7 +1613,7 @@ Built and uploaded to GitHub Releases (`v2026.07.02`):
 
 Release notes show 94 tok/s FLM, 97 tok/s C++ v12. Clean install: `tar xzf` → `bash install.sh` → `1bit chat`.
 
-### Stale Numbers Purge (July 2)
+#### Stale Numbers Purge (July 2)
 
 Every file in the repo still said 63 tok/s (old v9 number from June). The daemon swapped to FLM proxy weeks ago. Hunted down every occurrence:
 - `src/commands/chat.ts`: 63→94 tok/s
@@ -1941,7 +1623,7 @@ Every file in the repo still said 63 tok/s (old v9 number from June). The daemon
 - `engine/npu/BENCHMARKS.md`: full restructure with production FLM numbers at top
 - `~/.1bit/agent/settings.json`: npuEndpoint port 8081→9090
 
-### Site (July 2-3)
+#### Site (July 2-3)
 
 Deployed to Cloudflare Pages. Visual polish:
 - "Open source" in blue, "Zero dependencies" in pink
@@ -1949,7 +1631,7 @@ Deployed to Cloudflare Pages. Visual polish:
 - All port references updated to 9090
 - Footer shows FLM + C++ v12 numbers
 
-### GitHub Traffic (as of July 2)
+#### GitHub Traffic (as of July 2)
 
 | Metric | Value |
 |--------|-------|
@@ -1962,7 +1644,7 @@ Deployed to Cloudflare Pages. Visual polish:
 
 The Jun 21-22 clone spike (492 in one day) looks like a scraper or bot. Organic traffic is steady at 2-9 visitors/day from search and direct.
 
-### Files Changed
+#### Files Changed
 
 | File | Change |
 |------|--------|
@@ -1981,7 +1663,7 @@ The Jun 21-22 clone spike (492 in one day) looks like a scraper or bot. Organic 
 | `docs/journey.md` | This entry |
 | `.github/workflows/deploy.yml` | Cloudflare Pages deploy on push to main |
 
-### Current Status (July 3, 2026)
+#### Current Status (July 3, 2026)
 
 - **Production**: FLM proxy on port 9090, pmode=turbo, 94.7 tok/s
 - **C++ engine**: 5 models, 28 tok/s (ALL) / 97 tok/s (v12), auto-detect
@@ -1991,15 +1673,100 @@ The Jun 21-22 clone spike (492 in one day) looks like a scraper or bot. Organic 
 - **Next**: Fused xclbin port (blocked by IRON Python API)
 - **Traffic**: 296 unique cloners in 2 weeks, zero marketing
 
-### Repos
+#### Repos
 
 - `https://github.com/1bit-systems/1bit-systems` — This repo (source of truth)
 - `https://github.com/bong-water-water-bong/npu-infer` — INT8 engine + xclbin generators
 - `https://github.com/bong-water-water-bong/npu-gpu-cpu` — Handoff docs + unified control plane
 
-## Session 2026-07-03/04 — Triton-XDNA Eval, memlock Fix, Spec-Decode Reality Check
 
-### Triton-XDNA (AMD's Triton-to-XDNA compiler)
+### UPDATE 24 (2026-07-03): FUSED XCLBIN RESUMED — SCHEDULE FIXED, DEADLOCK ISOLATED, NEW KERNEL BUG FOUND
+
+Picked back up the fused-transformer-xclbin effort flagged as "next" at the end of Update 17
+(the intervening Updates 18-23 covering the fused-xclbin dead end, the pivot to the universal
+5-model v12 engine, and the merch store live in git history / other docs, not fully reflected
+in this file until now).
+
+#### What Was Found
+
+1. **Reconstructed the correct Q4NX weight-packing schedule** by cross-referencing the MLIR
+   generator against `qwen3_model.py::_projection_stream_from_schedule` — the fused xclbin
+   expects weight chunks distributed per-column/per-row (`row_chunk = block*16 + group*4 +
+   patch*2 + row_in_patch`), not replicated identically across columns as the old
+   `q4nx_stream.cpp` did. `npu-sandbox/npu-infer/tools/pack_fused_v3.py` already implements this
+   correctly (verified byte-identical on regen) by reading real Q4NX chunks straight out of
+   `model.q4nx`, no dequant/requant.
+2. **Schedule-correct weights alone didn't fix the full-layer deadlock** — re-ran `npu_engine_v13`,
+   still 62857ms timeout, all-zero output.
+3. **Isolated the deadlock to the O/UP/GATE/DOWN tail.** The smaller QKV-prefix xclbin (rebuilt
+   fresh via `full_layer_qkv_prefix_runner.py`) dispatches cleanly in ~4ms, no deadlock at all —
+   matching what the sibling BitNet port (`torch2aie/examples/bitnet-decode-layer`) found for the
+   identical design shape. The full-layer deadlock is a lock/dataflow bug specific to the tail
+   phases, not a data-scheduling problem.
+4. **Found a second, separate bug: QKV-prefix produces numerically wrong output**, even
+   deadlock-free. ~1000+ K/V cache mismatches vs. the CPU golden reference, at multiple token
+   positions. Traced RoPE and RMSNorm formulas in the Chess kernel (`postprocess_qkv.cc`) against
+   the Python reference — both match exactly. V-cache (no RoPE/norm at all) is *also* wrong,
+   narrowing the bug to the Q4NX GEMM/dequant kernel (`qwen3_decode_kernels.cc`) or record
+   absorption — unresolved, needs kernel-level debug instrumentation to pin down further.
+
+#### Status
+
+Fused xclbin is closer than before (schedule solved, deadlock scope narrowed) but still not
+working end-to-end — two distinct kernel bugs remain (tail deadlock, QKV numeric correctness).
+v12 (97 tok/s, standalone INT8 GEMM, zero Python) stays production. Full details in
+`docs/archive/FUSED-INTEGRATION-BLOCKER.md`.
+
+---
+
+
+### UPDATE 25 (2026-07-03): v12 WAS NEVER OUTPUT-VALIDATED — 3 REAL BUGS FOUND, STILL INCOHERENT
+
+Set out to swap the production daemon's NPU backend from FLM (proprietary, closed-source)
+to v12 (our own C++ engine, "97 tok/s, beats FLM's 94, Zero Python"). Before wiring it in,
+sanity-checked actual chat output against FLM for the same prompt. FLM answered "What is
+2+2?" correctly (" 4."). v12 — byte-identical reproduction of the unmodified original —
+produced complete garbage. Every doc and benchmark in this repo checks tok/s and "doesn't
+crash," never coherence. The 97 tok/s number is real; the output behind it never was.
+
+Found and fixed 3 real, confirmed bugs, all present in `npu_engine_cb.cpp` since it was
+first written and inherited by `npu_target_model.h` (spec-decode's target-model dispatch):
+
+1. **LM head weight substitution** — `lm_head.weight` gets correctly dequantized then
+   immediately discarded; the code computes final vocab logits against the *embedding*
+   table instead (assumes tied embeddings). Qwen3-0.6B's checkpoint stores them completely
+   separately (confirmed via Q4NX header data_offsets) — the model computes a reasonable
+   final hidden state, then reads logits off the wrong matrix.
+2. **Weight-packing transpose** — `dequant_i8_to_float` returns row-major
+   `[out_features, in_features]`; the GEMM dispatch needs `[in_features, out_features]`.
+   The packing loop read the buffer with the wrong stride, silently scrambling every
+   weight matrix (Q/K/V/O/Gate/Up/Down) while still producing finite, plausible-looking
+   numbers. Also: O-proj and Down-proj dequant calls used the wrong `in_features` (1024
+   default instead of their real 2048/3072), scrambling the tiling itself.
+3. **Activation quantization clipping** — hardcoded INT8 scale assumed activations stay
+   within [-5,5]; measured range is [-8.24,7.01]. Silently clipped every layer, compounding
+   across all 28.
+
+All three fixed, in all three copies of this logic (`npu_engine_cb.cpp`,
+`npu_engine_server.cpp` — a new persistent-server variant built for the daemon swap,
+and `spec-decode/engine/npu_target_model.h`). Chat output is **still incoherent** after
+all three fixes, individually and combined, tested against both RoPE conventions
+(interleaved-pairs and HF's actual rotate_half). Ruled out via ground-truth comparison
+against the real HF model: embedding lookup, RoPE theta/config, GQA head mapping, K/V
+extraction offsets — all correct. Remaining suspects: RoPE rotation convention (tested,
+inconclusive) or the compiled `.xclbin` kernels themselves, undebuggable without the AI
+Engine Simulator — blocked on this machine since Update 24's investigation (missing
+`aie2p_8x4_device.json` for NPU2). Full writeup: `docs/archive/V12-CORRECTNESS-BLOCKER.md`.
+
+**FLM proxy stays in production.** Do not wire v12/1bit.engine into the daemon until this
+is resolved and re-verified against real chat prompts, not just dispatch speed.
+
+---
+
+
+### Session 2026-07-03/04 — Triton-XDNA Eval, memlock Fix, Spec-Decode Reality Check
+
+#### Triton-XDNA (AMD's Triton-to-XDNA compiler)
 
 Evaluated `amd/Triton-XDNA` as a candidate to replace handwritten `edge_attention.cc`/`n1_core_i8_v2.py` MLIR. Cloned to `npu-sandbox/Triton-XDNA/`, built via prebuilt wheels (Python 3.12 venv, `sandbox/`).
 
@@ -2009,7 +1776,7 @@ Evaluated `amd/Triton-XDNA` as a candidate to replace handwritten `edge_attentio
 
 **Result**: `matmul_i8_m64_n64_k64` example compiles to a real AIE2P device binary (`.pdi`/`.elf`) and runs correctly on this exact hardware — validated bit-exact (`atol=0, rtol=0`) against PyTorch CPU reference across 8 shape combos (M,N,K ∈ {256,1024}), run twice each. Correctness only — no throughput benchmark run yet.
 
-### Spec-decode reality check
+#### Spec-decode reality check
 
 Ran the real `npu_spec_decode` binary (not the synthetic `spec_decode_bench` sweep) against the actual trained checkpoint at `checkpoints/eagle3_draft_2k.bin` (`eagle3_qwen3_0.6b_2k`, step_21). Same memlock issue hit here too — same fix applies repo-wide, not just Triton-XDNA.
 
@@ -2017,11 +1784,11 @@ Ran the real `npu_spec_decode` binary (not the synthetic `spec_decode_bench` swe
 
 Also noticed `checkpoints/eagle3_qwen3_0.6b_10k/` (the name `run_full_pipeline.sh` actually targets) is empty — no checkpoint saved — while the `_2k`-named run is the one that produced `step_21`. Divergence not investigated further this session.
 
-### NPU daemon verify
+#### NPU daemon verify
 
 Re-verified FLM proxy after the stop/restart: 91.6-93.0 tok/s decode, ~42 tok/s prefill, ~495ms TTFT — consistent with the 94±5 baseline (the 82 tok/s seen immediately post-restart was just cold-start noise). Separately noticed the GPU/Lemonade backend (`lemond`) is a dead zombie process (port 13305 not listening) — pre-existing, not caused by this session. Unrecognized model names silently route to it and fail with a raw connection-refused error instead of a clean "unknown model" response.
 
-### QKV weight cache corruption — the real root cause (July 5)
+#### QKV weight cache corruption — the real root cause (July 5)
 
 **Background**: two parallel bugfixes happened in the same session:
 - Decode off-by-one (commit `21864a41`): decode loop ran LM-head AFTER forward, re-running layers on the prefill's finalized hidden state.
@@ -2038,7 +1805,38 @@ A negative cos_sim means the cached INT8 weights are essentially uncorrelated ga
 
 The generator script that wrote `/tmp/hf_weights_cache/*.bin` is not in the repo. `docs/NPU-ENGINE-CORRECTNESS-STATUS.md` was updated to reflect this new finding.
 
-## Session 2026-07-05/06 — Q4NX/GGUF fully decoded, NPU GEMM root-caused, first validated 1-bit number, DSpark
+
+### UPDATE 26 (2026-07-05): ALL 3 BUGS CONFIRMED FIXED — AIE MICRO-TILING ROOT CAUSE RESOLVED
+
+**v12 is now coherent. 97 tok/s verified. GEMM kernel bit-exact.**
+
+A parallel investigation (branch `fix/npu-hf-cache-i32-kernel`) independently confirmed
+what UPDATE 25 suspected: the remaining bug was in the **compiled xclbin kernels**, not
+the host code. Root cause: `n1_core_i8_v2.py` (the INT8 MLIR generator) was **missing AIE
+micro-tiling** — the GEMM kernel received weights in the wrong internal layout despite
+being bit-for-bit correct at the BO level.
+
+Fixes applied:
+1. **xclbin output width** — matched INT8 generator output width to host's i32 Cm buffer
+   (`cd73e137`)
+2. **Smoke-test prompt** — replaced malformed prompt with valid chat template
+   (`3d984285`)
+3. **RMSNorm weight clip** — clipped weights to [-2,2] in cb/universal engines
+   (`49e78785`, partial)
+4. **GEMM kernel verified** — hardware dump-and-compare confirmed bit-exact
+   (`7f8f3586`)
+5. **Root cause identified** — missing AIE micro-tiling in n1_core_i8_v2.py
+   (`01a4b7f4`)
+6. **Parallel theories reconciled** — both investigation paths now agree
+   (`16016167`)
+
+All 6 fixes cherry-picked onto main as `232db025`..`bffe5a2e`.
+**97 tok/s v12 now produces coherent output.**
+
+---
+
+
+### Session 2026-07-05/06 — Q4NX/GGUF fully decoded, NPU GEMM root-caused, first validated 1-bit number, DSpark
 
 The longest push in the project's history. Two threads ran in parallel: a
 model-format thread (decode *any* model on either chip) and a correctness thread
@@ -2047,7 +1845,7 @@ silently corrupted every "97 tok/s" run was root-caused and fixed, Q4NX and Q2_0
 were both decoded bit-exact, and the first genuinely validated, coherent 1-bit
 number landed: **279 tok/s.**
 
-### GGUF ↔ Q4NX: decode any model, architecture-agnostic
+#### GGUF ↔ Q4NX: decode any model, architecture-agnostic
 
 Built `gguf_parser.h` (v2/v3, architecture-agnostic metadata via suffix matching;
 Q8_0/Q4_0/Q4_1/Q5_0/Q5_1/Q4_K/Q5_K/Q6_K/Q8_K/F32/F16/I8), `tools/gguf_to_q4nx.cpp`,
@@ -2056,7 +1854,7 @@ uploads to NPU BOs, and runs the whole decode loop (RMSNorm, RoPE, QKV/O/GU/D GE
 attention, SiLU, AVX-512 LM head). **Q4NX is fully decoded** and the NPU is no
 longer locked to one hand-produced model file — any GGUF can drive it.
 
-### NPU INT8 GEMM: the real root cause (it was never the host)
+#### NPU INT8 GEMM: the real root cause (it was never the host)
 
 Every prior "v12 97 tok/s" run produced incoherent output; four sessions of
 host-side fixes never fixed coherence. Settled it with hardware dump-and-compare:
@@ -2074,7 +1872,7 @@ to ~250 and started tracking the prompt. (`docs/research/GEMM-KERNEL-CORRECTNESS
 Also fixed: i16-vs-i32 xclbin output width (~120,000× error), a malformed smoke-test
 prompt, and unbounded RMSNorm weights that were masking the broken kernel.
 
-### Q2_0 ternary: bit-exact, and the first real 1-bit number
+#### Q2_0 ternary: bit-exact, and the first real 1-bit number
 
 The prism-ml Ternary-Bonsai Q2_0 format isn't publicly documented. Reverse-
 engineered from raw bytes, verified **bit-exact vs the F16 reference
@@ -2086,7 +1884,7 @@ Then measured, on hardware, coherent: **Ternary-Bonsai-1.7B native Q2_0 (1.58-bi
 storage. `llama-bench` tg64 = 278.81 ± 2.95 t/s. This is the honest, reproducible
 "1bit" headline (`docs/VALIDATED-BENCHMARKS-2026-07-05.md`, `docs/one-bit-headline.md`).
 
-### ZINC Q2_0 kernel + build unstick
+#### ZINC Q2_0 kernel + build unstick
 
 Wrote `zinc:src/shaders/dmmv_q2_0.comp` (mirrors the proven `dmmv_q8_0` reduction)
 and wired it through loader/dispatch — **builds and runs the ternary model natively
@@ -2096,7 +1894,7 @@ Separately, ZINC's repo was stuck in a half-finished Zig 0.15→0.16 migration t
 built with neither toolchain; restored `main` to a clean 0.15.2 build and preserved
 the 0.16 attempt on `wip/zig-0.16-migration`.
 
-### DSpark (speculative-decode draft) — projected, not yet measured
+#### DSpark (speculative-decode draft) — projected, not yet measured
 
 DSpark is a small draft model (5-layer transformer + Markov head + confidence head)
 for speculative decoding. Measured **5.90× acceptance** (5.90/7 blocks, 73.7%) on
@@ -2106,7 +1904,7 @@ measurement — the draft is still training and rides on the NPU base engine. La
 it as a projection until measured; it is not a validated production number the way
 94 tok/s (FLM) and 279 tok/s (GPU ternary) are.
 
-### Honest status at session end
+#### Honest status at session end
 
 - ✅ **NPU production (FLM proxy): 94 tok/s, coherent** — validated live.
 - ✅ **GPU native 1.58-bit ternary: 279 tok/s, coherent** — validated, reproducible.
@@ -2119,7 +1917,7 @@ it as a projection until measured; it is not a validated production number the w
   that are.
 - ❌ `engine/fusion/main.zig` still prints a dispatch table and runs no inference.
 
-### 2026-07-11 addendum — the DSpark story continues
+#### 2026-07-11 addendum — the DSpark story continues
 
 The 279 tok/s / 572 tok/s-projection numbers above later drifted into a flat
 "disproven" claim (a 2026-07-07 test reported 0.1–0.2 tok/s at 0% acceptance with no
@@ -2132,7 +1930,24 @@ already-fragile training setup much worse. See `docs/wiki/performance.md` for th
 corrected "unresolved, not disproven" status and the real 0.8 tok/s / 0% acceptance
 measurement taken with the wiring bug fixed.
 
-## Session 2026-07-16/20 — FLM fully replaced, model-agnostic broadening, TQ2 ternary
+
+### UPDATE 27 (2026-07-06): FUSED LAYER ENGINE GOES PRODUCTION — 291 TOK/S (3× V12)
+
+**The fused layer engine now ships at 291 tok/s (3.4 ms/tok), 3× the v12 baseline, in a 38 KB binary.**
+
+What was delivered:
+1. **One xclbin call per transformer layer**: QKV projection, attention, O projection, gate+up, SiLU, and down projection all run on the NPU in a single dispatch. No CPU attention, no intermediate BO syncs. Uses `design_full_layer.xclbin` (416 KB) from the torch2aie toolchain with per-position instruction files.
+2. **3.4 ms/tok decode**: The fused dispatch eliminates the per-GEMM ioctl overhead that limited v12. At 291 tok/s, the NPU's INT8 throughput is now the bottleneck, not the dispatch layer.
+3. **38 KB binary**: The fused engine binary is smaller than the previous 74 KB daemon despite doing more per call. Static linking + stripped symbols + no Python runtime paths.
+4. **Fixed scale optimization in universal engine**: `dynamic_ascale()` replaced with `FIXED_ASCALE = 8.0f / 127.0f` — saves 35 μs per GEMM call (4 ms/batch across 112 calls). Worth +11% on decode.
+5. **FLM v0.9.44 workaround in daemon**: FLM's `/v1/chat/completions` has a `basic_string::substr` bug. Daemon now converts chat messages to text prompts via a lightweight Qwen3 template and calls `/v1/completions` instead.
+
+**Narrative shift**: v12 (97 tok/s, C++ standalone INT8) is now the fallback path. The fused layer engine is the production path. All docs, badges, and benchmarks updated to reflect this. Everything from "74 KB binary, 94 tok/s" to "38 KB binary, 291 tok/s."
+
+---
+
+
+### Session 2026-07-16/20 — FLM fully replaced, model-agnostic broadening, TQ2 ternary
 
 The single biggest architectural change since the last addendum: **FastFlowLM is no
 longer the default NPU path, and its native `.so`-dependency is gone entirely.**
@@ -2228,7 +2043,71 @@ misconfigured to point a non-MoE-scoped test at a real MoE model, not a code bug
 
 ---
 
-## 2026-08-07 — the unified control plane lands (pool wired, spec decode in-server, zoo 5/5)
+
+### UPDATE 28 (2026-07-20): MAMBA1 GPU BACKEND — 79.4 TOK/S, 9 BUGS KILLED
+
+**The Mamba1 GPU backend (`mamba1_engine.hip` + `backend_mamba1.cpp`) is now fully built, linked, and validated end-to-end on Strix Halo. BlackMamba 1.5B: 79.4 tok/s. BlackMamba 2.8B: 46.1 tok/s.**
+
+What was delivered:
+
+1. **Build linkage fixed**: `create_mamba1_backend` was only compiled into `unified_server`, not `libbackend_manager.a` — every other binary (test_backend, backend_demo, vision_server, etc.) failed to link. Moved `backend_mamba1.cpp` into the static lib. HIP device stubs were also missing because the file was compiled as CXX despite launching kernels with `<<<>>>` syntax; moved all kernel launches into `extern "C"` wrapper functions in `mamba1_engine.hip` so callers compile as plain CXX.
+2. **Conv state buffer overflow fixed**: the conv state shift loop wrote to `cs[(d_conv-1) * d_inner + i]` but the buffer was only `[d_conv-1, d_inner]` (max valid index `d_conv-2`). This caused silent GPU memory corruption on every SSM layer forward pass. Fixed the loop bound from `dc-2` to `dc-3`.
+3. **A_log exponentiation fixed**: Mamba1 parameterizes `A = -exp(A_log)`, but the selective scan kernel used `A_log` directly as `A` in `A_bar = exp(dt * A)`. This meant the SSM dynamics were completely wrong. Added `-expf()` in the scan loop to compute `A = -exp(A_log)` before discretization.
+4. **Model routing fixed**: GGUF Mamba models are now routed to `mamba1_gpu` backend (was falling through to ZINC GPU catch-all).
+5. **Both BlackMamba sizes converted and benchmarked**: 1.5B (30 layers, 15 SSM + 15 MoE) at 79.4 tok/s, 2.8B (36 layers, 18 SSM + 18 MoE) at 46.1 tok/s — both on Strix Halo iGPU via ROCm HIP, alternating SSM/MoE layer dispatch.
+6. **Diagnostic tool**: `tools/test_mamba1_backend.cpp` loads a Mamba1 GGUF directly into the HIP backend without the HTTP server — warmup, benchmark, and generation in one shot.
+
+**The BlackMamba `⚠️` in the README is gone.**
+
+---
+
+
+## PART 2 — THE MEMORY CAMPAIGN & THE CONTROL PLANE (2026-08-03 → 2026-08-10)
+
+
+
+**The engine survived contact with reality; now it had to survive contact with memory. Arena-frag leaks, a 10-bug audit, the amdxdna 0.16.0 regression that turned a 35B model into garbage soup, the IOMMU wedge saga, and raw-ioctl firmware execution proven bit-exact. Every update below is dated and every claim maps to code in this repo.**
+
+
+### UPDATE 29 (2026-08-03): MEMORY CAMPAIGN — ARENA-FRAG LEAK FIXED, TOP-1 BACKEND INIT, 10-BUG AUDIT
+
+**The long-unexplained host-RSS creep in `unified_server` is root-caused and fixed, the multi-backend memory bloat is cut by ~10 GB, and the 10-bug audit (#1429–#1438) landed. Release v2026.08.03 shipped and the memory fixes are deployed on the live service.**
+
+#### The leak that wasn't a leak: glibc arena fragmentation (#1428)
+
+For weeks the server's host RSS crept ~0.1–1.7 MB per generation request — monotonic, never returned, ~90 MB/hr at 1 req/s, and 6.8 GB baseline after 50 min uptime. Every container was ruled out by triage. A heaptrack capture settled it:
+
+- **Zero unfreed bytes on the generate/forward/lm_head path.** Nothing leaked.
+- The culprit: `FusedBackend::generate()` allocated `std::vector<float> l(VOCAB)` (**608 KB** for Qwen3) on the stack **every token** and freed it every token.
+- That's the **glibc dynamic mmap-threshold trap**: the first 608 KB block is mmap'd, but after the first free glibc raises its threshold and services later same-size requests from the **brk arena**, interleaving them with the small per-token HIP/kernel allocations. Top-of-heap never becomes trimmable → RSS creeps up and never comes back. This is exactly why `/proc/maps` stayed flat while `VmData` grew, and why the rate tracked tokens.
+- Fix: hoist `h`/`l` to reusable member buffers sized once in `init()`. Zero per-token host allocation → nothing to fragment. Measured: mt=128 creep decays 208 → **20 kB per 10 reqs** (old: 17 MB per 10 reqs, ~160×) and plateaus; the `MALLOC_MMAP_THRESHOLD_`/`TRIM_THRESHOLD_` env band-aid on the service became unnecessary and was removed.
+
+#### The 15 GB serving baseline (#1427)
+
+`BackendManager::init_in_order()` loaded **every** backend × full model copy — fused (f32 GPU + host), hip_1bp (bf16 GPU), vulkan_hpp (pools), cpu_generic (f32 RAM) — ~15 GB (7 GB RSS + 8.2 GB GTT) for a 0.6B model, so systemd-oomd killed desktop apps when CI built concurrently. Two fixes:
+
+1. **Dead host weights freed**: `cpu_L`/`cpu_embed`/`cpu_final_norm`/`cpu_output` are pure load→GPU/NPU-pack buffers — provably unread at inference. Freed after load: RSS 6768 → 5163 MB.
+2. **Top-1 + CPU fallback init**: keep the first accelerator + one CPU fallback; the rest stay discoverable and init **lazily via the existing failover path**. This was safe because the per-token cross-backend routing those extra copies paid for was **KV-incoherent anyway** — each backend keeps a private KV cache + `pos`, so a token routed to a backend that never saw the prefix attends to empty KV. Instance GTT: 8.2 → **2.6 GB**.
+
+#### Everything else since UPDATE 28
+
+- **Coherent GPU inference** (#1397): QK-norm, per-layer KV, residual fixes — GPU paths became output-valid; `fused_gpu_npu` is the production path at **321 tok/s (3.1 ms/tok)**.
+- **One ELF to rule them all** (08-02): `build/1bit` = zaya + unified + router + jarvis + vision + agent CLI in a single binary; `1bit pull`/`list` in pure C++; packaging ships one binary; the 296-line bash launcher is dead.
+- **Lemonade embedded** (08-01): 14 Lemonade backends run in-process; `unified_server --lemonade` hands off to the full server.
+- **Exact SiLU + `-ffast-math` dropped** (41d0977e7): Q4NX ppl was *backend*-broken, not converter-broken — the #1243 audit's 6.5% density red flag resolved with per-vocab ppl gates + prefill M=128 fused chain (#1413).
+- **RVQ-VAE codec in C++** (#1368) with GGUF export.
+- **10-bug audit resolved** (#1429–#1438): SSRF, unkillable-server, OOB/SIGFPE/bad_alloc families, loader/backend hardening.
+- **Clean shutdown** (#1426): `_exit()` instead of the static-dtor ABRT that segfaulted on every stop.
+- **Release pipeline fixed** (#1404–#1425): tag builds run on the runner (not container), `onebin` target restored after sync merges clobbered it, libdrm/glslc/spirv-headers dep parity with CI.
+- **Narrative purges** (#1412 + follow-ups): TheRock-era and Rust-era claims swept — the stack is pure C++23, zero Python at runtime.
+- **Ponytail purge** (#1325): ~48K lines of dead code deleted (with the few survivors restored in #1390).
+
+**The environment bit back once**: a driver wedge during sustained load forced a cold reboot on 08-03; post-reboot the NPU (RyzenAI-npu5, firmware 1.1.2.65) and iGPU came back clean, and the memory campaign above was verified on the recovered hardware.
+
+---
+
+
+### 2026-08-07 — the unified control plane lands (pool wired, spec decode in-server, zoo 5/5)
 
 **What happened**: the 1bit engine went from "5 models working one at a time" to
 **one process, one API, all models resident** — plus a lossless speculative
@@ -2263,3 +2142,327 @@ unified (one process, one API, pooled models). The NPU-side single device-heap
 carve + one chained EXEC_CMD (docs/plans/one-heap-pivot.md) is still DRAFT —
 that's the next milestone, on a kernel/driver surface that's already present
 in amdxdna.
+
+
+### UPDATE 30 (2026-08-07): THE ONE-HEAP POOL — ALL MODELS RESIDENT, SPEC-DECODE IN-SERVER
+
+**The unified server now boots with every model in the zoo resident in one mmap'd pool (11 slots, ~6 GB on Strix), runs lossless speculative decoding in-process (`--draft-model`), and finally produces coherent answers from all 9 models end-to-end — Zamba2, the NPU FLM path, and the HIP 1BP backends all fixed. 13 commits landed on main via PR #1535.**
+
+#### The unified model pool (#1535)
+
+The pool idea from UPDATE 29's roadmap is now end-to-end. `UnifiedModelPool` was generalized: any model file (gguf/q4nx/h1b/1bp) is mmap'd resident — `.1bp` gets header-parsed metadata, everything else generic. `--pool` makes the server load every discovered model at boot; `POST /v1/pool` reports residency, `/v1/models` tags pooled models. One process, one API, all models resident. Measured through the single endpoint: Qwen3-4B (NPU FLM) 20.8 tok/s, Llama-3.2-1B/Qwen3-0.6B (Vulkan) 12.4, Bonsai (HIP 1BP) 3.1, Zamba2 Q8_0 (HIP) 2.2; zoo-smoke 5/5 PASS.
+
+#### In-server speculative decode
+
+Phase 2 core is now a server flag, not a demo. The backend interface gained the three spec-decode primitives (`decode_one` / `verify_batch` / `rollback`), implemented by the ggml-vulkan backend with multi-token `llama_decode` (per-position logits + KV rollback via `llama_memory_seq_rm`). `--draft-model` loads a second side-by-side ggml-vulkan backend; `--spec-decode` runs the lossless loop (draft proposes N greedy tokens, target verifies in one batch, longest consistent prefix accepted, rejected positions rolled back and fix re-decoded). Two real bugs found along the way: `reset()` was a no-op — every request extended ONE unbounded sequence, so KV never actually cleared per request; and the first-token bug — draft and target logits share a vocab size but NOT a vocab, and a shared buffer made the first output token the draft's argmax.
+
+#### Zamba2 end-to-end (5dcef800)
+
+Zamba2-1.2B-Instruct-v2 now generates coherent answers through the unified server on the HIP GPU engine — verified vs HF transformers with identical top-1 (`'4<|im_end|>'` greedy). Three root causes, all found:
+
+1. **The GGUF on disk was corrupt** — ~60% of weight elements didn't match the checkpoint (spot-checked ssm_in, embedding). Re-converted a clean F16 GGUF from the safetensors.
+2. **Converter bugs**: `use_shared_attention_adapter=True` never folded the q/k/v LoRA adapters (only the FFN gate_up one was) — every attention head computed with raw weights; and the tokenizer vocab was never written, so `.htok` synthesis failed and the server fell back to the previous model's tokenizer (Qwen3 ids fed to a 32k-vocab model).
+3. **Merges format**: `tokenizer.json` merges are `[a, b]` pairs, the gguf lib wants `'a b'` strings.
+
+#### Model zoo sweep: 8/9 coherent (04271bd8, 0bab2f6e)
+
+Full regression sweep of all 9 models through the unified server — 8/9 now generate coherent responses. Tokenizer synthesis was the big one: the server now builds a fresh `.htok` from the model's own or sibling GGUF (`GgufReader::write_htok`), because the checked-in `tokenizer.htok` was a stale Llama-era v1 file and without it every non-NPU model decoded as ASCII-garbage `[id]` soup. Plus: byte-piece fallbacks for non-GPT-2 vocabs, the ggml_vulkan sampler chain switched from greedy (which made small models loop) to temp 0.8/top_p 0.95/dist, and a nasty `cur_p.selected` bug — it's an INDEX into the candidates array, not the token id.
+
+NPU FLM went end-to-end too: an ODR collision where two distinct `OnebpModel` classes (CPU vs NPU) shared one dtor symbol meant every NPU-side object was destroyed with the wrong layout → SIGSEGV after any failed 1BP open (fixed by renaming the NPU-side class to `NpuOnebpModel`). The FLM backend got a `generate_text()` hook driving the subprocess REPL with the whole prompt (FLM tokenizes internally; a token loop can't drive it), with REPL artifacts (ANSI codes, `<<RESET>>` echoes, `[FLM]` log lines) stripped from responses. And the Qwen3-4B-NPU2 model cache was corrupt — bad download pre-reboot.
+
+#### Zaya 1BP + routing (9ed7eb94, 7ae82829, 4c68f3ff)
+
+The HIP 1BP backend is wired into the router chain with logits-based sampling (temperature/top-p/repetition penalty — replacing argmax), `rope_theta` passed from the `.1bp` header, and per-arch chat templates — verified with a real-prompt coherence probe.
+
+#### CI + housekeeping
+
+- The e2e smoke job no longer breaks when built without the llama.cpp submodule (`backend_ggml_vulkan.h` self-stubs the factory, mirroring the `.cpp`'s `#else` stub); submodule pinned to the fork so CI can fetch the zamba2-quantize commit.
+- ShellCheck SC2034 in `scripts/zoo-smoke.sh` fixed (unused loop var — was blocking the required C++ check on every PR).
+- **Branch cleanup**: 7 stale remote branches deleted (3 dependabot bumps, superseded fingerprint-dispatch docs, merged/closed eeg-zuna-research, zamba2-ssm-a-convention, ws05 per-vocab-ppl-gates), 4 stale PRs closed. `origin/main` had been sitting at Aug 5 — the whole Aug 7 work landed via PR #1535.
+- **CI flake found, not fixed**: the smoke-test's NPU `mmap EAGAIN` failures are the `pool-probe` job wedging the amdxdna driver (`Can not get flush memory` in dmesg) — the server runs clean locally with the NPU free. Root-caused in the wiki; workaround is a reboot before needing smoke green.
+
+---
+
+
+### UPDATE 31 (2026-08-08): THE TILEFUSE DAY — NPU KERNEL FROM SCRATCH, Q4NX PIVOT, CONVERTER LADDER
+
+**The single busiest day in the window: an original NPU int4 GEMV kernel built from scratch (inspired by, but not copied from, the TileFuse paper — its actual kernel code was never public), a pivot to official Q4NX weights after community GGUF conversions proved unusable, a 15× serve-mode speedup, MoE expert ops running on the real 22GB 35B model for the first time, a from-scratch ONNX INT8 pipeline, and a four-rung Qwen2.5 converter debugging ladder (1.5B → 3B → 7B) that found a different silent corruption bug at every rung.**
+
+#### An original NPU int4 GEMV kernel (TileFuse-inspired), milestones M1→M4
+
+Official Q4NX weights turned out to be a dead end for custom-converted models (confirmed later the same day — see the Q4NX pivot below), so the day pivots to building an NPU int4 GEMV kernel from first principles. The TileFuse paper (arXiv 2606.11357) describes the dataflow, but its actual kernel code was never released — only a static docs site — so the AIE kernel itself is original work guided by the paper's description, not a port.
+
+- **M1 — the pre-tiler.** `docs/research/tilefuse_prep.py`: 128×64 tiles, int4 codes packed as adjacent-column nibbles, bf16 per-channel scales, int8 code-domain zero-points. Round-trip passed on synthetic data (max err 0.0087 vs. an int4 physics ceiling of 0.0101) and on a real Llama-3.2-1B `q_proj` slice (err 0.0288 vs. ceiling 0.0383). Three bugs fixed en route: int4 bytes pack adjacent *columns*, not row-pairs; the zero-point must be stored in the int8 code domain, not as a raw float minimum (storing `round(lo)` produced a 30× error); and constant-column tiles need `scale=|lo|`.
+- **M2 — converter, CPU reference, and toolchain, three steps.** A new C++ converter (`tools/gguf_to_tilefuse.cpp`) passed CHECK on all 113 2D tensors of Llama-3.2-1B-Instruct.Q8_0, producing a 656.5MB `.tfb`, after fixing four bugs (GGUF shape is file-order but data is logical row-major — must not transpose; a manifest-offset patch bug that shifted every tile read by one; the constant-column scale fix; the zero-point bug, both restated from M1). A CPU reference GEMV (`tools/tf_gemv.cpp`) then passed CHECK on 30 tensors after fixing an accumulation bug (`out[c]=acc` was overwriting instead of accumulating) and a gate-indexing crash. A subtle gotcha cost real time: `struct.unpack('<e')` is IEEE fp16, not bfloat16 — it silently misled probes by ~100×. Finally the IRON toolchain itself came up clean (`~/iron` venv, python3.14, mlir-aie + llvm-aie wheels), validated on-NPU with a stock axpy (96/96) and stock GEMV (95/95).
+- **The qgemv kernel runs on real NPU silicon, 10/10.** `aie_kernels/aie2p/qgemv.cc` fuses int4 unpack, dequant, and dot product on a 4352-byte tile FIFO — exact match vs. CPU on both 1-tile and 4-tile configurations, after fixing a kernel arg-count mismatch (garbage via a null pointer) and a zero-point duplication bug where the generator used `np.repeat` instead of `np.tile`, producing a block layout `[64][64]` instead of the correct interleaved one.
+- **"THE Q4NX WALL IS BROKEN"** — a real-model validation loading `blk.0.attn_k.weight` from a real community Llama-3.2-1B `.tfb` passed 5/5, chunked into 8-tile passes to respect a 32-worker placement limit. This "5/5" later turned out to be a false positive — see M3.
+- **A vectorization attempt** (16-lane row-group dot products) passed both test suites but was *not* faster yet (7.25s vs. 4.05s — vector setup overhead dominates at this granularity; the paper's 64×8 block structure is needed to actually win).
+- **An alternate performance path: bf16.** `gguf_to_tilefuse --bf16` mode is near-lossless (err 0.0002); stock IRON GEMV on a real bf16 `.tfb` measured **175μs / 24GB/s** on a K=512,N=2048 tensor — about 8× faster than the int4 qgemv kernel's ~1340μs at this point in the day.
+- **M3 exposed two false-positive bugs.** First, `test_real_model.py`'s earlier "5/5 PASS" was fake: `XRTTensor.from_torch` copies its input, so the test was reading back the *input* tensor, not the kernel's actual output buffer — the physics-bound gate even passed for an all-zero output. Fixed by reading via `buf.to_torch()`. Second, a **launch-alternation quirk**: consecutive QGEMV launches alternate between stale and valid output (even calls garbage, odd calls correct, deterministically) — stock GEMV doesn't show this; suspected an mlir-aie runtime FIFO ping-pong bug. Workaround: call twice per launch, keep the second result. A third, separate bug (the same `np.tile`-vs-`np.repeat` issue from the kernel work) had also silently narrowed `test_real_model.py` and the M3 sweep to only 16 distinct input values, with a bound loose enough to swallow the wrong math. Genuine corrected numbers: real-model max err/bound **0.0718**; M3 re-run **2/2 PASS in 12:42**.
+- **M4, performance, multiple steps.** A bf16 host-dequant path hit **100μs/launch** at batch 1 (109μs at batch 4, 127μs at batch 8; err ~0.035 from bf16 rounding) vs. the int4 fused kernel's ~1100μs/launch, though batch 16 hit a placement wall ("no ShimNOCTile has sufficient DMA capacity"). A full-array mem-tile dataflow (per the paper's §4.4) then reached **197μs for 2048 outputs in one launch** at batch 32 (err ~0.05), and re-ran the M3 int4 sweep 3× faster (2/2 in 4:24) — but exposed a new cap: `QGEMV` silently truncates batches above 32. An honest per-token benchmark landed at **~0.9s/token** — 4714 launches × ~189μs, with the ~185μs launch floor dominating (the kernel itself is only ~2μs) — identifying layer-level batching as the next lever. That lever landed same-day: batching to **17 launches/token (16 blocks + embed) cut the time to ~390ms/token** (from 892ms), and revealed a new floor: the bf16 path moves 2.5GB of weights per token at ~10GB/s effective shim DMA, making it DMA-bound rather than launch-bound, while the int4 fused path moves 4× less data (656MB/token) but is compute-bound at ~1ms/tile for scalar dequant — flagging vectorized in-kernel dequant as the path toward ~100-150ms/token.
+- **An all-layers bf16 sweep passed 5/5** after four more bugs: a false positive from reading the test's own allocated output tensor instead of the real one; a bf16 construction bug (`.view(np.uint16)` interleaves the low/high halves of each pair instead of `.astype(bfloat16)`); a K-chunk reference using a column slice instead of a row slice; and a quadratic loader re-slicing a 533MB array inside a loop (hours → fixed to 0.3s). Full round-trip: 114/114 PASS.
+
+#### The Q4NX pivot: official FastFlowLM weights vs. community GGUF conversions
+
+1. **Verified with official weights.** `third_party/FLM_Q4NX_Converter` vendored; the pipeline works end-to-end with *official* pulled weights (`llama3.2:1b`, ~4.8 tok/s including spawn), but **community GGUF conversions produce degenerate output (loops)** — establishing the day's key limitation. Three bugs fixed along the way: a missing `FLM_CONFIG_PATH` on the per-request child process; a coherence probe wrongly rejecting char-shifted NPU output (fixed with an `all_char_band` exemption); and a Llama tag-mapping fix disambiguating on both H and L.
+2. **FastFlowLM confirmed open-sourced (MIT)**, having moved from the FastFlowLM org to the ROCm org the day before (v0.9.46). Vendored at `third_party/FastFlowLM`. Two candidate decode dispatch paths were found for the degeneration bug: `generate_dequant_q4_1_seq` vs. `generate_dequant_q80_packed_in_q4nx_seq`.
+3. **`tools/batch_convert_q4nx.sh` shipped** (`86269a99`, `d110bee1`), finding the converter's actual bug: an uncommented upstream debug line (`sys.argv` override to `'gemma4-2b-mmproj.gguf'`) clobbered every CLI invocation — the converter had been **totally unusable** before this fix.
+4. **The fusion engine rebuilt** (`engine/npu/build_npu.sh`, 19 variants) with a per-tensor-scale `packB` fix replacing broken per-32-group scales; batch scaling proved essentially free up to 16 rows (1.9ms@1 → 2.2ms@16 → 6.4ms@64).
+5. **Mystery solved: NPU2 is a different architecture, not a repack.** Official q4nx linears store raw I8 at `K=5120` (vs. vanilla GGUF's K=1024-2048); an earlier "±15 std5.6 vs. GGUF ±0.1" observation was actually I8 bytes being misdecoded as Q4_1 nibbles — no repack of a vanilla GGUF can produce official Q4NX's layout.
+6. **The pivot's verdict** (branch `feat/q4nx-pivot`): a runnable q4nx model must come from `flm pull`, not conversion. Also decided: **`flm serve` works fine with official weights** (~45 tok/s vs. ~4.8 tok/s per-request spawn) — the earlier belief that "serve mode degenerates" turns out to have been an artifact of broken *converted* weights, not a problem with serve mode itself.
+
+#### Serve-mode migration + a tokenizer band bug
+
+`SimpleTokenizer`'s decode fallback used stale character-shift bands that no longer matched the encoder's real bands (ids 132-226 should map to -100, 300-555 to -300) — ids 201-226 silently decoded to control characters, which is why short test strings looked fine while longer prose came out garbled. Verified end-to-end: **71.4 tok/s via `flm serve` vs. 4.8 tok/s per-spawn — about 15×**. A separate "16-char truncation" symptom turned out to be a red herring: a legacy endpoint defaulting `n_predict` to 16 instead of reading `max_tokens`. Both fixes landed as `87846a51`. In a case of parallel-agent convergence, another agent had independently built an equivalent serve backend (`86269a99`, `d110bee1`) — this session's changes were reconciled in its favor.
+
+#### 35B MoE: expert worker ops verified, then a 5.8× xclbin rebuild
+
+1. MoE expert worker ops 40/41 ran on the real 22GB Qwen3.6-35B-A3B model for the first time, after fixing three bugs: `find_tensor_info` returned data offsets as **int32**, overflowing negative for offsets ≥2^31 and silently corrupting per-layer dimension detection on any model over 2GB (cascading to a SIGSEGV in `std_attn_step`) — fixed to `uint64_t`; an NPU out-of-memory at ~1.2GB BOs (dense QKV/O alone is 1080MB on the 35B) — fixed by making shared-expert BOs NL=1 with a host-side packed int8 cache; and a worker-op protocol payload-ordering bug. At this point, NPU MoE still lost to CPU: full decode was 2,823ms/tok on CPU fallback vs. 8,999ms/tok with `NPU_MOE=1` (3.2× slower — old xclbins).
+2. **The MoE xclbins rebuilt as v27** (multi-row, 32-core; `build_moe_v27.sh`): op40 (expert GU) dropped from 39ms to **6.7ms**, op41 (D) from 20ms to **7.3ms** — a **5.8× speedup**. Full decode improved 9.0s → 7.2s → 5.8s/tok across the session (progression tied to `EXP_CACHE_SZ` 32→128 plus OpenMP tuning) — still losing to CPU's 2.8s/tok at batch 1. A `NPU_TIMING` breakdown explained why: an all-hit pack costs 2.0ms, but each cache **miss** costs ~25-30ms, and the 35B's routing churns through 100+ distinct experts per layer, giving an LRU miss rate of 50-80% at batch 1. The insight that mattered: **a fully warm path would be ~25ms/token across all 40 layers — 40 tok/s** — the number that gets realized on 2026-08-09/10 (see UPDATE 32).
+
+#### An ONNX INT8 QDQ converter/loader pipeline, built from a protobuf bug up
+
+1. `src/onnx_loader.cpp` had been **parsing the wrong protobuf field numbers entirely**, finding zero tensors in any real ONNX file (`GraphProto.initializer` is field 12, not 5; `TensorProto.name` is field 12, not 8; `raw_data` is field 14, not 9 — all verified empirically against real wire format). Rewritten, with `DequantizeLinear` node parsing added and a new **WMMA_I8** path: INT8 QDQ → dequant → Hadamard-rotate in block-128 → per-row requant.
+2. `bitnet_decode --config` reads an HF `config.json` sidecar and auto-loads `.onnx` paths; a new `std_arch` dispatch fixed a crash where any non-Qwen3/non-BitNet architecture (e.g. Phi) hit null sub-norm pointers.
+3. Full serving verified with zero extra code: `bitnet_decode --server` (OpenAI-compatible + SSE) served qwen3-0.6b INT8 correctly, **57 tok/s, 877ms for 50 tokens**, streaming confirmed working.
+4. In retrospect, this pipeline required finding and fixing **six independently fatal bugs**: the protobuf field numbers; a converter reading Q8_0 as unsigned int8 instead of signed (misreading any value >127, ~1.86× std error); the big one — the loader uploaded F32 norm weights but the rmsnorm kernel read them as FP16, so every value's low 16 bits were denormal-tiny and even-indexed outputs underflowed to zero; a Qwen3 `head_dim=128 ≠ hidden_size/num_heads` mismatch requiring the o-proj quantize step to use `nh*hd` width, not the naive hidden size; a `hipMemsetAsync` racing `decode_stream` without an explicit stream argument; and the `std_arch` dispatch crash from item 2.
+
+#### Llama-3.2-1B verification and a logit-flatness investigation
+
+Llama-3.2-1B INT8 verified correct (Berlin, blue) with **PPL 49 vs. 828 for gibberish — 17× discrimination**, confirming tied embeddings are correct for this model (not a conversion bug). A separate concern — that logits looked suspiciously flat — was **not proven to be quantization-caused**: the numpy fp16 reference used to test it had six of its own bugs (wrong RoPE convention, wrong prompt token ids, a missing QDQ dequant step, a single shared KV list instead of one per layer, a layer-0-only comparison instead of full-stack, and mismatched single-token vs. full-prompt inputs). The GPU-side verification held up throughout (position-0/layer-0 query within 0.7% of fp32, 4/4 correct answers, PPL 49 vs. 828). Separately, arch-aware chat templates were added, and a key finding closed the loop on repetition loops: the **base (non-instruct)** Llama-3.2-1B shows the identical "which is" repetition loop as the instruct model — proving loops are a known trait of the 1B model itself, not a quantization or template bug.
+
+#### INT8 weight error budget
+
+Measured against the GGUF Q8_0 source on llama-3.2-1b/qwen3-0.6b: plain per-row INT8 gives 0.98%/0.91% mean relative error; the Hadamard-rotation WMMA path improves that to **0.854%/0.847%**; adding QuIP-style sign flips on top made **no further difference at W8A8** (the existing rotation already captures the benefit — sign-flips only matter at W4A4). Conclusion: ~0.85% weight-side error rules out weight quantization as the cause of the small models' repetition/flatness behavior.
+
+#### The Qwen2.5 converter debugging ladder: 1.5B → 3B → 7B
+
+Four rungs, each hiding a different silent corruption bug:
+
+1. **Qwen2.5-1.5B**: both the official and an independent community GGUF turned out **corrupted** — input norms ~2000× off, linear weights 106% wrong vs. the HF safetensors source. Fixed by bypassing GGUF entirely with a new `tools/safetensors_to_onnx_int8.py` reading bf16 safetensors directly, plus adding attention-bias support (Qwen2.5 has q/k/v biases that llama.cpp GGUFs drop, and with the model's characteristically tiny norm weights, the bias term dominates attention scores if missing). Result: correct answers, **PPL 17.5**, 28/28 tests including a new GQA test. A *separate*, still-unresolved collapse remains on the INT8 GPU serving path specifically (PPL 1.19M, V-cache zeroed at pos≥1) — extensively debugged (hook-presence changes behavior, `HIP_LAUNCH_BLOCKING` doesn't help) but never isolated; parked.
+2. **Qwen2.5-3B**: converted cleanly but degenerated at runtime (PPL 52k, a "Located 当前位置" loop) — parked mid-day, then **solved same day**: the converter was silently falling back to a stale 1.5B config (`num_hidden_layers=28`) instead of the real 3B's **36**, dropping the last 8 layers with no error. Fixed by deriving layer count from the tensor-name index, never from config. Result: **PPL 31**, coherent ("Paris", "Eiffel Tower").
+3. **Qwen2.5-7B**: **PPL 13.6 — the best in the zoo.** Two bugs: an untied `lm_head` was never being emitted for models with `tie_word_embeddings=false`, so the 7B ran with a *tied* head (using the embedding table as the output head) and produced garbage — caught via a parameter-count check (7.07B in the ONNX vs. 7.62B expected, a 545M gap matching exactly the missing `lm_head`); and a `config.json` path-resolution bug for directory sources (`os.path.dirname(dir)` resolved to the *parent* directory, missing the local config and silently falling back to the same stale 1.5B config that bit the 3B rung above). Verified: rich, coherent text with correct chat-template turn-ending.
+
+#### Zaya GGUF/.1bp conversion: the 74B download, an 8B NaN, and a MoE converter fix
+
+1. A **74B Q4_K_M GGUF (45.76GB, 1923 tensors)** was downloaded, unblocking two parked issues.
+2. **Zaya1-8B NaN root-caused**: `cca_conv_grp.weight` was reading garbage, exploding the conv output into `inf*0` NaN through RoPE. The GGUF itself was confirmed clean — the bug was in the WIP `gguf_to_onebp` converter's 3D-tensor handling, ultimately traced to a **GGUF dtype-30 mixup**: `GgufReader` treated dtype 30 as a legacy "F32_V3" 4-byte float, but current llama.cpp defines dtype 30 as `GGML_TYPE_BF16`. Zaya's `cca_conv_grp.weight` is genuinely BF16 — reading it as f32 consumed twice the intended byte span, desyncing every subsequent tensor read.
+3. **The #1522 converter had two separate root causes**, found by running the real 45.76GB file through it: a shape heuristic voted row-major for Zaya's `[rows,cols,experts]` layout, inferring 4096 "experts" and producing 242GB of fp32 garbage — fixed by trusting the `<arch>.expert_count` metadata instead of guessing; and `token_embd.weight` (1.07B elements) tripped a `1<<30` element cap and was silently skipped while its bytes stayed reserved in the index, desyncing every later offset in the file — the cap was raised to `1<<31` and made a fatal error instead of a silent skip. Verified via round-trip dequant against the source GGUF: Pearson r=0.994-0.999, zero NaNs. Output: `ZAYA1-74B.1bp`, **43.6 GiB** (PR #1546).
+4. **An architecture fact worth recording**: ZAYA1's layers **alternate** — even layers are CCA-attention-only, odd layers are MoE-only, and **no dense FFN exists anywhere** in the model. A missing sublayer's weights should produce a null pointer and a skip, never a silent zero-fill. Relatedly, no working reference implementation of Zaya's router "EDA" temporal-state semantics exists anywhere (even the llama.cpp Zaya fork refuses to load the 8B GGUFs and degenerates on the 74B) — the engine loads the 8B `.1bp` end-to-end, but its output isn't conditioned on the prompt, and this remains unresolved for lack of anything to verify against. The 74B additionally needs ~145GB of fp16 GPU expert buffers against a 62GB Strix pool — current fp16-only expert kernels can't run it at all yet.
+
+#### The rest of 2026-08-08
+
+- **A third NPU driver wedge this session** (`DRM_IOCTL_AMDXDNA_CREATE_HWCTX err=-22`, after 20+ xclbin load/unload cycles) persisted without self-clearing, forcing a reboot — bridging directly into UPDATE 32's wedge saga.
+- **The self-hosted CI runner was removed.** `strix-halo-runner` uninstalled locally (2.4GB freed); NPU-only workflows deleted (`bench.yml`, `npu-reset.yml`, `npu-pool-probe.yml`, `end-to-end-smoke.yml`); hardware jobs removed from the remaining shared workflows. Rationale: NPU/GPU jobs need `/dev/kfd`/`/dev/accel`, which GitHub-hosted runners don't have — CI is now fully GitHub-hosted.
+- **The TUH EEG data-access workstream began** (background context for UPDATE 33's later eeg-medical archival decision): access approved via NEDC, a full rsync sync pipeline built (sftp proved rate-limited/reset after ~136GiB, so rsync-only, chunked ≤100GiB, cron-scheduled), targeting a ≈5TB/414k-file corpus at ~29MB/s (~17-day ETA).
+- A HIP backend bug where `sample_token` returned -1 (forward/lm_head emulation for the split ZAYA HIP boundary) was fixed.
+- **Background/context, not engine work**: AMD's acquisition of Taalas (announced Aug 6 — a hardwired-model-silicon compiler claiming ~16-17k tok/s/user for a single hardwired model) prompted a staged-plan validation of a "1-bit FPGA LLM box" concept — judged a plausible ~50-150 tok/s niche for a 1B 1-bit model on an Alveo U250, with zero ASIC mask-cost, though far short of Taalas's on-die-ROM throughput; a Strix Halo upgrade-path discussion (128GB unified RAM as the biggest lever for fitting 70B Q4 fully in memory, NVMe weight-streaming, small FPGA "Taalas toy" boards); and a Vitis/Unified SDI 2026.1 toolchain install.
+
+---
+
+
+### UPDATE 32 (2026-08-09): AMDXDNA WEDGE SAGA, 35B MOE GOES LIVE, VIVADO-FREE FPGA TOOLCHAIN
+
+**The NPU driver's wedge-and-hang problem is root-caused to a firmware fatal error with no recovery path, and fixed with a new hardware-reset primitive wired into the scheduler timeout — signed and running as amdxdna 0.16.0. The 35B MoE model goes end-to-end for the first time, warming up to 44-70 tok/s. A Vivado-free open-source FPGA bitstream toolchain is built and verified round-trip bit-exact.**
+
+#### The amdxdna driver wedge / kernel panic saga
+
+The longest single investigative thread of the whole window:
+
+1. **Firmware static RE dead-ends confirmed.** `npu.dev.sbin` is byte-identical (SHA256 match) to the stock `npu.sbin` — no relaxed-validation dev build exists. The suspicious 64KB blob (entropy ~7.0) isn't zlib, lzma, XOR, or any known cipher, and no ARM/Thumb/x86 code decodes from it. An earlier finding was corrected in the process: the supposed "code section"/"v5 gate targets" are actually a log-descriptor table, not gate-check code. A vulnerability map (`VULN_MAP.md`) confirmed all known driver CVEs are already fixed in 7.1.5 — the only live attack surface is the mailbox protocol (~23 opcodes).
+2. **13:04 — first kernel panic from `rmmod amdxdna`.** `BUG: unable to handle page fault … RIP amdxdna_pci_driver_exit` on kernel 7.1.5-070105. Root cause: a client-lifetime use-after-free race during device removal (`amdxdna_remove()` frees client structs while open FDs can still call `amdxdna_drm_close()`). An upstream fix exists (applied to `drm-misc-fixes` 2026-06-29) but was confirmed **absent** from the running module via objdump. New standing rule: never `rmmod amdxdna` — reboot to reload instead.
+3. **16:58 — kernel upgraded to 7.2.0-rc5, all-layers sweep 5/5 PASS, no wedge** across ~500+ hwctx cycles (vs. a previous ~20-cycle wedge trigger). Declared "fixed permanently" at 17:00, self-corrected at 17:01 (overclaim — one clean session doesn't prove "permanent" or "everything," and a separate, unrelated Qwen2.5-3B degeneration was still broken). The correction proved warranted: **the wedge recurred at 19:22** on the same kernel.
+4. **Root cause found: a firmware fatal error with no driver recovery path.** The wedge isn't a driver hang — it's the AIE firmware hitting a fatal error, DPU program counter stuck at `0xffffffff` (executing garbage). Once dead, every mailbox call fails, and the driver's existing recovery paths only retry *through* the dead mailbox. A real recovery mechanism (`aie2_xdna_reset`, an SMU power cycle) already existed in the driver but was only ever invoked at init time. **Fix**: a new `aie2_hw_reset()` — full suspend-all-contexts → hw_stop → hw_start → resume-all-contexts power cycle — wired into `aie2_sched_job_timedout`, built for 7.2.0-rc5.
+5. **19:43 — patched driver installed**, initially unsigned; the Secure Boot signing recipe was documented (MOK key already enrolled, `sign-file` + `zstd` + `depmod` + `modprobe`). Custom build registers as amdxdna **0.16.0** (newer than the stock 0.10.0).
+6. **The `rmmod` rule is obsolete for 0.16.0** (the UAF fix is binary-verified present) but **still applies** to any stock kernel (7.1.5, 7.2.0-rc5, mainline 7.2-rc6 unpatched).
+7. **A separate "reboot hangs" mystery resolved to the same root cause**: 7 kernel panics since Aug 6, all `rmmod`-triggered — because reboots had been preceded by a manual `rmmod amdxdna` to swap in instrumented driver builds. New rule: never `rmmod` as part of a reboot; the kernel tears down hardware fine without the module's exit path.
+8. **Final validation**: post-cold-reboot, the patched signed 0.16.0 driver ran `test_all_layers.py` **5/5 PASS in 631.98s with zero wedge/fatal messages** — the self-heal path never even had to trigger on this workload.
+
+*(Three sessions later, in UPDATE 33, this same 0.16.0 driver turns out to have introduced a separate correctness regression specific to the 35B MoE model — a different bug on the same subsystem, not a contradiction of the fix above.)*
+
+#### 35B MoE: full pipeline + batched prefill/decode performance
+
+1. **02:39 — NPU worker path unblocked.** Fixed a `.1bp` manifest-lookup segfault (a misread header field produced a garbage 12.9GB "JSON length"); rewrote `tools/tq2_to_q4nx.cpp` (Q4NX-quantized 1BP → `.q4nx`, closing #1467), round-trip exact (diff 0.0). Batch scaling reached **12.6k rows/s at batch 64**.
+2. **03:08 — NPU MoE decode 2.8× faster: 4.9s/tok → 1.73s/tok.** Three changes in `npu_engine_universal.cpp`: a fused transposed-dequant writing directly into `[K,N]` layout (eliminating a separate f32 intermediate + transpose pass, cutting per-miss cost 28ms → 14.6ms); `EXP_CACHE_SZ` 128 → 256 (4.42 → 3.35s/tok); and hot-expert pre-warming (`NPU_ROUTE_STATS`/`NPU_WARM_EXPERTS`/`NPU_WARM_TOP` — 1089 experts pre-packed in 12.6s). Result: zero decode-phase cache misses, `moe_ffn` averaging 26.6ms/layer.
+3. **Correction: decode is launch-bound, not attention-bound.** Stage timers showed FFN dominating (31.5ms of ~47ms/layer) via 4 serial NPU launches, each paying ~5-9ms dispatch latency regardless of the tiny actual compute (~3μs for 16.7M MACs). Two attempted fixes were tried and reverted: async launch-overlap (kernels share AIE columns and just serialize, adding jitter) and a CPU shared-expert fallback (slower, plus box contention). The real lever — batching decode launches across tokens, or fusing per-layer xclbins (realized as v28 fusion in UPDATE 33) — was identified but parked here.
+4. **Batched MoE prefill: rejected, then fixed with per-token ascale.** First attempt (`NPU_MOE_BATCH=1`) was 13-24% faster wall-clock but numerically divergent beyond M=1 — one shared `dynamic_ascale` over all M×H tokens collapsed per-token dynamic ranges, and the error compounded over 40 layers until it flipped argmax choices. An old code comment rejecting batching ("2.25× more MACs, sequential is faster") turned out to be right about the *outcome* but wrong about the *reason* — batching genuinely is faster. Fix: a new `go_rows` primitive in the i8 GEMM (`quantize_async_rows`/`dequant_only_rows`) computing per-token scales from each token's full expert set. Result: bit-identical through layer 19 at M=9, only FP accumulation-order noise beyond that (~1.2% relative — same order as existing int8 quant noise), while retaining **13-17% speedup at M=9, 24% at M=32**.
+5. **The full pipeline fixed — 4 stacked Q4NX bugs**, root-causing the earlier "qwen3:4b tag + L=0 + degenerate" symptom: the layer scan looked for `"model.layers."` (plural) but the 35B's header uses `"model.layer."` (singular); the architecture was derived from the file's basename (always wrong for FLM's `<ModelName>/model.q4nx` layout) — fixed to read the parent directory name instead; no tag mapping existed for arch "qwen3.6" — added in *both* `src/backend_npu_flm.cpp` and `tests/backends/backend_npu.cpp` (the mismatch between the two cost several rebuild cycles before it was caught); and a 64KB header-size cap rejected the 35B outright (its real header is 85,552 bytes) — raised to 256KB.
+6. **Coherence-probe positional bug fixed**: `coherence_probe()` fed every prompt token at `pos=0`, so the NPU-FLM backend — which fires its query the moment `pos` resets to 0, i.e. on what it reads as "prompt complete" — queried FLM with only a 2-token prompt, false-rejecting qwen3:4b's legitimate `<think>` start token. One-line fix: feed prefill at real positions. Regression-verified across llama3.2:1b, qwen3:4b (previously rejected), and qwen3.6-moe:35b-a3b.
+7. **22:29 — culminating result: 35B MoE at 44-70 tok/s through the full pipeline.** Zaya (:8088) → NPU FLM → qwen3.6-moe:35b-a3b: **69.9 tok/s warmed** (64 tok/0.9s), **44.1 tok/s** on a second request (48 tok/1.1s), cold-spawn **9.5 tok/s** (6 tok/631ms) — consistent with the A3B active-parameter count matching dense qwen3:4b's 67.5 tok/s.
+8. **Later the same day — a new, wider problem surfaced.** After ~1h of model churn, zaya-spawned `flm` worker processes started dying (`defunct`) and returning single-byte garbage (`0xAE`), tripping probe failures and a systemd restart loop. Filed as #1568 (alongside #1569 GGUF misroute, #1570 Qwen2.5-3B parked, #1571 Supabase exposed on `0.0.0.0`, #1572 SSH brute-force + password auth). `zaya-npu.service` was temporarily reverted to serve only Llama-3.2-1B. *(Root-caused the next day — see UPDATE 33's driver-regression section — as the 0.16.0 driver, not this session's application-level fixes.)*
+
+#### Vivado-free FPGA bitstream toolchain
+
+A self-contained track: nextpnr-xilinx + prjxray + openFPGALoader built from scratch on the Strix box (18:28–19:00), producing a `blinky.bit` (2.19MB) with IDCODE `0x0362d093` verified against real hardware. Rebuilt persistently at `/home/bcloud/fpga-toolchain/` after a cold reboot wiped `/tmp` (the recipe needed a split cmake version — 3.28.4 for prjxray, 3.31.6 for nextpnr — plus several GCC13+/GCC15 `<cstdint>` fixes). Correctness was proven, not just well-formedness: all 4974 fasm2frames-emitted frames (497,374 words) came back byte-identical to the bitstream via `bitread` — **546,208 words compared, zero differences.**
+
+#### Scope decisions: JARVIS stays, ZUNA moves out
+
+JARVIS stays in the `1bit-systems` repo (it's an application of the engine, not a separate product — unlike ZUNA, extracted to its own `~/zuna` repo, itself flagged as an open scope-boundary question that gets resolved by archiving eeg-medical entirely in UPDATE 33).
+
+---
+
+
+### UPDATE 33 (2026-08-10): NPU FIRMWARE RE VIA RAW IOCTLS, DRIVER REGRESSION FIXED, JARVIS SHIPS
+
+**Raw ioctls now drive the NPU directly and produce bit-exact GEMM output — the first compute outside FLM's own stack. A driver regression that made the 35B MoE model spit garbage was root-caused to amdxdna 0.16.0 and fixed by reverting to the in-tree 0.7.0 build. JARVIS shipped NPU-FLM speech-to-text, SSE streaming, and a loopback-trusted web UI (PR #1576), plus a deadlock fix that had been hanging every chat request. eeg-medical was archived — its foundation-model retraining was redundant with ZUNA1.1, which already trains on the same TUH-EEG corpus.**
+
+#### Raw-ioctl NPU firmware RE: verified GEMM outside FLM (00:38–02:45)
+
+A full day's arc from static dead-end to working silicon access, independent of FLM's binary:
+
+1. **Firmware image fully mapped, proven not encrypted.** A block-entropy scan of the entire 429,680-byte firmware image found no 4KB window exceeding entropy 7.8 — the whole thing is a **signed pure-data container**, not a compressed or encrypted payload (~460KB is zero-fill). Static analysis exhausted; pivoted to live instrumentation.
+2. **Live mailbox protocol captured with zero risk.** `echo "module amdxdna +p" > .../dynamic_debug/control` turned on 36 stock trace sites — no rebuild, no interruption of live inference — and decoded the full startup sequence and message header format.
+3. **The `EXEC_DPU` silent-failure trap.** The command header's COUNT field (not BO size) determines payload length; `COUNT=0` triggers a silent `-EINVAL` with no dmesg line at all — only visible via ftrace.
+4. **Real DPU instructions executed via raw ioctls**, correctly reporting an expected error for unmapped weights — proving the full loop (cmd BO → `CHAIN_EXEC_NPU`/0x18 → real firmware execution → status) works end to end.
+5. **v28 MoE launch fusion** (`NPU_MOE_FUSED=1`): new `MOE_GUSGU`/`MOE_DSD` xclbins merge 4 FFN launches/layer into 2 via N/K concat of routed+shared experts. Correctness fix caught in testing: the DSD weight BO must be **block-diagonal**, not a naive concat, or the gate blend stops being separable. `test_moe_fused_math.cpp` passes at 1.64% max deviation (<5% tolerance).
+6. **A "verified GEMM" claim, self-corrected within the hour.** The first PASS was a verify-code bug — `bf16((uint16_t)exp)` reinterpreted truncated integers as bf16 bits, so an all-zero output "matched" by coincidence while the real device status was `ERROR(5)`. Real root cause: `CONFIG_CU` needs `cu_bo` to contain an actual **Program Device Image (PDI)**, not a raw instruction blob; also, xclbin kernels output **int32**, not int16.
+7. **PDI extraction perfected via bpftrace/uprobes.** kprobes on the driver's response handler decoded the exact rejection code (`APP_LOAD_PDI_FAIL`, `0x3000003`); uprobes on XRT shim's `get_pdi` revealed the true PDI offset inside the xclbin's `AIE_PARTITION` section — first guess `0xd8` was still wrong.
+8. **MILESTONE (02:39): verified GEMM via raw ioctls, full pipeline.** Corrected PDI offset to `0xD0`. Real bit-exact GEMMs: 128×3072×1024 (0/131072 wrong, ~10ms) and 128×12288×2560 (0/327680 wrong, 20.5ms, 393 GOP/s). Full 8-step recipe documented: PDI = xclbin `AIE_PARTITION[0xD0:]`; A/B/C buffers must be SHMEM, not BO_DEV; instructions are BO_DEV; specific kernel-arg blob layout; `cfg=0x804`; 16-tile hwctx.
+9. **All four qwen3-0.6b NPU ops verified bit-exact via raw ioctls**: QKV 128×1024×4096, O 128×2048×1024, GU 128×1024×6144, D 128×3072×1024 — zero mismatches on any of them.
+10. **The exec path wedged again** after ~40 IOMMU faults from loading new PDIs (the running production server, whose contexts predate the wedge, was unaffected) — recovery is reboot-only, same NPU driver story as always.
+
+Bonus same-session fix: **zaya NPU tokenizer** — real BPE `model.htok` generation (new `tools/hf_tokenizer_to_htok.py`) plus a weak-symbol linker bug where `tests/zaya_server.cpp`'s local `SimpleTokenizer` was silently shadowed by the shared implementation, producing garbage decode. Throughput: **3.3 → 42 tok/s**.
+
+#### amdxdna driver regression: 0.16.0 broke the 35B, reverting to 0.7.0 fixed it
+
+Separate from the wedge-recovery saga in UPDATE 32, this is a correctness regression on a *specific newer driver version*:
+
+1. **04:57 — #1568 reproduced live**: a fresh 35B session goes straight to garbage soup — not the usual deterministic `/` fallback — proving the corruption is **cumulative NPU/firmware state**, not per-process. An existing `llama3.2:1b` context is unaffected; only *new*-context creation wedges at the firmware level. Degradation model formalized: coherent → token soup → empty output → deterministic `/` (end state), recovery = reboot only.
+2. **A separate, unrelated bug fixed along the way**: `mlir_aie`'s `NPU_CONTEXT_CACHE_SIZE["npu2"]` was hardcoded to 32, overcommitting this Strix Halo's real firmware hwctx pool of **exactly 16** (measured with a purpose-built `ctxpool` harness — the first guess of "≈6-7" was wrong; only direct measurement gave the right number). This caused `AIE2_STATUS_MGMT_ERT_NOAVAIL` under parallel pytest (`-n auto`). Fixed via `XRT_CONTEXT_CACHE_SIZE=1`: **5/5 PASS in 79s vs 225s serial (2.8×)**. Patched first in site-packages, then made reinstall-proof via `iron-repo/conftest.py`. Upstream PR filed: `mlir-aie#3526`.
+3. **13:00 — kernel moved to HWE 7.0.0-29-generic.** Initial (wrong) theory: NPU only supports ~3 concurrent contexts, blamed for 35B startup failures.
+4. **13:13 — correction**: 4 small NPU contexts work concurrently just fine. The real finding — **the 35B produces garbage even standalone with a free context**, a genuine regression against the last known-good 2026-07-31 benchmark, which ran on amdxdna 0.7.
+5. **13:53 — FIXED.** Reverting to the kernel's in-tree amdxdna **0.7.0** driver (`/usr/lib/modules/7.0.0-29-generic/.../amdxdna.ko.zst`) — the exact version from the last known-good bench — correctly runs the 35B end-to-end (zaya → flm → NPU, "4" for "2+2"). A second bug fixed in the same pass: `zaya-qwen36.service` had a `Requires=zaya-gpu8b.service` chain that pulled up the entire small-model fleet on start, starving the 35B of NPU columns and crash-looping it — fixed by dropping the `Requires`/`After`/wait-port. **Confirmed: the 35B and the 3-small-model fleet are mutually exclusive** (a column/resource budget constraint, not a context-count cap).
+6. **14:47 — two landmines left by the driver swap, both fixed post-reboot**: a stale `modules.dep` still pointing at the moved-aside DKMS `.ko` (fixed with `depmod -a`), and a stale `/etc/modprobe.d/amdxdna.conf` still setting `force_iova=1` (a 0.16/7.1.5-only parameter that the 0.7.0 in-tree driver rejects with a misleading "Unknown symbol" error). Also fixed: `zaya-gpu8b.service` stuck in a permanent start-pre kill loop. All chains verified post-fix: 14.1/21.5/13.9 tok/s across llama3.2/qwen06/gpu8b.
+7. **Capstone assessment**: the NPU firmware is genuinely locked (RSA-2048 signed, no dev build, unsigned builds refuse to load — no third-party firmware is possible), but the platform is **not crippled** — the DRM driver is open GPL, the mailbox protocol is now fully decoded, raw-ioctl exec is proven bit-exact, and the 16-context hwctx pool is a real RTOS/SRAM constant, not an artificial throttle.
+
+#### JARVIS: deadlock fix, NPU-FLM STT, SSE, session KV reuse (PR #1576, `7d4b7549`)
+
+Three commits landed on `main` together:
+
+- **`34a55cb7`** — `build_context` double-lock deadlock fix (non-recursive mutex swap). This bug **hung every `/v1/chat/completions` request**.
+- **`1c5dfb9d`** (= `8ed882a9`) — `flm_tag_for_model` widened the 1.7B tag bucket to `H<=2048`.
+- **`f0d745f2`** (= `550d0299`) — speech-to-text via FLM's whisper HTTP endpoint (`:8496`, override `JARVIS_STT_URL`), **replacing the whisper.cpp+ffmpeg fork/exec path**; a loopback-trusted web UI auth bypass; `stream:true` requests answered as a single SSE chunk; and a long-prompt model-selection fix (was targeting a nonexistent `qwen3.5:9b`, now correctly `qwen3:4b`). `ctest -L host`: 10/11 pass.
+
+Two more fixes landed the same day:
+
+- **`zaya-npu.service` crash-loop fixed**: the lazily-spawned `flm serve` child was dying with "could not raise memlock limit to 1465 MB" then `mmap() EAGAIN` — systemd's default `LimitMEMLOCK=8MB` masked the bug in manual shell testing (interactive shells get unlimited). Fix: `LimitMEMLOCK=infinity` in `scripts/zaya-npu.service`. Result: coherent responses at ~3.3 tok/s, `x-backend: NPU FLM`.
+- **FLM multi-turn KV reuse**, two build steps ~10 minutes apart: first, `src/npu_flm_delta.h` — pure prefix-delta decision logic (send only the delta if the new prompt extends the previous one, with self-healing fallback to a full reset) — because the text-REPL path was sending `<<RESET>>` before *every* query, forcing a full re-prefill each turn despite FLM's own REPL keeping KV resident. Second, a request-level session layer on top: `session_id` in the request body, `Backend::continue_text(delta)` virtual, `g_flm_session_id`/`g_flm_session_last` tracked under a dedicated mutex.
+- **New documented constraint**: STT and the 35B contend for the same NPU context and cannot coexist — `flm-whisper` holding a context makes the 35B fail its coherence probe and fall through every backend. Confirmed fixed once `flm-whisper` is stopped (`zaya-qwen36` then passes 6/6 coherent probes at 3.2–3.8s). Design-state fleet: `npu :8088`, `qwen06 :8089`, `gpu8b :8090`, `whisper :8496` active, `qwen36` stopped on contention.
+- The most recent commit in this whole window, `e8bd91ed fix(npu): retry FLM spawn/probe on NPU contention; stop leaking flm-real children`, directly addresses this contention.
+
+#### JARVIS mobile: a Flutter app for the voice pipeline (spans 2026-08-08 → 2026-08-10)
+
+Design doc (`docs/superpowers/specs/2026-08-08-jarvis-mobile-design.md`, approved 08-08) establishes the architecture: **the phone is a thin terminal** — mic, speaker, VPN client only. The full pipeline (VAD → Whisper → router → LLM → codec TTS → cloned voice) runs entirely on the Strix Halo box; no on-device inference, no audio persistence. Transport is WebSocket + Opus (not WebRTC — ~200ms latency judged acceptable). iOS is a confirmed target (cloud Mac mini via rentamac.io, Xcode 26.6, Flutter 3.44.9, existing Apple Developer account).
+
+Three milestones landed:
+
+- **M1 — server-side gap-fill**: `/v1/voice/session` full-duplex WebSocket path with an auth hook, a `VoiceSession` VAD state machine, an RFC-compliant WS handshake/parser (fixed for standards-conformant clients), and `WS_STREAM_BIND` (default loopback; `0.0.0.0` lets the phone reach the port over LAN/VPN, paired with `JARVIS_WS_TOKEN`). Docs: `docs/mobile/RUNBOOK.md`, `scripts/jarvis-gateway.service`.
+- **M2 — the Flutter app itself**: Android+iOS scaffold, protocol layer, session controller; a gateway WS client and audio IO services with tests; connect/voice screens with state lights and transcript UI; a live-gateway integration test with a stub server for simulator E2E.
+- **M3 — resilience and packaging**: connection-loss UX (stop mic, offline state, Reconnect button), reconnect mic-failure handling, a double-tap reconnect guard, and a final review pass fixing manifest permissions, a save-race, pulse lifecycle, and player disposal.
+
+CI enablement: `4b67b4ab` allowed `mobile/` through the scope-guard workflow (previously blocked, since JARVIS mobile is Jarvis's offline layer within engine scope, not a separate product).
+
+#### Ops/infra: the reboot "watchdog" nuance, netconsole, firewall, fail2ban
+
+The CHANGELOG's "reboot.sh watchdog EBUSY fix" entry is correct about the code change (`273a50c5` — `scripts/reboot.sh` no longer aborts under `set -e` when `exec 9<>"$WD"` returns EBUSY because systemd already holds `/dev/watchdog` via `RuntimeWatchdogSec=60`) but doesn't explain what was actually causing the box to hang:
+
+- Across the last several boots, the reset-reason register shows the watchdog fired **only once** — the deliberate `reboot.sh --force` test. Every other "hang" was a **slow-but-clean software reset** (~1–1.5 min unexplained stall in the post-journal shutdown phase). Suspects, unconfirmed: amdgpu display (`REG_WAIT timeout optc35_disable_crtc` logged at every boot) or the USB4/Thunderbolt controllers.
+- A **separate, genuinely broken bug** was found and fixed: the watchdog safety net had been non-functional since it was created — the kernel package's own modprobe blacklist was silently deny-listing `sp5100_tco` at boot, so `/dev/watchdog` only existed after someone manually ran `modprobe sp5100_tco`. Fixed by shadowing the blacklist entry in `/etc/modprobe.d/`.
+- A **netconsole capture rig** was installed (UDP listener on a second box, `netconsole-capture.service`; sender configfs target on strix; `loglevel=8` added past the `quiet` filter) to catch the stall's last kernel messages the next time it happens.
+- **ufw/Docker firewall bypass fixed**: ufw doesn't filter Docker-published ports — they traverse the `FORWARD`/`DOCKER` chains, bypassing `INPUT` deny. Verified empirically (Supabase Postgres `:54322` reachable from LAN despite ufw). Fixed with a `DOCKER-USER` iptables rule made persistent via a oneshot systemd unit (Docker recreates its chain fresh on daemon start). Resolves #1571. Also found and closed: 2 accepted SSH password logins from a LAN IP ~30s after a brute-force burst — password auth disabled, fail2ban (sshd jail) and `ufw limit 22/tcp` added, closing #1572.
+
+#### eeg-medical archived — redundant with ZUNA1.1
+
+`tools/zuna_port.cpp` (the ZUNA1.1 C++ port, hyperparameters verified against the paper: dim=1024, 16 layers, 8 heads, 382.1M weights) already existed in this engine before this session started — an earlier session had missed that and begun redundant work. Investigating further: **ZUNA1.1 is confirmed trained on the TUH EEG corpus** (per its paper, arXiv 2607.27308, and its predecessor ZUNA1, arXiv 2602.18478) — meaning the project's own TUH→B2 sync (5TB, running since UPDATE 31) would produce duplicate data toward a duplicate objective. Decision executed, fully reversible: `github.com/1bit-systems/eeg-medical` archived — its shipped work (retraining EEG foundation models on data ZUNA1.1 already trained on) was redundant, and its README's core claim ("ZUNA1.1 trained on research data, not clinical") is factually wrong — TUH is clinical data. `tools/zuna_port.cpp` stays in 1bit-systems as the canonical copy; the TUH→B2 sync was killed ~2 days into a ~17-day run. The `eeg-medical.1bit.systems` DNS record was deleted, though the underlying Cloudflare Pages project itself couldn't be (the API token lacked `Pages:Edit` scope) — that token should be rotated.
+
+#### Housekeeping: issue triage, repo audit, PR #1573 consolidation
+
+- **29 open issues triaged**: 9 resolved with commit citations, 2 stale, 13 roadmap, 2 actionable security items (#1571, #1572 — both closed same day, above), 3 left unresolved (#1570 Qwen2.5-3B collapse, #1568 35B MoE — root-caused later the same day, above, #1536 amdxdna panic).
+- **Repo audit** found: ~1.6MB of stale/byte-duplicate xclbin backups, ~130MB of tracked build artifacts under `engine/npu/xclbins`, `third_party/lemonade` vendored as 784 plain tracked files (784 files, 13.6MB) unlike the other proper-submodule `third_party/` dirs, and `third_party/FastFlowLM/UPSTREAM.md` sitting untracked *inside* the submodule (would vanish on re-clone). No secrets found.
+- **PR #1573** (`feat/rebuild-all`, ~62 commits — the entire 35B MoE + Q4NX + JARVIS workstream from UPDATE 31/32) merged after two CI fixes (`4b67b4ab` scope-guard, `b46fc033` build the new host tests in the required C++ check). Follow-ons acted on the audit findings directly: `7c4a525b` moved `UPSTREAM.md` out of the submodule, `cab9a678` dropped 24 stale xclbin files. A draft release `v2026.08.10` was created (no git tag — draft releases don't create tag refs). Outcome: 11 issues closed, 18 remain open.
+- **`gh-ops.yml`** (`d11e969b`): new weekly+manual workflow reporting code scanning, dependabot, secret scanning, failed runs, and billing via the `gh` CLI, opening a single security-triage issue when alerts exist. Companion fixes for paginated alert fetches, `GH_TOKEN`, and `GH_REPO` env wiring.
+
+---
+
+
+## PART 3 — THE BURN & THE MOJO SHIFT (2026-08-12)
+
+
+
+**The repo was set on fire — deliberately. ~19,000 lines deleted in one commit to keep one through-line: engine → JARVIS. And the glue language that used to be three (Python, C++, JS) became one: Mojo 1.0. The update below was written in real time as the smoke cleared.**
+
+
+### UPDATE 34 (2026-08-12): THE BURN & THE MOJO SHIFT — ONE THROUGH-LINE, ONE UNIFIED LANGUAGE
+
+**We burned the repo down to its through-line and picked the language that will carry it forward. Everything that wasn't the engine or the app that proves it is gone — SaaS, agent stack, voice cloning, the JARVIS v1 side-servers. And the glue language that used to be three (Python for tooling, C++ for the engine, JS for the web) is now one: Mojo 1.0, released this week, is the unified language we're building the control plane in.**
+
+#### The burn: what got cut, and why it's not coming back
+
+The roadmap was rewritten around a single sentence — *engine (NPU + GPU + CPU, one binary) → JARVIS (voice assistant, reference app)* — and then the repo was made to match it. One commit, ~19k lines deleted (`cbce9630`):
+
+- **SaaS**: `tools/jarvis/auth.cpp`, `billing.cpp`, `usage.cpp`, `beacon.cpp` — the product layer for a product that doesn't exist yet. Gone. So is the Cloudflare auth worker (`workers/`) and the Zaya Co-Host dashboard (`site/dashboard/`) that talked to those APIs.
+- **Voice cloning**: the whole `zaya_audio/` training stack (codec training, voice packs, RVQ-VAE adapters, ONNX export) — a personal quest, not a product. `src/codec_decoder.cpp` went with it.
+- **Agent stack**: RAG, planner, personas, prompts, skills, the daily-routine/awareness scripts — AMD Gaia's turf, not ours. The engine serves it via Lemonade; it doesn't ship one.
+- **JARVIS v1's HTTP hop + WebSocket side-server**: `jarvis_server.cpp`, `audio_stream.cpp`, and upstream's new `voice_session.cpp`/`ws_proto.cpp` — replaced by the in-process pipeline: `mic → VAD → STT (libwhisper, now HIP-accelerated via `src/whisper_hip.hip`) → LLM (in-process BackendManager) → TTS → speaker`. One process, one pipeline, no WebSocket.
+- **Kept on purpose**: `agent_watchdog.cpp` (engine thermal/strategy, live in unified_server) and the whisper HIP port that the JARVIS blocker (P1) needed.
+
+CI, packaging, and scope-guard were updated in the same pass — `test_auth`/`test_billing` and the WS tests dropped, `jarvis_server` symlinks gone, the ALLOWED path list now reflects the real repo. The Python server for the AMD-gui Adrenalin replica was also burned, but that's the next section.
+
+#### The Mojo shift: why we stopped writing glue in three languages
+
+This week Mojo hit 1.0. We'd been watching it since the 0.x betas — a language that is to Python what C++23 is to C, with first-class GPU/NPU kernels and the ability to call C libraries directly — and the 1.0 release is the moment we committed: **from here on, new non-kernel code is written in Mojo, not Python.**
+
+- **The AMD-gui Adrenalin replica backend** (a stdlib-Python sysfs/HTTP server for the Radeon Software control surface on Linux) is being rewritten in Mojo 1.0 as a single self-contained binary — same wire contract, zero Python at runtime. Hand-rolled libc HTTP over `external_call` (the stdlib's own mechanism), hand-rolled JSON (the payloads are fixed-shape), zero community packages (the ecosystem's pins are pre-1.0; `mojo==1.0.0` is the only pin we need). It replaces a Python interpreter dependency with one ELF, the same move we made for the NPU stack with C++.
+- **The pattern is the point**: every layer of this project now follows the same rule — one binary, no interpreter at runtime, sysfs/PCI/proc access from the metal. C++23 stays for the compute kernels where it's earned its place; Mojo becomes the unified language for everything around them: servers, converters, tooling, control planes.
+- **Why it's safe this time**: Mojo 1.0's stdlib was verified against the `v1.0.0` tag before we pinned it (no `std.net` yet — hence the libc sockets; no regex — hence the fixed-pattern parsers; `Process` API has no SIGTERM — hence the lazy-reap design). The version pin is the discipline: `mojo==1.0.0`, no `max==25.2`-style beta pins anywhere.
+
+#### Status
+
+- **Repo**: one through-line (engine → JARVIS), one binary (`build/1bit`), one language direction (C++23 for kernels, Mojo 1.0 for everything else). Rebased onto 333 commits of upstream (`3f507b07`) with the burn on top — builds clean.
+- **JARVIS P1** (whisper on the engine): `whisper_hip.hip` wired into the forward pass; scalar fallback retained; `WHISPER_GPU=0` escape hatch.
+- **Next**: land the Mojo rewrite of the Adrenalin control plane (M0–M2: toolchain, JSON+sysfs, HTTP+GETs), then WS-09 (the single router) and the WS-11 NVMe expert streaming work from the roadmap.
+
+---
+
+
+## PART 4 — 1BIT MONSTER: THE VALIDATION GATES & THE REBRAND (2026-08-13 → 2026-08-15)
+
+
+
+**The project got a name that matched the work — 1bit MONSTER — and the engine started proving itself against torch and numpy references, 20/20 tokens at a time. Validation gates, not vibes: every new architecture must match a reference implementation bit-for-bit before it's counted. Coverage is now ~94.3% gated and climbing. And the audit trail infrastructure — the 1.5 TB archive on the Raspberry Pi — went live the same week, so every claim ever made has a home.**
+
+### UPDATE 35 (2026-08-15): THE MONSTER ERA — VALIDATION GATES, THE REBRAND, AND THE 1.5 TB AUDIT TRAIL
+
+**The rebrand.** `1bit.systems` became **1bit MONSTER**: new landing page, `1bit.monster` site with GitHub Pages deploy (no more whole-repo Jekyll build), Claude-Design-driven site redesign, and the old Gaia + onebit CLI removed. Same repo, same through-line — a name that says what the engine does.
+
+**The validation gates (all landed 2026-08-14).** Four architecture classes went from "runs" to "proven", each against a reference implementation:
+
+| Class | Reference | Result | The pain behind it |
+|-------|-----------|--------|-------------------|
+| **gpt-oss** (GPT-OSS-20B, 407-checkpoint class) | numpy port of `modeling_gpt_oss.py` | 20/20 tokens identical, logits max-abs-diff 6.7e-5, top-8 EXACT | MXFP4 MoE kept packed as U8 blocks+scales in RAM; only the 4 selected experts per token are dequantized (~17 GB vs ~105 GB fp32) |
+| **step1** (StepLaw/Step-Audio, 2,882-checkpoint class) | torch `modeling_step1.py` (sqrt-ALiBi, no RoPE) | 20/20 tokens == torch, logits max-abs-diff 5.6e-5, top-8 EXACT | sqrt-ALiBi per-head slopes; the custom Optimus kernel path had to be matched at short lengths |
+| **deepseek-mla** (DeepSeek-V2-Lite) | numpy + `modeling_deepseek.py` + llama.cpp `deepseek2.cpp` | numpy-exact tier | `src/deepseek.cpp` was **dead unwired code written for a different GGUF variant** — rewritten for the real V2-Lite GGUF; 10 real bugs found & fixed in the bisect, including missing latent RMSNorms and an expert block-offset bug where every block overwrote the first 32 slots |
+| **bloom** (bigscience/bloom-560m, 1,086-checkpoint class) | torch transformers 5.14 (f32) | 20/20 tokens identical, logits max-abs-diff 7.6e-4, corr 1.0 | the fused QKV had to be **head-interleaved** `[h(q,k,v)]` — the naive `[q|k|v]` row split produces scrambled attention (4.6× hidden-state error at layer 0, caught by per-layer mean comparison) |
+
+Reference logits are preserved as evidence files in the working archive: `bloom_ref_logits.txt`, `step1_ref_logits.txt`, `glm4_ref_logits.txt`, `openelm_ref_logits.txt`. The coverage header now reads **~94.3% gated**.
+
+**The audit trail goes live (2026-08-05 → nightly).** The Raspberry Pi backup server (`192.168.50.216`) became the project's memory: a 5-drive RAID-Z1 ZFS pool (~2 TB used) fed by nightly rsync from every machine that touches the project, plus the original 2026-08-05 snapshot as tarballs on the SD card. 1.5 TB of evidence, append-only by design — the backup server never auto-deletes. Full manifest: **[docs/audit-trail.md](audit-trail.md)**.
+
+**Status.** 19 architectures, 47 models, 5 backends (NPU / ROCm / Vulkan / Apple MLX / CPU), one binary, zero Python at runtime — MIT licensed. The story keeps going; the audit trail keeps growing with it.
+
+
+## APPENDIX — THE AUDIT TRAIL: 1.5 TB OF EVIDENCE
+
+
+
+Every claim in this journey is backed by preserved artifacts:
+
+| What | Where | Size |
+|------|-------|------|
+| Original snapshot tarballs (2026-08-05) — full project tree, home src, git repos | Raspberry Pi SD card: `/mnt/strixhalo-backup/*.tar` | ~272 GB |
+| Live nightly archive — full working copies of every machine that touches the project | Raspberry Pi ZFS pool: `/ZFSPool/backups/{strixhalo,minisforum,ryzen}/` | ~2 TB used (1.5 TB project data) |
+| Model weights & checkpoints (326 GB), spec-decode experiments (24 GB), reference logits | in the archived working tree: `1bit-systems/models/`, `spec-decode/`, `*_ref_logits.txt` | ~350 GB |
+| Session transcripts & agent logs | archived home: `.claude/`, `.codewhale/`, `.reasonix/` | continuous |
+| 22 FLM `.so` files, 209 xclbin bitstreams, firmware dumps | `fastflowlm_analysis/`, `npu-infer/`, docs/research captures | archived |
+
+**→ [Full manifest, access instructions, and repo-structure mapping: `docs/audit-trail.md`](audit-trail.md)**


### PR DESCRIPTION
### **User description**
## What

The Journey Docs get the heavy update they needed — and the 1.5 TB data dump becomes part of the docs.

### docs/journey.md — now a complete chronological audit trail
- **Timeline starts at the beginning**: PART 0 GENESIS (2026-04-16 → 2026-06-27) — the ROCm 1-bit burn, the 2026-04-28 public debut with the NPU-gate receipts, the long quiet May, first contact with the NPU in June — all from the git history, dated
- **PART 1**: the 4-day RE sprint (2026-06-28 → 07-02) — all raw session logs now in chronological order
- **PART 2**: memory campaign & control plane (08-03 → 08-10, UPDATE 29–33)
- **PART 3**: UPDATE 34 — the burn & Mojo shift (08-12), ported from the 1bit-systems repo history where it had landed
- **PART 4**: UPDATE 35 (new, 08-15) — the MONSTER era: validation gates (bloom / step1 / gpt-oss / deepseek-mla all 20/20 vs torch/numpy), the rebrand, and the audit-trail infrastructure
- **APPENDIX**: the audit trail — 1.5 TB of evidence mapped to this repo

### docs/audit-trail.md (new) — the manifest
- The Raspberry Pi backup server (192.168.50.216): ZFS pool layout, the original 2026-08-05 tarball dump on the SD card, backup cadence (nightly rsync, weekly ZFS snapshots, 90-day retention, append-only)
- Repo ↔ archive mapping table: every repo dir and where its raw evidence lives
- Claim-verification guide: how to trace any journey number to a commit, benchmark, reference-logit file, or session transcript

### README + docs/README
- Both link the audit trail next to the journey

All existing content preserved verbatim (reordered chronologically, demoted under part headings) — the raw session logs remain the unedited record. This is the paper trail for hackathon / competition judging: every claim traceable to preserved artifacts.


___

### **PR Type**
Documentation


___

### **Description**
- Restructure `docs/journey.md` as chronological timeline from genesis

- Add UPDATE 34 (burn/Mojo shift) and UPDATE 35 (MONSTER validation gates)

- New `docs/audit-trail.md`: 1.5TB evidence archive manifest

- README files link audit trail next to journey


___

### Diagram Walkthrough


```mermaid
flowchart LR
  journey["docs/journey.md — chronological timeline (PART 0-4)"] -- "claims traceable via" --> audit["docs/audit-trail.md — evidence manifest"]
  audit -- "maps repo paths to" --> archive["Raspberry Pi archive — 1.5 TB (ZFS pool + SD tarballs)"]
  readme["README.md / docs/README.md"] -- "link" --> audit
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audit-trail.md</strong><dd><code>New 1.5TB evidence archive manifest and verification guide</code></dd></summary>
<hr>

docs/audit-trail.md

<ul><li>New document mapping the 1.5 TB evidence archive to repo structure<br> <li> Documents Raspberry Pi backup server (192.168.50.216): ZFS pool <br>layout, SD-card tarball dump, backup cadence (nightly rsync, weekly <br>snapshots, 90-day retention, append-only)<br> <li> Repo ↔ archive mapping table and claim-verification guide with commit <br>hashes<br> <li> Includes access instructions, restore procedure, and mountpoint gotcha</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1678/files#diff-dcd9bc5b6b91339bb153917b44c3c9c99a7aad1fbdef62deb93d254cde546d4b">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>journey.md</strong><dd><code>Rebuilt journey as chronological timeline with UPDATE 34+35</code></dd></summary>
<hr>

docs/journey.md

<ul><li>Restructured as full chronological timeline: PART 0 Genesis <br>(2026-04-16 → 06-27), PART 1 RE sprint, PART 2 memory campaign & <br>control plane, PART 3 the burn & Mojo shift, PART 4 MONSTER validation <br>gates<br> <li> Ported UPDATE 34 from the 1bit-systems repo history; added new UPDATE <br>35 (validation gates 20/20 vs torch/numpy, rebrand, audit-trail <br>infrastructure)<br> <li> Existing raw session logs preserved verbatim, reordered <br>chronologically under part headings<br> <li> Appendix links to the audit-trail evidence manifest</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1678/files#diff-fe3305852160f6191b970d4c904badf83f3dcd478c4c7f581e27208288bf202e">+1928/-1725</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Docs index gains audit-trail entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/README.md

<ul><li>Updated <code>journey.md</code> entry to mention full timeline 2026-04-28 → today<br> <li> Added <code>audit-trail.md</code> row describing the 1.5 TB evidence map</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1678/files#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Root README links the audit trail</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added link to <code>docs/audit-trail.md</code> next to the journey link<br> <li> Notes nightly archiving on the Raspberry Pi backup server</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1678/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

