### PR TITLE
docs(readme): restore family nav, land FLM-free milestone, fix stale census stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ The full-catalog end state — 500+ models, HuggingFace-native bring-up — is p
 
 **→ [All families, indexed](docs/model-families/README.md)** · **→ [Combined support SSOT](docs/wiki/models.md)**
 
+### Model families
+
+Every architecture the engine detects has its own page — params, 1BP size, backends, measured perf. 500+ HuggingFace-native bring-up is the end-state goal ([roadmap](docs/plans/monster-500-models.md)); today's manifest already spans:
+
+[Zyphra](docs/model-families/zyphra.md) · [Qwen](docs/model-families/qwen.md) · [Llama](docs/model-families/llama.md) · [Mistral](docs/model-families/mistral.md) · [Gemma](docs/model-families/gemma.md) · [Phi](docs/model-families/phi.md) · [Falcon](docs/model-families/falcon.md) · [OLMo](docs/model-families/olmo.md) · [Granite](docs/model-families/granite.md) · [SmolLM](docs/model-families/smollm.md) · [DeepSeek](docs/model-families/deepseek.md) · [GPT-OSS](docs/model-families/gpt-oss.md) · [Laguna](docs/model-families/laguna.md) · [Kimi](docs/model-families/kimi.md) · [BitNet / Bonsai](docs/model-families/bitnet-bonsai.md) · [Whisper](docs/model-families/whisper.md)
+
 ## Frontier gates: 5/5 validated against reference implementations
 
 
@@ -85,6 +91,8 @@ Six hardware targets are probed at startup (`has_npu`, `has_hip_gpu`, `has_vulka
 **22 proprietary libraries. 209 bitstreams. Zero documentation.**
 
 AMD shipped the Ryzen AI Max+ 395 with a 50 TOPS XDNA 2 NPU and locked it behind a closed-source runtime. Nothing else could touch that chip. We reverse-engineered the whole stack in 4 days and replaced it with open C++ — one MIT-licensed engine that runs LLMs on the NPU, on AMD / NVIDIA / Apple GPUs, or on plain CPU.
+
+**As of 2026-08-15, the last proprietary dependency is gone.** The engine's own instruction-stream generator emits **byte-identical** output to the closed-source runtime's own dumps (verified `cmp`-exact on every op), builds xclbins with the fully open `aiecc`/`peano-clang` toolchain, and now **beats** the proprietary stack's own kernels by 11-15% — 2× on a 35B MoE model. Not just replicated: outperformed, with nothing closed-source left in the loop.
 
 **→ [Read the full journey](docs/journey.md)** — every crash, breakthrough, and bug, documented in real time.
 **→ [The Audit Trail](docs/audit-trail.md)** — 1.5 TB of raw evidence, archived nightly on the Raspberry Pi backup server.

--- a/docs/model-families/README.md
+++ b/docs/model-families/README.md
@@ -1,6 +1,6 @@
 # Model Families
 
-1bit auto-detects **32 architecture tokens / 120+ HF arch strings** from GGUF/1BP/safetensors headers — no config files, no per-model glue code. Point the engine at a model and run. Coverage is measured against a full HF census: **302,330 / 322,029 arch-bearing text-gen checkpoints (93.88%) map to an engine token** — see the [models SSOT](../wiki/models.md).
+1bit auto-detects **32 architecture tokens / 120+ HF arch strings** from GGUF/1BP/safetensors headers — no config files, no per-model glue code. Point the engine at a model and run. Coverage is measured against a full HF census: **317,310 / 317,310 arch-bearing text-gen checkpoints (100.00%) map to an engine token** — see the [models SSOT](../wiki/models.md).
 
 Every family below has its **own page** with a full breakdown: parameter sizes, 1BP file size, supported backends, and real measured performance. Numbers trace back to the [performance SSOT](../wiki/performance.md); model-support detail traces back to [wiki/models.md](../wiki/models.md).
 


### PR DESCRIPTION
### **User description**
## Summary
- Restore the per-family nav links in `README.md` (Zyphra, Qwen, Llama, Mistral, ...) that got orphaned when the Design-export README (#1648) replaced the previous version — the `docs/model-families/*.md` pages themselves were never deleted, just no longer linked inline. Framed against the real 500+ end-state goal rather than implying it's already reached.
- Add the 2026-08-15 FLM-free milestone to the "hard truth" section: the engine's own instruction-stream generator is now byte-identical to FastFlowLM's proprietary dumps and beats its kernels 11-15% (2x on the 35B), with zero remaining proprietary dependency. This is documented in `docs/journey.md` (UPDATE 34) but was never surfaced in the top-level README.
- Fix `docs/model-families/README.md`, which still showed the stale 93.88% (302,330/322,029) census figure — every other doc (`README.md`, `docs/wiki/models.md`, `docs/journey.md`) already reflects the current 100.00% (317,310/317,310) number from the 2026-08-16 census.

## Test plan
- [ ] Visual check of rendered README on GitHub (tables/links render correctly)
- [ ] `python3 scripts/generate_readme_numbers.py --check` (numbers unchanged by this PR, but confirms no drift)


___

### **PR Type**
Documentation


___

### **Description**
- Restore per-family nav links section in `README.md`

- Add FLM-free milestone: byte-identical streams, 11-15% faster

- Fix stale census stat in `docs/model-families/README.md` (100.00%)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  readme["README.md"] -- "restores" --> nav["Model families nav links"]
  readme -- "adds" --> milestone["FLM-free milestone announcement"]
  families["docs/model-families/README.md"] -- "updates" --> census["Census stat to 317,310/317,310 (100.00%)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Restore family nav links and add FLM-free milestone</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added <code>Model families</code> section with links to 16 per-family pages <br>(<code>docs/model-families/*.md</code>), framed against the 500+ model roadmap goal<br> <li> Added FLM-free milestone paragraph: engine's instruction-stream <br>generator is byte-identical to FastFlowLM dumps and beats its kernels <br>by 11-15% (2x on 35B MoE), with no proprietary dependency remaining</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1701/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Fix stale census coverage figure to 100%</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/model-families/README.md

<ul><li>Updated HF census coverage stat from stale 302,330/322,029 (93.88%) to <br>current 317,310/317,310 (100.00%), matching other docs</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1701/files#diff-4df23b46e64a148db2785c6da4ac7c504cc2921513b5566ff4736396d9f3d73c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

