### PR TITLE
docs(readme): badge colors → site cyan/amber (00e5ff/ff9f1c)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 ### 100% HF model coverage. Any hardware. One open-source, pure-C++ inference engine — NPU + GPU + CPU in a single engine. Model agnostic. Hardware agnostic. Zero Python.
 
 [![CI](https://github.com/1bit-MONSTER/1bit-MONSTER/actions/workflows/ci.yml/badge.svg)](https://github.com/1bit-MONSTER/1bit-MONSTER/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/license-MIT-0E80BE?style=flat-square&labelColor=021621)](LICENSE)
-[![HF coverage](https://img.shields.io/badge/HF%20coverage-100%25-0E80BE?style=flat-square&labelColor=021621)](docs/model-families/README.md)
-[![Hardware](https://img.shields.io/badge/hardware-NPU%20%C2%B7%20HIP%20%C2%B7%20Vulkan%20%C2%B7%20CUDA%20%C2%B7%20Metal%20%C2%B7%20CPU-B26400?style=flat-square&labelColor=021621)](docs/guides/architecture.md)
-[![Gates](https://img.shields.io/badge/gates-17%2F17%20green-0E80BE?style=flat-square&labelColor=021621)](Testing/run_all.sh)
-[![Prefill](https://img.shields.io/badge/prefill-43.2%20TFLOPS-B26400?style=flat-square&labelColor=021621)](docs/wiki/performance.md)
-[![Site](https://img.shields.io/badge/site-1bit.monster-0E80BE?style=flat-square&labelColor=021621)](https://1bit.monster)
+[![License: MIT](https://img.shields.io/badge/license-MIT-00e5ff?style=flat-square&labelColor=021621)](LICENSE)
+[![HF coverage](https://img.shields.io/badge/HF%20coverage-100%25-00e5ff?style=flat-square&labelColor=021621)](docs/model-families/README.md)
+[![Hardware](https://img.shields.io/badge/hardware-NPU%20%C2%B7%20HIP%20%C2%B7%20Vulkan%20%C2%B7%20CUDA%20%C2%B7%20Metal%20%C2%B7%20CPU-ff9f1c?style=flat-square&labelColor=021621)](docs/guides/architecture.md)
+[![Gates](https://img.shields.io/badge/gates-17%2F17%20green-00e5ff?style=flat-square&labelColor=021621)](Testing/run_all.sh)
+[![Prefill](https://img.shields.io/badge/prefill-43.2%20TFLOPS-ff9f1c?style=flat-square&labelColor=021621)](docs/wiki/performance.md)
+[![Site](https://img.shields.io/badge/site-1bit.monster-00e5ff?style=flat-square&labelColor=021621)](https://1bit.monster)
 
 **[Website](https://1bit.monster)** · **[Docs](docs/README.md)** · **[Model families](docs/model-families/README.md)** · **[Benchmarks](docs/wiki/performance.md)** · **[JARVIS](docs/jarvis.md)** · **[The story](docs/journey.md)** · **[Roadmap](docs/guides/roadmap.md)**
 


### PR DESCRIPTION
### **User description**
README badges now use the 1bit.monster palette per the Get-started gradient (#00e5ff → #ff9f1c, labelColor #021621). Primary badges cyan, hardware/prefill accents amber. Replaces steel 0E80BE/B26400.


___

### **PR Type**
Documentation


___

### **Description**
- Recolor README badges to 1bit.monster site palette

- Primary badges now cyan `00e5ff` (was `0E80BE`)

- Hardware/prefill accent badges now amber `ff9f1c` (was `B26400`)

- Badge links, text, and `labelColor` unchanged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["Badges: steel 0E80BE / B26400"] -- "recolor to site palette" --> new["Badges: cyan 00e5ff / amber ff9f1c"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Recolor README badges to site cyan/amber palette</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>License, HF coverage, gates, and site badges: <code>0E80BE</code> → <code>00e5ff</code> cyan<br> <li> Hardware and prefill badges: <code>B26400</code> → <code>ff9f1c</code> amber<br> <li> No changes to badge text, links, style, or <code>labelColor=021621</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1707/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

