### PR TITLE
chore(benchmarks): daily auto re-measure

### DIFF
--- a/benchmarks/latest.json
+++ b/benchmarks/latest.json
@@ -195,11 +195,11 @@
     "tolerance": 0.15
   },
   "benchmarks": {
-    "halo_gemv_gbps": 148.2,
-    "prefill_tflops_4h": 29.7,
-    "prefill_tflops_i8apre": 40.99,
-    "sherry_gemv_gbps": 155.2,
-    "tq1_gemv_gbps": 201.1
+    "halo_gemv_gbps": 158.6,
+    "prefill_tflops_4h": 30.05,
+    "prefill_tflops_i8apre": 41.85,
+    "sherry_gemv_gbps": 155.3,
+    "tq1_gemv_gbps": 184.7
   },
   "repo": {
     "forks": 4,

--- a/packaging/services/1bit-benchmark-validate.service
+++ b/packaging/services/1bit-benchmark-validate.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=1bit.MONSTER daily benchmark re-validation
+Documentation=https://1bit.monster
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=REPO=__REPO_ROOT__
+Environment=TOOLS_SRC=__TOOLS_SRC__
+# Runs from __TOOLS_SRC__, not the worktree at __REPO_ROOT__: the script's
+# own first step (git checkout -B) resets that worktree to origin/main each
+# run, which would rewrite this very file out from under itself mid-execution
+# if it were the one being interpreted. __TOOLS_SRC__ is plain files, not a
+# git checkout, so it's stable across the reset. Keep the two copies in sync
+# (packaging/services/daily-benchmark-validate.sh here is the checked-in,
+# human-readable reference).
+ExecStart=__TOOLS_SRC__/daily-benchmark-validate.sh

--- a/packaging/services/1bit-benchmark-validate.timer
+++ b/packaging/services/1bit-benchmark-validate.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run 1bit.MONSTER benchmark re-validation daily
+
+[Timer]
+# Same slot the old CI cron used (.github/workflows/validate-claims.yml, now
+# retired — see tools/validate_claims.py docstring).
+OnCalendar=*-*-* 04:17:00 UTC
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target

--- a/packaging/services/daily-benchmark-validate.sh
+++ b/packaging/services/daily-benchmark-validate.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# daily-benchmark-validate.sh — re-measure the 5 hardware-verified benchmark
+# claims and publish the result as a PR against origin/main.
+#
+# Runs entirely inside a dedicated worktree/branch (benchmarks/auto-update)
+# so it never touches whatever is checked out in the main working copy.
+# Force-pushes a single fresh commit each run: rebuilt from current
+# origin/main plus today's measurement, so the branch never accumulates
+# history and a still-open PR just gets its diff updated.
+#
+# Within tolerance  -> commit + push + open/refresh the PR.
+# Drift or a failed  -> no publish; open/comment on a tracking issue instead.
+#   benchmark run
+# No GPU present     -> log and exit clean (not a claims failure).
+set -euo pipefail
+
+REPO="${REPO:-$HOME/1bit-MONSTER-benchmarks}"
+TOOLS_SRC="${TOOLS_SRC:-$HOME/1bit-benchmark-tools}"
+BRANCH="benchmarks/auto-update"
+TODAY="$(date -u +%F)"
+
+# Files this pipeline owns, relative to $REPO. None of these exist on
+# origin/main yet, so `git checkout -B ... origin/main` below wipes them from
+# the worktree every run -- $TOOLS_SRC/repo-files mirrors this same relative
+# layout as a durable copy (plain files, not a git checkout) that survives
+# the reset and gets restaged fresh each run.
+MANAGED_FILES=(
+    tools/validate_claims.py
+    tools/sync_numbers.py
+    packaging/services/daily-benchmark-validate.sh
+    packaging/services/1bit-benchmark-validate.service
+    packaging/services/1bit-benchmark-validate.timer
+)
+
+cd "$REPO"
+echo "=== $(date -u +%FT%TZ) daily benchmark validate ==="
+
+git fetch origin main
+# -f: discard any leftover local modifications to tracked files (e.g. a
+# stray manual test run) rather than aborting -- this worktree is dedicated
+# to this job, nothing here is meant to be preserved across runs.
+git checkout -f -B "$BRANCH" origin/main
+
+cp -r "$TOOLS_SRC/repo-files/." .
+
+cmake --build build --target bench_sherry bench_prefill_variants -j"$(nproc)"
+
+set +e
+python3 tools/validate_claims.py --build-dir build --repeat 3 --warmup 1 --update --json /tmp/1bit-validate-report.json
+rc=$?
+set -e
+
+if [ "$rc" -eq 2 ]; then
+    echo "hardware unavailable this run -- nothing measured, nothing published"
+    exit 0
+fi
+
+if [ "$rc" -ne 0 ]; then
+    echo "drift or benchmark failure (exit $rc) -- opening/updating an issue instead of publishing"
+    body="$(python3 - <<'PY'
+import json
+r = json.load(open("/tmp/1bit-validate-report.json"))
+lines = [
+    "Automated daily re-measure (tools/validate_claims.py) found a published",
+    "benchmark claim drifted beyond the 15% tolerance, or a benchmark run failed.",
+    "",
+]
+for d in r.get("drifted", []):
+    lines.append(f"- DRIFT: {d}")
+for f in r.get("failures", []):
+    lines.append(f"- FAILURE: {f}")
+if r.get("crashes"):
+    lines.append("")
+    lines.append("Crashes (retried once each; did not by themselves cause this):")
+    for c in r["crashes"]:
+        lines.append(f"- {c}")
+print("\n".join(lines))
+PY
+)"
+    existing="$(gh issue list --search '"[benchmark drift]" in:title is:open' --json number --jq '.[0].number' 2>/dev/null || true)"
+    if [ -n "$existing" ]; then
+        gh issue comment "$existing" --body "$body"
+    else
+        gh issue create --title "[benchmark drift] daily re-measure $TODAY" --body "$body"
+    fi
+    exit 0
+fi
+
+python3 tools/sync_numbers.py
+
+if git diff --quiet -- benchmarks/latest.json site/numbers.json site/index.html site/benchmarks.html; then
+    echo "no change vs current origin/main -- nothing to publish"
+    exit 0
+fi
+
+git add benchmarks/latest.json site/numbers.json site/index.html site/benchmarks.html "${MANAGED_FILES[@]}"
+git commit -m "chore(benchmarks): daily re-measure $TODAY
+
+Automated via tools/validate_claims.py --update. All published claims
+re-measured within the 15% tolerance this run. See benchmarks/latest.json
+for per-key medians and spread."
+
+git push --force-with-lease origin "$BRANCH:$BRANCH"
+
+# gh pr view/create's branch-name matching is unreliable from a detached,
+# non-interactive context; rather than gate on it, just try to create and
+# swallow the (expected, common) "already exists" failure -- the push above
+# already updated any existing PR's diff, so a failed create here is a no-op.
+gh pr create \
+    --title "chore(benchmarks): daily auto re-measure" \
+    --body "Automated daily re-measurement of the 5 hardware-verified benchmark claims (tools/validate_claims.py). This branch is force-pushed fresh off current main every run, so the diff always reflects the latest measurement — safe to merge whenever, or let tomorrow's run supersede it." \
+    --base main --head "$BRANCH" 2>&1 | tee /tmp/1bit-gh-pr-create.log || true
+if grep -q "already exists" /tmp/1bit-gh-pr-create.log 2>/dev/null; then
+    echo "PR already exists for $BRANCH -- push above already updated it"
+fi
+
+echo "done"

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -71,7 +71,7 @@
       <p class="lead">Every number here carries its hardware and its date. Reference machine: <strong>AMD Ryzen AI MAX+ 395</strong> · Radeon 8060S · 32 GB UMA. If a number has no provenance, treat it as a bug in the docs.</p>
     </div>
     <div class="stats">
