### PR TITLE
fix(scan): clear first-party CodeQL integer-widening warnings

### DIFF
--- a/Testing/e2e_safetensors_selfcheck.cpp
+++ b/Testing/e2e_safetensors_selfcheck.cpp
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
     for (int i = 0; i < 8; i++) { t = gg->generate(t); chain_gg.push_back(t); }
     int same = 0;
     for (size_t i = 0; i < chain_st.size(); i++) if (chain_st[i] == chain_gg[i]) same++;
-    std::printf("8-step chain: %zu/%zu identical tokens\n", same, chain_st.size());
+    std::printf("8-step chain: %zu/%zu identical tokens\n", (size_t)same, chain_st.size());
 
     if (mismatch == 0 && same == (int)chain_st.size()) {
         std::printf("SUSPICIOUS: loaders agree everywhere — verify safetensors weights are real (torch oracle)\n");

--- a/site/dashboard/app.js
+++ b/site/dashboard/app.js
@@ -728,8 +728,8 @@ async function renderApiKeys(main) {
                   <tr>
                     <td style="font-family:var(--mono);font-size:12px;">${esc(k.key)}</td>
                     <td><span class="badge ${k.active ? 'ok' : 'err'}"><span class="dot"></span>${k.active ? 'Active' : 'Revoked'}</span></td>
-                    <td>${k.created_at || '—'}</td>
-                    <td>${k.expires_at || '—'}</td>
+                    <td>${esc(k.created_at) || '—'}</td>
+                    <td>${esc(k.expires_at) || '—'}</td>
                     <td>${k.active ? `<button class="btn btn-danger btn-sm" onclick="revokeApiKey('${esc(k.key)}')">Revoke</button>` : ''}</td>
                   </tr>`).join('')}
                 </tbody>

--- a/src/afmoe_engine.cpp
+++ b/src/afmoe_engine.cpp
@@ -266,8 +266,8 @@ private:
     }
 
     void attention_mix(const float* x, const AfmoeLayer& ly, int l, int pos, float* out) {
-        std::vector<float> q(NH * HD), k(NKV * HD), v(NKV * HD), gate(NH * HD);
-        std::vector<float> qn(NH * HD), kn(NKV * HD), qr(NH * HD), kr(NKV * HD);
+        std::vector<float> q((size_t)NH * HD), k((size_t)NKV * HD), v((size_t)NKV * HD), gate((size_t)NH * HD);
+        std::vector<float> qn((size_t)NH * HD), kn((size_t)NKV * HD), qr((size_t)NH * HD), kr((size_t)NKV * HD);
         mm(ly.q_proj, x, H, NH * HD, q.data());
         mm(ly.k_proj, x, H, NKV * HD, k.data());
         mm(ly.v_proj, x, H, NKV * HD, v.data());
@@ -278,22 +278,22 @@ private:
             rope_apply(qn.data(), NH, HD, qr.data(), pos);
             rope_apply(kn.data(), NKV, HD, kr.data(), pos);
         } else {
-            memcpy(qr.data(), qn.data(), NH * HD * sizeof(float));
-            memcpy(kr.data(), kn.data(), NKV * HD * sizeof(float));
+            memcpy(qr.data(), qn.data(), (size_t)NH * HD * sizeof(float));
+            memcpy(kr.data(), kn.data(), (size_t)NKV * HD * sizeof(float));
         }
         auto& kk = attn_k[l]; auto& vv = attn_v[l];
         for (int i = 0; i < NKV * HD; i++) { kk.push_back(kr[i]); vv.push_back(v[i]); }
         int T = (int)kk.size() / (NKV * HD);
         float scale = 1.0f / std::sqrt((float)HD);
         int groups = NH / NKV;
-        std::vector<float> out_heads(NH * HD);
+        std::vector<float> out_heads((size_t)NH * HD);
         for (int hh = 0; hh < NH; hh++) {
             int kh = hh / groups;
             std::vector<float> scores(T);
             float mx = -1e30f;
             for (int t = 0; t < T; t++) {
                 float s = 0;
-                for (int d = 0; d < HD; d++) s += qr[hh * HD + d] * kk[(size_t)t * NKV * HD + kh * HD + d];
+                for (int d = 0; d < HD; d++) s += qr[(size_t)hh * HD + d] * kk[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 scores[t] = s * scale;
                 if (scores[t] > mx) mx = scores[t];
             }
@@ -301,7 +301,7 @@ private:
             for (int t = 0; t < T; t++) { scores[t] = std::exp(scores[t] - mx); sum += scores[t]; }
             for (int d = 0; d < HD; d++) {
                 float acc = 0;
-                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + kh * HD + d];
+                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 out_heads[hh * HD + d] = acc;
             }
         }

--- a/src/backend_generic.cpp
+++ b/src/backend_generic.cpp
@@ -881,9 +881,9 @@ struct GenericBackend : Backend {
                 std::vector<float> qkvb;
                 snprintf(buf, sizeof(buf), "h.%d.attn.c_attn.bias", l);
                 if (r.get_tensor_f32(buf, qkvb) && (int)qkvb.size() == 3 * NH * HD) {
-                    std::vector<float> bq(qkvb.begin(), qkvb.begin() + NH * HD);
-                    std::vector<float> bk(qkvb.begin() + NH * HD, qkvb.begin() + 2 * NH * HD);
-                    std::vector<float> bv(qkvb.begin() + 2 * NH * HD, qkvb.end());
+                    std::vector<float> bq(qkvb.begin(), qkvb.begin() + (size_t)NH * HD);
+                    std::vector<float> bk(qkvb.begin() + (size_t)NH * HD, qkvb.begin() + 2 * (size_t)NH * HD);
+                    std::vector<float> bv(qkvb.begin() + 2 * (size_t)NH * HD, qkvb.end());
                     lw.bq = push(std::move(bq)); lw.bk = push(std::move(bk)); lw.bv = push(std::move(bv));
                 }
                 load2("attn.c_proj.bias", lw.bo, 1, NH * HD);

--- a/src/cohere2moe_engine.cpp
+++ b/src/cohere2moe_engine.cpp
@@ -256,8 +256,8 @@ private:
     }
 
     void attention_mix(const float* x, const C2mLayer& ly, int l, int pos, float* out) {
-        std::vector<float> q(NH * HD), k(NKV * HD), v(NKV * HD);
-        std::vector<float> qr(NH * HD), kr(NKV * HD);
+        std::vector<float> q((size_t)NH * HD), k((size_t)NKV * HD), v((size_t)NKV * HD);
+        std::vector<float> qr((size_t)NH * HD), kr((size_t)NKV * HD);
         mm(ly.q_proj, x, H, NH * HD, q.data());
         mm(ly.k_proj, x, H, NKV * HD, k.data());
         mm(ly.v_proj, x, H, NKV * HD, v.data());
@@ -265,22 +265,22 @@ private:
             rope_apply(q.data(), NH, HD, qr.data(), pos);
             rope_apply(k.data(), NKV, HD, kr.data(), pos);
         } else {
-            memcpy(qr.data(), q.data(), NH * HD * sizeof(float));
-            memcpy(kr.data(), k.data(), NKV * HD * sizeof(float));
+            memcpy(qr.data(), q.data(), (size_t)NH * HD * sizeof(float));
+            memcpy(kr.data(), k.data(), (size_t)NKV * HD * sizeof(float));
         }
         auto& kk = attn_k[l]; auto& vv = attn_v[l];
         for (int i = 0; i < NKV * HD; i++) { kk.push_back(kr[i]); vv.push_back(v[i]); }
         int T = (int)kk.size() / (NKV * HD);
         float scale = 1.0f / std::sqrt((float)HD);
         int groups = NH / NKV;
-        std::vector<float> out_heads(NH * HD);
+        std::vector<float> out_heads((size_t)NH * HD);
         for (int hh = 0; hh < NH; hh++) {
             int kh = hh / groups;
             std::vector<float> scores(T);
             float mx = -1e30f;
             for (int t = 0; t < T; t++) {
                 float s = 0;
-                for (int d = 0; d < HD; d++) s += qr[hh * HD + d] * kk[(size_t)t * NKV * HD + kh * HD + d];
+                for (int d = 0; d < HD; d++) s += qr[(size_t)hh * HD + d] * kk[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 scores[t] = s * scale;
                 if (scores[t] > mx) mx = scores[t];
             }
@@ -288,7 +288,7 @@ private:
             for (int t = 0; t < T; t++) { scores[t] = std::exp(scores[t] - mx); sum += scores[t]; }
             for (int d = 0; d < HD; d++) {
                 float acc = 0;
-                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + kh * HD + d];
+                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 out_heads[hh * HD + d] = acc;
             }
         }

--- a/src/deepseek_v4.cpp
+++ b/src/deepseek_v4.cpp
@@ -94,12 +94,12 @@ static void mhc_forward(const std::vector<std::vector<float>>& streams, int H,
         post[k] = 2.0f / (1.0f + std::exp(-(mixes[hc + k] * scale[1] + base[hc + k])));
     }
     // comb: mixes[2hc:] * scale[2] + base[2hc:]  -> [hc, hc]
-    std::vector<float> comb(hc * hc);
+    std::vector<float> comb((size_t)hc * hc);
     for (int i = 0; i < hc * hc; i++)
         comb[i] = mixes[2 * hc + i] * scale[2] + base[2 * hc + i];
     // softmax over last dim (per row)
     for (int r = 0; r < hc; r++) {
-        float mx = comb[r * hc];
+        float mx = comb[(size_t)r * hc];
         for (int c = 1; c < hc; c++) mx = std::max(mx, comb[r * hc + c]);
         float ssum = 0;
         for (int c = 0; c < hc; c++) { comb[r * hc + c] = std::exp(comb[r * hc + c] - mx); ssum += comb[r * hc + c]; }
@@ -133,7 +133,7 @@ static void mhc_forward(const std::vector<std::vector<float>>& streams, int H,
     post_out = std::move(post);
     comb_out.assign(hc, std::vector<float>(hc));
     for (int r = 0; r < hc; r++)
-        std::copy(comb.begin() + r * hc, comb.begin() + (r + 1) * hc, comb_out[r].begin());
+        std::copy(comb.begin() + (size_t)r * hc, comb.begin() + (size_t)(r + 1) * hc, comb_out[r].begin());
 }
 
 } // namespace ds4math

--- a/src/ernie45moe_engine.cpp
+++ b/src/ernie45moe_engine.cpp
@@ -250,8 +250,8 @@ private:
     }
 
     void attention_mix(const float* x, const ErnieMoeLayer& ly, int l, int pos, float* out) {
-        std::vector<float> q(NH * HD), k(NKV * HD), v(NKV * HD);
-        std::vector<float> qr(NH * HD), kr(NKV * HD);
+        std::vector<float> q((size_t)NH * HD), k((size_t)NKV * HD), v((size_t)NKV * HD);
+        std::vector<float> qr((size_t)NH * HD), kr((size_t)NKV * HD);
         mm(ly.q_proj, x, H, NH * HD, q.data());
         mm(ly.k_proj, x, H, NKV * HD, k.data());
         mm(ly.v_proj, x, H, NKV * HD, v.data());
@@ -262,14 +262,14 @@ private:
         int T = (int)kk.size() / (NKV * HD);
         float scale = 1.0f / std::sqrt((float)HD);
         int groups = NH / NKV;
-        std::vector<float> out_heads(NH * HD);
+        std::vector<float> out_heads((size_t)NH * HD);
         for (int hh = 0; hh < NH; hh++) {
             int kh = hh / groups;
             std::vector<float> scores(T);
             float mx = -1e30f;
             for (int t = 0; t < T; t++) {
                 float s = 0;
-                for (int d = 0; d < HD; d++) s += qr[hh * HD + d] * kk[(size_t)t * NKV * HD + kh * HD + d];
+                for (int d = 0; d < HD; d++) s += qr[(size_t)hh * HD + d] * kk[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 scores[t] = s * scale;
                 if (scores[t] > mx) mx = scores[t];
             }
@@ -277,7 +277,7 @@ private:
             for (int t = 0; t < T; t++) { scores[t] = std::exp(scores[t] - mx); sum += scores[t]; }
             for (int d = 0; d < HD; d++) {
                 float acc = 0;
-                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + kh * HD + d];
+                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 out_heads[hh * HD + d] = acc;
             }
         }

--- a/src/exaonemoe_engine.cpp
+++ b/src/exaonemoe_engine.cpp
@@ -255,8 +255,8 @@ private:
     }
 
     void attention_mix(const float* x, const ExMoeLayer& ly, int l, int pos, float* out) {
-        std::vector<float> q(NH * HD), k(NKV * HD), v(NKV * HD);
-        std::vector<float> qn(NH * HD), kn(NKV * HD), qr(NH * HD), kr(NKV * HD);
+        std::vector<float> q((size_t)NH * HD), k((size_t)NKV * HD), v((size_t)NKV * HD);
+        std::vector<float> qn((size_t)NH * HD), kn((size_t)NKV * HD), qr((size_t)NH * HD), kr((size_t)NKV * HD);
         mm(ly.q_proj, x, H, NH * HD, q.data());
         mm(ly.k_proj, x, H, NKV * HD, k.data());
         mm(ly.v_proj, x, H, NKV * HD, v.data());
@@ -270,14 +270,14 @@ private:
         int T = (int)kk.size() / (NKV * HD);
         float scale = 1.0f / std::sqrt((float)HD);
         int groups = NH / NKV;
-        std::vector<float> out_heads(NH * HD);
+        std::vector<float> out_heads((size_t)NH * HD);
         for (int hh = 0; hh < NH; hh++) {
             int kh = hh / groups;
             std::vector<float> scores(T);
             float mx = -1e30f;
             for (int t = 0; t < T; t++) {
                 float s = 0;
-                for (int d = 0; d < HD; d++) s += qr[hh * HD + d] * kk[(size_t)t * NKV * HD + kh * HD + d];
+                for (int d = 0; d < HD; d++) s += qr[(size_t)hh * HD + d] * kk[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 scores[t] = s * scale;
                 if (scores[t] > mx) mx = scores[t];
             }
@@ -285,7 +285,7 @@ private:
             for (int t = 0; t < T; t++) { scores[t] = std::exp(scores[t] - mx); sum += scores[t]; }
             for (int d = 0; d < HD; d++) {
                 float acc = 0;
-                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + kh * HD + d];
+                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 out_heads[hh * HD + d] = acc;
             }
         }

--- a/src/falconh1_engine.cpp
+++ b/src/falconh1_engine.cpp
@@ -357,7 +357,7 @@ private:
         auto& kcache = attn_k[l];
         auto& vcache = attn_v[l];
         int klen = (int)(kcache.size() / (NKV * HD));
-        std::vector<float> q(NH * HD), k(NKV * HD), v(NKV * HD);
+        std::vector<float> q((size_t)NH * HD), k((size_t)NKV * HD), v((size_t)NKV * HD);
         mm(ly.q_proj, xn, H, NH * HD, q.data());
         mm(ly.k_proj, xn, H, NKV * HD, k.data());
         for (int i = 0; i < NKV * HD; i++) k[i] *= key_mult;
@@ -399,7 +399,7 @@ private:
             for (int t = 0; t < seq; t++) { float e = std::exp(srow[t] - mx); probs[(size_t)h * seq + t] = e; sum += e; }
             for (int t = 0; t < seq; t++) probs[(size_t)h * seq + t] /= sum;
         }
-        std::vector<float> acc(NH * HD, 0.0f);
+        std::vector<float> acc((size_t)NH * HD, 0.0f);
         for (int h = 0; h < NH; h++) {
             int kh = h / (NH / NKV);
             const float* vv = vcache.data() + (size_t)kh * HD;

--- a/src/glm_moe_dsa.cpp
+++ b/src/glm_moe_dsa.cpp
@@ -287,8 +287,8 @@ std::vector<float> glm_moe_dsa_forward(GlmMoeDsaModel& model, int token_id,
 
     std::vector<float> ffn_out(H), shared_out(H);
     std::vector<float> exp_gate_up(2 * cfg.moe_intermediate), exp_act(cfg.moe_intermediate);
-    std::vector<float> sh_g(cfg.n_shared_experts * cfg.moe_intermediate);
-    std::vector<float> sh_u(cfg.n_shared_experts * cfg.moe_intermediate);
+    std::vector<float> sh_g((size_t)cfg.n_shared_experts * cfg.moe_intermediate);
+    std::vector<float> sh_u((size_t)cfg.n_shared_experts * cfg.moe_intermediate);
     std::vector<float> router_logits(cfg.n_routed_experts);
     std::vector<float> router_scores(cfg.n_routed_experts);
     std::vector<float> group_scores(cfg.n_group);

--- a/src/granitemoehybrid_engine.cpp
+++ b/src/granitemoehybrid_engine.cpp
@@ -294,17 +294,17 @@ private:
         const float* dt_b = wt(ly.dt_bias);
         const float* Dp = wt(ly.D);
         float* rec = rec_state.data() + (size_t)l * MH * MHD * DS;
-        std::vector<float> y(MH * MHD);
+        std::vector<float> y((size_t)MH * MHD);
         // precompute dB [MH*MHD*DS] and dA
-        std::vector<float> dA(MH * MHD * DS), dBx(MH * MHD * DS);
+        std::vector<float> dA((size_t)MH * MHD * DS), dBx((size_t)MH * MHD * DS);
         for (int hh = 0; hh < MH; hh++) {
             float dt = softplus(dt_in[hh] + dt_b[hh]);
             float A = -std::exp(A_log[hh]);
             for (int d = 0; d < MHD; d++) {
                 float dt_d = dt;  // time_step_limit (0, inf): no clamp
                 for (int s = 0; s < DS; s++) {
-                    dA[(size_t)hh * MHD * DS + d * DS + s] = std::exp(dt_d * A);
-                    dBx[(size_t)hh * MHD * DS + d * DS + s] = dt_d * Bp[hh % NG * DS + s] * h[hh * MHD + d];
+                    dA[(size_t)hh * MHD * DS + (size_t)d * DS + s] = std::exp(dt_d * A);
+                    dBx[(size_t)hh * MHD * DS + (size_t)d * DS + s] = dt_d * Bp[(size_t)(hh % NG) * DS + s] * h[(size_t)hh * MHD + d];
                 }
             }
         }
@@ -313,7 +313,7 @@ private:
             for (int d = 0; d < MHD; d++) {
                 float acc = 0;
                 for (int s = 0; s < DS; s++)
-                    acc += rec[(size_t)hh * MHD * DS + d * DS + s] * Cp[hh % NG * DS + s];
+                    acc += rec[(size_t)hh * MHD * DS + (size_t)d * DS + s] * Cp[(size_t)(hh % NG) * DS + s];
                 y[hh * MHD + d] = acc + h[hh * MHD + d] * Dp[hh];
             }
         }
@@ -325,7 +325,7 @@ private:
     }
 
     void attention_mix(const float* x, const GmhLayer& ly, int l, float* out) {
-        std::vector<float> q(NH * HD), k(NKV * HD), v(NKV * HD);
+        std::vector<float> q((size_t)NH * HD), k((size_t)NKV * HD), v((size_t)NKV * HD);
         mm(ly.q_proj, x, H, NH * HD, q.data());
         mm(ly.k_proj, x, H, NKV * HD, k.data());
         mm(ly.v_proj, x, H, NKV * HD, v.data());
@@ -333,7 +333,7 @@ private:
         auto& kk = attn_k[l]; auto& vv = attn_v[l];
         for (int i = 0; i < NKV * HD; i++) { kk.push_back(k[i]); vv.push_back(v[i]); }
         int T = (int)kk.size() / (NKV * HD);
-        std::vector<float> out_heads(NH * HD);
+        std::vector<float> out_heads((size_t)NH * HD);
         for (int hh = 0; hh < NH; hh++) {
             int kh = hh % NKV;
             // scores
@@ -341,7 +341,7 @@ private:
             float mx = -1e30f;
             for (int t = 0; t < T; t++) {
                 float s = 0;
-                for (int d = 0; d < HD; d++) s += q[hh * HD + d] * kk[(size_t)t * NKV * HD + kh * HD + d];
+                for (int d = 0; d < HD; d++) s += q[(size_t)hh * HD + d] * kk[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 scores[t] = s * attn_mult;
                 if (scores[t] > mx) mx = scores[t];
             }
@@ -349,7 +349,7 @@ private:
             for (int t = 0; t < T; t++) { scores[t] = std::exp(scores[t] - mx); sum += scores[t]; }
             for (int d = 0; d < HD; d++) {
                 float acc = 0;
-                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + kh * HD + d];
+                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 out_heads[hh * HD + d] = acc;
             }
         }

--- a/src/hyv3_engine.cpp
+++ b/src/hyv3_engine.cpp
@@ -259,8 +259,8 @@ private:
     }
 
     void attention_mix(const float* x, const Hyv3Layer& ly, int l, int pos, float* out) {
-        std::vector<float> q(NH * HD), k(NKV * HD), v(NKV * HD);
-        std::vector<float> qn(NH * HD), kn(NKV * HD), qr(NH * HD), kr(NKV * HD);
+        std::vector<float> q((size_t)NH * HD), k((size_t)NKV * HD), v((size_t)NKV * HD);
+        std::vector<float> qn((size_t)NH * HD), kn((size_t)NKV * HD), qr((size_t)NH * HD), kr((size_t)NKV * HD);
         mm(ly.q_proj, x, H, NH * HD, q.data());
         mm(ly.k_proj, x, H, NKV * HD, k.data());
         mm(ly.v_proj, x, H, NKV * HD, v.data());
@@ -273,14 +273,14 @@ private:
         int T = (int)kk.size() / (NKV * HD);
         float scale = 1.0f / std::sqrt((float)HD);
         int groups = NH / NKV;
-        std::vector<float> out_heads(NH * HD);
+        std::vector<float> out_heads((size_t)NH * HD);
         for (int hh = 0; hh < NH; hh++) {
             int kh = hh / groups;  // repeat_interleave mapping
             std::vector<float> scores(T);
             float mx = -1e30f;
             for (int t = 0; t < T; t++) {
                 float s = 0;
-                for (int d = 0; d < HD; d++) s += qr[hh * HD + d] * kk[(size_t)t * NKV * HD + kh * HD + d];
+                for (int d = 0; d < HD; d++) s += qr[(size_t)hh * HD + d] * kk[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 scores[t] = s * scale;
                 if (scores[t] > mx) mx = scores[t];
             }
@@ -288,7 +288,7 @@ private:
             for (int t = 0; t < T; t++) { scores[t] = std::exp(scores[t] - mx); sum += scores[t]; }
             for (int d = 0; d < HD; d++) {
                 float acc = 0;
-                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + kh * HD + d];
+                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 out_heads[hh * HD + d] = acc;
             }
         }

--- a/src/jetmoe_engine.cpp
+++ b/src/jetmoe_engine.cpp
@@ -244,24 +244,24 @@ private:
         int idx[64]; float gates[64];
         topk_gate(x, ly.attn_router, E, TOPK, idx, gates);
         // per-expert query projections
-        std::vector<float> qs(TOPK * qdim);
+        std::vector<float> qs((size_t)TOPK * qdim);
         for (int k = 0; k < TOPK && k < 64; k++) {
             mm3(ly.attn_input_linear, idx[k], x, H, qdim, qs.data() + (size_t)k * qdim);
         }
         // shared kv
         std::vector<float> kv(2 * qdim);
         mm(ly.kv_proj, x, H, 2 * qdim, kv.data());
-        std::vector<float> k(NKV * HD), v(NKV * HD);
+        std::vector<float> k((size_t)NKV * HD), v((size_t)NKV * HD);
         memcpy(k.data(), kv.data(), qdim * sizeof(float));
         memcpy(v.data(), kv.data() + qdim, qdim * sizeof(float));
-        std::vector<float> kr(NKV * HD);
+        std::vector<float> kr((size_t)NKV * HD);
         rope_apply(k.data(), NKV, HD, kr.data(), pos);
         auto& kk = attn_k[l]; auto& vv = attn_v[l];
         for (int i = 0; i < qdim; i++) { kk.push_back(kr[i]); vv.push_back(v[i]); }
         int T = (int)kk.size() / qdim;
         float scale = 1.0f / std::sqrt((float)HD);
         // attention per (expert, head) — kv shared, groups=1 (repeat not interleave)
-        std::vector<float> outs(TOPK * qdim);
+        std::vector<float> outs((size_t)TOPK * qdim);
         for (int k = 0; k < TOPK && k < 64; k++) {
             std::vector<float> qr(qdim);
             rope_apply(qs.data() + (size_t)k * qdim, NKV, HD, qr.data(), pos);
@@ -270,7 +270,7 @@ private:
                 float mx = -1e30f;
                 for (int t = 0; t < T; t++) {
                     float s = 0;
-                    for (int d = 0; d < HD; d++) s += qr[hh * HD + d] * kk[(size_t)t * qdim + hh * HD + d];
+                    for (int d = 0; d < HD; d++) s += qr[(size_t)hh * HD + d] * kk[(size_t)t * qdim + (size_t)hh * HD + d];
                     scores[t] = s * scale;
                     if (scores[t] > mx) mx = scores[t];
                 }
@@ -278,8 +278,8 @@ private:
                 for (int t = 0; t < T; t++) { scores[t] = std::exp(scores[t] - mx); sum += scores[t]; }
                 for (int d = 0; d < HD; d++) {
                     float acc = 0;
-                    for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * qdim + hh * HD + d];
-                    outs[(size_t)k * qdim + hh * HD + d] = acc;
+                    for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * qdim + (size_t)hh * HD + d];
+                    outs[(size_t)k * qdim + (size_t)hh * HD + d] = acc;
                 }
             }
         }

--- a/src/lfm2moe_engine.cpp
+++ b/src/lfm2moe_engine.cpp
@@ -296,28 +296,28 @@ private:
     }
 
     void attention_mix(const float* x, const L2mLayer& ly, int l, int pos, float* out) {
-        std::vector<float> q(NH * HD), k(NKV * HD), v(NKV * HD);
-        std::vector<float> qn(NH * HD), kn(NKV * HD);
+        std::vector<float> q((size_t)NH * HD), k((size_t)NKV * HD), v((size_t)NKV * HD);
+        std::vector<float> qn((size_t)NH * HD), kn((size_t)NKV * HD);
         mm(ly.q_proj, x, H, NH * HD, q.data());
         mm(ly.k_proj, x, H, NKV * HD, k.data());
         mm(ly.v_proj, x, H, NKV * HD, v.data());
         for (int hh = 0; hh < NH; hh++) rmsnorm(q.data() + hh * HD, wt(ly.q_ln), HD, eps, qn.data() + hh * HD);
         for (int hh = 0; hh < NKV; hh++) rmsnorm(k.data() + hh * HD, wt(ly.k_ln), HD, eps, kn.data() + hh * HD);
-        std::vector<float> qr(NH * HD), kr(NKV * HD);
+        std::vector<float> qr((size_t)NH * HD), kr((size_t)NKV * HD);
         rope_apply(qn.data(), NH, HD, qr.data(), pos);
         rope_apply(kn.data(), NKV, HD, kr.data(), pos);
         auto& kk = attn_k[l]; auto& vv = attn_v[l];
         for (int i = 0; i < NKV * HD; i++) { kk.push_back(kr[i]); vv.push_back(v[i]); }
         int T = (int)kk.size() / (NKV * HD);
         float scale = 1.0f / std::sqrt((float)HD);
-        std::vector<float> out_heads(NH * HD);
+        std::vector<float> out_heads((size_t)NH * HD);
         for (int hh = 0; hh < NH; hh++) {
             int kh = hh % NKV;
             std::vector<float> scores(T);
             float mx = -1e30f;
             for (int t = 0; t < T; t++) {
                 float s = 0;
-                for (int d = 0; d < HD; d++) s += qr[hh * HD + d] * kk[(size_t)t * NKV * HD + kh * HD + d];
+                for (int d = 0; d < HD; d++) s += qr[(size_t)hh * HD + d] * kk[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 scores[t] = s * scale;
                 if (scores[t] > mx) mx = scores[t];
             }
@@ -325,7 +325,7 @@ private:
             for (int t = 0; t < T; t++) { scores[t] = std::exp(scores[t] - mx); sum += scores[t]; }
             for (int d = 0; d < HD; d++) {
                 float acc = 0;
-                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + kh * HD + d];
+                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 out_heads[hh * HD + d] = acc;
             }
         }

--- a/src/mellum_engine.cpp
+++ b/src/mellum_engine.cpp
@@ -289,8 +289,8 @@ private:
     }
 
     void attention_mix(const float* x, const MellumLayer& ly, int l, int pos, float* out) {
-        std::vector<float> q(NH * HD), k(NKV * HD), v(NKV * HD);
-        std::vector<float> qn(NH * HD), kn(NKV * HD), qr(NH * HD), kr(NKV * HD);
+        std::vector<float> q((size_t)NH * HD), k((size_t)NKV * HD), v((size_t)NKV * HD);
+        std::vector<float> qn((size_t)NH * HD), kn((size_t)NKV * HD), qr((size_t)NH * HD), kr((size_t)NKV * HD);
         mm(ly.q_proj, x, H, NH * HD, q.data());
         mm(ly.k_proj, x, H, NKV * HD, k.data());
         mm(ly.v_proj, x, H, NKV * HD, v.data());
@@ -303,14 +303,14 @@ private:
         int T = (int)kk.size() / (NKV * HD);
         float scale = 1.0f / std::sqrt((float)HD);
         int groups = NH / NKV;
-        std::vector<float> out_heads(NH * HD);
+        std::vector<float> out_heads((size_t)NH * HD);
         for (int hh = 0; hh < NH; hh++) {
             int kh = hh / groups;
             std::vector<float> scores(T);
             float mx = -1e30f;
             for (int t = 0; t < T; t++) {
                 float s = 0;
-                for (int d = 0; d < HD; d++) s += qr[hh * HD + d] * kk[(size_t)t * NKV * HD + kh * HD + d];
+                for (int d = 0; d < HD; d++) s += qr[(size_t)hh * HD + d] * kk[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 scores[t] = s * scale;
                 if (scores[t] > mx) mx = scores[t];
             }
@@ -318,7 +318,7 @@ private:
             for (int t = 0; t < T; t++) { scores[t] = std::exp(scores[t] - mx); sum += scores[t]; }
             for (int d = 0; d < HD; d++) {
                 float acc = 0;
-                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + kh * HD + d];
+                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 out_heads[hh * HD + d] = acc;
             }
         }

--- a/src/mimo_v2.cpp
+++ b/src/mimo_v2.cpp
@@ -264,7 +264,7 @@ std::vector<float> mimo_v2_forward(MiMoV2Model& model, int token_id,
         rmsnorm(norm.data(), x.data(), l.rms_attn_w.data(), H, cfg.rms_norm_eps);
 
         // projections
-        std::vector<float> q(nh * hd), k(nkv * hd), v(nkv * vd);
+        std::vector<float> q((size_t)nh * hd), k((size_t)nkv * hd), v((size_t)nkv * vd);
         matmul(q.data(), norm.data(), l.q_proj.data(), nh * hd, H);
         matmul(k.data(), norm.data(), l.k_proj.data(), nkv * hd, H);
         matmul(v.data(), norm.data(), l.v_proj.data(), nkv * vd, H);
@@ -289,7 +289,7 @@ std::vector<float> mimo_v2_forward(MiMoV2Model& model, int token_id,
         const int seq_len = pos + 1;
         const float scale = 1.0f / std::sqrt((float)hd);
         const int win_start = is_swa ? std::max(0, seq_len - cfg.sliding_window) : 0;
-        std::vector<float> attn_out(nh * vd, 0.0f);
+        std::vector<float> attn_out((size_t)nh * vd, 0.0f);
         for (int h = 0; h < nh; h++) {
             const int kvh = h / kv_groups;
             const float* qh = &q[(size_t)h * hd];

--- a/src/minimax_engine.cpp
+++ b/src/minimax_engine.cpp
@@ -244,13 +244,13 @@ private:
     }
 
     void lightning_mix(const float* x, const MiniMaxLayer& ly, int l, float* out) {
-        std::vector<float> qkv(NH * HD * 3);
+        std::vector<float> qkv((size_t)NH * HD * 3);
         mm(ly.qkv_proj, x, H, NH * HD * 3, qkv.data());
-        std::vector<float> act(NH * HD * 3);
+        std::vector<float> act((size_t)NH * HD * 3);
         for (int i = 0; i < NH * HD * 3; i++) act[i] = gelu(qkv[i]);
         float* st = lt_state.data() + (size_t)l * NH * HD * HD;
         float ratio = std::exp(-ly.slope);
-        std::vector<float> out_heads(NH * HD);
+        std::vector<float> out_heads((size_t)NH * HD);
         for (int hh = 0; hh < NH; hh++) {
             const float* q = act.data() + hh * 3 * HD;
             const float* k = q + HD;
@@ -266,15 +266,15 @@ private:
             }
         }
         rmsnorm(out_heads.data(), wt(ly.norm_attn), NH * HD, 1e-6f, out_heads.data());
-        std::vector<float> gate(NH * HD);
+        std::vector<float> gate((size_t)NH * HD);
         mm(ly.output_gate, x, H, NH * HD, gate.data());
         for (int i = 0; i < NH * HD; i++) out_heads[i] *= 1.0f / (1.0f + std::exp(-gate[i]));
         mm(ly.out_proj, out_heads.data(), NH * HD, H, out);
     }
 
     void attention_mix(const float* x, const MiniMaxLayer& ly, int l, int pos, float* out) {
-        std::vector<float> q(NH * HD), k(NKV * HD), v(NKV * HD);
-        std::vector<float> qr(NH * HD), kr(NKV * HD);
+        std::vector<float> q((size_t)NH * HD), k((size_t)NKV * HD), v((size_t)NKV * HD);
+        std::vector<float> qr((size_t)NH * HD), kr((size_t)NKV * HD);
         mm(ly.q_proj, x, H, NH * HD, q.data());
         mm(ly.k_proj, x, H, NKV * HD, k.data());
         mm(ly.v_proj, x, H, NKV * HD, v.data());
@@ -285,14 +285,14 @@ private:
         int T = (int)kk.size() / (NKV * HD);
         float scale = 1.0f / std::sqrt((float)HD);
         int groups = NH / NKV;
-        std::vector<float> out_heads(NH * HD);
+        std::vector<float> out_heads((size_t)NH * HD);
         for (int hh = 0; hh < NH; hh++) {
             int kh = hh / groups;
             std::vector<float> scores(T);
             float mx = -1e30f;
             for (int t = 0; t < T; t++) {
                 float s = 0;
-                for (int d = 0; d < HD; d++) s += qr[hh * HD + d] * kk[(size_t)t * NKV * HD + kh * HD + d];
+                for (int d = 0; d < HD; d++) s += qr[(size_t)hh * HD + d] * kk[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 scores[t] = s * scale;
                 if (scores[t] > mx) mx = scores[t];
             }
@@ -300,7 +300,7 @@ private:
             for (int t = 0; t < T; t++) { scores[t] = std::exp(scores[t] - mx); sum += scores[t]; }
             for (int d = 0; d < HD; d++) {
                 float acc = 0;
-                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + kh * HD + d];
+                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 out_heads[hh * HD + d] = acc;
             }
         }

--- a/src/minimaxm2_engine.cpp
+++ b/src/minimaxm2_engine.cpp
@@ -225,7 +225,7 @@ private:
         auto& kcache = attn_k[l];
         auto& vcache = attn_v[l];
         int klen = (int)(kcache.size() / (NKV * HD));
-        std::vector<float> q(NH * HD), k(NKV * HD), v(NKV * HD);
+        std::vector<float> q((size_t)NH * HD), k((size_t)NKV * HD), v((size_t)NKV * HD);
         mm(ly.q_proj, xn, H, NH * HD, q.data());
         mm(ly.k_proj, xn, H, NKV * HD, k.data());
         mm(ly.v_proj, xn, H, NKV * HD, v.data());
@@ -270,7 +270,7 @@ private:
             for (int t = 0; t < seq; t++) { float e = std::exp(srow[t] - mx); probs[(size_t)h * seq + t] = e; sum += e; }
             for (int t = 0; t < seq; t++) probs[(size_t)h * seq + t] /= sum;
         }
-        std::vector<float> acc(NH * HD, 0.0f);
+        std::vector<float> acc((size_t)NH * HD, 0.0f);
         for (int h = 0; h < NH; h++) {
             int kh = h / (NH / NKV);
             const float* vv = vcache.data() + (size_t)kh * HD;

--- a/src/nemotron_h_engine.cpp
+++ b/src/nemotron_h_engine.cpp
@@ -379,7 +379,7 @@ private:
         auto& kcache = attn_k[l];
         auto& vcache = attn_v[l];
         int klen = (int)(kcache.size() / (NKV * HD));
-        std::vector<float> q(NH * HD), k(NKV * HD), v(NKV * HD);
+        std::vector<float> q((size_t)NH * HD), k((size_t)NKV * HD), v((size_t)NKV * HD);
         mm(ly.q_proj, xn, H, NH * HD, q.data());
         mm(ly.k_proj, xn, H, NKV * HD, k.data());
         mm(ly.v_proj, xn, H, NKV * HD, v.data());
@@ -403,7 +403,7 @@ private:
             for (int t = 0; t < seq; t++) { float e = std::exp(srow[t] - mx); probs[(size_t)h * seq + t] = e; sum += e; }
             for (int t = 0; t < seq; t++) probs[(size_t)h * seq + t] /= sum;
         }
-        std::vector<float> acc(NH * HD, 0.0f);
+        std::vector<float> acc((size_t)NH * HD, 0.0f);
         for (int h = 0; h < NH; h++) {
             int kh = h / (NH / NKV);
             const float* vv = vcache.data() + (size_t)kh * HD;

--- a/src/phimoe_engine.cpp
+++ b/src/phimoe_engine.cpp
@@ -223,8 +223,8 @@ private:
     }
 
     void attention_mix(const float* x, const PhimoeLayer& ly, int l, int pos, float* out) {
-        std::vector<float> q(NH * HD), k(NKV * HD), v(NKV * HD);
-        std::vector<float> qr(NH * HD), kr(NKV * HD);
+        std::vector<float> q((size_t)NH * HD), k((size_t)NKV * HD), v((size_t)NKV * HD);
+        std::vector<float> qr((size_t)NH * HD), kr((size_t)NKV * HD);
         mm(ly.q_proj, x, H, NH * HD, q.data());
         mm(ly.k_proj, x, H, NKV * HD, k.data());
         mm(ly.v_proj, x, H, NKV * HD, v.data());
@@ -235,14 +235,14 @@ private:
         int T = (int)kk.size() / (NKV * HD);
         float scale = 1.0f / std::sqrt((float)HD);
         int groups = NH / NKV;
-        std::vector<float> out_heads(NH * HD);
+        std::vector<float> out_heads((size_t)NH * HD);
         for (int hh = 0; hh < NH; hh++) {
             int kh = hh / groups;
             std::vector<float> scores(T);
             float mx = -1e30f;
             for (int t = 0; t < T; t++) {
                 float s = 0;
-                for (int d = 0; d < HD; d++) s += qr[hh * HD + d] * kk[(size_t)t * NKV * HD + kh * HD + d];
+                for (int d = 0; d < HD; d++) s += qr[(size_t)hh * HD + d] * kk[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 scores[t] = s * scale;
                 if (scores[t] > mx) mx = scores[t];
             }
@@ -250,7 +250,7 @@ private:
             for (int t = 0; t < T; t++) { scores[t] = std::exp(scores[t] - mx); sum += scores[t]; }
             for (int d = 0; d < HD; d++) {
                 float acc = 0;
-                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + kh * HD + d];
+                for (int t = 0; t < T; t++) acc += scores[t] / sum * vv[(size_t)t * NKV * HD + (size_t)kh * HD + d];
                 out_heads[hh * HD + d] = acc;
             }
         }

--- a/src/qwen3_5.cpp
+++ b/src/qwen3_5.cpp
@@ -224,7 +224,7 @@ std::vector<float> qwen3_5_forward(Qwen3_5Model& model, int token_id,
     std::vector<float> q((size_t)NVH * KHD), k((size_t)NVH * KHD), v((size_t)NVH * VHD);
     std::vector<float> out_h((size_t)NVH * VHD);
     // full attention buffers
-    std::vector<float> qg(NH * HD * 2), qs(NH * HD), gate_buf(NH * HD), ks(NKV * HD), vs(NKV * HD);
+    std::vector<float> qg((size_t)NH * HD * 2), qs((size_t)NH * HD), gate_buf((size_t)NH * HD), ks((size_t)NKV * HD), vs((size_t)NKV * HD);
     std::vector<float> scores_buf(4096), probs_buf(4096);
 
     for (int il = 0; il < cfg.num_layers; il++) {
@@ -242,7 +242,7 @@ std::vector<float> qwen3_5_forward(Qwen3_5Model& model, int token_id,
             {
                 const int K = cfg.linear_conv_kernel_dim;
                 float* st = cache.conv_state[il].data();  // [conv_dim][K-1]
-                std::vector<float> full(conv_dim * K);
+                std::vector<float> full((size_t)conv_dim * K);
                 for (int i = 0; i < conv_dim; i++) {
                     for (int j = 0; j < K - 1; j++) full[i * K + j] = st[i * (K - 1) + j];
                     full[i * K + (K - 1)] = mixed_qkv[i];
@@ -263,7 +263,7 @@ std::vector<float> qwen3_5_forward(Qwen3_5Model& model, int token_id,
             for (int i = 0; i < key_dim; i++) k[i] = conv_out[key_dim + i];
             for (int i = 0; i < value_dim; i++) v[i] = conv_out[key_dim * 2 + i];
             // reshape to heads
-            std::vector<float> qh(NKH * KHD), kh(NKH * KHD), vh(NVH * VHD);
+            std::vector<float> qh((size_t)NKH * KHD), kh((size_t)NKH * KHD), vh((size_t)NVH * VHD);
             for (int h = 0; h < NKH; h++)
                 for (int d = 0; d < KHD; d++) { qh[h * KHD + d] = q[h * KHD + d]; kh[h * KHD + d] = k[h * KHD + d]; }
             for (int h = 0; h < NVH; h++)
@@ -279,17 +279,17 @@ std::vector<float> qwen3_5_forward(Qwen3_5Model& model, int token_id,
                 g[h] = -std::exp(l.A_log[h]) * softplus(a[h] + l.dt_bias[h]);
             }
             // repeat q/k heads (NVH/NKH)
-            std::vector<float> qr(NVH * KHD), kr(NVH * KHD);
+            std::vector<float> qr((size_t)NVH * KHD), kr((size_t)NVH * KHD);
             const int rep = NVH / NKH;
             for (int h = 0; h < NVH; h++)
                 for (int d = 0; d < KHD; d++) { qr[h * KHD + d] = qh[(h / rep) * KHD + d]; kr[h * KHD + d] = kh[(h / rep) * KHD + d]; }
 
             // l2norm q/k + scale
-            std::vector<float> ql(NVH * KHD), kl(NVH * KHD);
+            std::vector<float> ql((size_t)NVH * KHD), kl((size_t)NVH * KHD);
             const float scale = 1.0f / std::sqrt((float)KHD);
             for (int h = 0; h < NVH; h++) {
-                l2norm(&ql[h * KHD], &qr[h * KHD], KHD);
-                l2norm(&kl[h * KHD], &kr[h * KHD], KHD);
+                l2norm(&ql[(size_t)h * KHD], &qr[(size_t)h * KHD], KHD);
+                l2norm(&kl[(size_t)h * KHD], &kr[(size_t)h * KHD], KHD);
                 for (int d = 0; d < KHD; d++) { ql[h * KHD + d] *= scale; }
             }
 
@@ -327,12 +327,12 @@ std::vector<float> qwen3_5_forward(Qwen3_5Model& model, int token_id,
 
             // RMSNormGated(out, z): plain rmsnorm, then * weight, then * silu(z)
             for (int h = 0; h < NVH; h++) {
-                float* oh = &out_h[h * VHD];
+                float* oh = &out_h[(size_t)h * VHD];
                 // plain rmsnorm (no affine)
                 float ss = 0;
                 for (int d = 0; d < VHD; d++) ss += oh[d] * oh[d];
                 float inv = 1.0f / std::sqrt(ss / VHD + cfg.rms_norm_eps);
-                const float* zw = &z[h * VHD];
+                const float* zw = &z[(size_t)h * VHD];
                 const float* ww = l.lnn_gated_w.data();
                 for (int d = 0; d < VHD; d++)
                     oh[d] = oh[d] * inv * ww[d] * silu(zw[d]);
@@ -354,14 +354,14 @@ std::vector<float> qwen3_5_forward(Qwen3_5Model& model, int token_id,
             matmul(vs.data(), norm.data(), l.v_proj.data(), NKV * HD, H);
             // q_norm/k_norm: RMSNorm on head dim (per head)
             for (int h = 0; h < NH; h++)
-                rmsnorm15(&qs[h * HD], &qs[h * HD], l.q_norm.data(), HD, cfg.rms_norm_eps);
+                rmsnorm15(&qs[(size_t)h * HD], &qs[(size_t)h * HD], l.q_norm.data(), HD, cfg.rms_norm_eps);
             for (int h = 0; h < NKV; h++)
-                rmsnorm15(&ks[h * HD], &ks[h * HD], l.k_norm.data(), HD, cfg.rms_norm_eps);
+                rmsnorm15(&ks[(size_t)h * HD], &ks[(size_t)h * HD], l.k_norm.data(), HD, cfg.rms_norm_eps);
             // partial rope on first rope_dim
             for (int h = 0; h < NH; h++)
-                rope_partial_first(&qs[h * HD], &qs[h * HD], rope_dim, pos, cfg.rope_theta);
+                rope_partial_first(&qs[(size_t)h * HD], &qs[(size_t)h * HD], rope_dim, pos, cfg.rope_theta);
             for (int h = 0; h < NKV; h++)
-                rope_partial_first(&ks[h * HD], &ks[h * HD], rope_dim, pos, cfg.rope_theta);
+                rope_partial_first(&ks[(size_t)h * HD], &ks[(size_t)h * HD], rope_dim, pos, cfg.rope_theta);
             // store kv
             {
                 float* krow = cache.k_cache[il].data() + (size_t)pos * (NKV * HD);
@@ -373,10 +373,10 @@ std::vector<float> qwen3_5_forward(Qwen3_5Model& model, int token_id,
             const int seq_len = pos + 1;
             const float scale = 1.0f / std::sqrt((float)HD);
             const int kv_groups = NH / NKV;
-            std::vector<float> attn_out(NH * HD, 0.0f);
+            std::vector<float> attn_out((size_t)NH * HD, 0.0f);
             for (int h = 0; h < NH; h++) {
                 const int kvh = h / kv_groups;
-                const float* qh = &qs[h * HD];
+                const float* qh = &qs[(size_t)h * HD];
                 const float* kbase = cache.k_cache[il].data() + (size_t)kvh * HD;
                 const float* vbase = cache.v_cache[il].data() + (size_t)kvh * HD;
                 for (int t = 0; t < seq_len; t++) {

--- a/src/qwen3next_engine.cpp
+++ b/src/qwen3next_engine.cpp
@@ -350,11 +350,11 @@ private:
             }
         }
         int rep = NV / NK;
-        std::vector<float> qh(NK * KHD), kh(NK * KHD), vh(VD);
+        std::vector<float> qh((size_t)NK * KHD), kh((size_t)NK * KHD), vh(VD);
         std::memcpy(qh.data(), conv_out.data(), KD * sizeof(float));
         std::memcpy(kh.data(), conv_out.data() + KD, KD * sizeof(float));
         std::memcpy(vh.data(), conv_out.data() + 2 * KD, VD * sizeof(float));
-        std::vector<float> qr(NV * KHD), kr(NV * KHD);
+        std::vector<float> qr((size_t)NV * KHD), kr((size_t)NV * KHD);
         for (int h = 0; h < NV; h++) {
             int src = (h / rep) * KHD;
             std::memcpy(qr.data() + (size_t)h * KHD, qh.data() + src, KHD * sizeof(float));
@@ -420,14 +420,14 @@ private:
         auto& kcache = attn_k[l];
         auto& vcache = attn_v[l];
         int klen = (int)(kcache.size() / (NKV * HD));
-        std::vector<float> qg(NH * HD * 2), k(NKV * HD), v(NKV * HD);
+        std::vector<float> qg((size_t)NH * HD * 2), k((size_t)NKV * HD), v((size_t)NKV * HD);
         mm(ly.q_proj, xn, H, NH * HD * 2, qg.data());
         mm(ly.k_proj, xn, H, NKV * HD, k.data());
         mm(ly.v_proj, xn, H, NKV * HD, v.data());
         // q_proj out is [NH*HD*2]; torch views [seq, NH, HD*2] then chunks on
         // the LAST dim -> per-head interleaved [q_h | gate_h] pairs, NOT
         // first-half/second-half.
-        std::vector<float> q(NH * HD), gate(NH * HD);
+        std::vector<float> q((size_t)NH * HD), gate((size_t)NH * HD);
         for (int h = 0; h < NH; h++) {
             std::memcpy(q.data() + (size_t)h * HD, qg.data() + (size_t)h * 2 * HD, HD * sizeof(float));
             std::memcpy(gate.data() + (size_t)h * HD, qg.data() + (size_t)h * 2 * HD + HD, HD * sizeof(float));
@@ -494,7 +494,7 @@ private:
             for (int t = 0; t < seq; t++) { float e = std::exp(srow[t] - mx); probs[(size_t)h * seq + t] = e; sum += e; }
             for (int t = 0; t < seq; t++) probs[(size_t)h * seq + t] /= sum;
         }
-        std::vector<float> acc(NH * HD, 0.0f);
+        std::vector<float> acc((size_t)NH * HD, 0.0f);
         for (int h = 0; h < NH; h++) {
             int kh = h / (NH / NKV);
             const float* vv = vcache.data() + (size_t)kh * HD;  // head kh, pos 0


### PR DESCRIPTION
### **User description**
## What
Cast first factor to `size_t` in vector-size, index, and memcpy arithmetic across `src/` engine files (`cpp/integer-multiplication-cast-to-long`, 176 alerts), escape `created_at`/`expires_at` in the dashboard API-key table (`js/xss-through-dom`), and cast `same` to `size_t` for `%zu` (`cpp/wrong-type-format-argument`).

## Scope
- 20 `src/*.cpp` engine files: `(size_t)` cast of first factor in alloc/index/memcpy expressions (107 insertions / 107 deletions total)
- `site/dashboard/app.js`: `esc()` on two interpolated fields
- `Testing/e2e_safetensors_selfcheck.cpp`: printf cast

## Why
Clears the first-party half of the CodeQL warning backlog. The other 1,013 open alerts (vendored `third_party/` code: llama.cpp, ggml, stable-diffusion.cpp, audio.cpp) were dismissed as won't-fix — upstream code, not actionable in this repo.

Mechanical per CodeQL rule semantics: cast first factor, e.g. `std::vector<float> q(NH * HD)` → `q((size_t)NH * HD)`. No behavior change — dims are small; casts touch alloc/index arithmetic only, never float math.


___

### **PR Type**
Bug fix


___

### **Description**
- Add `size_t` casts in 20 src engine files

- Escape API key dates in dashboard (XSS fix)

- Cast printf arg to `size_t` in selfcheck test

- No behavior change; clears first-party CodeQL backlog


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CodeQL first-party alerts"] --> B["size_t casts in 20 src engine files"]
  A --> C["esc() API-key dates in dashboard"]
  A --> D["size_t cast in selfcheck printf"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>20 files</summary><table>
<tr>
  <td><strong>e2e_safetensors_selfcheck.cpp</strong><dd><code>Cast `same` to `size_t` for `%zu` format argument</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-d4a351f57154b8f54442f20374431fc7740c4a4ddfa6a38c44eb0824ee5884b8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app.js</strong><dd><code>Escape `created_at`/`expires_at` in API key table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-9c9073e406d447950ad1a3f7793e90f0fa8367234607c812159d3276f24fb0aa">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>afmoe_engine.cpp</strong><dd><code>Add `size_t` casts to attention buffer sizing and indexing</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-419cd9ec6a6b336d3540b473eca580e3592a89cf77100d4a44c39864153238d5">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backend_generic.cpp</strong><dd><code>Add `size_t` casts to qkv bias split iterator offsets</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-82c4d3084e1369da4c917a8935387c33afa514e729d6753dd0bb508a05a8da0e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cohere2moe_engine.cpp</strong><dd><code>Add `size_t` casts to attention buffer sizing and indexing</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-f363caeb2954203c0ae79fedf2c7ecd338252ecf5ca974856327f9beb3e54528">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>deepseek_v4.cpp</strong><dd><code>Add `size_t` casts in mhc comb matrix arithmetic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-97e9f2e1d1790ecd5713e6792dcc6cc8782031a8330de3aa9d1e127a272597e9">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ernie45moe_engine.cpp</strong><dd><code>Add `size_t` casts to attention buffer sizing and indexing</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-ba2508fea7110c301ae48813d70d08bce47e37a67a71413bb457ae5668a40b95">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>exaonemoe_engine.cpp</strong><dd><code>Add `size_t` casts to attention buffer sizing and indexing</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-76c83509430031198c16914511fa4885710fb3297aca3bf8310c555400f97553">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>falconh1_engine.cpp</strong><dd><code>Add `size_t` casts to attention vector allocations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-9a8808e748fc213b85cfcb056f54f586d0f5bc4ec4bfe2bbfde1b7f7c98ed86f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>glm_moe_dsa.cpp</strong><dd><code>Add `size_t` casts to shared-expert buffer allocations</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-c6b32f815ec30d84bb3197a3c433bc8d02622c2949576ee5d2023a061d7eb29c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>granitemoehybrid_engine.cpp</strong><dd><code>Add `size_t` casts to mamba and attention index arithmetic</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-948e9a693c852b2b0d4f7743af1a1e0d10a7772568627e9abb0af31d966e4ae9">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>jetmoe_engine.cpp</strong><dd><code>Add `size_t` casts to MoA attention buffer arithmetic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-4fd1877f97ceeeaee8f77257cfe73dfdfc7682712cc70cc24469f7df938f6e2c">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lfm2moe_engine.cpp</strong><dd><code>Add `size_t` casts to attention buffer sizing and indexing</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-832e72fd82b2a4c4d379105ac18622f67f74321ee1b03b00f43c90ab1ff89b88">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mellum_engine.cpp</strong><dd><code>Add `size_t` casts to attention buffer sizing and indexing</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-4e8743a3ab327e32152e87617c4f9e966fa58fd1b31727dd4300d33d6a054547">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mimo_v2.cpp</strong><dd><code>Add `size_t` casts to attention vector allocations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-171a5cb8eaaa5036683715f0e63c514eea503ffea6442bf93a65ee1db217c29b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>minimax_engine.cpp</strong><dd><code>Add `size_t` casts to lightning and attention buffer sizing</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-974a74cd10848e9569551305dff582efd9f8755dd12a76791c6cb9b472cd44c8">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>minimaxm2_engine.cpp</strong><dd><code>Add `size_t` casts to attention vector allocations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-3d6a0abb55189852e413c0cd8b8b4e1225a2cfcd68e37fab241553c613a1e925">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nemotron_h_engine.cpp</strong><dd><code>Add `size_t` casts to attention vector allocations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-1efd92626e9e7b78adf4022cfe685c8b5cab823b6eff52f3842a07f4ef685df6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>qwen3_5.cpp</strong><dd><code>Add `size_t` casts to delta-net and attention buffer arithmetic</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-c4d0524b35ddbdba69a5d7c5d5b6df3882b347ed395938d3b15f5723608f804b">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>qwen3next_engine.cpp</strong><dd><code>Add `size_t` casts to conv and attention buffer allocations</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-a948fbed2889483af25ea841dd47f0102ad4162515cce12b08dd30d8689a9c31">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>hyv3_engine.cpp</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-a7c4fc6af5e800fc256c7ad156040ebeef67801b096e5cb4a75f55eff88010ea">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>phimoe_engine.cpp</strong></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1697/files#diff-5a79fb7a4ea25939781cad9d4f5f0c9c92b40af8c05b5aa80b83ab941383d5e6">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

