### PR TITLE
ci(pr-agent): self-hosted runner + GitNexus rc.204 (#2432 fix)

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   pr_agent:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, pr-agent]
     timeout-minutes: 20
     # Only run for same-repo PRs and trusted commenters (not external forks)
     if: |
@@ -23,32 +23,26 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0  # needed for gitnexus compare against origin/main
+          clean: false    # self-hosted: keep .gitnexus across runs so analyze is incremental
 
       # GitNexus: build/refresh the local knowledge-graph index (incremental),
       # then map the PR diff to indexed symbols + affected execution flows.
       # The report is injected into the review via artifact_path below.
       # Only on pull_request events: comment-triggered runs have no
       # pull_request.base.sha for the cache key (PR agent still runs).
-      - name: Cache GitNexus index
-        if: github.event_name == 'pull_request'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: .gitnexus
-          key: gitnexus-${{ github.event.pull_request.base.sha }}
-          restore-keys: |
-            gitnexus-
-
+      # NOTE: self-hosted runner — the GitNexus index persists in the work
+      # dir across runs, so analyze is incremental (no cold rebuild per PR).
       - name: GitNexus impact analysis
         if: github.event_name == 'pull_request'
         run: |
           set +e  # GitNexus is context-only; infra hiccups must not block the review
-          npm install -g gitnexus@1.6.9
+          npm install -g gitnexus@1.6.10-rc.204 2>/dev/null || true  # pre-installed on the self-hosted runner; no-op here
           # Register a restored cache index (no-op if absent), then refresh
-          # incrementally. analyze can transiently fail to finalize on fresh
-          # runners — retry once per its own diagnostic.
+          # incrementally. rc.204 pins the #2432 native-worker abort fix
+          # (SIGABRT in Napi::Error on analyze) — 1.6.9 lacks it.
           gitnexus index . 2>/dev/null
           gitnexus analyze || gitnexus analyze
-          gitnexus detect-changes --scope compare --base-ref "origin/${{ github.event.pull_request.base.ref }}" --repo 1bit-systems \
+          gitnexus detect-changes --scope compare --base-ref "origin/${{ github.event.pull_request.base.ref }}" --repo 1bit-MONSTER \
             > gitnexus-context.md 2>&1
           echo "--- gitnexus report (first 30 lines) ---"
           head -30 gitnexus-context.md


### PR DESCRIPTION
### **User description**
PR-Agent ran ~19min/PR on a fresh ubuntu VM because GitNexus cold-rebuilt its knowledge graph every run. Two changes:

1. **Self-hosted runner** — job now runs on `strix-halo-pr-agent` (persistent, registered on the Ryzen box). `clean: false` on checkout keeps `.gitnexus` across runs → `analyze` is incremental instead of a cold rebuild.

2. **GitNexus 1.6.10-rc.204** — npm `latest` (1.6.9) aborts in a native worker (`Napi::Error` SIGABRT, upstream #2432, fixed 07-11 but never released to npm latest). Pinned to the rc that contains the fix; verified on host: 25,528 nodes / 48,986 edges indexed without abort.

Also fixes `detect-changes --repo 1bit-systems` → `1bit-MONSTER` (was querying the wrong repo).


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Migrate PR-Agent job to self-hosted runner

- Persist `.gitnexus` index via `clean: false`

- Remove now-redundant GitNexus cache step

- Pin `gitnexus@1.6.10-rc.204` fixing native SIGABRT (#2432)

- Fix `detect-changes --repo` name to `1bit-MONSTER`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR-Agent workflow"] -- "runs-on" --> B["Self-hosted runner"]
  B -- "clean: false" --> C["Persisted .gitnexus index"]
  C -- "incremental analyze" --> D["Faster PR reviews"]
  A -- "pin rc.204" --> E["Fix #2432 SIGABRT"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>Self-hosted runner migration and GitNexus rc.204 pin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>Switch <code>runs-on</code> from <code>ubuntu-latest</code> to <code>[self-hosted, pr-agent]</code><br> <li> Add <code>clean: false</code> to checkout so <code>.gitnexus</code> persists across runs<br> <li> Remove the <code>actions/cache</code> GitNexus index step (no longer needed)<br> <li> Pin <code>gitnexus@1.6.10-rc.204</code> to include #2432 native-worker abort fix<br> <li> Correct <code>detect-changes --repo</code> from <code>1bit-systems</code> to <code>1bit-MONSTER</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1692/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+8/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

