### PR TITLE
fix(dashboard): escape stored API key in input value

### DIFF
--- a/site/dashboard/app.js
+++ b/site/dashboard/app.js
@@ -744,7 +744,7 @@ async function renderApiKeys(main) {
           <div class="form-row">
             <div class="form-group" style="flex:3">
               <label>API Key for Dashboard Requests</label>
-              <input class="form-input" id="api-key-input" placeholder="sk-..." value="${localStorage.getItem('zaya_api_key') || ''}">
+              <input class="form-input" id="api-key-input" placeholder="sk-..." value="${esc(localStorage.getItem('zaya_api_key') || '')}">
               <div class="form-hint">Stored in localStorage. Used for all dashboard API calls.</div>
             </div>
             <div class="form-group" style="flex:0">


### PR DESCRIPTION
### **User description**
One-line fix: `esc()` the `localStorage.getItem('zaya_api_key')` interpolation in the API-key input's `value` attribute. CodeQL `js/xss-through-dom` (app.js:719) traces localStorage → `innerHTML` through this unescaped interpolation; `esc()` escapes `"` → `&quot;`, closing the attribute-breakout path.


___

### **PR Type**
Bug fix


___

### **Description**
- Escape stored API key in input value attribute

- Closes CodeQL js/xss-through-dom attribute-breakout path


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ls["localStorage zaya_api_key"] -- "esc()" --> input["input value attribute"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.js</strong><dd><code>Escape stored API key to fix XSS in attribute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/dashboard/app.js

<ul><li>Wrap <code>localStorage.getItem('zaya_api_key')</code> in <code>esc()</code> inside the input <br><code>value</code> attribute<br> <li> Prevents quote-based attribute breakout flagged by CodeQL <br><code>js/xss-through-dom</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1700/files#diff-9c9073e406d447950ad1a3f7793e90f0fa8367234607c812159d3276f24fb0aa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