-      <div><b>43.2</b><span>TFLOPS int8 prefill (WMMA)</span></div>
+      <div><b>41.9</b><span>TFLOPS int8 prefill (WMMA)</span></div>
       <div><b>662</b><span>tok/s peak decode</span></div>
       <div><b>6</b><span>hardware targets</span></div>
       <div><b>5/5</b><span>zoo smoke pass</span></div>

--- a/site/numbers.json
+++ b/site/numbers.json
@@ -1,7 +1,7 @@
 {
   "_warning": "Site data file. Headline perf numbers synced from benchmarks (source of truth). binary/ repo/ site/ keys are unique to this file.",
   "_missing": [],
-  "_benchmarks_remeasured": "2026-08-01, median of runs on real gfx1151 hardware (bench_sherry, bench_prefill_variants, llama-bench GGML-Vulkan) \u2014 see _sources.",
+  "_benchmarks_remeasured": "2026-08-17, median of 3 runs on real gfx1151 hardware (bench_sherry, bench_prefill_variants) \u2014 see _sources.",
   "binary": {
     "onebin_bytes": 70458416,
     "onebin_kb": 68807,
@@ -16,20 +16,20 @@
     "note": "ONE ELF (build/1bit): zaya_server + unified_server + unified_router + jarvis_server + vision_server + the agent CLI, dispatched by argv[0]/subcommand; legacy names ship as symlinks. zaya/unified entries kept as historical pre-merge sizes."
   },
   "benchmarks": {
-    "halo_gemv_gbps": 156.0,
-    "prefill_tflops_4h": 30.43,
-    "prefill_tflops_i8apre": 43.2,
-    "sherry_gemv_gbps": 157.0,
-    "tq1_gemv_gbps": 201.3,
-    "tflops": 43.2,
-    "note": "prefill_tflops_i8apre now 43.2 (2026-08-01 re-measure); 4h variant 30.43; tq1/sherry essentially unchanged. See benchmarks.json engines.prefill_i8."
+    "halo_gemv_gbps": 158.6,
+    "prefill_tflops_4h": 30.05,
+    "prefill_tflops_i8apre": 41.85,
+    "sherry_gemv_gbps": 155.3,
+    "tq1_gemv_gbps": 184.7,
+    "tflops": 41.85,
+    "note": "Auto re-measured 2026-08-17 by tools/validate_claims.py (bench_sherry, bench_prefill_variants, median of 3 runs, 1 warmup discarded). See benchmarks/latest.json for full history."
   },
   "_sources": {
-    "halo_gemv_gbps": "bench_sherry 6912 2560 256 -- halo baseline kernel",
+    "halo_gemv_gbps": "bench_sherry -- halo baseline kernel",
     "prefill_tflops_4h": "bench_prefill_variants 2560 6912 2560 -- variant 4h (64x64 cached A+B)",
-    "prefill_tflops_i8apre": "bench_prefill_variants 2560 6912 2560 -- variant 4i-I8-APRE (I8 A + tiled B)",
-    "sherry_gemv_gbps": "bench_sherry 6912 2560 256 -- M=6912 K=2560, sherry kernel",
-    "tq1_gemv_gbps": "bench_sherry 6912 2560 256 -- tq1 kernel"
+    "prefill_tflops_i8apre": "bench_prefill_variants 2560 6912 2560 -- variant 4i-I8-APRE (I8 A + tiled B), median of 3",
+    "sherry_gemv_gbps": "bench_sherry -- M=6912 K=2560, sherry kernel, 256 iters",
+    "tq1_gemv_gbps": "bench_sherry -- tq1 kernel, fastest GEMV variant"
   },
   "repo": {
     "forks": 4,
@@ -44,8 +44,8 @@
     "backends": 9,
     "models": 47
   },
-  "prefill_tflops_i8apre": 43.2,
-  "tflops": 43.2,
+  "prefill_tflops_i8apre": 41.85,
+  "tflops": 41.85,
   "blackmamba_1_5b_tok_s": 79.4,
   "blackmamba_2_8b_tok_s": 46.0,
   "engines": {

--- a/tools/sync_numbers.py
+++ b/tools/sync_numbers.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Sync the 5 hardware-verified benchmark keys from benchmarks/latest.json
+into site/numbers.json and the one static HTML figure derived from them.
+
+Narrow by design: only touches what tools/validate_claims.py --update just
+refreshed --  benchmarks/_sources/_benchmarks_remeasured in numbers.json,
+plus the single "prefill_tflops_i8apre" figure printed on the live site
+(site/index.html and site/benchmarks.html). Everything else in numbers.json
+(binary/repo/site/engines/blackmamba_*/...) is left byte-for-byte alone --
+those come from a different, human-governed pipeline (site/benchmarks.json),
+out of scope here.
+
+Usage:
+    python3 tools/sync_numbers.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+LATEST = REPO / "benchmarks/latest.json"
+NUMBERS = REPO / "site/numbers.json"
+INDEX_HTML = REPO / "site/index.html"
+BENCHMARKS_HTML = REPO / "site/benchmarks.html"
+
+KEYS = (
+    "halo_gemv_gbps",
+    "prefill_tflops_4h",
+    "prefill_tflops_i8apre",
+    "sherry_gemv_gbps",
+    "tq1_gemv_gbps",
+)
+
+
+def sync_numbers_json(today: str) -> tuple[bool, float]:
+    latest = json.loads(LATEST.read_text())
+    numbers = json.loads(NUMBERS.read_text())
+
+    bm = dict(numbers.get("benchmarks", {}))
+    changed = any(bm.get(k) != latest["benchmarks"][k] for k in KEYS)
+
+    for k in KEYS:
+        bm[k] = latest["benchmarks"][k]
+    bm["tflops"] = bm["prefill_tflops_i8apre"]
+    bm["note"] = (
+        f"Auto re-measured {today} by tools/validate_claims.py "
+        f"(bench_sherry, bench_prefill_variants, median of 3 runs, "
+        f"1 warmup discarded). See benchmarks/latest.json for full history."
+    )
+    numbers["benchmarks"] = bm
+    numbers["_sources"] = dict(latest["_sources"])
+    numbers["_benchmarks_remeasured"] = (
+        f"{today}, median of 3 runs on real gfx1151 hardware "
+        f"(bench_sherry, bench_prefill_variants) — see _sources."
+    )
+    numbers["prefill_tflops_i8apre"] = bm["prefill_tflops_i8apre"]
+    numbers["tflops"] = bm["prefill_tflops_i8apre"]
+
+    NUMBERS.write_text(json.dumps(numbers, indent=2) + "\n")
+    return changed, bm["prefill_tflops_i8apre"]
+
+
+def patch_index_html(new_value: str, today: str) -> bool:
+    text = INDEX_HTML.read_text(encoding="utf-8")
+    m = re.search(r"measured (\d{4}-\d{2}-\d{2})\. Plus ([\d.]+) TFLOPS INT8 prefill\.", text)
+    if not m:
+        print("WARN: site/index.html anchor sentence not found -- skipping", file=sys.stderr)
+        return False
+    old_date, old_value = m.group(1), m.group(2)
+    if old_value == new_value:
+        return False
+    new_text = text[: m.start()] + f"measured {today}. Plus {new_value} TFLOPS INT8 prefill." + text[m.end() :]
+    INDEX_HTML.write_text(new_text, encoding="utf-8")
+    print(f"site/index.html: {old_value} -> {new_value} (measured {old_date} -> {today})")
+    return True
+
+
+def patch_benchmarks_html(new_value: str) -> bool:
+    text = BENCHMARKS_HTML.read_text(encoding="utf-8")
+    m = re.search(r"<b>([\d.]+)</b><span>TFLOPS int8 prefill \(WMMA\)</span>", text)
+    if not m:
+        print("WARN: site/benchmarks.html anchor not found -- skipping", file=sys.stderr)
+        return False
+    old_value = m.group(1)
+    if old_value == new_value:
+        return False
+    new_text = text[: m.start(1)] + new_value + text[m.end(1) :]
+    BENCHMARKS_HTML.write_text(new_text, encoding="utf-8")
+    print(f"site/benchmarks.html: {old_value} -> {new_value}")
+    return True
+
+
+def main() -> int:
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    changed, i8apre = sync_numbers_json(today)
+    print(f"site/numbers.json: {'updated' if changed else 'unchanged'} (prefill_tflops_i8apre={i8apre})")
+
+    display_value = f"{i8apre:.1f}"
+    patch_index_html(display_value, today)
+    patch_benchmarks_html(display_value)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate_claims.py
+++ b/tools/validate_claims.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Re-measure every published benchmark claim against real hardware.
+
+Designed to run unattended every 24h (see packaging/services/1bit-benchmark-validate.timer).
+
+Exit codes:
+    0  every published claim re-measured within tolerance
+    1  a published claim drifted beyond tolerance, or a benchmark crashed
+    2  hardware unavailable -- nothing was measured (not a failure of the claims)
+
+Usage:
+    python3 tools/validate_claims.py --build-dir build
+    python3 tools/validate_claims.py --build-dir build --update   # rewrite measured values
+    python3 tools/validate_claims.py --json report.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+BENCH = REPO / "benchmarks/latest.json"
+
+GPU_ENV = {
+    "HSA_OVERRIDE_GFX_VERSION": "11.5.1",
+    "HSA_ENABLE_SDMA": "0",
+}
+
+
+def have_gpu() -> bool:
+    return Path("/dev/kfd").exists()
+
+
+def have_npu() -> bool:
+    return any(Path("/dev/accel").glob("accel*")) if Path("/dev/accel").is_dir() else False
+
+
+def run(argv: list[str], cwd: Path, timeout: int = 600) -> tuple[int, str]:
+    env = dict(os.environ)
+    env.update(GPU_ENV)
+    env["LD_LIBRARY_PATH"] = f"{cwd}:/opt/rocm/lib:" + env.get("LD_LIBRARY_PATH", "")
+    try:
+        p = subprocess.run(
+            argv, cwd=cwd, env=env, timeout=timeout,
+            capture_output=True, text=True,
+        )
+    except subprocess.TimeoutExpired:
+        return 124, "TIMEOUT"
+    except FileNotFoundError:
+        return 127, f"not found: {argv[0]}"
+    return p.returncode, p.stdout + p.stderr
+
+
+# ---- parsers: benchmark stdout -> {key: measured value} -------------------
+
+def parse_prefill(out: str) -> dict[str, float]:
+    """Pin to *named* variants.
+
+    `Fastest variant:` is not a stable metric -- which variant wins varies
+    run to run, so the number it reports is not comparable across runs.
+    """
+    got: dict[str, float] = {}
+    # "4i-I8-APRE (I8 A+ tiled B)              2.5468      35.57"
+    for label, key in (("4i-I8-APRE", "prefill_tflops_i8apre"),
+                       ("4h", "prefill_tflops_4h")):
+        m = re.search(rf"^\s*{re.escape(label)}\s+\(.*?\)\s+([\d.]+)\s+([\d.]+)\s*$", out, re.M)
+        if m:
+            got[key] = float(m.group(2))
+    return got
+
+
+def parse_sherry(out: str) -> dict[str, float]:
+    got: dict[str, float] = {}
+    # "[bench_sherry] sherry     : 18.58 us/call  148.8 GB/s"
+    for kernel, key in (("sherry", "sherry_gemv_gbps"),
+                        ("tq1", "tq1_gemv_gbps"),
+                        ("halo", "halo_gemv_gbps")):
+        m = re.search(rf"^\[bench_sherry\]\s+{kernel}\s*:.*?([\d.]+)\s*GB/s", out, re.M)
+        if m:
+            got[key] = float(m.group(1))
+    return got
+
+
+PARSERS = {
+    "bench_prefill_variants": parse_prefill,
+    "bench_sherry": parse_sherry,
+}
+
+
+def parse_shell_bench(out: str) -> dict[str, float]:
+    """
+    Parse '<key> <value>' lines from a shell-script benchmark.
+
+    Used by validate_claims.py for end-to-end benches like bench_gpu_1bit.sh
+    and bench_npu_flm.sh. The scripts print one '<key> <float>' line on stdout
+    on success, or exit 2 with no line on infra-missing. (issue #191)
+    """
+    got: dict[str, float] = {}
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 1)
+        if len(parts) == 2:
+            try:
+                got[parts[0]] = float(parts[1])
+            except ValueError:
+                pass
+    return got
+
+
+PARSERS["bench_gpu_1bit"] = parse_shell_bench
+PARSERS["bench_npu_flm"] = parse_shell_bench
+PARSERS["bench_rocm_hip"] = parse_shell_bench
+PARSERS["bench_zinc_vulkan"] = parse_shell_bench
+
+
+# README benchmark-table engines whose tok/s figures live in
+# benchmarks/latest.json _unverified (i.e. have NO reproducible source in this
+# repo). If the README marks any of these as measured/validated/reported, that
+# is a false claim -- the honest status is one of the hedged markers
+# (⚙️ raw / ❌ broken / 🔶 unresolved / ❓ unsourced). (issue #185, #190)
+README_ENGINES_WITHOUT_SOURCE = {
+    "GPU 1-bit": "gpu_1bit_llama_tok_s",
+    "NPU FLM": "npu_validated_tok_s",
+    "GPU ternary": "gpu_ternary_tok_s",
+    "GPU ROCm HIP": "rocm_decode_tok_s",
+    "NPU fused": "npu_fused_raw_tok_s",
+}
+
+
+def check_readme_consistency() -> list[str]:
+    """Fail if README.md stamps a tok/s figure as measured/validated/reported
+    for an engine that benchmarks/latest.json has quarantined in _unverified.
+
+    Hardware-free: safe to run on any CI runner (see --check-readme)."""
+    readme = REPO / "README.md"
+    if not readme.is_file():
+        return ["README.md missing"]
+    spec = json.loads(BENCH.read_text())
+    unverified = set(spec.get("_unverified", {})) - {"_comment"}
+
+    violations: list[str] = []
+    # Data rows end with: | **<num>** | <status> |
+    row = re.compile(r"\|\s*\*\*([0-9.]+)\*\*\s*\|\s*([^|]+?)\s*\|\s*$")
+    for line in readme.read_text().splitlines():
+        for engine, key in README_ENGINES_WITHOUT_SOURCE.items():
+            if engine not in line:
+                continue
+            if key not in unverified:
+                continue
+            m = row.search(line)
+            if not m:
+                continue
+            num, status = m.group(1), m.group(2).strip()
+            positive = any(p in status for p in ("measured", "validated", "reported"))
+            if positive:
+                violations.append(
+                    f'ReADME marks "{engine}" {num} tok/s as "{status}", but '
+                    f"{key} is quarantined in _unverified (no reproducible source). "
+                    "Use a hedged status instead."
+                )
+    return violations
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--build-dir", default="build")
+    ap.add_argument("--update", action="store_true", help="rewrite measured values into latest.json")
+    ap.add_argument("--json", help="write a machine-readable report here")
+    ap.add_argument("--repeat", type=int, default=3,
+                    help="runs per benchmark; the median is used (default 3)")
+    ap.add_argument("--warmup", type=int, default=1,
+                    help="discarded warmup runs per benchmark (default 1)")
+    ap.add_argument("--check-readme", action="store_true",
+                    help="hardware-free: fail if README marks an _unverified "
+                         "engine as measured/validated/reported (issue #185)")
+    args = ap.parse_args()
+
+    if args.check_readme:
+        violations = check_readme_consistency()
+        if violations:
+            print("README/_unverified consistency check FAILED:", file=sys.stderr)
+            for v in violations:
+                print(f"  - {v}", file=sys.stderr)
+            return 1
+        print("README benchmark statuses are consistent with _unverified")
+        return 0
+
+    build_dir = (REPO / args.build_dir).resolve()
+    spec = json.loads(BENCH.read_text())
+    claims = spec["benchmarks"]
+    verify = spec["_verify"]
+    tol = verify["tolerance"]
+
+    print(f"validate_claims: gpu={have_gpu()} npu={have_npu()} build_dir={build_dir}")
+
+    if not have_gpu():
+        print("no /dev/kfd -- GPU absent, nothing measured", file=sys.stderr)
+        return 2
+    if not build_dir.is_dir():
+        print(f"build dir missing: {build_dir}", file=sys.stderr)
+        return 2
+
+    measured: dict[str, float] = {}
+    spread: dict[str, tuple[float, float]] = {}
+    failures: list[str] = []
+
+    crashes: list[str] = []
+
+    # Pre-validate that all commands have parsers (fixes #616)
+    for name in verify["commands"]:
+        if name not in PARSERS:
+            failures.append(f"{name}: no parser registered in PARSERS dict")
+            print(f"  FAIL {name}: no parser for this benchmark")
+
+    for name, cfg in verify["commands"].items():
+        if name not in PARSERS:
+            continue  # skip benchmarks without parsers (already reported above)
+
+        samples: dict[str, list[float]] = {}
+
+        # Discard a cold run: the GPU clocks up over the first invocation, and a
+        # cold sample reads ~13% low (observed 35.6 vs 41.0 TFlops on 4i-I8-APRE).
+        if args.warmup:
+            run(cfg["argv"], cwd=build_dir)
+
+        for i in range(args.repeat):
+            rc, out = run(cfg["argv"], cwd=build_dir)
+            if rc == 2:
+                # Exit code 2 = infrastructure unavailable (no NPU, missing
+                # model/bin, etc.). Soft skip — not a claim failure. (issue #191)
+                print(f"  SKIP {name}: infra unavailable (exit 2)")
+                break  # skip remaining repeats for this benchmark (fixes #616)
+            if rc != 0:
+                # Retry once so a genuine one-off hardware flake can't set a
+                # claim.
+                crashes.append(f"{name}: exit {rc} on run {i + 1} (retrying)")
+                print(f"  CRASH {name}: exit {rc} (run {i + 1}) -- retrying")
+                rc, out = run(cfg["argv"], cwd=build_dir)
+                if rc == 2:
+                    print(f"  SKIP {name}: infra unavailable (exit 2)")
+                    break  # skip remaining repeats (fixes #616)
+                if rc != 0:
+                    failures.append(f"{name}: exited {rc} twice on run {i + 1}")
+                    print(f"  FAIL {name}: exit {rc} twice")
+                    break
+            for k, v in PARSERS[name](out).items():
+                samples.setdefault(k, []).append(v)
+
+        for k in cfg["keys"]:
+            vals = samples.get(k, [])
+            if not vals:
+                failures.append(f"{name}: could not parse `{k}` from output")
+                print(f"  FAIL {name}: no `{k}` in output")
+                continue
+            measured[k] = round(statistics.median(vals), 2)
+            spread[k] = (min(vals), max(vals))
+
+    # Compare
+    print(f"\n{'claim':<26} {'published':>10} {'median':>9} {'drift':>7}  {'spread(min-max)':>17}  status")
+    print("-" * 84)
+    drifted: list[str] = []
+    for key, published in claims.items():
+        if key not in measured:
+            continue
+        got = measured[key]
+        lo, hi = spread[key]
+        drift = abs(got - published) / published if published else 0.0
+        ok = drift <= tol
+        if not ok:
+            drifted.append(f"{key}: published {published}, median {got} ({drift:.1%} drift)")
+        rng = f"{lo:.2f}-{hi:.2f}"
+        print(f"{key:<26} {published:>10} {got:>9} {drift:>6.1%}  {rng:>17}  {'ok' if ok else 'DRIFT'}")
+
+    unmeasured = [k for k in claims if k not in measured]
+    if unmeasured:
+        print(f"\nnot re-measured this run: {', '.join(unmeasured)}")
+
+    n_unver = len([k for k in spec["_unverified"] if not k.startswith("_")])
+    print(f"\n{n_unver} claim(s) quarantined in _unverified (not published) -- see benchmarks/latest.json")
+
+    if args.update and measured:
+        for k, v in measured.items():
+            spec["benchmarks"][k] = v
+        BENCH.write_text(json.dumps(spec, indent=2) + "\n")
+        print(f"\nupdated {BENCH.relative_to(REPO)} with {len(measured)} measured values")
+
+    if crashes:
+        print("\nintermittent crashes (retried, did not set claims):")
+        for c in crashes:
+            print(f"  ! {c}")
+
+    exit_code = 1 if (failures or drifted) else 0
+    report = {
+        "exit_code": exit_code,
+        "gpu": have_gpu(), "npu": have_npu(),
+        "measured": measured, "spread": {k: list(v) for k, v in spread.items()},
+        "drifted": drifted, "failures": failures,
+        "crashes": crashes, "unmeasured": unmeasured,
+    }
+    if args.json:
+        Path(args.json).write_text(json.dumps(report, indent=2) + "\n")
+
+    if failures or drifted:
+        print("\nFAILED:", file=sys.stderr)
+        for f in failures + drifted:
+            print(f"  - {f}", file=sys.stderr)
+        return exit_code
+
+    print("\nall published claims re-measured within tolerance")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### **User description**
Automated daily re-measurement of the 5 hardware-verified benchmark claims (tools/validate_claims.py). This branch is force-pushed fresh off current main every run, so the diff always reflects the latest measurement — safe to merge whenever, or let tomorrow's run supersede it.

Restores the daily benchmark-claim integrity check that was disconnected when the self-hosted GitHub Actions runner was removed (#1555) — now runs locally on the box via a systemd timer instead of a self-hosted runner. See the commit message for details.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `validate_claims.py` for unattended hardware benchmark re-measurement

- Add `sync_numbers.py` syncing measured values into site files

- Refresh published benchmark medians from 2026-08-16 run

- Update site headline int8 prefill figure (43.2 to 39.7)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["tools/validate_claims.py re-measures on hardware"] -- "updates medians" --> B["benchmarks/latest.json"]
  B -- "read by" --> C["tools/sync_numbers.py"]
  C -- "writes benchmark keys" --> D["site/numbers.json"]
  C -- "patches static figure" --> E["site/index.html & site/benchmarks.html"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate_claims.py</strong><dd><code>Add unattended benchmark claim validation script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/validate_claims.py

<ul><li>New script re-measuring all published benchmark claims on real <br>hardware<br> <li> Median of 3 runs with 1 discarded warmup; pins named prefill variants <br>for stable metrics<br> <li> Compares against published values with 15% tolerance; distinct exit <br>codes for drift, crash, or missing hardware<br> <li> <code>--update</code> mode rewrites measured values into <code>benchmarks/latest.json</code>; <br>optional JSON report output<br> <li> Retries once on intermittent benchmark crashes so flakes cannot set <br>claims</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1708/files#diff-c425be5b33b3649ab8fbcd2b19e000d95d6d5a0548080f4b2fc27dfab90e6435">+217/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sync_numbers.py</strong><dd><code>Add benchmark-to-site number sync script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/sync_numbers.py

<ul><li>New script syncing 5 hardware-verified benchmark keys from <br><code>benchmarks/latest.json</code> into <code>site/numbers.json</code><br> <li> Updates <code>_sources</code>, <code>_benchmarks_remeasured</code> provenance, and derived <br><code>tflops</code> keys<br> <li> Patches the static int8 prefill figure in <code>site/index.html</code> and <br><code>site/benchmarks.html</code> via regex anchors<br> <li> Intentionally narrow scope: leaves human-governed keys byte-for-byte <br>unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1708/files#diff-478747bac76d645d0f289fc5dc6ecff46a19b4dd029dce510fcf80b071924f11">+110/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>latest.json</strong><dd><code>Refresh published benchmark medians</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

benchmarks/latest.json

<ul><li>Re-measured benchmark medians from the 2026-08-16 automated run<br> <li> <code>prefill_tflops_i8apre</code> 40.99 to 39.7; <code>halo_gemv_gbps</code> 148.2 to 150.4<br> <li> <code>sherry_gemv_gbps</code>, <code>tq1_gemv_gbps</code>, <code>prefill_tflops_4h</code> adjusted within <br>tolerance</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1708/files#diff-af1efb921bcbf6903e629539d79f5f1b4ce0d07ee91003b208233c8b0d0e2e90">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>numbers.json</strong><dd><code>Sync site numbers to latest measurements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/numbers.json

<ul><li>Benchmark block synced to 2026-08-16 values with new auto re-measure <br>note<br> <li> <code>_benchmarks_remeasured</code> date updated; <code>_sources</code> descriptions revised<br> <li> Top-level <code>prefill_tflops_i8apre</code>/<code>tflops</code> lowered from 43.2 to 39.7<br> <li> Trailing newline added at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1708/files#diff-ae47c5374645db1ea2408362085c7a2a5c4c466f4cb7c4f6115a316007aadf79">+15/-15</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>benchmarks.html</strong><dd><code>Update headline prefill TFLOPS figure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/benchmarks.html

- Headline stat updated: int8 prefill (WMMA) from 43.2 to 39.7 TFLOPS


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1708/files#diff-0ebc731d3211b2c8d5b4e0aca643b9e71ba0835fee02005d46a909d9b0a18cc5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

