### PR TITLE
docs(journey): fix Table of Contents — 8 sections were undiscoverable

### DIFF
--- a/docs/journey.md
+++ b/docs/journey.md
@@ -6,6 +6,10 @@
 
 ## Table of Contents
 
+- [2026-08-16 — The Frontier Gates: 5/5 Validated, Then the Repo Tried to Eat It](#2026-08-16--the-frontier-gates-55-validated-then-the-repo-tried-to-eat-it)
+- [2026-08-15 — 100% HF Coverage: Every Arch-Bearing Checkpoint Maps to an Engine Token](#2026-08-15--100-hf-coverage-every-arch-bearing-checkpoint-maps-to-an-engine-token)
+- [2026-08-07 — The Unified Control Plane Lands](#2026-08-07--the-unified-control-plane-lands-pool-wired-spec-decode-in-server-zoo-55)
+- [UPDATE 34: FLM Is Fully Gone — Byte-Identical Streams, True Batch, 2× on the 35B](#update-34-2026-08-15-flm-is-fully-gone--byte-identical-streams-true-batch-2×-on-the-35b)
 - [UPDATE 33: NPU Firmware RE via Raw ioctls, Driver Regression Fixed, JARVIS Ships](#update-33-2026-08-10-npu-firmware-re-via-raw-ioctls-driver-regression-fixed-jarvis-ships)
 - [UPDATE 32: amdxdna Wedge Saga, 35B MoE Goes Live, Vivado-Free FPGA Toolchain](#update-32-2026-08-09-amdxdna-wedge-saga-35b-moe-goes-live-vivado-free-fpga-toolchain)
 - [UPDATE 31: The TileFuse Day — NPU Kernel From Scratch, Q4NX Pivot, Converter Ladder](#update-31-2026-08-08-the-tilefuse-day--npu-kernel-from-scratch-q4nx-pivot-converter-ladder)
@@ -25,6 +29,10 @@
 - [UPDATE 17: M=16 Batch Decode — 16 ms/tok](#update-17-2026-07-02-0300-adt-m16-batch-decode--16-mstok-152×-speedup)
 - [UPDATE 16: Full Profile + 50 ms/tok Batch-4](#update-16-2026-07-02-0200-adt-full-profile--50-mstok-batch-4-decode)
 - [UPDATE 15: PR-Agent Live, Landing Page](#update-15-2026-07-01-1500-adt-pr-agent-live-landing-page-deployed-242-mstok-verified)
+- [Session 2026-07-16/20 — FLM Fully Replaced, Model-Agnostic Broadening, TQ2 Ternary](#session-2026-07-1620--flm-fully-replaced-model-agnostic-broadening-tq2-ternary)
+- [Session 2026-07-05/06 — Q4NX/GGUF Fully Decoded, NPU GEMM Root-Caused, First Validated 1-Bit Number, DSpark](#session-2026-07-0506--q4nxgguf-fully-decoded-npu-gemm-root-caused-first-validated-1-bit-number-dspark)
+- [Session 2026-07-03/04 — Triton-XDNA Eval, memlock Fix, Spec-Decode Reality Check](#session-2026-07-0304--triton-xdna-eval-memlock-fix-spec-decode-reality-check)
+- [Session 2026-07-02/03 — Production Stack, Release, Site Refresh](#session-2026-07-0203--production-stack-release-site-refresh)
 - [Earlier Updates (14–1)](#earlier-updates)
 
 ---


### PR DESCRIPTION
### **User description**
## Summary
`docs/journey.md`'s Table of Contents stopped at UPDATE 33 + a collapsed "Earlier Updates" link, but the document actually continues another ~450 lines with UPDATE 34 and seven more major dated sections that were never linked from the top.

Most notably missing: the 2026-08-16 entry *"the frontier gates: 5/5 validated, then the repo tried to eat it"* — which documents a merge that silently dropped a whole validated session's work from `main`, recovered via `git reflog`. That's the kind of thing that should be one click away from the TOC, not buried at the very bottom of a 2,400-line file.

Added (same list style as existing entries):
- UPDATE 34 (2026-08-15): FLM is fully gone
- 2026-08-07: the unified control plane lands
- 2026-08-15: 100% HF coverage
- 2026-08-16: the frontier gates / recovery incident
- Session 2026-07-02/03, 2026-07-03/04, 2026-07-05/06, 2026-07-16/20

Verified every new anchor against the actual heading slugs with a script; the few pre-existing entries containing "×" that a naive ASCII-only slugifier flags are a known false positive, confirmed against already-working entries using the identical pattern.

**Not addressed here, flagging for a separate decision:** the file's physical section order isn't strictly chronological — the four `Session` entries above (and a block of 2025/2026-06-28 content earlier in the file) sit out of date order relative to their neighbors. That's a real restructuring question, not something to bundle into a TOC fix.

## Test plan
- [ ] Click through all 8 new TOC links on GitHub's rendered view to confirm they land on the right section


___

### **PR Type**
Documentation


___

### **Description**
- Add 8 missing entries to `docs/journey.md` Table of Contents

- Link recent sections: UPDATE 34, 2026-08-16 frontier gates incident

- Link four retro `Session` entries predating numbered updates

- Anchors verified against actual heading slugs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  toc["Table of Contents"] -- "adds 4 recent entries" --> recent["UPDATE 34 + 2026-08 sections"]
  toc -- "adds 4 session entries" --> sessions["Session 2026-07 entries"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>journey.md</strong><dd><code>Complete journey TOC with 8 previously unlinked sections</code>&nbsp; </dd></summary>
<hr>

docs/journey.md

<ul><li>Added 4 TOC entries before UPDATE 33: 2026-08-16 frontier gates <br>incident, 2026-08-15 100% HF coverage, 2026-08-07 unified control <br>plane, UPDATE 34 (FLM gone)<br> <li> Added 4 TOC entries before "Earlier Updates": Sessions 2026-07-16/20, <br>2026-07-05/06, 2026-07-03/04, 2026-07-02/03<br> <li> Anchors match existing heading slugs; no content sections modified</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1706/files#diff-fe3305852160f6191b970d4c904badf83f3dcd478c4c7f581e27208288bf202e">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

