### PR TITLE
ci: add merge_group triggers for the new merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/scope-guard.yml
+++ b/.github/workflows/scope-guard.yml
@@ -14,6 +14,7 @@ name: Scope Guard
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
 
 permissions:
   contents: read
@@ -30,8 +31,8 @@ jobs:
 
       - name: Check changed paths against engine scope
         env:
-          BASE: ${{ github.event.pull_request.base.sha }}
-          HEAD: ${{ github.event.pull_request.head.sha }}
+          BASE: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
### **User description**
Enabled a merge_queue rule on main's ruleset. Without a merge_group trigger, CI and Scope Guard (both required checks) never run on the queue's speculative merge commits — queued PRs would silently time out after 60 min. Also fixes scope-guard.yml's BASE/HEAD env vars, which only worked under pull_request events.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add `merge_group` trigger to CI workflow

- Add `merge_group` trigger to Scope Guard

- Fix BASE/HEAD env vars for merge_group events


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MQ["Merge queue event"] -- "merge_group trigger" --> CI["CI workflow"]
  MQ -- "merge_group trigger" --> SG["Scope Guard workflow"]
  SG -- "event-aware BASE/HEAD SHAs" --> CK["Path scope check"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Add merge_group trigger to CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Added <code>merge_group</code> trigger to the <code>on:</code> section<br> <li> Ensures CI runs on merge queue speculative merge commits</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1679/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scope-guard.yml</strong><dd><code>Add merge_group trigger and event-aware SHAs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/scope-guard.yml

<ul><li>Added <code>merge_group</code> trigger to the <code>on:</code> section<br> <li> Fixed <code>BASE</code>/<code>HEAD</code> env vars to branch on <code>github.event_name</code><br> <li> Reads <code>merge_group.base_sha</code>/<code>head_sha</code> for merge_group events<br> <li> Falls back to <code>pull_request.base.sha</code>/<code>head.sha</code> otherwise</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1679/files#diff-68674a7eaf52bc78824a15f418af98049be2056459048d0a4637ddb31190829e">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

