### PR TITLE
feat(metal): gate/ffn buffers + sync MPS gemv waits, model export + real gate test

### DIFF
--- a/Testing/export_metal_model.py
+++ b/Testing/export_metal_model.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""export_metal_model.py — dump a real HF model into backend_metal's .bin
+layout + emit the torch greedy-oracle tokens the Mac-side gate compares
+against. Run on the host with torch; ship the .bin dir + oracle.json to the
+Mac.
+
+Usage:
+    python3 Testing/export_metal_model.py <hf_model_id> <out_dir>
+"""
+import json
+import os
+import struct
+import sys
+
+import torch
+from transformers import AutoModelForCausalLM, AutoConfig, AutoTokenizer
+
+
+def write_f32(path, tensor):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    t = tensor.detach().to(torch.float32).cpu().numpy()
+    with open(path, "wb") as f:
+        f.write(t.tobytes())
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("usage: export_metal_model.py <hf_id> <out_dir>")
+        return 1
+    hf_id, wdir = sys.argv[1], sys.argv[2]
+    cfg = AutoConfig.from_pretrained(hf_id)
+    model = AutoModelForCausalLM.from_pretrained(hf_id, torch_dtype=torch.float32)
+    model.eval()
+    tok = AutoTokenizer.from_pretrained(hf_id)
+    sd = model.state_dict()
+
+    H = cfg.hidden_size
+    L = cfg.num_hidden_layers
+    V = cfg.vocab_size
+
+    write_f32(f"{wdir}/model_embed_tokens_weight.bin", sd["model.embed_tokens.weight"])
+    write_f32(f"{wdir}/model_norm_weight.bin", sd["model.norm.weight"])
+    write_f32(f"{wdir}/model_input_hidden_states_scale.bin", torch.ones(H))
+    write_f32(f"{wdir}/model_input_hidden_states_bias.bin", torch.zeros(H))
+    for il in range(L):
+        p = f"model.layers.{il}"
+        write_f32(f"{wdir}/model_layers_{il}_self_attn_q_proj.weight.bin", sd[f"{p}.self_attn.q_proj.weight"])
+        write_f32(f"{wdir}/model_layers_{il}_self_attn_k_proj.weight.bin", sd[f"{p}.self_attn.k_proj.weight"])
+        write_f32(f"{wdir}/model_layers_{il}_self_attn_v_proj.weight.bin", sd[f"{p}.self_attn.v_proj.weight"])
+        write_f32(f"{wdir}/model_layers_{il}_self_attn_o_proj.weight.bin", sd[f"{p}.self_attn.o_proj.weight"])
+        write_f32(f"{wdir}/model_layers_{il}_mlp_gate_proj.weight.bin", sd[f"{p}.mlp.gate_proj.weight"])
+        write_f32(f"{wdir}/model_layers_{il}_mlp_down_proj.weight.bin", sd[f"{p}.mlp.down_proj.weight"])
+        write_f32(f"{wdir}/model_layers_{il}_mlp_up_proj.weight.bin", sd[f"{p}.mlp.up_proj.weight"])
+        write_f32(f"{wdir}/model_layers_{il}_input_layernorm.weight.bin", sd[f"{p}.input_layernorm.weight"])
+        write_f32(f"{wdir}/model_layers_{il}_post_attention_layernorm.weight.bin", sd[f"{p}.post_attention_layernorm.weight"])
+
+    # ── Greedy oracle: seed → chain of N greedy tokens (torch, fp32) ──
+    oracle = {"model": hf_id, "hidden": H, "layers": L, "heads": cfg.num_attention_heads,
+              "kv_heads": cfg.num_key_value_heads, "head_dim": H // cfg.num_attention_heads,
+              "intermediate": cfg.intermediate_size, "vocab": V,
+              "seeds": {}}
+    for seed in (5, 42, 99, 1000, 31337):
+        with torch.no_grad():
+            t = torch.tensor([[seed]])
+            chain = [seed]
+            for _ in range(6):
+                out = model(t)
+                nxt = int(out.logits[0, -1].argmax())
+                chain.append(nxt)
+                t = torch.tensor([[nxt]])
+        oracle["seeds"][str(seed)] = chain
+    with open(f"{wdir}/oracle.json", "w") as f:
+        json.dump(oracle, f, indent=1)
+
+    # sizes
+    tot = 0
+    for root, _, files in os.walk(wdir):
+        for fn in files:
+            tot += os.path.getsize(os.path.join(root, fn))
+    print(f"exported {hf_id} → {wdir} ({tot/1e6:.0f} MB, oracle {len(oracle['seeds'])} seeds)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Testing/metal_real_gate.mm
+++ b/Testing/metal_real_gate.mm
@@ -1,0 +1,98 @@
+// metal_real_gate.mm — real-model correctness gate for the Metal backend.
+// Loads a real HF model exported via Testing/export_metal_model.py (.bin
+// layout), runs greedy generate() from the same seeds as the torch oracle,
+// and requires an exact token match. This is what makes the "Apple support"
+// claim mean token-correct inference, not just "it runs".
+//
+// Build (macOS only):
+//   clang++ -std=c++17 -fobjc-arc -Iinclude -Isrc Testing/metal_real_gate.mm \
+//       src/backend_metal.mm -framework Metal -framework MetalPerformanceShaders \
+//       -framework MetalPerformanceShadersGraph -o /tmp/metal_real_gate
+//   /tmp/metal_real_gate <model_dir>          (expects <dir>/oracle.json)
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+
+#include "backend.h"
+#include "common.h"
+
+extern "C" Backend* create_metal_backend();
+
+static std::string slurp(const std::string& p) {
+    std::ifstream f(p, std::ios::binary | std::ios::ate);
+    if (!f) return "";
+    size_t n = f.tellg(); f.seekg(0);
+    std::string s(n, '\0'); f.read(&s[0], n);
+    return s;
+}
+
+// minimal JSON: find "key": value (int) or "key": [ ... ] (int list)
+static int jint(const std::string& j, const char* key) {
+    auto at = j.find(key);
+    if (at == std::string::npos) return -1;
+    at = j.find(':', at);
+    while (at < j.size() && (j[at] < '0' || j[at] > '9') && j[at] != '-') at++;
+    return atoi(j.c_str() + at);
+}
+static std::vector<int> jlist(const std::string& j, const char* key) {
+    std::vector<int> out;
+    auto at = j.find(key);
+    if (at == std::string::npos) return out;
+    at = j.find('[', at);
+    while (at < j.size() && j[at] != ']') {
+        while (at < j.size() && (j[at] < '0' || j[at] > '9') && j[at] != '-') at++;
+        if (at >= j.size() || j[at] == ']') break;
+        out.push_back(atoi(j.c_str() + at));
+        while (at < j.size() && (j[at] == '-' || (j[at] >= '0' && j[at] <= '9'))) at++;
+    }
+    return out;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) { fprintf(stderr, "usage: %s <model_dir>\n", argv[0]); return 2; }
+    std::string wd = argv[1];
+    if (!wd.empty() && wd.back() != '/') wd += '/';
+
+    std::string oj = slurp(wd + "oracle.json");
+    if (oj.empty()) { fprintf(stderr, "FAIL: no oracle.json in %s\n", wd.c_str()); return 1; }
+
+    ModelConfig cfg;
+    cfg.hidden = cfg.hidden_size = jint(oj, "\"hidden\"");
+    cfg.n_layers = cfg.num_layers = jint(oj, "\"layers\"");
+    cfg.n_heads = cfg.num_heads = jint(oj, "\"heads\"");
+    cfg.n_kv_heads = cfg.num_kv_heads = jint(oj, "\"kv_heads\"");
+    cfg.head_dim = jint(oj, "\"head_dim\"");
+    cfg.n_ff = cfg.intermediate_size = jint(oj, "\"intermediate\"");
+    cfg.vocab = cfg.vocab_size = jint(oj, "\"vocab\"");
+    cfg.max_seq_len = 4096;
+
+    Backend* b = create_metal_backend();
+    if (!b) { fprintf(stderr, "FAIL: create_metal_backend() null\n"); return 1; }
+    if (!b->init(cfg, wd)) { fprintf(stderr, "FAIL: init\n"); return 1; }
+
+    int fails = 0, total = 0;
+    for (const char* sk : {"5", "42", "99", "1000", "31337"}) {
+        std::string key = "\"" + std::string(sk) + "\"";
+        auto chain = jlist(oj, key.c_str());
+        if (chain.empty()) continue;
+        b->reset();
+        int tok = chain[0];
+        int matched = 0;
+        for (size_t i = 1; i < chain.size(); i++) {
+            int got = b->generate(tok);
+            total++;
+            if (got == chain[i]) matched++;
+            else fails++;
+            tok = got;
+        }
+        printf("  seed %-6s %zu/%zu tokens match\n", sk, matched, chain.size() - 1);
+    }
+    b->destroy();
+    delete b;
+
+    if (fails == 0) { printf("METAL REAL GATE PASS (%d tokens, exact vs torch)\n", total); return 0; }
+    printf("METAL REAL GATE FAIL (%d/%d tokens mismatch vs torch)\n", fails, total);
+    return 1;
+}

--- a/src/backend_metal.mm
+++ b/src/backend_metal.mm
@@ -132,6 +132,8 @@ struct MetalBackend : Backend {
     id<MTLBuffer> d_hs = nil;
     id<MTLBuffer> d_ao = nil;
     id<MTLBuffer> d_tmp = nil;
+    id<MTLBuffer> d_gate = nil;
+    id<MTLBuffer> d_ffn = nil;
     id<MTLBuffer> d_fnw = nil;
     id<MTLBuffer> d_embed = nil;
     id<MTLBuffer> d_kcache = nil;
@@ -242,13 +244,19 @@ struct MetalBackend : Backend {
         MPSMatrixMultiplication* mm = [[MPSMatrixMultiplication alloc]
             initWithDevice:device resultRows:M resultColumns:N interiorColumns:K];
         
+        // CPU-side ops between gemvs read these buffers — the MPS kernel must
+        // complete before they do. Each gemv gets its own command buffer,
+        // committed + waited here (synchronous, correct-first).
         [mm encodeToCommandBuffer:cb leftMatrix:mat_a rightMatrix:mat_b resultMatrix:mat_c];
+        [cb commit];
+        [cb waitUntilCompleted];
     }
 
     // GEMV: out[M] = in[K] @ wt[K, M] using MPS as GeMM with N=1
-    void metal_gemv(id<MTLCommandBuffer> cb,
-                    id<MTLBuffer> out, const id<MTLBuffer> in_vec,
+    void metal_gemv(id<MTLBuffer> out, const id<MTLBuffer> in_vec,
                     const id<MTLBuffer> wt, int M, int K) {
+        // Fresh command buffer per gemv — a committed buffer cannot be reused.
+        id<MTLCommandBuffer> cb = [cmd_queue commandBuffer];
         metal_matmul(cb, out, in_vec, wt, 1, M, K);
     }
 
@@ -282,12 +290,17 @@ struct MetalBackend : Backend {
             return d;
         };
         
-        auto to_half_buffer = [&](const std::vector<float>& src) -> id<MTLBuffer> {
+        // Weights come from torch as [out, in] row-major; the MPS gemv treats
+        // the buffer as [K, N] = [in, out] row-major. Transpose at load so the
+        // matmul is mathematically correct: B[k][n] = w[n][k].
+        auto to_half_buffer = [&](const std::vector<float>& src, int rows, int cols) -> id<MTLBuffer> {
             if (src.empty()) return nil;
-            std::vector<half> h(src.size());
-            for (size_t i = 0; i < src.size(); i++) h[i] = half(src[i]);
+            std::vector<half> h((size_t)rows * cols);
+            for (int r = 0; r < rows; r++)
+                for (int c = 0; c < cols; c++)
+                    h[(size_t)c * rows + r] = half(src[(size_t)r * cols + c]);
             return [device newBufferWithBytes:h.data()
-                                       length:src.size() * sizeof(half)
+                                       length:h.size() * sizeof(half)
                                       options:MTLResourceStorageModeShared];
         };
 
@@ -306,10 +319,12 @@ struct MetalBackend : Backend {
         d_hs = [device newBufferWithLength:mps_round(buf_size) options:MTLResourceStorageModeShared];
         d_ao = [device newBufferWithLength:mps_round(buf_size) options:MTLResourceStorageModeShared];
         d_tmp = [device newBufferWithLength:mps_round(std::max(hidden, 2 * n_ff) * sizeof(half)) options:MTLResourceStorageModeShared];
-        d_fnw = to_half_buffer(fnorm);
-        d_embed = to_half_buffer(embed);
-        d_ibias = to_half_buffer(ibias);
-        d_iscale = to_half_buffer(iscale);
+        d_gate = [device newBufferWithLength:mps_round(n_ff * sizeof(half)) options:MTLResourceStorageModeShared];
+        d_ffn = [device newBufferWithLength:mps_round(hidden * sizeof(half)) options:MTLResourceStorageModeShared];
+        d_fnw = to_half_buffer(fnorm, hidden, 1);
+        d_embed = to_half_buffer(embed, vocab, hidden);  // [V,H] → transposed [H,V] for lm_head B
+        d_ibias = to_half_buffer(ibias, hidden, 1);
+        d_iscale = to_half_buffer(iscale, hidden, 1);
         
         int kv_elem = n_layers * max_seq * n_kv_heads * head_dim;
         d_kcache = [device newBufferWithLength:kv_elem * sizeof(half) options:MTLResourceStorageModeShared];
@@ -321,6 +336,9 @@ struct MetalBackend : Backend {
         d_lm_vocab = [device newBufferWithLength:mps_round(vocab * sizeof(float)) options:MTLResourceStorageModeShared];
         d_argmax_idx = [device newBufferWithLength:sizeof(int) options:MTLResourceStorageModeShared];
         d_argmax_val = [device newBufferWithLength:sizeof(float) options:MTLResourceStorageModeShared];
+
+        size_t qd = n_heads * head_dim;
+        size_t kd = n_kv_heads * head_dim;
 
         // Load per-layer weights
         for (int il = 0; il < n_layers; il++) {
@@ -335,15 +353,15 @@ struct MetalBackend : Backend {
             auto rms_a = load(p + "input_layernorm.weight.bin");
             auto rms_f = load(p + "post_attention_layernorm.weight.bin");
 
-            layer_wq.push_back(to_half_buffer(wq));
-            layer_wk.push_back(to_half_buffer(wk));
-            layer_wv.push_back(to_half_buffer(wv));
-            layer_wo.push_back(to_half_buffer(wo));
-            layer_w1.push_back(to_half_buffer(w1));
-            layer_w2.push_back(to_half_buffer(w2));
-            layer_w3.push_back(to_half_buffer(w3));
-            layer_rms_a.push_back(to_half_buffer(rms_a));
-            layer_rms_f.push_back(to_half_buffer(rms_f));
+            layer_wq.push_back(to_half_buffer(wq, qd, hidden));
+            layer_wk.push_back(to_half_buffer(wk, kd, hidden));
+            layer_wv.push_back(to_half_buffer(wv, kd, hidden));
+            layer_wo.push_back(to_half_buffer(wo, hidden, qd));
+            layer_w1.push_back(to_half_buffer(w1, n_ff, hidden));
+            layer_w2.push_back(to_half_buffer(w2, hidden, n_ff));
+            layer_w3.push_back(to_half_buffer(w3, n_ff, hidden));
+            layer_rms_a.push_back(to_half_buffer(rms_a, hidden, 1));
+            layer_rms_f.push_back(to_half_buffer(rms_f, hidden, 1));
         }
 
         try {
@@ -396,6 +414,9 @@ struct MetalBackend : Backend {
                 half val = half((raw + ibias[i]) * iscale[i]);
                 ((half*)[d_hs contents])[i] = val;
             }
+            {double m=0;half* dbg=(half*)[d_hs contents];for(int i=0;i<hidden;i++)m+=(double)dbg[i]*(double)dbg[i];
+             fprintf(stderr,"  embed mag=%.4f (embed vec size=%zu)\n",sqrt(m/hidden),embed.size());
+             fprintf(stderr,"  wq0 size=%zu wq1 size=%zu\n", layer_wq.empty()?0:(size_t)layer_wq[0].length, layer_wq.size()>1?(size_t)layer_wq[1].length:0);}
             
             size_t qd = n_heads * head_dim;
             size_t kd = n_kv_heads * head_dim;
@@ -416,13 +437,13 @@ struct MetalBackend : Backend {
                 
                 // QKV projections via MPS
                 if (layer_wq[il]) {
-                    metal_gemv(cb, d_qout, d_tmp, layer_wq[il], qd, hidden);
+                    metal_gemv(d_qout, d_tmp, layer_wq[il], qd, hidden);
                 }
                 if (layer_wk[il]) {
-                    metal_gemv(cb, d_kout, d_tmp, layer_wk[il], kd, hidden);
+                    metal_gemv(d_kout, d_tmp, layer_wk[il], kd, hidden);
                 }
                 if (layer_wv[il]) {
-                    metal_gemv(cb, d_vout, d_tmp, layer_wv[il], kd, hidden);
+                    metal_gemv(d_vout, d_tmp, layer_wv[il], kd, hidden);
                 }
                 
                 // Store KV in cache (host-side for simplicity)
@@ -431,41 +452,59 @@ struct MetalBackend : Backend {
                 memcpy(k_dst, [d_kout contents], kd * sizeof(half));
                 memcpy(v_dst, [d_vout contents], kd * sizeof(half));
                 
-                // Attention (simplified CPU-side for v1)
+                {
+                    double mq=0,mk=0,mv=0;
+                    half* dq=(half*)[d_qout contents]; half* dk=(half*)[d_kout contents]; half* dv=(half*)[d_vout contents];
+                    for(int i=0;i<qd;i++)mq+=(double)dq[i]*(double)dq[i];
+                    for(int i=0;i<kd;i++)mk+=(double)dk[i]*(double)dk[i];
+                    for(int i=0;i<kd;i++)mv+=(double)dv[i]*(double)dv[i];
+                    fprintf(stderr,"  L0 qkv mag: q=%.4f k=%.4f v=%.4f\n",sqrt(mq/qd),sqrt(mk/kd),sqrt(mv/kd));
+                }
+                // Attention (CPU-side accumulation; Metal kernel for production)
                 int seq_len = pos + 1;
                 float scale = 1.0f / sqrtf((float)head_dim);
+                half* ao_out = (half*)[d_ao contents];
+                int heads_per_kv = n_kv_heads > 0 ? n_heads / n_kv_heads : 1;
                 for (int h = 0; h < n_heads; h++) {
-                    float max_score = -1e38f;
-                    float exp_sum = 0;
-                    float acc = 0;
-                    
+                    int kh = h / heads_per_kv;  // GQA: query head h shares KV head kh
+                    // scores[t] = q·k_t * scale
+                    std::vector<float> scores(seq_len);
                     for (int t = 0; t < seq_len; t++) {
                         float s = 0;
                         for (int d = 0; d < head_dim; d++) {
                             s += (float)((half*)[d_qout contents])[h * head_dim + d] *
-                                 (float)((half*)[d_kcache contents])[(size_t)il * max_seq * kd + (size_t)t * kd + h * head_dim + d];
+                                 (float)((half*)[d_kcache contents])[(size_t)il * max_seq * kd + (size_t)t * kd + kh * head_dim + d];
                         }
-                        s *= scale;
-                        
-                        float new_max = fmax(max_score, s);
-                        float e = expf(s - new_max);
-                        float e_old = expf(max_score - new_max);
-                        exp_sum = exp_sum * e_old + e;
-                        max_score = new_max;
-                        
-                        float v = (float)((half*)[d_vcache contents])[(size_t)il * max_seq * kd + (size_t)t * kd + h * head_dim + 0];
-                        // Simplified: just take first element of V for the weighted sum
-                        // Full implementation accumulates all dimensions
+                        scores[t] = s * scale;
+                    }
+                    // softmax over scores
+                    float mx = *std::max_element(scores.begin(), scores.end());
+                    float esum = 0;
+                    for (int t = 0; t < seq_len; t++) esum += expf(scores[t] - mx);
+                    // weighted V sum: out[d] = Σ_t softmax(t) * V[t][h][d]
+                    for (int d = 0; d < head_dim; d++) {
+                        float acc = 0;
+                        for (int t = 0; t < seq_len; t++) {
+                            float w = expf(scores[t] - mx) / esum;
+                            acc += w * (float)((half*)[d_vcache contents])[(size_t)il * max_seq * kd + (size_t)t * kd + kh * head_dim + d];
+                        }
+                        ao_out[h * head_dim + d] = half(acc);
                     }
                 }
+                if (il==0){double m=0;for(int i=0;i<qd;i++)m+=(double)ao_out[i]*(double)ao_out[i];fprintf(stderr,"  L0 attn-out mag=%.4f\n",sqrt(m/qd));}
                 
-                // Output projection via MPS
+                // Output projection via MPS → d_ffn, then residual: hs += Wo·attn
                 if (layer_wo[il]) {
-                    metal_gemv(cb, d_hs, d_ao, layer_wo[il], hidden, qd);
+                    metal_gemv(d_ffn, d_ao, layer_wo[il], hidden, qd);
+                    if (il==0){double m=0;half* dbg=(half*)[d_ffn contents];for(int i=0;i<hidden;i++)m+=(double)dbg[i]*(double)dbg[i];fprintf(stderr,"  L0 Wo mag=%.4f\n",sqrt(m/hidden));}
+                    half* hs_in = (half*)[d_hs contents];
+                    half* attn_out = (half*)[d_ffn contents];
+                    for (int i = 0; i < hidden; i++) hs_in[i] = half((float)hs_in[i] + (float)attn_out[i]);
+                    if (il==0){double m=0;for(int i=0;i<hidden;i++)m+=(double)hs_in[i]*(double)hs_in[i];fprintf(stderr,"  L0 after attn-resid mag=%.4f\n",sqrt(m/hidden));}
                 }
                 
                 // FFN
-                // RMS norm
+                // RMS norm of the residual hs → tmp
                 ss = 0;
                 for (int i = 0; i < hidden; i++) ss += (float)hs[i] * (float)hs[i];
                 rms = sqrtf(ss / hidden + 1e-5f);
@@ -473,25 +512,28 @@ struct MetalBackend : Backend {
                 rms_w = (half*)[layer_rms_f[il] contents];
                 for (int i = 0; i < hidden; i++) tmp[i] = half((float)hs[i] * inv_rms * (float)rms_w[i]);
                 
-                // Gate and up projections via MPS
+                // gate = W1·norm → d_gate ; up = W3·norm → d_ao (separate buffers!)
                 if (layer_w1[il]) {
-                    metal_gemv(cb, d_tmp, d_tmp, layer_w1[il], n_ff, hidden);
+                    metal_gemv(d_gate, d_tmp, layer_w1[il], n_ff, hidden);
                 }
                 if (layer_w3[il]) {
-                    metal_gemv(cb, d_ao, d_tmp, layer_w3[il], n_ff, hidden);
+                    metal_gemv(d_ao, d_tmp, layer_w3[il], n_ff, hidden);
                 }
                 
-                // SiLU(gate) * up
-                half* gate = (half*)[d_tmp contents];
+                // tmp = silu(gate) * up  (reuse d_tmp as the product buffer)
+                half* gate = (half*)[d_gate contents];
                 half* up = (half*)[d_ao contents];
                 for (int i = 0; i < n_ff; i++) {
                     float v = (float)gate[i];
-                    gate[i] = half((v / (1.0f + expf(-v))) * (float)up[i]);
+                    tmp[i] = half((v / (1.0f + expf(-v))) * (float)up[i]);
                 }
                 
-                // Down projection via MPS
+                // Down projection → d_ffn, then residual: hs += W2·product
                 if (layer_w2[il]) {
-                    metal_gemv(cb, d_hs, d_tmp, layer_w2[il], hidden, n_ff);
+                    metal_gemv(d_ffn, d_tmp, layer_w2[il], hidden, n_ff);
+                    half* hs_in = (half*)[d_hs contents];
+                    half* ffn_out = (half*)[d_ffn contents];
+                    for (int i = 0; i < hidden; i++) hs_in[i] = half((float)hs_in[i] + (float)ffn_out[i]);
                 }
             }
             
@@ -505,17 +547,19 @@ struct MetalBackend : Backend {
             for (int i = 0; i < hidden; i++) hs[i] = half((float)hs[i] * inv_rms * (float)fnw[i]);
             
             // 4. LM head via MPS
-            metal_gemv(cb, d_lm_vocab, d_hs, d_embed, vocab, hidden);
+            metal_gemv(d_lm_vocab, d_hs, d_embed, vocab, hidden);
             
             [cb commit];
             [cb waitUntilCompleted];
             
-            // 5. Argmax on CPU
-            float* logits = (float*)[d_lm_vocab contents];
+            // 5. Argmax on CPU — MPS wrote fp16 into d_lm_vocab (desc is
+            // MPSDataTypeFloat16), so read it as half, not float.
+            half* logits_h = (half*)[d_lm_vocab contents];
             int next_token = 0;
-            float best_val = logits[0];
+            float best_val = (float)logits_h[0];
             for (int i = 1; i < vocab; i++) {
-                if (logits[i] > best_val) { best_val = logits[i]; next_token = i; }
+                float v = (float)logits_h[i];
+                if (v > best_val) { best_val = v; next_token = i; }
             }
             
             pos++;
@@ -549,6 +593,8 @@ struct MetalBackend : Backend {
         METAL_RELEASE(d_hs);
         METAL_RELEASE(d_ao);
         METAL_RELEASE(d_tmp);
+        METAL_RELEASE(d_gate);
+        METAL_RELEASE(d_ffn);
         METAL_RELEASE(d_fnw);
         METAL_RELEASE(d_embed);
         METAL_RELEASE(d_kcache);


### PR DESCRIPTION
### **User description**
In-progress Metal backend work from the working tree: d_gate/d_ffn buffers, per-gemv command-buffer commit+wait (synchronous, correct-first), llama.cpp submodule bump, Testing/export_metal_model.py + Testing/metal_real_gate.mm.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fix Metal backend token correctness
  - Transpose torch [out,in] weights for MPS gemv
  - Proper GQA attention with softmax over full V dims
  - Add missing attention/FFN residual connections
  - Fix FFN buffer aliasing via new `d_gate`/`d_ffn` buffers
  - Read fp16 logits correctly in CPU argmax

- Make each MPS gemv synchronous (own command buffer, commit+wait)

- Add `export_metal_model.py` HF-to-.bin exporter with torch greedy oracle

- Add `metal_real_gate.mm` exact-token-match correctness gate

- Bump llama.cpp submodule


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HF model"] -- "export_metal_model.py" --> B[".bin weights + oracle.json"]
  B -- "loads" --> C["metal_real_gate.mm"]
  D["backend_metal.mm fixes"] -- "greedy generate" --> C
  C -- "exact token match vs torch" --> E["PASS/FAIL gate"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llama.cpp</strong><dd><code>Bump llama.cpp submodule commit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/llama.cpp

- Bump llama.cpp submodule from `bc8ce02` to `4df29be`


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1696/files#diff-323b73a231ec4405be25a8c20273187be6c68fb65badf8d36b96ab04ca7c6215">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>export_metal_model.py</strong><dd><code>Add HF model exporter with torch greedy oracle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Testing/export_metal_model.py

<ul><li>New script exporting HF model weights to backend_metal <code>.bin</code> layout <br>(fp32)<br> <li> Emits <code>oracle.json</code> with greedy token chains for seeds <br>5/42/99/1000/31337<br> <li> Records model dims (hidden, layers, heads, kv_heads, vocab) in oracle</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1696/files#diff-db997dd0af686c559a9792aa7a7321e1d9c365947b78ba33865b7b6e48b8d228">+85/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>metal_real_gate.mm</strong><dd><code>Add real-model exact-token Metal correctness gate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Testing/metal_real_gate.mm

<ul><li>New macOS correctness gate loading exported <code>.bin</code> model via <br><code>create_metal_backend()</code><br> <li> Runs greedy <code>generate()</code> per oracle seed, requires exact token match vs <br>torch<br> <li> Includes minimal hand-rolled JSON parsing for <code>oracle.json</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1696/files#diff-2c66d658272d2f9328c7f604ccd707a3cab73986c650e5dd00dee0c487ae8314">+98/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_metal.mm</strong><dd><code>Fix Metal inference correctness and sync gemv execution</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/backend_metal.mm

<ul><li>Transpose torch <code>[out,in]</code> weights to <code>[in,out]</code> at load for correct MPS <br>gemv<br> <li> Rewrite CPU attention: GQA KV-head mapping, full softmax, weighted V <br>over all dims<br> <li> Add residual adds after attention and FFN; new <code>d_gate</code>/<code>d_ffn</code> buffers <br>fix FFN aliasing (<code>silu(gate)*up</code> wrote into gemv input <code>d_tmp</code>)<br> <li> Make <code>metal_gemv</code> synchronous: fresh command buffer, commit + <br><code>waitUntilCompleted</code> per gemv<br> <li> Fix argmax reading fp16 logits buffer as float; add debug <code>fprintf</code> <br>magnitude logging</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1696/files#diff-d949cc32ef3e6b56b4fe7a8f4f57dfe6bd8661005580554fe17b54691e5998bd">+101/-55</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

