### PR TITLE
site: Bold Hero branding on all pages, 1bit JARVIS rename, real-page redirects

### DIFF
--- a/site/_redirects
+++ b/site/_redirects
@@ -10,39 +10,40 @@
 # 1bit coding agent
 /agent        /                                                            301
 
-# Marketing site + single-page docs collapsed into ONE /index.html
-# All doc pages redirect to the correct section on the single-page site.
-# Note: kept as plain 301/302 (no trailing `!`) — forced redirects were
-# found to silently never fire on this deployment; each of these paths
-# also has a matching meta-refresh stub file as a working fallback.
-/docs                       /#faq                      301
-/docs/                      /#faq                      301
-/docs/index.html            /                           301
-/docs/install.html          /#quickstart               301
-/docs/install               /#quickstart               301
-/docs/quickstart.html       /#quickstart               301
-/docs/quickstart            /#quickstart               301
-/docs/troubleshooting.html  /#faq                      301
-/docs/troubleshooting       /#faq                      301
-/docs/faq.html              /#faq                      301
-/docs/faq                   /#faq                      301
-/docs/architecture.html     /#backends                 301
-/docs/architecture          /#backends                 301
-/docs/models.html           /#models                   301
-/docs/models                /#models                   301
-/models.html                /#models                   301
-/models/                    /#models                   301
-/models                     /#models                   301
-/docs/api.html              /                           301
-/docs/api                   /                           301
-/docs/benchmarks.html       /#benchmarks               301
-/docs/benchmarks            /#benchmarks               301
-/docs/why.html              /#top                      301
-/docs/why                   /#top                      301
-/docs/contributing.html     /                           301
-/docs/contributing          /                           301
-/docs/changelog.html        /                           301
-/docs/changelog             /                           301
+# Real pages exist at models.html / benchmarks.html / docs.html — route the
+# legacy collapse paths (and the old single-page anchors) to them.
+# Each path also has a matching meta-refresh stub file as a fallback.
+/models                     /models.html               301
+/models/                    /models.html               301
+/models.html                /models.html               301
+/benchmarks                 /benchmarks.html          301
+/benchmarks/                /benchmarks.html          301
+/benchmarks.html            /benchmarks.html          301
+/docs                       /docs.html                301
+/docs/                      /docs.html                301
+/docs/index.html            /docs.html                301
+/docs/install.html          /docs.html                301
+/docs/install               /docs.html                301
+/docs/quickstart.html       /docs.html                301
+/docs/quickstart            /docs.html                301
+/docs/troubleshooting.html  /docs.html                301
+/docs/troubleshooting       /docs.html                301
+/docs/faq.html              /docs.html                301
+/docs/faq                   /docs.html                301
+/docs/architecture.html     /docs.html                301
+/docs/architecture          /docs.html                301
+/docs/models.html           /models.html              301
+/docs/models                /models.html              301
+/docs/api.html              /docs.html                301
+/docs/api                   /docs.html                301
+/docs/benchmarks.html       /benchmarks.html          301
+/docs/benchmarks            /benchmarks.html          301
+/docs/why.html              /docs.html                301
+/docs/why                   /docs.html                301
+/docs/contributing.html     /docs.html                301
+/docs/contributing          /docs.html                301
+/docs/changelog.html        /docs.html                301
+/docs/changelog             /docs.html                301
 
 # Repo docs (paths removed from /docs/ collapse)
 /wiki/models        https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/wiki/models.md        302

--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -16,14 +16,13 @@
 <meta name="description" content="Measured decode and prefill numbers, with hardware and date attached.">
 <link rel="icon" href="assets/favicon.svg?v=2" type="image/svg+xml">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Mono:wght@400;500&display=swap">
-<link rel="stylesheet" href="assets/1bm.css">
-<link rel="canonical" href="https://1bit.monster/">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Mono:wght@400;500;700&display=swap">
+<link rel="canonical" href="https://1bit.monster/benchmarks.html">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="Benchmarks — 1bit MONSTER">
 <meta property="og:description" content="Measured decode and prefill numbers, with hardware and date attached.">
-<meta property="og:url" content="https://1bit.monster/">
+<meta property="og:url" content="https://1bit.monster/benchmarks.html">
 <meta property="og:image" content="https://1bit.monster/assets/og-card.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Benchmarks — 1bit MONSTER">
@@ -33,9 +32,9 @@
 {
   "@context": "https://schema.org",
   "@type": "WebPage",
-  "name": "Benchmarks \u2014 1bit MONSTER",
+  "name": "Benchmarks — 1bit MONSTER",
   "description": "Measured decode and prefill numbers, with hardware and date attached.",
-  "url": "https://1bit.monster/",
+  "url": "https://1bit.monster/benchmarks.html",
   "about": {
     "@type": "SoftwareApplication",
     "name": "1bit MONSTER"
@@ -44,100 +43,88 @@
 </script>
 
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics -->
+<style>
+  body{margin:0}
+  *{box-sizing:border-box}
+  .bh-nav a:hover{color:#ff9f1c}
+  .bh-cta-ghost:hover{border-color:#00e5ff;color:#00e5ff}
+  .bh-row:hover{background:rgba(0,229,255,.04)}
+</style>
 </head>
 <body>
-<div class="shell">
-  <aside class="rail">
-    <div>
-      <span class="mark">1bm</span>
-      <span class="wordmark">1bit<br>MONSTER</span>
-      <p class="quote">"Sorry but not sorry." <span>— bong-water-water-bong</span></p>
-    </div>
-    <nav>
-      <a href="index.html">overview</a>
-      <a href="models.html">models</a>
-      <a href="benchmarks.html" aria-current="page">benchmarks</a>
-      <a href="docs.html">docs</a>
-      <a href="story.html">the story</a>
-      <a href="jarvis/">jarvis</a>
-      <a href="blog/">blog</a>
-      <a href="store/">store</a>
-      <a href="demo/">demos</a>
-      <a href="live.html">live</a>
-      <a href="analytics/">analytics</a>
-      <a href="https://github.com/1bit-MONSTER/1bit-MONSTER">github</a>
-    </nav>
-    <div class="status"><span class="dot"></span>engine online</div>
-    <div class="meta">MIT<br>pure C++23<br>no python<br>6 hw targets</div>
-  </aside>
-  <main>
-    <div class="topbar"><span>100% HF coverage · any hardware · one engine</span><span>measured 2026-08-01 / 08-07</span></div>
-    <div class="hero">
-      <h1>Measured, <span style="color:var(--cyan)">not estimated</span></h1>
-      <p class="lead">Every number here carries its hardware and its date. Reference machine: <strong>AMD Ryzen AI MAX+ 395</strong> · Radeon 8060S · 32 GB UMA. If a number has no provenance, treat it as a bug in the docs.</p>
-    </div>
-    <div class="stats">
-      <div><b>41.9</b><span>TFLOPS int8 prefill (WMMA)</span></div>
-      <div><b>662</b><span>tok/s peak decode</span></div>
-      <div><b>6</b><span>hardware targets</span></div>
-      <div><b>5/5</b><span>zoo smoke pass</span></div>
-    </div>
-    <section>
-      <h2>Headline decode, end-to-end</h2>
-      <p class="note" style="margin-bottom:16px">Single-model path (<code>zaya</code>), measured 2026-08-01.</p>
-      <table>
-        <tr><th>model</th><th style="text-align:right">tok/s</th><th>backend</th></tr>
-        <tr><td>SmolLM2-135M</td><td class="n">662</td><td class="b">GGML-Vulkan</td></tr>
-        <tr><td>Qwen3-0.6B</td><td class="n">373</td><td class="b">GGML-Vulkan</td></tr>
-        <tr><td>Qwen2.5-VL-3B</td><td class="n">100</td><td class="b">GGML-Vulkan</td></tr>
-        <tr><td>BlackMamba-1.5B</td><td class="n">79.4</td><td class="b">Mamba1 HIP</td></tr>
-        <tr><td>Qwen3.5-4B</td><td class="n">65</td><td class="b">GGML-Vulkan</td></tr>
-        <tr><td>DeepSeek-R1-Distill-Llama-8B</td><td class="n">44</td><td class="b">GGML-Vulkan</td></tr>
-        <tr><td>ZAYA1-74B-preview</td><td class="n">17.6</td><td class="b">GGML-Vulkan</td></tr>
-      </table>
-      <p class="note" style="margin-top:12px">ZAYA1-74B-preview also measured at 16.7 tok/s on HIP (2026-08-05).</p>
-    </section>
-    <section>
-      <h2>Frontier gates</h2>
-      <p class="note" style="margin-bottom:16px">The five newest architecture families, each held to a <strong>generation gate</strong> — full-logit comparison against the HuggingFace reference on a real (or mini) checkpoint, 2026-08-16. tok/s is measured end-to-end through the engine's <code>generate()</code> chain.</p>
-      <table>
-        <tr><th>family</th><th>arch</th><th>gate result</th><th style="text-align:right">tok/s</th><th>backend</th></tr>
-        <tr><td>Nemotron 3</td><td>LayerNorm1P + relu2 MLP + partial RoPE</td><td class="b">✅ real 8B ckpt, top1 == HF, corr 0.99986</td><td class="n">1.04</td><td class="b">CPU generic (fp32)</td></tr>
-        <tr><td>Qwen3.5</td><td>GatedDeltaNet + gated GQA hybrid</td><td class="b">✅ mini-gate top1 == HF, 20/20, corr 1.0</td><td class="n">65</td><td class="b">GGML-Vulkan (4B)</td></tr>
-        <tr><td>DeepSeek V4</td><td>Shared-KV MQA + mHC (Sinkhorn) + hash-MoE</td><td class="b">✅ mini-gate top1 == HF, 20/20</td><td class="n">—</td><td class="b">ckpt 160 GB &gt; this box</td></tr>
-        <tr><td>GLM-5.2</td><td>V3-MLA + DSA indexer</td><td class="b">✅ mini-gate top1 == HF, 20/20</td><td class="n">—</td><td class="b">full ckpt &gt; this box</td></tr>
-        <tr><td>MiMo V2</td><td>MoD hybrid SWA+full GQA, sigmoid group-topk</td><td class="b">✅ mini-gate top1 == HF, 20/20</td><td class="n">—</td><td class="b">ckpt 313 GB &gt; this box</td></tr>
-      </table>
-      <p class="note" style="margin-top:12px">Nemotron 3 8B measured 2026-08-16 on this box (fp32, generic CPU path — no GPU backend wired for Nemotron yet; expect a step change when it lands). Qwen3.5 row is the 4B member already in the headline table. The three <code>—</code> rows are gate-validated but their real checkpoints (160–315 GB MoEs) exceed this machine — numbers land when the GPU box gets them.</p>
-    </section>
-    <section>
-      <h2>Unified control plane</h2>
-      <p class="note" style="margin-bottom:16px">The single control plane is measured but <strong>not finished</strong>. The supported out-of-box path today is toolbox-backed Strix Halo inference.</p>
-      <p class="lead">All five zoo models served from <strong>one</strong> <code>unified</code> process — <code>--pool</code> keeps every model resident — through a single OpenAI-compatible endpoint. Measured end-to-end via <code>POST /v1/chat/completions</code>, including per-request model routing. 2026-08-07.</p>
-      <table style="margin-top:18px">
-        <tr><th>model</th><th style="text-align:right">tok/s</th><th>backend</th></tr>
-        <tr><td>Qwen3-4B</td><td class="n">20.8</td><td class="b">NPU FLM (XDNA)</td></tr>
-        <tr><td>Qwen3-0.6B Instruct</td><td class="n">12.4</td><td class="b">GGML-Vulkan</td></tr>
-        <tr><td>Llama-3.2-1B Instruct</td><td class="n">12.4</td><td class="b">GGML-Vulkan</td></tr>
-        <tr><td>Bonsai-1.7B-TQ2</td><td class="n">3.1</td><td class="b">HIP 1BP</td></tr>
-        <tr><td>Zamba2-1.2B-Instruct-v2</td><td class="n">2.2</td><td class="b">HIP (Mamba2 SSD)</td></tr>
-      </table>
-      <p class="note" style="margin-top:12px">Four backends in one process. <code>scripts/zoo-smoke.sh</code> runs the same path (5/5 PASS); <code>POST /v1/pool</code> reports residency — 11 slots across <code>.1bp</code> and <code>.gguf</code>. Speculative decoding is available in-process via <code>--draft-model</code> + <code>--spec-decode</code>, lossless vs greedy.</p>
-    </section>
-    <section>
-      <h2>How to reproduce</h2>
-      <pre>./build/1bit zaya -m &lt;checkpoint&gt; -p <span class="s">"Hello world"</span>
+<div style="background:radial-gradient(1200px 600px at 15% -10%, rgba(0,229,255,.12), transparent 60%),radial-gradient(1000px 550px at 90% 0%, rgba(255,159,28,.10), transparent 60%),#021621;color:#e7f6fd;font-family:'DM Mono',ui-monospace,Menlo,monospace;line-height:1.6;min-height:100vh">
+<nav style="display:flex;align-items:center;justify-content:space-between;max-width:1100px;margin:0 auto;padding:28px 24px">
+<a href="index.html" style="font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a>
+<div class="bh-nav" style="display:flex;gap:28px;font-size:13px;color:#a0d9f8;flex-wrap:wrap;justify-content:flex-end">
+<a href="models.html" style="color:inherit;text-decoration:none">Models</a>
+<a href="benchmarks.html" style="color:#00e5ff;text-decoration:none">Benchmarks</a>
+<a href="docs.html" style="color:inherit;text-decoration:none">Docs</a>
+<a href="jarvis/" style="color:inherit;text-decoration:none">1bit JARVIS</a>
+<a href="blog/" style="color:inherit;text-decoration:none">Blog</a>
+<a href="store/" style="color:inherit;text-decoration:none">Store</a>
+<a href="demo/" style="color:inherit;text-decoration:none">Demos</a>
+<a href="analytics/" style="color:inherit;text-decoration:none">Analytics</a>
+<a href="https://github.com/1bit-MONSTER/1bit-MONSTER" style="color:inherit;text-decoration:none">GitHub</a>
+</div>
+</nav>
+<div style="max-width:920px;margin:60px auto 0;padding:0 24px;text-align:center">
+<div class="bh-badge" style="display:inline-flex;align-items:center;gap:8px;padding:7px 16px;border:1px solid #0e80be;border-radius:999px;font-size:12px;color:#00e5ff;margin-bottom:28px"><span style="width:6px;height:6px;background:#ff9f1c;border-radius:999px"></span>measured on real hardware — 2026-08</div>
+<h1 style="font-family:'DM Serif Display',Georgia,serif;font-weight:400;font-size:clamp(40px,6.5vw,72px);line-height:1.02;margin:0 0 24px;letter-spacing:-.02em">Measured, <span style="color:#00e5ff">not estimated</span></h1>
+<p style="max-width:64ch;margin:0 auto 40px;font-size:17px;color:#a0d9f8">Every number here carries its hardware and its date. Reference machine: <strong style="color:#e7f6fd;font-weight:500">AMD Ryzen AI MAX+ 395</strong> · Radeon 8060S · 32 GB UMA. If a number has no provenance, treat it as a bug in the docs.</p>
+</div>
+<div style="display:grid;grid-template-columns:repeat(4,1fr);max-width:1000px;margin:0 auto 80px;padding:0 24px">
+<div style="text-align:center;padding:20px 12px"><b style="display:block;font-family:'DM Serif Display',Georgia,serif;font-size:40px;font-weight:400;line-height:1.1;color:#00e5ff">41.9</b><span style="font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:#5d9ec2">TFLOPS int8 prefill</span></div>
+<div style="text-align:center;padding:20px 12px;border-left:1px solid rgba(93,158,194,.2)"><b style="display:block;font-family:'DM Serif Display',Georgia,serif;font-size:40px;font-weight:400;line-height:1.1;color:#ff9f1c">662</b><span style="font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:#5d9ec2">tok/s peak decode</span></div>
+<div style="text-align:center;padding:20px 12px;border-left:1px solid rgba(93,158,194,.2)"><b style="display:block;font-family:'DM Serif Display',Georgia,serif;font-size:40px;font-weight:400;line-height:1.1;color:#0e80be">6</b><span style="font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:#5d9ec2">hardware targets</span></div>
+<div style="text-align:center;padding:20px 12px;border-left:1px solid rgba(93,158,194,.2)"><b style="display:block;font-family:'DM Serif Display',Georgia,serif;font-size:40px;font-weight:400;line-height:1.1;color:#00e5ff">5/5</b><span style="font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:#5d9ec2">zoo smoke pass</span></div>
+</div>
+<div style="max-width:920px;margin:0 auto 80px;padding:0 24px">
+<div style="display:flex;align-items:baseline;justify-content:space-between;font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;border-bottom:1px solid rgba(93,158,194,.24);padding-bottom:12px;margin-bottom:20px"><span>Headline decode, end-to-end</span><span>single-model path (zaya) · 2026-08-01</span></div>
+<div style="border:1px solid rgba(93,158,194,.24);border-radius:12px;overflow:hidden;background:rgba(4,32,47,.6)">
+<div style="display:grid;grid-template-columns:1fr 128px 1.2fr;gap:14px;padding:14px 20px;font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;border-bottom:1px solid rgba(93,158,194,.24)"><span>model</span><span style="text-align:right">tok/s</span><span style="text-align:right">backend</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 128px 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>SmolLM2-135M</span><span style="text-align:right;font-family:'DM Serif Display',Georgia,serif;font-size:19px;color:#00e5ff">662</span><span style="text-align:right;color:#5d9ec2">GGML-Vulkan</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 128px 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>Qwen3-0.6B</span><span style="text-align:right;font-family:'DM Serif Display',Georgia,serif;font-size:19px;color:#00e5ff">373</span><span style="text-align:right;color:#5d9ec2">GGML-Vulkan</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 128px 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>Qwen2.5-VL-3B</span><span style="text-align:right;font-family:'DM Serif Display',Georgia,serif;font-size:19px;color:#00e5ff">100</span><span style="text-align:right;color:#5d9ec2">GGML-Vulkan</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 128px 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>BlackMamba-1.5B</span><span style="text-align:right;font-family:'DM Serif Display',Georgia,serif;font-size:19px;color:#00e5ff">79.4</span><span style="text-align:right;color:#5d9ec2">Mamba1 HIP</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 128px 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>Qwen3.5-4B</span><span style="text-align:right;font-family:'DM Serif Display',Georgia,serif;font-size:19px;color:#00e5ff">65</span><span style="text-align:right;color:#5d9ec2">GGML-Vulkan</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 128px 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>DeepSeek-R1-Distill-Llama-8B</span><span style="text-align:right;font-family:'DM Serif Display',Georgia,serif;font-size:19px;color:#00e5ff">44</span><span style="text-align:right;color:#5d9ec2">GGML-Vulkan</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 128px 1.2fr;gap:14px;padding:14px 20px;font-size:13.5px"><span>ZAYA1-74B-preview</span><span style="text-align:right;font-family:'DM Serif Display',Georgia,serif;font-size:19px;color:#00e5ff">17.6</span><span style="text-align:right;color:#5d9ec2">GGML-Vulkan</span></div>
+</div>
+<p style="font-size:13px;color:#5d9ec2;margin:14px 0 0">ZAYA1-74B-preview also measured at 16.7 tok/s on HIP (2026-08-05).</p>
+</div>
+<div style="max-width:920px;margin:0 auto 80px;padding:0 24px">
+<div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;border-bottom:1px solid rgba(93,158,194,.24);padding-bottom:12px;margin-bottom:20px">Frontier gates — 5/5 validated</div>
+<div style="border:1px solid rgba(93,158,194,.24);border-radius:12px;overflow:hidden;background:rgba(4,32,47,.6)">
+<div style="display:grid;grid-template-columns:1fr 1.5fr 2fr 90px;gap:14px;padding:14px 20px;font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;border-bottom:1px solid rgba(93,158,194,.24)"><span>family</span><span>arch</span><span>gate result</span><span style="text-align:right">tok/s</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.5fr 2fr 90px;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:12.5px"><span>Nemotron 3</span><span style="color:#a0d9f8">LayerNorm1P + relu2 MLP + partial RoPE</span><span style="color:#00e5ff">✅ real 8B ckpt, top1 == HF, corr 0.99986</span><span style="text-align:right;color:#e7f6fd">1.04</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.5fr 2fr 90px;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:12.5px"><span>Qwen3.5</span><span style="color:#a0d9f8">GatedDeltaNet + gated GQA hybrid</span><span style="color:#00e5ff">✅ mini-gate top1 == HF, 20/20, corr 1.0</span><span style="text-align:right;color:#e7f6fd">65</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.5fr 2fr 90px;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:12.5px"><span>DeepSeek V4</span><span style="color:#a0d9f8">Shared-KV MQA + mHC (Sinkhorn) + hash-MoE</span><span style="color:#00e5ff">✅ mini-gate top1 == HF, 20/20</span><span style="text-align:right;color:#5d9ec2">—</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.5fr 2fr 90px;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:12.5px"><span>GLM-5.2</span><span style="color:#a0d9f8">V3-MLA + DSA indexer</span><span style="color:#00e5ff">✅ mini-gate top1 == HF, 20/20</span><span style="text-align:right;color:#5d9ec2">—</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.5fr 2fr 90px;gap:14px;padding:14px 20px;font-size:12.5px"><span>MiMo V2</span><span style="color:#a0d9f8">MoD hybrid SWA+full GQA, sigmoid group-topk</span><span style="color:#00e5ff">✅ mini-gate top1 == HF, 20/20</span><span style="text-align:right;color:#5d9ec2">—</span></div>
+</div>
+<p style="font-size:13px;color:#5d9ec2;margin:14px 0 0">Full-logit comparison against the HuggingFace reference, 2026-08-16. Nemotron 3 8B measured on the generic CPU path (no GPU backend wired yet — expect a step change). The three <span style="color:#a0d9f8">—</span> rows are gate-validated; their real checkpoints (160–315 GB MoEs) exceed this machine.</p>
+</div>
+<div style="max-width:920px;margin:0 auto 80px;padding:0 24px">
+<div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;border-bottom:1px solid rgba(93,158,194,.24);padding-bottom:12px;margin-bottom:20px">Unified control plane — one process, five models</div>
+<div style="border:1px solid rgba(93,158,194,.24);border-radius:12px;overflow:hidden;background:rgba(4,32,47,.6)">
+<div style="display:grid;grid-template-columns:1fr 100px 1.2fr;gap:14px;padding:14px 20px;font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;border-bottom:1px solid rgba(93,158,194,.24)"><span>model</span><span style="text-align:right">tok/s</span><span style="text-align:right">backend</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 100px 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13px"><span>Qwen3-4B</span><span style="text-align:right;font-family:'DM Serif Display',Georgia,serif;font-size:18px;color:#00e5ff">20.8</span><span style="text-align:right;color:#5d9ec2">NPU FLM (XDNA)</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 100px 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13px"><span>Qwen3-0.6B Instruct</span><span style="text-align:right;font-family:'DM Serif Display',Georgia,serif;font-size:18px;color:#00e5ff">12.4</span><span style="text-align:right;color:#5d9ec2">GGML-Vulkan</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 100px 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13px"><span>Llama-3.2-1B Instruct</span><span style="text-align:right;font-family:'DM Serif Display',Georgia,serif;font-size:18px;color:#00e5ff">12.4</span><span style="text-align:right;color:#5d9ec2">GGML-Vulkan</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 100px 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13px"><span>Bonsai-1.7B-TQ2</span><span style="text-align:right;font-family:'DM Serif Display',Georgia,serif;font-size:18px;color:#00e5ff">3.1</span><span style="text-align:right;color:#5d9ec2">HIP 1BP</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 100px 1.2fr;gap:14px;padding:14px 20px;font-size:13px"><span>Zamba2-1.2B-Instruct-v2</span><span style="text-align:right;font-family:'DM Serif Display',Georgia,serif;font-size:18px;color:#00e5ff">2.2</span><span style="text-align:right;color:#5d9ec2">HIP (Mamba2 SSD)</span></div>
+</div>
+<p style="font-size:13px;color:#5d9ec2;margin:14px 0 0">Four backends in one process, served through a single OpenAI-compatible endpoint, measured 2026-08-07. The single control plane is measured but <strong style="color:#a0d9f8;font-weight:500">not finished</strong> — the supported out-of-box path today is toolbox-backed Strix Halo inference.</p>
+</div>
+<div style="max-width:920px;margin:0 auto 96px;padding:0 24px">
+<div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;margin-bottom:14px">How to reproduce</div>
+<pre style="margin:0;background:#010d15;border:1px solid rgba(0,229,255,.22);border-radius:12px;padding:22px 24px;font-size:13px;line-height:1.9;overflow-x:auto;color:#a0d9f8;font-family:'DM Mono',ui-monospace,Menlo,monospace"><span style="color:#5d9ec2"># build Release, or the numbers will not match</span>
+./build/1bit zaya -m <span style="color:#00e5ff">&lt;checkpoint&gt;</span> -p <span style="color:#ff9f1c">"Hello world"</span>
 ./build/1bit unified --pool
-scripts/zoo-smoke.sh</pre>
-      <p class="note" style="margin-top:12px">Build <code>Release</code>, or the numbers will not match. Full per-model and per-kernel detail lives in the performance SSOT: <a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/wiki/performance.md">docs/wiki/performance.md →</a></p>
-    </section>
-    <footer>
-  <span>© 1bit MONSTER</span>
-  <span style="color:var(--cyan)">mit — do whatever you want</span>
-  <span>Metepenagiag Mi&rsquo;kmaq Nation &middot; New Brunswick, Canada &middot; <a href="mailto:admin@1bit.monster" style="color:var(--faint)">admin@1bit.monster</a></span>
-  <span style="text-transform:none;letter-spacing:0">&ldquo;Sorry but not sorry.&rdquo; &mdash; bong-water-water-bong</span>
-</footer>
-  </main>
+<span style="color:#00e5ff">scripts/zoo-smoke.sh</span></pre>
+<p style="font-size:13px;color:#5d9ec2;margin:14px 0 0">Full per-model and per-kernel detail lives in the performance SSOT: <a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/wiki/performance.md" style="color:#00e5ff;text-decoration:none">docs/wiki/performance.md →</a></p>
+</div>
+<footer style="text-align:center;padding:30px;font-size:12px;color:#5d9ec2;border-top:1px solid rgba(93,158,194,.2)">MIT License · github.com/1bit-MONSTER · "Sorry but not sorry."</footer>
 </div>
 </body>
 </html>

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -54,19 +54,69 @@
       <p class="muted">37 pre-built FLM models from ROCm/FastFlowLM v0.9.46 — 209 NPU xclbins, Qwen3.5 Omni multi-modal C++ source, Qwen3.6-MoE-35B with 256 experts. Auto-detection from Q4NX header. No config files.</p>
     </li>
     <li>
-      <span class="date">2026-07-24</span> &middot;
-      <a href="/blog/one-binary-all-formats">One binary, all formats — ternary/binary inference on NPU + GPU</a>
-      <p class="muted">Full support for every binary and ternary model format — Q1_0, TQ1, TQ2, IQ1_S/M, BitNet GGUF — on both GPU (HIP/Vulkan) and NPU (XDNA 2). Verified exact on real Strix Halo hardware. 4200 lines, 31 files.</p>
-    </li>
-    <li>
       <span class="date">2026-07-26</span> &middot;
       <a href="/blog/zyphra-family-complete">Zyphra family complete — Zamba2 hybrid SSM and ZR1 reasoning, all 1BP</a>
       <p class="muted">All four Zyphra models converted to 1BP and validated end-to-end on ZINC GPU. Zamba2 1.2B/2.7B/7B (Mamba2-hybrid) and ZR1-1.5B (reasoning-tuned dense) — 26 tok/s on Strix Halo. Two architectures, one engine, zero config.</p>
     </li>
     <li>
+      <span class="date">2026-07-24</span> &middot;
+      <a href="/blog/one-binary-all-formats">One binary, all formats — ternary/binary inference on NPU + GPU</a>
+      <p class="muted">Full support for every binary and ternary model format — Q1_0, TQ1, TQ2, IQ1_S/M, BitNet GGUF — on both GPU (HIP/Vulkan) and NPU (XDNA 2). Verified exact on real Strix Halo hardware. 4200 lines, 31 files.</p>
+    </li>
+    <li>
       <span class="date">2026-07-23</span> &middot;
       <a href="/blog/unsloth-for-amd">Unsloth for AMD — Train &amp; Fine-Tune LLMs on Radeon, Instinct &amp; Ryzen AI</a>
       <p class="muted">Unsloth announced native AMD GPU support for LLM training, fine-tuning, and RL. 2x faster, 70% less VRAM, runs on 3GB. Covers Radeon, Instinct, and Ryzen AI (including Strix Halo). Complementary stack to 1bit.monster inference.</p>
+    </li>
+    <li>
+      <span class="date">2026-07-11</span> &middot;
+      <a href="/blog/token-router">TokenRouter: Token-Level Multi-Backend LLM Inference on AMD Strix Halo</a>
+      <p class="muted">Open-source token-level routing for multi-backend LLM inference. NPU draft + GPU verify with real logprobs on AMD Strix Halo.</p>
+    </li>
+    <li>
+      <span class="date">2026-07-06</span> &middot;
+      <a href="/blog/what-reviews-didnt-tell-you-ryzen-ai-halo">What the Ryzen AI Halo reviews didn't tell you — AMD Strix Halo NPU</a>
+      <p class="muted">AMD Ryzen AI Halo ships with a 50 TOPS NPU. AMD's FLM runtime gets 11 tok/s, ROCm gets 41 tok/s. 1bit.monster drives the same NPU via a fused-layer engine. (Throughput figures are historical and unsourced — see correction.)</p>
+    </li>
+    <li>
+      <span class="date">2026-07-06</span> &middot;
+      <a href="/blog/dspark-speculative-decoding-572-tok-per-second">DSpark speculative decoding — the 572 tok/s projection, disproven</a>
+      <p class="muted">DSpark speculative decoding was projected to hit 572 tok/s on AMD Strix Halo. End-to-end measurement on the NPU disproved it: 0.1–0.2 tok/s at 0% draft acceptance. How and why, and what it would take to fix.</p>
+    </li>
+    <li>
+      <span class="date">2026-07-06</span> &middot;
+      <a href="/blog/three-bugs-broke-97-tok-per-second">Three bugs that broke 97 tok/s — debugging NPU inference</a>
+      <p class="muted">The 97 tok/s number was real. The output behind it never was. Three silent bugs — LM head substitution, weight transpose, and activation clipping — were producing garbage.</p>
+    </li>
+    <li>
+      <span class="date">2026-07-06</span> &middot;
+      <a href="/blog/one-engine-every-model-any-chip">One engine. Every model. Any chip. — 5 model families, auto-detect</a>
+      <p class="muted">How a single 38KB C++ binary auto-detects 73+ models across 6 backends — NPU, ROCm, Vulkan, CUDA, Metal, CPU — from one Q4NX header parse.</p>
+    </li>
+    <li>
+      <span class="date">2026-07-06</span> &middot;
+      <a href="/blog/npu-optimization-sprint-72x-speedup">244→3.4 ms/tok — the NPU optimization sprint</a>
+      <p class="muted">How 7 engine versions in 4 days took NPU inference from 1,930 ms/tok to 3.4 ms/tok — a 72× speedup through batch decode, fused dispatch, and INT8 GEMM.</p>
+    </li>
+    <li>
+      <span class="date">2026-07-06</span> &middot;
+      <a href="/blog/npu-benchmarks-55-tflops">50 TOPS on a laptop — benchmarking the XDNA 2 NPU</a>
+      <p class="muted">Historical NPU benchmark notes. The headline INT8-GEMM TFLOPS and fused-layer tok/s figures were later found unsourced and are quarantined in benchmarks/latest.json _unverified — see the correction banner.</p>
+    </li>
+    <li>
+      <span class="date">2026-07-06</span> &middot;
+      <a href="/blog/npu-132x-more-efficient-than-gpu">Retracted: &ldquo;the NPU is 132&times; more efficient than the GPU&rdquo; was unsourced</a>
+      <p class="muted">Retraction: the &lsquo;NPU is 132&times; more efficient than the GPU&rsquo; efficiency claim was built on an unsourced throughput figure and a power breakdown with no measurement behind it. See the correction and benchmarks/latest.json _unverified.</p>
+    </li>
+    <li>
+      <span class="date">2026-07-06</span> &middot;
+      <a href="/blog/fused-layer-engine-one-xclbin-per-layer">The fused layer engine — one xclbin call per transformer layer</a>
+      <p class="muted">How the fused layer engine combines QKV, attention, and FFN into a single NPU dispatch — eliminating 5/6 of per-layer xclbin calls. (Throughput figures in this post are historical and quarantined as unsourced — see correction.)</p>
+    </li>
+    <li>
+      <span class="date">2026-07-06</span> &middot;
+      <a href="/blog/reverse-engineered-amd-npu-4-days">I reverse-engineered AMD's NPU stack in 4 days — 38KB binary</a>
+      <p class="muted">How one person, a free Chess license, and a C++ compiler turned AMD's locked-down NPU into an open-source inference engine — a 38KB binary. (Throughput/speedup figures are historical and unsourced — see correction.)</p>
     </li>
     <li>
       <span class="date">2026-07-02</span> &middot;

--- a/site/blog/one-engine-every-model-any-chip.html
+++ b/site/blog/one-engine-every-model-any-chip.html
@@ -1,15 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-KV5N1VSM2S"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-KV5N1VSM2S');
-</script>
-
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>One engine. Every model. Any chip. — 5 model families, auto-detect · 1bit.monster</title>
@@ -18,15 +9,15 @@
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://1bit.monster/blog/one-binary-to-rule-them-all">
 <meta property="og:title" content="One engine. Every model. Any chip. — 5 model families, auto-detect">
-<meta property="og:image" content="https://1bit.monster/assets/og-card.png">
+<meta property="og:image" content="https://1bit.monster/assets/og-default.png">
 <meta property="og:description" content="A single 38KB binary auto-detects 73+ models across 6 backends. No config files. No model registry.">
 <meta property="og:url" content="https://1bit.monster/blog/one-binary-to-rule-them-all">
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
-<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg?v=2">
+<link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Serif+Text:ital@0;1&family=DM+Mono:wght@400;500&display=swap">
 <style>
-  :root{--bg:#021621;--panel:#04202f;--border:rgba(14,128,190,.42);--text:#e7f6fd;--muted:#a0d9f8;--dim:#5d9ec2;--green:#00e5ff;--pink:#ff9f1c;--blue:#0e80be;--sans:'DM Serif Text',ui-serif,Georgia,'Times New Roman',serif;--mono:'DM Mono','SF Mono',ui-monospace,Menlo,Consolas,monospace;--maxw:780px;}
+  :root{--bg:#0B0B0B;--panel:#141414;--border:#232323;--text:#EDEFEA;--muted:#A0A599;--dim:#6B706A;--green:#C6FF3D;--pink:#C6FF3D;--blue:#C6FF3D;--sans:'DM Serif Text',ui-serif,Georgia,'Times New Roman',serif;--mono:'DM Mono','SF Mono',ui-monospace,Menlo,Consolas,monospace;--maxw:780px;}
   *{margin:0;padding:0;box-sizing:border-box;}
   body{background:var(--bg);color:var(--text);font-family:var(--sans);line-height:1.7;}
   a{color:var(--blue);font-weight:600;text-decoration:none;}a:hover{color:var(--green);}
@@ -55,7 +46,7 @@
 </style>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head>
 <body>
-<!-- ⚠️ HISTORICAL POST --><div style="background:#1a0a0a;border:1px solid #00e5ff;border-radius:10px;padding:14px 18px;margin:12px auto;max-width:780px;font-size:13px;line-height:1.5;"><strong style="color:#00e5ff;">⚠️ Historical post</strong><br>This blog post documents an earlier phase of the project. Benchmarks, numbers, and architecture references may be stale. See <a href="https://1bit.monster/#benchmarks" style="color:#00e5ff;">current benchmarks →</a></div>
+<!-- ⚠️ HISTORICAL POST --><div style="background:#1a0a0a;border:1px solid #C6FF3D;border-radius:10px;padding:14px 18px;margin:12px auto;max-width:780px;font-size:13px;line-height:1.5;"><strong style="color:#C6FF3D;">⚠️ Historical post</strong><br>This blog post documents an earlier phase of the project. Benchmarks, numbers, and architecture references may be stale. See <a href="https://1bit.monster/#benchmarks" style="color:#C6FF3D;">current benchmarks →</a></div>
 
 <div style="background:#ffd;border:2px solid #ea0;padding:12px 20px;margin:0;text-align:center;font-size:14px;"><strong>⚠️ Benchmarks may be stale</strong> — This post was written before the 2026-07-26 re-measurement. See <a href="https://github.com/1bit-MONSTER/1bit-MONSTER" style="color:#06c;">the README</a> for current numbers.</div>
 <nav><div class="nav-in"><a class="mark" href="/">1bm</a><a class="wordmark" href="/"><span class="g">1</span>bit MONSTER</a><span style="flex:1"></span><a href="/" style="font-size:13px;color:var(--muted);">← Home</a></div></nav>

--- a/site/docs.html
+++ b/site/docs.html
@@ -16,14 +16,13 @@
 <meta name="description" content="Build it, run a model, serve an API. Architecture, model families, benchmarks.">
 <link rel="icon" href="assets/favicon.svg?v=2" type="image/svg+xml">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Mono:wght@400;500&display=swap">
-<link rel="stylesheet" href="assets/1bm.css">
-<link rel="canonical" href="https://1bit.monster/">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Mono:wght@400;500;700&display=swap">
+<link rel="canonical" href="https://1bit.monster/docs.html">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="Docs — 1bit MONSTER">
 <meta property="og:description" content="Build it, run a model, serve an API. Architecture, model families, benchmarks.">
-<meta property="og:url" content="https://1bit.monster/">
+<meta property="og:url" content="https://1bit.monster/docs.html">
 <meta property="og:image" content="https://1bit.monster/assets/og-card.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Docs — 1bit MONSTER">
@@ -33,9 +32,9 @@
 {
   "@context": "https://schema.org",
   "@type": "WebPage",
-  "name": "Docs \u2014 1bit MONSTER",
+  "name": "Docs — 1bit MONSTER",
   "description": "Build it, run a model, serve an API. Architecture, model families, benchmarks.",
-  "url": "https://1bit.monster/",
+  "url": "https://1bit.monster/docs.html",
   "about": {
     "@type": "SoftwareApplication",
     "name": "1bit MONSTER"
@@ -44,103 +43,94 @@
 </script>
 
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics -->
+<style>
+  body{margin:0}
+  *{box-sizing:border-box}
+  .bh-nav a:hover{color:#ff9f1c}
+  .bh-cta-ghost:hover{border-color:#00e5ff;color:#00e5ff}
+  .bh-link:hover{color:#e7f6fd}
+</style>
 </head>
 <body>
-<div class="shell">
-  <aside class="rail">
-    <div>
-      <span class="mark">1bm</span>
-      <span class="wordmark">1bit<br>MONSTER</span>
-      <p class="quote">"Sorry but not sorry." <span>— bong-water-water-bong</span></p>
-    </div>
-    <nav>
-      <a href="index.html">overview</a>
-      <a href="models.html">models</a>
-      <a href="benchmarks.html">benchmarks</a>
-      <a href="docs.html" aria-current="page">docs</a>
-      <a href="story.html">the story</a>
-      <a href="jarvis/">jarvis</a>
-      <a href="blog/">blog</a>
-      <a href="store/">store</a>
-      <a href="demo/">demos</a>
-      <a href="live.html">live</a>
-      <a href="analytics/">analytics</a>
-      <a href="https://github.com/1bit-MONSTER/1bit-MONSTER">github</a>
-    </nav>
-    <div class="status"><span class="dot"></span>engine online</div>
-    <div class="meta">MIT<br>pure C++23<br>no python<br>6 hw targets</div>
-  </aside>
-  <main>
-    <div class="topbar"><span>100% HF coverage · any hardware · one engine</span><span>pure C++23</span></div>
-    <div class="hero">
-      <h1>Documentation</h1>
-      <p class="lead">Build it, run a model, hit the API. Everything below lives in the repo under <code>docs/</code>.</p>
-      <div class="btns">
-        <a class="btn" href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/guides/getting-started.md">getting started</a>
-        <a class="btn ghost" href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/README.md">full docs index</a>
-      </div>
-    </div>
-    <section>
-      <h2>Quick start</h2>
-      <pre><span class="c"># build</span>
+<div style="background:radial-gradient(1200px 600px at 15% -10%, rgba(0,229,255,.12), transparent 60%),radial-gradient(1000px 550px at 90% 0%, rgba(255,159,28,.10), transparent 60%),#021621;color:#e7f6fd;font-family:'DM Mono',ui-monospace,Menlo,monospace;line-height:1.6;min-height:100vh">
+<nav style="display:flex;align-items:center;justify-content:space-between;max-width:1100px;margin:0 auto;padding:28px 24px">
+<a href="index.html" style="font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a>
+<div class="bh-nav" style="display:flex;gap:28px;font-size:13px;color:#a0d9f8;flex-wrap:wrap;justify-content:flex-end">
+<a href="models.html" style="color:inherit;text-decoration:none">Models</a>
+<a href="benchmarks.html" style="color:inherit;text-decoration:none">Benchmarks</a>
+<a href="docs.html" style="color:#00e5ff;text-decoration:none">Docs</a>
+<a href="jarvis/" style="color:inherit;text-decoration:none">1bit JARVIS</a>
+<a href="blog/" style="color:inherit;text-decoration:none">Blog</a>
+<a href="store/" style="color:inherit;text-decoration:none">Store</a>
+<a href="demo/" style="color:inherit;text-decoration:none">Demos</a>
+<a href="analytics/" style="color:inherit;text-decoration:none">Analytics</a>
+<a href="https://github.com/1bit-MONSTER/1bit-MONSTER" style="color:inherit;text-decoration:none">GitHub</a>
+</div>
+</nav>
+<div style="max-width:920px;margin:60px auto 0;padding:0 24px;text-align:center">
+<div class="bh-badge" style="display:inline-flex;align-items:center;gap:8px;padding:7px 16px;border:1px solid #0e80be;border-radius:999px;font-size:12px;color:#00e5ff;margin-bottom:28px"><span style="width:6px;height:6px;background:#ff9f1c;border-radius:999px"></span>pure C++23 · zero Python in the runtime</div>
+<h1 style="font-family:'DM Serif Display',Georgia,serif;font-weight:400;font-size:clamp(40px,6.5vw,72px);line-height:1.02;margin:0 0 24px;letter-spacing:-.02em">Documentation</h1>
+<p style="max-width:64ch;margin:0 auto 40px;font-size:17px;color:#a0d9f8">Build it, run a model, hit the API. Everything below lives in the repo under <span style="color:#e7f6fd">docs/</span>.</p>
+<div style="display:flex;gap:16px;justify-content:center;flex-wrap:wrap;margin-bottom:80px">
+<a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/guides/getting-started.md" class="bh-cta-primary" style="display:inline-flex;align-items:center;height:54px;padding:0 32px;border-radius:6px;font-size:13px;letter-spacing:.1em;text-transform:uppercase;font-weight:700;text-decoration:none;background:linear-gradient(90deg,#00e5ff,#ff9f1c);color:#021621;transition:filter .15s">Getting started</a>
+<a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/README.md" class="bh-cta-ghost" style="display:inline-flex;align-items:center;height:54px;padding:0 32px;border-radius:6px;font-size:13px;letter-spacing:.1em;text-transform:uppercase;font-weight:700;text-decoration:none;border:1px solid #5d9ec2;color:#e7f6fd;transition:border-color .15s,color .15s">Full docs index</a>
+</div>
+</div>
+<div style="max-width:820px;margin:0 auto 80px;padding:0 24px">
+<div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;margin-bottom:14px">Quick start</div>
+<pre style="margin:0;background:#010d15;border:1px solid rgba(0,229,255,.22);border-radius:12px;padding:22px 24px;font-size:13px;line-height:1.9;overflow-x:auto;color:#a0d9f8;font-family:'DM Mono',ui-monospace,Menlo,monospace"><span style="color:#5d9ec2"># build</span>
 git clone https://github.com/1bit-MONSTER/1bit-MONSTER
 cd 1bit-MONSTER &amp;&amp; cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j
 
-<span class="c"># run a model — GGUF, ONNX or native 1BP</span>
-./build/1bit zaya -m model.1bp -p <span class="s">"Hello world"</span>
+<span style="color:#5d9ec2"># run a model — GGUF, ONNX or native 1BP</span>
+<span style="color:#00e5ff">./build/1bit</span> zaya -m model.1bp -p <span style="color:#ff9f1c">"Hello world"</span>
 
-<span class="c"># serve an OpenAI-compatible API with a resident model pool</span>
-./build/1bit unified --pool</pre>
-      <p class="note" style="margin-top:12px">No installer yet — build from source.</p>
-    </section>
-    <section class="cols">
-      <div>
-        <h3>Guides</h3>
-        <ul class="plain">
-          <li><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/guides/getting-started.md">Getting started</a> — build, run, serve</li>
-          <li><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/guides/building.md">Build guide</a> — platforms, backend flags, troubleshooting</li>
-          <li><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/guides/architecture.md">Architecture</a> — how one engine reaches five backends</li>
-          <li><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/guides/roadmap.md">Roadmap</a> — shipped vs in progress</li>
-        </ul>
-      </div>
-      <div>
-        <h3>Reference</h3>
-        <ul class="plain">
-          <li><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/model-families/README.md">Model families</a> — 19 classes, one page each</li>
-          <li><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/wiki/performance.md">Performance SSOT</a> — every measured number</li>
-          <li><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/wiki/models.md">Support SSOT</a> — combined matrix</li>
-          <li><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/jarvis.md">JARVIS pipeline</a> — local voice, end to end</li>
-        </ul>
-      </div>
-    </section>
-    <section>
-      <h2>Subcommands</h2>
-      <table>
-        <tr><th>subcommand</th><th>what it does</th></tr>
-        <tr><td>zaya</td><td class="b">single-model CLI inference</td></tr>
-        <tr><td>unified</td><td class="b">multi-model server, OpenAI-compatible API, model pool</td></tr>
-        <tr><td>jarvis</td><td class="b">end-to-end local voice assistant</td></tr>
-        <tr><td>vision</td><td class="b">vision-language models</td></tr>
-        <tr><td>chat</td><td class="b">interactive terminal chat</td></tr>
-        <tr><td>image_server</td><td class="b">Stable-Diffusion-family image and video generation</td></tr>
-      </table>
-    </section>
-    <section>
-      <h2>Conventions</h2>
-      <ul class="plain">
-        <li><strong>Every number is measured</strong>, and carries its hardware and date.</li>
-        <li><strong>Shipped and planned are separated.</strong> Anything not yet shipped says so.</li>
-        <li>No Python in the runtime. Tooling may use it; the engine may not.</li>
-      </ul>
-    </section>
-    <footer>
-  <span>© 1bit MONSTER</span>
-  <span style="color:var(--cyan)">mit — do whatever you want</span>
-  <span>Metepenagiag Mi&rsquo;kmaq Nation &middot; New Brunswick, Canada &middot; <a href="mailto:admin@1bit.monster" style="color:var(--faint)">admin@1bit.monster</a></span>
-  <span style="text-transform:none;letter-spacing:0">&ldquo;Sorry but not sorry.&rdquo; &mdash; bong-water-water-bong</span>
-</footer>
-  </main>
+<span style="color:#5d9ec2"># serve an OpenAI-compatible API with a resident model pool</span>
+<span style="color:#00e5ff">./build/1bit</span> unified --pool</pre>
+<p style="font-size:13px;color:#5d9ec2;margin:14px 0 0">No installer yet — build from source.</p>
+</div>
+<div style="max-width:920px;margin:0 auto 80px;padding:0 24px;display:grid;grid-template-columns:1fr 1fr;gap:24px">
+<div style="border:1px solid rgba(93,158,194,.24);border-radius:12px;padding:28px;background:rgba(4,32,47,.6)">
+<div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;margin-bottom:16px">Guides</div>
+<ul style="list-style:none;margin:0;padding:0;font-size:14px;display:flex;flex-direction:column;gap:10px">
+<li><a class="bh-link" href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/guides/getting-started.md" style="color:#00e5ff;text-decoration:none">Getting started</a> <span style="color:#5d9ec2">— build, run, serve</span></li>
+<li><a class="bh-link" href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/guides/building.md" style="color:#00e5ff;text-decoration:none">Build guide</a> <span style="color:#5d9ec2">— platforms, backend flags, troubleshooting</span></li>
+<li><a class="bh-link" href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/guides/architecture.md" style="color:#00e5ff;text-decoration:none">Architecture</a> <span style="color:#5d9ec2">— how one engine reaches five backends</span></li>
+<li><a class="bh-link" href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/guides/roadmap.md" style="color:#00e5ff;text-decoration:none">Roadmap</a> <span style="color:#5d9ec2">— shipped vs in progress</span></li>
+</ul>
+</div>
+<div style="border:1px solid rgba(93,158,194,.24);border-radius:12px;padding:28px;background:rgba(4,32,47,.6)">
+<div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;margin-bottom:16px">Reference</div>
+<ul style="list-style:none;margin:0;padding:0;font-size:14px;display:flex;flex-direction:column;gap:10px">
+<li><a class="bh-link" href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/model-families/README.md" style="color:#00e5ff;text-decoration:none">Model families</a> <span style="color:#5d9ec2">— 19 classes, one page each</span></li>
+<li><a class="bh-link" href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/wiki/performance.md" style="color:#00e5ff;text-decoration:none">Performance SSOT</a> <span style="color:#5d9ec2">— every measured number</span></li>
+<li><a class="bh-link" href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/wiki/models.md" style="color:#00e5ff;text-decoration:none">Support SSOT</a> <span style="color:#5d9ec2">— combined matrix</span></li>
+<li><a class="bh-link" href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/jarvis.md" style="color:#00e5ff;text-decoration:none">1bit JARVIS pipeline</a> <span style="color:#5d9ec2">— local voice, end to end</span></li>
+</ul>
+</div>
+</div>
+<div style="max-width:920px;margin:0 auto 80px;padding:0 24px">
+<div style="display:flex;align-items:baseline;justify-content:space-between;font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;border-bottom:1px solid rgba(93,158,194,.24);padding-bottom:12px;margin-bottom:20px"><span>Subcommands</span><span>one binary, argv[0] dispatch</span></div>
+<div style="border:1px solid rgba(93,158,194,.24);border-radius:12px;overflow:hidden;background:rgba(4,32,47,.6)">
+<div style="display:grid;grid-template-columns:200px 1fr;gap:14px;padding:14px 20px;font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;border-bottom:1px solid rgba(93,158,194,.24)"><span>subcommand</span><span>what it does</span></div>
+<div style="display:grid;grid-template-columns:200px 1fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span style="color:#00e5ff">zaya</span><span style="color:#a0d9f8">single-model CLI inference</span></div>
+<div style="display:grid;grid-template-columns:200px 1fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span style="color:#00e5ff">unified</span><span style="color:#a0d9f8">multi-model server, OpenAI-compatible API, model pool</span></div>
+<div style="display:grid;grid-template-columns:200px 1fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span style="color:#00e5ff">jarvis</span><span style="color:#a0d9f8">end-to-end local voice assistant</span></div>
+<div style="display:grid;grid-template-columns:200px 1fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span style="color:#00e5ff">vision</span><span style="color:#a0d9f8">vision-language models</span></div>
+<div style="display:grid;grid-template-columns:200px 1fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span style="color:#00e5ff">chat</span><span style="color:#a0d9f8">interactive terminal chat</span></div>
+<div style="display:grid;grid-template-columns:200px 1fr;gap:14px;padding:14px 20px;font-size:13.5px"><span style="color:#00e5ff">image_server</span><span style="color:#a0d9f8">Stable-Diffusion-family image and video generation</span></div>
+</div>
+</div>
+<div style="max-width:920px;margin:0 auto 96px;padding:0 24px">
+<div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;border-bottom:1px solid rgba(93,158,194,.24);padding-bottom:12px;margin-bottom:20px">Conventions</div>
+<ul style="list-style:none;margin:0;padding:0;font-size:14px;color:#a0d9f8;display:flex;flex-direction:column;gap:12px">
+<li><strong style="color:#e7f6fd;font-weight:500">Every number is measured</strong> — and carries its hardware and date.</li>
+<li><strong style="color:#e7f6fd;font-weight:500">Shipped and planned are separated.</strong> Anything not yet shipped says so.</li>
+<li><strong style="color:#e7f6fd;font-weight:500">No Python in the runtime.</strong> Tooling may use it; the engine may not.</li>
+</ul>
+</div>
+<footer style="text-align:center;padding:30px;font-size:12px;color:#5d9ec2;border-top:1px solid rgba(93,158,194,.2)">MIT License · github.com/1bit-MONSTER · "Sorry but not sorry."</footer>
 </div>
 </body>
 </html>

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -7,7 +7,7 @@
   gtag('js', new Date());
   gtag('config', 'G-KV5N1VSM2S');
 </script>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/"><link rel="canonical" href="/"><title>1bit.monster API</title><link rel="canonical" href="https://1bit.monster/docs/">
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/docs.html"><link rel="canonical" href="/"><title>1bit.monster API</title><link rel="canonical" href="https://1bit.monster/docs/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="1bit.monster API">
@@ -19,4 +19,4 @@
 <meta name="twitter:description" content="1bit MONSTER — One engine. Every model. Any chip.">
 <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png">
 
-<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/">API docs moved to the landing page.</a></p></body></html>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/docs.html">API docs moved to the landing page.</a></p></body></html>

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -7,7 +7,7 @@
   gtag('js', new Date());
   gtag('config', 'G-KV5N1VSM2S');
 </script>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/#backends"><link rel="canonical" href="/#backends"><title>1bit.monster architecture</title><link rel="canonical" href="https://1bit.monster/docs/">
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/docs.html"><link rel="canonical" href="/#backends"><title>1bit.monster architecture</title><link rel="canonical" href="https://1bit.monster/docs/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="1bit.monster architecture">
@@ -19,4 +19,4 @@
 <meta name="twitter:description" content="1bit MONSTER — One engine. Every model. Any chip.">
 <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png">
 
-<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/#backends">Architecture moved to the landing page.</a></p></body></html>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/docs.html">Architecture moved to the landing page.</a></p></body></html>

--- a/site/docs/benchmarks.html
+++ b/site/docs/benchmarks.html
@@ -7,7 +7,7 @@
   gtag('js', new Date());
   gtag('config', 'G-KV5N1VSM2S');
 </script>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/#benchmarks"><link rel="canonical" href="/#benchmarks"><title>1bit.monster benchmarks</title><link rel="canonical" href="https://1bit.monster/docs/">
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/benchmarks.html"><link rel="canonical" href="/#benchmarks"><title>1bit.monster benchmarks</title><link rel="canonical" href="https://1bit.monster/docs/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="1bit.monster benchmarks">
@@ -19,4 +19,4 @@
 <meta name="twitter:description" content="1bit MONSTER — One engine. Every model. Any chip.">
 <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png">
 
-<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/#benchmarks">Benchmarks moved to the landing page.</a></p></body></html>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/benchmarks.html">Benchmarks moved to the landing page.</a></p></body></html>

--- a/site/docs/changelog.html
+++ b/site/docs/changelog.html
@@ -7,7 +7,7 @@
   gtag('js', new Date());
   gtag('config', 'G-KV5N1VSM2S');
 </script>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/"><link rel="canonical" href="/"><title>1bit.monster changelog</title><link rel="canonical" href="https://1bit.monster/docs/">
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/docs.html"><link rel="canonical" href="/"><title>1bit.monster changelog</title><link rel="canonical" href="https://1bit.monster/docs/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="1bit.monster changelog">
@@ -19,4 +19,4 @@
 <meta name="twitter:description" content="1bit MONSTER — One engine. Every model. Any chip.">
 <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png">
 
-<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/">Changelog moved to the landing page.</a></p></body></html>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/docs.html">Changelog moved to the landing page.</a></p></body></html>

--- a/site/docs/contributing.html
+++ b/site/docs/contributing.html
@@ -7,7 +7,7 @@
   gtag('js', new Date());
   gtag('config', 'G-KV5N1VSM2S');
 </script>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/"><link rel="canonical" href="/"><title>1bit.monster contributing</title><link rel="canonical" href="https://1bit.monster/docs/">
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/docs.html"><link rel="canonical" href="/"><title>1bit.monster contributing</title><link rel="canonical" href="https://1bit.monster/docs/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="1bit.monster contributing">
@@ -19,4 +19,4 @@
 <meta name="twitter:description" content="1bit MONSTER — One engine. Every model. Any chip.">
 <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png">
 
-<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/">Contributing moved to the landing page.</a></p></body></html>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/docs.html">Contributing moved to the landing page.</a></p></body></html>

--- a/site/docs/faq.html
+++ b/site/docs/faq.html
@@ -7,7 +7,7 @@
   gtag('js', new Date());
   gtag('config', 'G-KV5N1VSM2S');
 </script>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/#faq"><link rel="canonical" href="/#faq"><title>1bit.monster FAQ</title><link rel="canonical" href="https://1bit.monster/docs/">
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/docs.html"><link rel="canonical" href="/#faq"><title>1bit.monster FAQ</title><link rel="canonical" href="https://1bit.monster/docs/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="1bit.monster FAQ">
@@ -19,4 +19,4 @@
 <meta name="twitter:description" content="1bit MONSTER — One engine. Every model. Any chip.">
 <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png">
 
-<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/#faq">FAQ moved to the landing page.</a></p></body></html>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/docs.html">FAQ moved to the landing page.</a></p></body></html>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -7,7 +7,7 @@
   gtag('js', new Date());
   gtag('config', 'G-KV5N1VSM2S');
 </script>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/"><link rel="canonical" href="/"><title>1bit.monster docs</title><link rel="canonical" href="https://1bit.monster/docs/">
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/docs.html"><link rel="canonical" href="/"><title>1bit.monster docs</title><link rel="canonical" href="https://1bit.monster/docs/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="1bit.monster docs">
@@ -19,4 +19,4 @@
 <meta name="twitter:description" content="1bit MONSTER — One engine. Every model. Any chip.">
 <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png">
 
-<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/">1bit.monster docs moved to the landing page.</a></p></body></html>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/docs.html">1bit.monster docs moved to the landing page.</a></p></body></html>

--- a/site/docs/install.html
+++ b/site/docs/install.html
@@ -7,7 +7,7 @@
   gtag('js', new Date());
   gtag('config', 'G-KV5N1VSM2S');
 </script>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/#quickstart"><link rel="canonical" href="/#quickstart"><title>1bit.monster install</title><link rel="canonical" href="https://1bit.monster/docs/">
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/docs.html"><link rel="canonical" href="/#quickstart"><title>1bit.monster install</title><link rel="canonical" href="https://1bit.monster/docs/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="1bit.monster install">
@@ -19,4 +19,4 @@
 <meta name="twitter:description" content="1bit MONSTER — One engine. Every model. Any chip.">
 <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png">
 
-<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/#quickstart">Install docs moved to the landing page.</a></p></body></html>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/docs.html">Install docs moved to the landing page.</a></p></body></html>

--- a/site/docs/models.html
+++ b/site/docs/models.html
@@ -7,7 +7,7 @@
   gtag('js', new Date());
   gtag('config', 'G-KV5N1VSM2S');
 </script>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/#models"><link rel="canonical" href="/#models"><title>1bit.monster models</title><link rel="canonical" href="https://1bit.monster/docs/">
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/models.html"><link rel="canonical" href="/#models"><title>1bit.monster models</title><link rel="canonical" href="https://1bit.monster/docs/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="1bit.monster models">
@@ -19,4 +19,4 @@
 <meta name="twitter:description" content="1bit MONSTER — One engine. Every model. Any chip.">
 <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png">
 
-<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/#models">Model docs moved to the landing page.</a></p></body></html>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/models.html">Model docs moved to the landing page.</a></p></body></html>

--- a/site/docs/quickstart.html
+++ b/site/docs/quickstart.html
@@ -7,7 +7,7 @@
   gtag('js', new Date());
   gtag('config', 'G-KV5N1VSM2S');
 </script>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/#quickstart"><link rel="canonical" href="/#quickstart"><title>1bit.monster quickstart</title><link rel="canonical" href="https://1bit.monster/docs/">
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/docs.html"><link rel="canonical" href="/#quickstart"><title>1bit.monster quickstart</title><link rel="canonical" href="https://1bit.monster/docs/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="1bit.monster quickstart">
@@ -19,4 +19,4 @@
 <meta name="twitter:description" content="1bit MONSTER — One engine. Every model. Any chip.">
 <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png">
 
-<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/#quickstart">Quickstart moved to the landing page.</a></p></body></html>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/docs.html">Quickstart moved to the landing page.</a></p></body></html>

--- a/site/docs/troubleshooting.html
+++ b/site/docs/troubleshooting.html
@@ -7,7 +7,7 @@
   gtag('js', new Date());
   gtag('config', 'G-KV5N1VSM2S');
 </script>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/#faq"><link rel="canonical" href="/#faq"><title>1bit.monster troubleshooting</title><link rel="canonical" href="https://1bit.monster/docs/">
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/docs.html"><link rel="canonical" href="/#faq"><title>1bit.monster troubleshooting</title><link rel="canonical" href="https://1bit.monster/docs/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="1bit.monster troubleshooting">
@@ -19,4 +19,4 @@
 <meta name="twitter:description" content="1bit MONSTER — One engine. Every model. Any chip.">
 <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png">
 
-<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/#faq">Troubleshooting moved to the landing page.</a></p></body></html>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/docs.html">Troubleshooting moved to the landing page.</a></p></body></html>

--- a/site/docs/why.html
+++ b/site/docs/why.html
@@ -7,7 +7,7 @@
   gtag('js', new Date());
   gtag('config', 'G-KV5N1VSM2S');
 </script>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/#top"><link rel="canonical" href="/#top"><title>1bit.monster why</title><link rel="canonical" href="https://1bit.monster/docs/">
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0; url=/docs.html"><link rel="canonical" href="/#top"><title>1bit.monster why</title><link rel="canonical" href="https://1bit.monster/docs/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="1bit.monster why">
@@ -19,4 +19,4 @@
 <meta name="twitter:description" content="1bit MONSTER — One engine. Every model. Any chip.">
 <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png">
 
-<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/#top">Project overview moved to the landing page.</a></p></body></html>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics --></head><body><p><a href="/docs.html">Project overview moved to the landing page.</a></p></body></html>

--- a/site/index.html
+++ b/site/index.html
@@ -80,16 +80,15 @@
 <body>
 <div style="background:radial-gradient(1200px 600px at 15% -10%, rgba(0,229,255,.12), transparent 60%),radial-gradient(1000px 550px at 90% 0%, rgba(255,159,28,.10), transparent 60%),#021621;color:#e7f6fd;font-family:'DM Mono',ui-monospace,Menlo,monospace;line-height:1.6;min-height:100vh">
 <nav style="display:flex;align-items:center;justify-content:space-between;max-width:1100px;margin:0 auto;padding:28px 24px">
-<div style="font-family:'DM Serif Display',Georgia,serif;font-size:20px"><span style="color:#00e5ff">1bit</span>.MONSTER</div>
+<a href="index.html" style="font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a>
 <div class="bh-nav" style="display:flex;gap:28px;font-size:13px;color:#a0d9f8;flex-wrap:wrap;justify-content:flex-end">
 <a href="models.html" style="color:inherit;text-decoration:none">Models</a>
 <a href="benchmarks.html" style="color:inherit;text-decoration:none">Benchmarks</a>
 <a href="docs.html" style="color:inherit;text-decoration:none">Docs</a>
-<a href="jarvis/" style="color:inherit;text-decoration:none">JARVIS</a>
+<a href="jarvis/" style="color:inherit;text-decoration:none">1bit JARVIS</a>
 <a href="blog/" style="color:inherit;text-decoration:none">Blog</a>
 <a href="store/" style="color:inherit;text-decoration:none">Store</a>
 <a href="demo/" style="color:inherit;text-decoration:none">Demos</a>
-<a href="live.html" style="color:inherit;text-decoration:none">Live</a>
 <a href="analytics/" style="color:inherit;text-decoration:none">Analytics</a>
 <a href="https://github.com/1bit-MONSTER/1bit-MONSTER" style="color:inherit;text-decoration:none">GitHub</a>
 </div>

--- a/site/jarvis/index.html
+++ b/site/jarvis/index.html
@@ -12,15 +12,15 @@
 
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>JARVIS — 1bit.monster</title>
-<meta name="description" content="JARVIS — your private AI assistant. Runs entirely on-device on 1bit.monster NPU+GPU+CPU. 94 tok/s. Chat, voice, vision, RAG, agents. Zero cloud. Zero subscriptions. Open source.">
-<meta property="og:title" content="JARVIS — Private AI on 1bit.monster">
+<title>1bit JARVIS — 1bit.monster</title>
+<meta name="description" content="1bit JARVIS — your private AI assistant. Runs entirely on-device on 1bit.monster NPU+GPU+CPU. 94 tok/s. Chat, voice, vision, RAG, agents. Zero cloud. Zero subscriptions. Open source.">
+<meta property="og:title" content="1bit JARVIS — Private AI on 1bit.monster">
 <meta property="og:description" content="Your private AI assistant. NPU+GPU+CPU. 94 tok/s. Chat, voice, vision, RAG. Zero cloud. Open source.">
 <meta property="og:image" content="/assets/og-card.png">
 <meta property="og:url" content="https://1bit.monster/jarvis/">
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="JARVIS — 1bit.monster">
+<meta name="twitter:title" content="1bit JARVIS — 1bit.monster">
 <meta name="twitter:description" content="Private AI on your hardware. 94 tok/s. Chat, voice, vision. Zero cloud.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://1bit.monster/jarvis/">
@@ -129,7 +129,7 @@
 <!-- ─── NAV ─── -->
 <nav>
   <div class="nav-in">
-    <a class="brand" href="/"><span class="mark">J</span><span class="wordmark"><span class="g">J</span>AR<span class="p">V</span>IS</span></a>
+    <a class="brand" href="/"><span class="mark">J</span><span class="wordmark">1bit <span class="g">J</span>AR<span class="p">V</span>IS</span></a>
     <div class="nav-links"><a href="#capabilities">Capabilities</a><a href="#architecture">Architecture</a><a href="#open-knowledge">Knowledge</a><a href="#install">Install</a><a href="https://1bit.monster">1bit.monster</a></div>
     <div class="nav-cta"><a class="btn btn-ghost btn-sm" href="https://github.com/1bit-MONSTER/1bit-MONSTER" target="_blank">GitHub</a><a class="btn btn-primary btn-sm" href="#install">Get Started</a></div>
   </div>
@@ -138,11 +138,11 @@
 <!-- ─── HERO ─── -->
 <section class="hero wrap">
   <span class="eyebrow">Private AI · On-device · Zero Cloud</span>
-  <h1><span class="g">J</span>AR<span class="p">V</span>IS</h1>
+  <h1>1bit <span class="g">J</span>AR<span class="p">V</span>IS</h1>
   <h2 style="margin-top:2px;font-size:clamp(20px,2.6vw,32px);font-weight:800;letter-spacing:-.025em;line-height:1.04;"><span class="b">Your Private AI. On Your Hardware.</span></h2>
   <p class="sub">Chat, voice, vision, RAG, agents — running entirely on your NPU+GPU+CPU. 94 tok/s on an AMD Strix Halo laptop. No cloud. No subscriptions. No data leaves your machine.</p>
   <div class="cta-row">
-    <a class="btn btn-primary btn-md" href="#install">Install JARVIS →</a>
+    <a class="btn btn-primary btn-md" href="#install">Install 1bit JARVIS →</a>
     <a class="btn btn-ghost btn-md" href="#capabilities">See capabilities</a>
   </div>
   <div style="display:flex;flex-wrap:wrap;gap:8px;justify-content:center;margin-top:18px;">
@@ -157,7 +157,7 @@
   <div class="hero-panel">
     <div class="console-hd">
       <span class="dots"><span style="background:var(--pink)"></span><span style="background:var(--blue)"></span><span style="background:var(--green)"></span></span>
-      <span class="mono" style="font-size:12px;color:var(--muted);">JARVIS — NPU+GPU+CPU Fused</span>
+      <span class="mono" style="font-size:12px;color:var(--muted);">1bit JARVIS — NPU+GPU+CPU Fused</span>
       <span style="flex:1"></span>
       <span class="pill dark"><span class="dot"></span>live · 94 tok/s</span>
     </div>
@@ -166,7 +166,7 @@
 <span class="g">  -F</span> <span class="t">"message=What can you do?"</span>
 
 <span class="b">{</span>
-<span class="b">  "response": "I'm JARVIS — your private AI assistant.</span>
+<span class="b">  "response": "I'm 1bit JARVIS — your private AI assistant.</span>
 <span class="b">  I can chat, see images, hear your voice, search your</span>
 <span class="b">  documents, write code, and control your system.</span>
 <span class="b">  Everything runs locally on your NPU+GPU+CPU.",</span>
@@ -189,25 +189,25 @@
     <div class="card" style="padding:22px;">
       <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;"><span class="tag voice">VOICE</span><span class="mono" style="font-size:11px;color:var(--muted);">Whisper-v3 + Piper</span></div>
       <h3 style="font-size:18px;font-weight:800;color:var(--text);">Speech In & Out</h3>
-      <p style="font-size:13px;color:var(--muted);margin:8px 0 14px;line-height:1.55;">Talk to JARVIS naturally. Whisper-v3 on NPU converts speech to text. Piper TTS reads responses aloud. Push-to-talk from the web UI.</p>
+      <p style="font-size:13px;color:var(--muted);margin:8px 0 14px;line-height:1.55;">Talk to 1bit JARVIS naturally. Whisper-v3 on NPU converts speech to text. Piper TTS reads responses aloud. Push-to-talk from the web UI.</p>
       <div class="pill ok" style="font-size:10px;"><span class="dot"></span>NPU-powered STT</div>
     </div>
     <div class="card" style="padding:22px;">
       <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;"><span class="tag vision">VISION</span><span class="mono" style="font-size:11px;color:var(--muted);">Qwen3-VL-4B</span></div>
       <h3 style="font-size:18px;font-weight:800;color:var(--text);">See & Understand</h3>
-      <p style="font-size:13px;color:var(--muted);margin:8px 0 14px;line-height:1.55;">Upload images, screenshots, or photos. JARVIS describes, analyzes, and answers questions about what it sees. Runs on NPU at 11 tok/s.</p>
+      <p style="font-size:13px;color:var(--muted);margin:8px 0 14px;line-height:1.55;">Upload images, screenshots, or photos. 1bit JARVIS describes, analyzes, and answers questions about what it sees. Runs on NPU at 11 tok/s.</p>
       <div class="pill info" style="font-size:10px;"><span class="dot"></span>11 tok/s on NPU</div>
     </div>
     <div class="card" style="padding:22px;">
       <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;"><span class="tag rag">RAG</span><span class="mono" style="font-size:11px;color:var(--muted);">Open Knowledge</span></div>
       <h3 style="font-size:18px;font-weight:800;color:var(--text);">Document Intelligence</h3>
-      <p style="font-size:13px;color:var(--muted);margin:8px 0 14px;line-height:1.55;">Upload PDFs, text files, or notes. JARVIS indexes them locally and answers questions from your knowledge base. All files are human-readable markdown.</p>
+      <p style="font-size:13px;color:var(--muted);margin:8px 0 14px;line-height:1.55;">Upload PDFs, text files, or notes. 1bit JARVIS indexes them locally and answers questions from your knowledge base. All files are human-readable markdown.</p>
       <div class="pill ok" style="font-size:10px;"><span class="dot"></span>Transparent format</div>
     </div>
     <div class="card" style="padding:22px;">
       <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;"><span class="tag agent">AGENTS</span><span class="mono" style="font-size:11px;color:var(--muted);">Tool Calling</span></div>
       <h3 style="font-size:18px;font-weight:800;color:var(--text);">Tool-Using Agent</h3>
-      <p style="font-size:13px;color:var(--muted);margin:8px 0 14px;line-height:1.55;">Calculator, Python execution, file operations, system control. JARVIS decides when to use tools and explains what it found.</p>
+      <p style="font-size:13px;color:var(--muted);margin:8px 0 14px;line-height:1.55;">Calculator, Python execution, file operations, system control. 1bit JARVIS decides when to use tools and explains what it found.</p>
       <div class="pill warn" style="font-size:10px;"><span class="dot"></span>Python · calc · files</div>
     </div>
     <div class="card" style="padding:22px;">
@@ -218,8 +218,8 @@
     </div>
     <div class="card" style="padding:22px;">
       <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;"><span class="tag voice">MOBILE</span><span class="mono" style="font-size:11px;color:var(--muted);">Flutter · iOS · Android</span></div>
-      <h3 style="font-size:18px;font-weight:800;color:var(--text);">JARVIS on Your Phone</h3>
-      <p style="font-size:13px;color:var(--muted);margin:8px 0 14px;line-height:1.55;">Native Flutter app with the same JARVIS theme. Connect via ngrok tunnel with QR code pairing. JARVIS in your pocket.</p>
+      <h3 style="font-size:18px;font-weight:800;color:var(--text);">1bit JARVIS on Your Phone</h3>
+      <p style="font-size:13px;color:var(--muted);margin:8px 0 14px;line-height:1.55;">Native Flutter app with the same 1bit JARVIS theme. Connect via ngrok tunnel with QR code pairing. 1bit JARVIS in your pocket.</p>
       <div class="pill ok" style="font-size:10px;"><span class="dot"></span>App Store + Play Store</div>
     </div>
   </div>
@@ -230,7 +230,7 @@
 <!-- ─── ARCHITECTURE ─── -->
 <section id="architecture" class="wrap block">
   <span class="eyebrow">Architecture</span>
-  <h2 style="margin:16px 0 8px;">How JARVIS works — end to end.</h2>
+  <h2 style="margin:16px 0 8px;">How 1bit JARVIS works — end to end.</h2>
   <p class="lead" style="margin-bottom:24px;">Every component runs locally. The fused engine dispatches per-operation to NPU, GPU, or CPU.</p>
   <div class="panel-a">
     <div class="console-hd">
@@ -274,12 +274,12 @@
 <section id="open-knowledge" class="wrap block">
   <span class="eyebrow">Open Knowledge Format</span>
   <h2 style="margin:16px 0 8px;">Your knowledge. Your format. No lock-in.</h2>
-  <p class="lead" style="margin-bottom:24px;">Every fact JARVIS learns is a human-readable .md file with YAML frontmatter. You can read, edit, add, or delete with any text editor. No proprietary databases. No vendor lock-in.</p>
+  <p class="lead" style="margin-bottom:24px;">Every fact 1bit JARVIS learns is a human-readable .md file with YAML frontmatter. You can read, edit, add, or delete with any text editor. No proprietary databases. No vendor lock-in.</p>
   <div class="grid2">
     <div class="code" style="font-size:12px;">
 <span class="c"># 📁 /home/bcloud/jarvis/data/knowledge/</span>
 <span class="c">├── index.json           # Auto-generated search index</span>
-<span class="c">├── facts/               # Structured facts JARVIS learned</span>
+<span class="c">├── facts/               # Structured facts 1bit JARVIS learned</span>
 <span class="c">│   ├── npu_benchmark.md</span>
 <span class="c">│   ├── model_config_qwen3.md</span>
 <span class="c">│   └── hardware_specs.md</span>
@@ -314,7 +314,7 @@
         <div class="check"><span class="ck">✓</span><span class="txt"><strong style="color:var(--green);">No lock-in</strong> — Move your knowledge anywhere. No export needed.</span></div>
         <div class="check"><span class="ck">✓</span><span class="txt"><strong style="color:var(--green);">Structured metadata</strong> — YAML frontmatter for type, tags, confidence.</span></div>
         <div class="check"><span class="ck">✓</span><span class="txt"><strong style="color:var(--green);">Full-text search</strong> — Built-in keyword search across all entries.</span></div>
-        <div class="check"><span class="ck">✓</span><span class="txt"><strong style="color:var(--green);">Confidence scoring</strong> — JARVIS tracks how certain it is about each fact.</span></div>
+        <div class="check"><span class="ck">✓</span><span class="txt"><strong style="color:var(--green);">Confidence scoring</strong> — 1bit JARVIS tracks how certain it is about each fact.</span></div>
       </div>
     </div>
   </div>
@@ -324,7 +324,7 @@
 <section class="wrap block">
   <span class="eyebrow">Multimodal</span>
   <h2 style="margin:16px 0 8px;">Talk, see, search. All offline.</h2>
-  <p class="lead" style="margin-bottom:24px;">JARVIS processes speech, images, and documents — all on-device, all private.</p>
+  <p class="lead" style="margin-bottom:24px;">1bit JARVIS processes speech, images, and documents — all on-device, all private.</p>
   <div class="grid3">
     <div class="card" style="padding:20px;">
       <div class="code" style="font-size:11px;border:none;background:transparent;padding:0;">
@@ -366,7 +366,7 @@
 <span class="b">│ description         │</span>
 <span class="c">│ → 11 tok/s          │</span>
 <span class="c">└─────────────────────┘</span></div>
-      <p style="font-size:12px;color:var(--muted);margin-top:10px;">Upload images, screenshots, or photos. JARVIS describes what it sees. Works in the chat.</p>
+      <p style="font-size:12px;color:var(--muted);margin-top:10px;">Upload images, screenshots, or photos. 1bit JARVIS describes what it sees. Works in the chat.</p>
     </div>
     <div class="card" style="padding:20px;">
       <div class="code" style="font-size:11px;border:none;background:transparent;padding:0;">
@@ -385,7 +385,7 @@
 <span class="b">│ Context injection   │</span>
 <span class="c">│ → Grounded answers  │</span>
 <span class="c">└─────────────────────┘</span></div>
-      <p style="font-size:12px;color:var(--muted);margin-top:10px;">Upload files, notes, or entire directories. JARVIS indexes and answers from your knowledge.</p>
+      <p style="font-size:12px;color:var(--muted);margin-top:10px;">Upload files, notes, or entire directories. 1bit JARVIS indexes and answers from your knowledge.</p>
     </div>
   </div>
 </section>
@@ -393,7 +393,7 @@
 <!-- ─── INSTALL ─── -->
 <section id="install" class="wrap block">
   <span class="eyebrow">Get Started</span>
-  <h2 style="margin:16px 0 8px;">Run JARVIS in 3 commands.</h2>
+  <h2 style="margin:16px 0 8px;">Run 1bit JARVIS in 3 commands.</h2>
   <p class="lead" style="margin-bottom:24px;">Prerequisites: AMD Strix Halo (Ryzen AI Max+ 395) with NPU drivers installed.</p>
   <div class="grid2">
     <div class="card" style="padding:24px;">
@@ -404,34 +404,34 @@
       <p style="font-size:13px;color:var(--muted);margin-top:12px;">The NPU v12 engine runs the model on the XDNA2 NPU. One command, zero config.</p>
     </div>
     <div class="card" style="padding:24px;">
-      <h3 style="font-size:17px;font-weight:800;color:var(--text);margin-bottom:8px;">2. Start the JARVIS server</h3>
+      <h3 style="font-size:17px;font-weight:800;color:var(--text);margin-bottom:8px;">2. Start the 1bit JARVIS server</h3>
       <div class="code" style="font-size:12px;"><span class="g">source jarvis-env/bin/activate</span>
 <span class="g">cd jarvis && python3 server.py</span>
-<span class="b">→ JARVIS running on :8080</span></div>
+<span class="b">→ 1bit JARVIS running on :8080</span></div>
       <p style="font-size:13px;color:var(--muted);margin-top:12px;">Python FastAPI server. Orchestrator, agent, voice I/O, RAG, knowledge base — all in one process.</p>
     </div>
     <div class="card" style="padding:24px;">
       <h3 style="font-size:17px;font-weight:800;color:var(--text);margin-bottom:8px;">3. Open the web UI</h3>
       <div class="code" style="font-size:12px;"><span class="g">open http://localhost:8080/chat</span>
-<span class="b">→ JARVIS interface loads</span></div>
+<span class="b">→ 1bit JARVIS interface loads</span></div>
       <p style="font-size:13px;color:var(--muted);margin-top:12px;">Full chat UI with streaming, voice, vision, and file upload. Works in Chrome, Firefox, Safari.</p>
     </div>
     <div class="card" style="padding:24px;">
       <h3 style="font-size:17px;font-weight:800;color:var(--text);margin-bottom:8px;">Mobile access</h3>
       <div class="code" style="font-size:12px;"><span class="g">curl -fsSL 1bit.monster/mobile.sh | sh</span>
 <span class="b">→ ngrok tunnel + QR code</span></div>
-      <p style="font-size:13px;color:var(--muted);margin-top:12px;">Expose JARVIS via ngrok. Scan the QR code with JARVIS Mobile (iOS/Android) to chat from anywhere.</p>
+      <p style="font-size:13px;color:var(--muted);margin-top:12px;">Expose 1bit JARVIS via ngrok. Scan the QR code with 1bit JARVIS Mobile (iOS/Android) to chat from anywhere.</p>
     </div>
   </div>
   <div class="code" style="margin-top:24px;font-size:13px;text-align:center;padding:20px;">
 <span class="g">curl -fsSL https://1bit.monster/jarvis/install.sh | sh</span>
-<span class="c"># Coming soon: one-command JARVIS install</span></div>
+<span class="c"># Coming soon: one-command 1bit JARVIS install</span></div>
 </section>
 
 <!-- ─── CTA ─── -->
 <section class="wrap block" style="padding-top:0;">
   <div class="cta-band">
-    <h2 style="font-weight:900;">Your private JARVIS. On your machine.</h2>
+    <h2 style="font-weight:900;">Your private 1bit JARVIS. On your machine.</h2>
     <p class="lead" style="margin:14px auto 0;max-width:500px;">94 tok/s. Zero cloud. Zero subscriptions. Full voice, vision, and RAG. Open source.</p>
     <div class="cta-row" style="display:flex;flex-wrap:wrap;gap:12px;justify-content:center;margin-top:24px;">
       <a class="btn btn-primary btn-md" href="https://github.com/1bit-MONSTER/1bit-MONSTER" target="_blank">View on GitHub →</a>
@@ -449,7 +449,7 @@
 <footer>
   <div class="wrap">
     <div class="foot-in">
-      <a class="brand" href="/"><span class="mark" style="width:32px;height:32px;font-size:12px;">J</span><span class="wordmark" style="font-size:15px;"><span class="g">J</span>AR<span class="p">V</span>IS</span></a>
+      <a class="brand" href="/"><span class="mark" style="width:32px;height:32px;font-size:12px;">J</span><span class="wordmark" style="font-size:15px;">1bit <span class="g">J</span>AR<span class="p">V</span>IS</span></a>
       <span style="flex:1"></span>
       <div class="foot-links">
         <a href="https://github.com/1bit-MONSTER/1bit-MONSTER" target="_blank">GitHub</a>
@@ -505,8 +505,8 @@
       table.innerHTML = html;
     }
 
-    console.log('JARVIS: ' + d.order.length + ' engines loaded — v12='+v12+' tok/s, ROCm='+roc+' tok/s, ternary='+ter+' tok/s');
-  }).catch(function(e){console.warn('JARVIS: benchmarks.json not available, using defaults');});
+    console.log('1bit JARVIS: ' + d.order.length + ' engines loaded — v12='+v12+' tok/s, ROCm='+roc+' tok/s, ternary='+ter+' tok/s');
+  }).catch(function(e){console.warn('1bit JARVIS: benchmarks.json not available, using defaults');});
 })();
 </script>
 </body>

--- a/site/models.html
+++ b/site/models.html
@@ -16,14 +16,13 @@
 <meta name="description" content="100% HF model coverage across 32 architecture tokens. Coverage by class, not by port.">
 <link rel="icon" href="assets/favicon.svg?v=2" type="image/svg+xml">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Mono:wght@400;500&display=swap">
-<link rel="stylesheet" href="assets/1bm.css">
-<link rel="canonical" href="https://1bit.monster/">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Mono:wght@400;500;700&display=swap">
+<link rel="canonical" href="https://1bit.monster/models.html">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="Models — 1bit MONSTER">
 <meta property="og:description" content="100% HF model coverage across 32 architecture tokens. Coverage by class, not by port.">
-<meta property="og:url" content="https://1bit.monster/">
+<meta property="og:url" content="https://1bit.monster/models.html">
 <meta property="og:image" content="https://1bit.monster/assets/og-card.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Models — 1bit MONSTER">
@@ -33,9 +32,9 @@
 {
   "@context": "https://schema.org",
   "@type": "WebPage",
-  "name": "Models \u2014 1bit MONSTER",
+  "name": "Models — 1bit MONSTER",
   "description": "100% HF model coverage across 32 architecture tokens. Coverage by class, not by port.",
-  "url": "https://1bit.monster/",
+  "url": "https://1bit.monster/models.html",
   "about": {
     "@type": "SoftwareApplication",
     "name": "1bit MONSTER"
@@ -44,79 +43,75 @@
 </script>
 
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics -->
+<style>
+  body{margin:0}
+  *{box-sizing:border-box}
+  .bh-nav a:hover{color:#ff9f1c}
+  .bh-cta-ghost:hover{border-color:#00e5ff;color:#00e5ff}
+  .bh-row:hover{background:rgba(0,229,255,.04)}
+</style>
 </head>
 <body>
-<div class="shell">
-  <aside class="rail">
-    <div>
-      <span class="mark">1bm</span>
-      <span class="wordmark">1bit<br>MONSTER</span>
-      <p class="quote">"Sorry but not sorry." <span>— bong-water-water-bong</span></p>
-    </div>
-    <nav>
-      <a href="index.html">overview</a>
-      <a href="models.html" aria-current="page">models</a>
-      <a href="benchmarks.html">benchmarks</a>
-      <a href="docs.html">docs</a>
-      <a href="story.html">the story</a>
-      <a href="jarvis/">jarvis</a>
-      <a href="blog/">blog</a>
-      <a href="store/">store</a>
-      <a href="demo/">demos</a>
-      <a href="live.html">live</a>
-      <a href="analytics/">analytics</a>
-      <a href="https://github.com/1bit-MONSTER/1bit-MONSTER">github</a>
-    </nav>
-    <div class="status"><span class="dot"></span>engine online</div>
-    <div class="meta">MIT<br>pure C++23<br>no python<br>6 hw targets</div>
-  </aside>
-  <main>
-    <div class="topbar"><span>100% HF coverage · any hardware · one engine</span><span>32 arch tokens · 302,330 / 322,029 checkpoints</span></div>
-    <div class="hero">
-      <h1>100% HF coverage, <span style="color:var(--cyan)">one engine</span></h1>
-      <p class="lead">Coverage is defined at the <strong>architecture class</strong>, not per checkpoint. A class that works brings its whole family with it — including checkpoints that did not exist when the class was written. Roughly 50 classes cover the long tail of what HuggingFace hosts; 19 are live.</p>
-      <p class="lead">Three components make a new class cheap: the <strong>registry</strong> (detection and metadata), the <strong>kernel path</strong> (reused ops, quant-aware), and the <strong>validation harness</strong> (numerical comparison against the reference). All three are proven.</p>
-    </div>
-    <section>
-      <h2>Families</h2>
-      <table>
-        <tr><th>family</th><th>class</th><th>highlight</th></tr>
-        <tr><td>Zyphra</td><td class="b">dense · MoE · Mamba/SSM</td><td class="b">BlackMamba-1.5B — 79.4 tok/s</td></tr>
-        <tr><td>Qwen</td><td class="b">dense · MoE · vision-language</td><td class="b">Qwen3-0.6B — 373 tok/s</td></tr>
-        <tr><td>Llama</td><td class="b">dense</td><td class="b">widest third-party fine-tune surface</td></tr>
-        <tr><td>Mistral</td><td class="b">dense · MoE</td><td class="b">sliding-window attention</td></tr>
-        <tr><td>Gemma</td><td class="b">dense</td><td class="b">GeGLU, distinct norm layout</td></tr>
-        <tr><td>Phi</td><td class="b">dense</td><td class="b">strong draft-model candidate</td></tr>
-        <tr><td>Falcon</td><td class="b">dense</td><td class="b">multi-query attention</td></tr>
-        <tr><td>OLMo</td><td class="b">dense</td><td class="b">clean-room numerics reference</td></tr>
-        <tr><td>Granite</td><td class="b">dense · MoE</td><td class="b">enterprise + code variants</td></tr>
-        <tr><td>SmolLM</td><td class="b">dense</td><td class="b">SmolLM2-135M — 662 tok/s</td></tr>
-        <tr><td>DeepSeek</td><td class="b">dense · MoE</td><td class="b">R1-Distill-Llama-8B — 44 tok/s</td></tr>
-        <tr><td>GPT-OSS</td><td class="b">MoE</td><td class="b">expert routing at scale</td></tr>
-        <tr><td>Laguna</td><td class="b">dense</td><td class="b">shared dense kernel path</td></tr>
-        <tr><td>Kimi</td><td class="b">dense · MoE</td><td class="b">long-context KV residency</td></tr>
-        <tr><td>BitNet / Bonsai</td><td class="b">ternary</td><td class="b">native 1BP TQ2 layouts</td></tr>
-        <tr><td>Whisper</td><td class="b">speech (STT)</td><td class="b">front end of the JARVIS pipeline</td></tr>
-      </table>
-      <p class="note" style="margin-top:14px">Per-family pages, with measured numbers where published: <a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/model-families/README.md">docs/model-families →</a></p>
-    </section>
-    <section class="cols">
-      <div>
-        <h3>Formats</h3>
-        <p class="lead">GGUF, ONNX, and the native 1BP format are read directly. Architecture detection is automatic; there is no per-model configuration file and no conversion step to babysit.</p>
-      </div>
-      <div>
-        <h3>Featured: Zyphra</h3>
-        <p class="lead">The one family that spans the entire stack — EEG → LLM (dense, MoE, Mamba) → TTS → voice cloning — all on the same binary. ZAYA1-74B-preview at 17.6 tok/s; BlackMamba-1.5B at 79.4.</p>
-      </div>
-    </section>
-    <footer>
-  <span>© 1bit MONSTER</span>
-  <span style="color:var(--cyan)">mit — do whatever you want</span>
-  <span>Metepenagiag Mi&rsquo;kmaq Nation &middot; New Brunswick, Canada &middot; <a href="mailto:admin@1bit.monster" style="color:var(--faint)">admin@1bit.monster</a></span>
-  <span style="text-transform:none;letter-spacing:0">&ldquo;Sorry but not sorry.&rdquo; &mdash; bong-water-water-bong</span>
-</footer>
-  </main>
+<div style="background:radial-gradient(1200px 600px at 15% -10%, rgba(0,229,255,.12), transparent 60%),radial-gradient(1000px 550px at 90% 0%, rgba(255,159,28,.10), transparent 60%),#021621;color:#e7f6fd;font-family:'DM Mono',ui-monospace,Menlo,monospace;line-height:1.6;min-height:100vh">
+<nav style="display:flex;align-items:center;justify-content:space-between;max-width:1100px;margin:0 auto;padding:28px 24px">
+<a href="index.html" style="font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a>
+<div class="bh-nav" style="display:flex;gap:28px;font-size:13px;color:#a0d9f8;flex-wrap:wrap;justify-content:flex-end">
+<a href="models.html" style="color:#00e5ff;text-decoration:none">Models</a>
+<a href="benchmarks.html" style="color:inherit;text-decoration:none">Benchmarks</a>
+<a href="docs.html" style="color:inherit;text-decoration:none">Docs</a>
+<a href="jarvis/" style="color:inherit;text-decoration:none">1bit JARVIS</a>
+<a href="blog/" style="color:inherit;text-decoration:none">Blog</a>
+<a href="store/" style="color:inherit;text-decoration:none">Store</a>
+<a href="demo/" style="color:inherit;text-decoration:none">Demos</a>
+<a href="analytics/" style="color:inherit;text-decoration:none">Analytics</a>
+<a href="https://github.com/1bit-MONSTER/1bit-MONSTER" style="color:inherit;text-decoration:none">GitHub</a>
+</div>
+</nav>
+<div style="max-width:920px;margin:60px auto 0;padding:0 24px;text-align:center">
+<div class="bh-badge" style="display:inline-flex;align-items:center;gap:8px;padding:7px 16px;border:1px solid #0e80be;border-radius:999px;font-size:12px;color:#00e5ff;margin-bottom:28px"><span style="width:6px;height:6px;background:#ff9f1c;border-radius:999px"></span>100% HF coverage — 32 arch tokens</div>
+<h1 style="font-family:'DM Serif Display',Georgia,serif;font-weight:400;font-size:clamp(40px,6.5vw,72px);line-height:1.02;margin:0 0 24px;letter-spacing:-.02em">Every family. <span style="color:#00e5ff">One</span> engine.</h1>
+<p style="max-width:64ch;margin:0 auto 40px;font-size:17px;color:#a0d9f8">Coverage is defined at the <strong style="color:#e7f6fd;font-weight:500">architecture class</strong>, not per checkpoint. A class that works brings its whole family with it — including checkpoints that did not exist when the class was written. Roughly 50 classes cover the long tail of what HuggingFace hosts; 19 are live, mapped through 32 arch tokens.</p>
+</div>
+<div style="display:grid;grid-template-columns:repeat(4,1fr);max-width:1000px;margin:0 auto 80px;padding:0 24px">
+<div style="text-align:center;padding:20px 12px"><b style="display:block;font-family:'DM Serif Display',Georgia,serif;font-size:40px;font-weight:400;line-height:1.1;color:#00e5ff">100%</b><span style="font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:#5d9ec2">HF checkpoints</span></div>
+<div style="text-align:center;padding:20px 12px;border-left:1px solid rgba(93,158,194,.2)"><b style="display:block;font-family:'DM Serif Display',Georgia,serif;font-size:40px;font-weight:400;line-height:1.1;color:#ff9f1c">302,330</b><span style="font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:#5d9ec2">/ 322,029 mapped</span></div>
+<div style="text-align:center;padding:20px 12px;border-left:1px solid rgba(93,158,194,.2)"><b style="display:block;font-family:'DM Serif Display',Georgia,serif;font-size:40px;font-weight:400;line-height:1.1;color:#0e80be">19</b><span style="font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:#5d9ec2">classes live today</span></div>
+<div style="text-align:center;padding:20px 12px;border-left:1px solid rgba(93,158,194,.2)"><b style="display:block;font-family:'DM Serif Display',Georgia,serif;font-size:40px;font-weight:400;line-height:1.1;color:#00e5ff">3</b><span style="font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:#5d9ec2">formats read directly</span></div>
+</div>
+<div style="max-width:920px;margin:0 auto 80px;padding:0 24px">
+<div style="display:flex;align-items:baseline;justify-content:space-between;font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;border-bottom:1px solid rgba(93,158,194,.24);padding-bottom:12px;margin-bottom:20px"><span>Families</span><span>class → highlight</span></div>
+<div style="border:1px solid rgba(93,158,194,.24);border-radius:12px;overflow:hidden;background:rgba(4,32,47,.6)">
+<div style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;border-bottom:1px solid rgba(93,158,194,.24)"><span>family</span><span>class</span><span style="text-align:right">highlight</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>Zyphra</span><span style="color:#a0d9f8">dense · MoE · Mamba/SSM</span><span style="text-align:right;color:#00e5ff">BlackMamba-1.5B — 79.4 tok/s</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>Qwen</span><span style="color:#a0d9f8">dense · MoE · vision-language</span><span style="text-align:right;color:#00e5ff">Qwen3-0.6B — 373 tok/s</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>Llama</span><span style="color:#a0d9f8">dense</span><span style="text-align:right;color:#5d9ec2">widest fine-tune surface</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>Mistral</span><span style="color:#a0d9f8">dense · MoE</span><span style="text-align:right;color:#5d9ec2">sliding-window attention</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>Gemma</span><span style="color:#a0d9f8">dense</span><span style="text-align:right;color:#5d9ec2">GeGLU, distinct norm layout</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>Phi</span><span style="color:#a0d9f8">dense</span><span style="text-align:right;color:#5d9ec2">strong draft-model candidate</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>Falcon</span><span style="color:#a0d9f8">dense</span><span style="text-align:right;color:#5d9ec2">multi-query attention</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>OLMo</span><span style="color:#a0d9f8">dense</span><span style="text-align:right;color:#5d9ec2">clean-room numerics reference</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>Granite</span><span style="color:#a0d9f8">dense · MoE</span><span style="text-align:right;color:#5d9ec2">enterprise + code variants</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>SmolLM</span><span style="color:#a0d9f8">dense</span><span style="text-align:right;color:#00e5ff">SmolLM2-135M — 662 tok/s</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>DeepSeek</span><span style="color:#a0d9f8">dense · MoE</span><span style="text-align:right;color:#5d9ec2">R1-Distill-Llama-8B — 44 tok/s</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>GPT-OSS</span><span style="color:#a0d9f8">MoE</span><span style="text-align:right;color:#5d9ec2">expert routing at scale</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>Laguna</span><span style="color:#a0d9f8">dense</span><span style="text-align:right;color:#5d9ec2">shared dense kernel path</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>Kimi</span><span style="color:#a0d9f8">dense · MoE</span><span style="text-align:right;color:#5d9ec2">long-context KV residency</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;border-bottom:1px solid rgba(93,158,194,.16);font-size:13.5px"><span>BitNet / Bonsai</span><span style="color:#a0d9f8">ternary</span><span style="text-align:right;color:#5d9ec2">native 1BP TQ2 layouts</span></div>
+<div class="bh-row" style="display:grid;grid-template-columns:1fr 1.1fr 1.2fr;gap:14px;padding:14px 20px;font-size:13.5px"><span>Whisper</span><span style="color:#a0d9f8">speech (STT)</span><span style="text-align:right;color:#5d9ec2">front end of the 1bit JARVIS pipeline</span></div>
+</div>
+<p style="font-size:13px;color:#5d9ec2;margin:14px 0 0">Per-family pages, with measured numbers where published: <a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/model-families/README.md" style="color:#00e5ff;text-decoration:none">docs/model-families →</a></p>
+</div>
+<div style="max-width:920px;margin:0 auto 96px;padding:0 24px;display:grid;grid-template-columns:1fr 1fr;gap:24px">
+<div style="border:1px solid rgba(93,158,194,.24);border-radius:12px;padding:28px;background:rgba(4,32,47,.6)">
+<div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;margin-bottom:12px">Formats</div>
+<p style="margin:0;font-size:14px;color:#a0d9f8">GGUF, ONNX, and the native 1BP format are read directly. Architecture detection is automatic; there is no per-model configuration file and no conversion step to babysit.</p>
+</div>
+<div style="border:1px solid rgba(255,159,28,.35);border-radius:12px;padding:28px;background:rgba(255,159,28,.05)">
+<div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;margin-bottom:12px">Featured — Zyphra</div>
+<p style="margin:0;font-size:14px;color:#a0d9f8">The one family that spans the entire stack — EEG → LLM (dense, MoE, Mamba) → TTS → voice cloning — all on the same binary. <strong style="color:#e7f6fd;font-weight:500">ZAYA1-74B-preview at 17.6 tok/s; BlackMamba-1.5B at 79.4.</strong></p>
+</div>
+</div>
+<footer style="text-align:center;padding:30px;font-size:12px;color:#5d9ec2;border-top:1px solid rgba(93,158,194,.2)">MIT License · github.com/1bit-MONSTER · "Sorry but not sorry."</footer>
 </div>
 </body>
 </html>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -25,12 +25,6 @@
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://1bit.monster/live.html</loc>
-    <lastmod>2026-08-02</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
     <loc>https://1bit.monster/blog/</loc>
     <lastmod>2026-08-02</lastmod>
     <changefreq>weekly</changefreq>

--- a/site/story.html
+++ b/site/story.html
@@ -16,14 +16,13 @@
 <meta name="description" content="22 proprietary libraries, 209 bitstreams, zero documentation — reverse-engineered in 4 days.">
 <link rel="icon" href="assets/favicon.svg?v=2" type="image/svg+xml">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Mono:wght@400;500&display=swap">
-<link rel="stylesheet" href="assets/1bm.css">
-<link rel="canonical" href="https://1bit.monster/">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Mono:wght@400;500;700&display=swap">
+<link rel="canonical" href="https://1bit.monster/story.html">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="1bit MONSTER">
 <meta property="og:title" content="The story — 1bit MONSTER">
 <meta property="og:description" content="22 proprietary libraries, 209 bitstreams, zero documentation — reverse-engineered in 4 days.">
-<meta property="og:url" content="https://1bit.monster/">
+<meta property="og:url" content="https://1bit.monster/story.html">
 <meta property="og:image" content="https://1bit.monster/assets/og-card.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="The story — 1bit MONSTER">
@@ -32,97 +31,71 @@
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
-  "@type": "Article",
-  "headline": "The story \u2014 1bit MONSTER",
-  "description": "22 proprietary libraries, 209 bitstreams, zero documentation \u2014 reverse-engineered in 4 days.",
-  "author": {
-    "@type": "Person",
-    "name": "bong-water-water-bong"
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "1bit.monster"
+  "@type": "WebPage",
+  "name": "The story — 1bit MONSTER",
+  "description": "22 proprietary libraries, 209 bitstreams, zero documentation — reverse-engineered in 4 days.",
+  "url": "https://1bit.monster/story.html",
+  "about": {
+    "@type": "SoftwareApplication",
+    "name": "1bit MONSTER"
   }
 }
 </script>
 
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1fdeba29ed164ab5bd63abf15e0418f0"}'></script><!-- End Cloudflare Web Analytics -->
+<style>
+  body{margin:0}
+  *{box-sizing:border-box}
+  .bh-nav a:hover{color:#ff9f1c}
+  .bh-cta-ghost:hover{border-color:#00e5ff;color:#00e5ff}
+  .bh-cta-primary:hover{filter:brightness(1.08)}
+  .bh-card:hover{border-color:#00e5ff}
+</style>
 </head>
 <body>
-<div class="shell">
-  <aside class="rail">
-    <div>
-      <span class="mark">1bm</span>
-      <span class="wordmark">1bit<br>MONSTER</span>
-      <p class="quote">"Sorry but not sorry." <span>— bong-water-water-bong</span></p>
-    </div>
-    <nav>
-      <a href="index.html">overview</a>
-      <a href="models.html">models</a>
-      <a href="benchmarks.html">benchmarks</a>
-      <a href="docs.html">docs</a>
-      <a href="story.html" aria-current="page">the story</a>
-      <a href="jarvis/">jarvis</a>
-      <a href="blog/">blog</a>
-      <a href="store/">store</a>
-      <a href="demo/">demos</a>
-      <a href="live.html">live</a>
-      <a href="analytics/">analytics</a>
-      <a href="https://github.com/1bit-MONSTER/1bit-MONSTER">github</a>
-    </nav>
-    <div class="status"><span class="dot"></span>engine online</div>
-    <div class="meta">MIT<br>pure C++23<br>no python<br>6 hw targets</div>
-  </aside>
-  <main>
-    <div class="topbar"><span>100% HF coverage · any hardware · one engine</span><span>// the hard truth</span></div>
-    <div class="hero">
-      <span class="eyebrow">// the hard truth</span>
-      <h1>22 libraries. 209 bitstreams. <span style="color:var(--cyan)">Zero docs.</span></h1>
-      <p class="lead">AMD shipped the Ryzen AI Max+ 395 with a 50 TOPS XDNA 2 NPU and locked it behind a closed-source runtime: 22 proprietary <code>.so</code> files, 209 bitstreams, no documentation. Nothing outside AMD's own tooling could touch that chip.</p>
-      <p class="lead">We reverse-engineered the whole stack in <strong>4 days</strong> and replaced it with open C++ — one MIT-licensed engine that runs LLMs on the NPU, on AMD / NVIDIA / Apple GPUs, or on plain CPU.</p>
-      <div class="btns">
-        <a class="btn" href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/journey.md">read the full journey</a>
-      </div>
-      <span class="note">Every crash, breakthrough and bug, documented in real time.</span>
-    </div>
-    <section class="cols">
-      <div>
-        <h3>What it started as</h3>
-        <p class="lead">A laptop, a disassembler, and no documentation. The goal was narrow: get one model running on the NPU without the vendor runtime.</p>
-      </div>
-      <div>
-        <h3>What it became</h3>
-        <p class="lead">An inference engine covering five backends and 19 architecture classes, with a unified control plane, speculative decoding, image generation and a full local voice pipeline on top.</p>
-      </div>
-    </section>
-    <section>
-      <span class="eyebrow">// why it is hard to copy</span>
-      <div class="cols" style="margin-top:18px">
-        <div class="card">
-          <span class="eyebrow">the NPU path exists at all</span>
-          <p class="lead">Recovered from a closed runtime and reimplemented in open C++. The engine is MAX-free by design; the <a href="https://github.com/1bit-systems/max-xdna-backend">max-xdna-backend</a> repo stands as separate evidence that the chip can be driven from outside AMD tooling.</p>
-        </div>
-        <div class="card">
-          <span class="eyebrow">no python in the runtime</span>
-          <p class="lead">Most of the field is a Python stack over vendor kernels. That is a deployment ceiling this engine does not have: one auditable binary, embeddable where a CUDA container cannot go.</p>
-        </div>
-        <div class="card">
-          <span class="eyebrow">coverage compounds</span>
-          <p class="lead">Class-level support means each new architecture is cheaper than the last, and every one widens the catalog permanently — including checkpoints that do not exist yet.</p>
-        </div>
-        <div class="card">
-          <span class="eyebrow">one artifact</span>
-          <p class="lead">A single MIT-licensed engine, no runtime to install. Deployment is copying a file.</p>
-        </div>
-      </div>
-    </section>
-    <footer>
-  <span>© 1bit MONSTER</span>
-  <span style="color:var(--cyan)">mit — do whatever you want</span>
-  <span>Metepenagiag Mi&rsquo;kmaq Nation &middot; New Brunswick, Canada &middot; <a href="mailto:admin@1bit.monster" style="color:var(--faint)">admin@1bit.monster</a></span>
-  <span style="text-transform:none;letter-spacing:0">&ldquo;Sorry but not sorry.&rdquo; &mdash; bong-water-water-bong</span>
-</footer>
-  </main>
+<div style="background:radial-gradient(1200px 600px at 15% -10%, rgba(0,229,255,.12), transparent 60%),radial-gradient(1000px 550px at 90% 0%, rgba(255,159,28,.10), transparent 60%),#021621;color:#e7f6fd;font-family:'DM Mono',ui-monospace,Menlo,monospace;line-height:1.6;min-height:100vh">
+<nav style="display:flex;align-items:center;justify-content:space-between;max-width:1100px;margin:0 auto;padding:28px 24px">
+<a href="index.html" style="font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a>
+<div class="bh-nav" style="display:flex;gap:28px;font-size:13px;color:#a0d9f8;flex-wrap:wrap;justify-content:flex-end">
+<a href="models.html" style="color:inherit;text-decoration:none">Models</a>
+<a href="benchmarks.html" style="color:inherit;text-decoration:none">Benchmarks</a>
+<a href="docs.html" style="color:inherit;text-decoration:none">Docs</a>
+<a href="jarvis/" style="color:inherit;text-decoration:none">1bit JARVIS</a>
+<a href="blog/" style="color:inherit;text-decoration:none">Blog</a>
+<a href="store/" style="color:inherit;text-decoration:none">Store</a>
+<a href="demo/" style="color:inherit;text-decoration:none">Demos</a>
+<a href="analytics/" style="color:inherit;text-decoration:none">Analytics</a>
+<a href="https://github.com/1bit-MONSTER/1bit-MONSTER" style="color:inherit;text-decoration:none">GitHub</a>
+</div>
+</nav>
+<div style="max-width:920px;margin:60px auto 0;padding:0 24px;text-align:center">
+<div class="bh-badge" style="display:inline-flex;align-items:center;gap:8px;padding:7px 16px;border:1px solid #0e80be;border-radius:999px;font-size:12px;color:#00e5ff;margin-bottom:28px"><span style="width:6px;height:6px;background:#ff9f1c;border-radius:999px"></span>the hard truth</div>
+<h1 style="font-family:'DM Serif Display',Georgia,serif;font-weight:400;font-size:clamp(40px,6.5vw,72px);line-height:1.02;margin:0 0 24px;letter-spacing:-.02em">22 libraries. 209 bitstreams. <span style="color:#ff9f1c">Zero docs.</span></h1>
+<p style="max-width:64ch;margin:0 auto 40px;font-size:17px;color:#a0d9f8">AMD shipped the Ryzen AI Max+ 395 with a 50 TOPS XDNA 2 NPU and locked it behind a closed-source runtime: 22 proprietary <span style="color:#e7f6fd">.so</span> files, 209 bitstreams, no documentation. Nothing outside AMD's own tooling could touch that chip. We reverse-engineered the whole stack in <strong style="color:#e7f6fd;font-weight:500">4 days</strong> and replaced it with open C++ — one MIT-licensed engine that runs LLMs on the NPU, on AMD / NVIDIA / Apple GPUs, or on plain CPU.</p>
+<div style="display:flex;gap:16px;justify-content:center;flex-wrap:wrap;margin-bottom:80px">
+<a href="https://github.com/1bit-MONSTER/1bit-MONSTER/blob/main/docs/journey.md" class="bh-cta-primary" style="display:inline-flex;align-items:center;height:54px;padding:0 32px;border-radius:6px;font-size:13px;letter-spacing:.1em;text-transform:uppercase;font-weight:700;text-decoration:none;background:linear-gradient(90deg,#00e5ff,#ff9f1c);color:#021621;transition:filter .15s">Read the full journey</a>
+</div>
+</div>
+<div style="max-width:920px;margin:0 auto 80px;padding:0 24px;display:grid;grid-template-columns:1fr 1fr;gap:24px">
+<div style="border:1px solid rgba(93,158,194,.24);border-radius:12px;padding:28px;background:rgba(4,32,47,.6)">
+<div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;margin-bottom:12px">What it started as</div>
+<p style="margin:0;font-size:14px;color:#a0d9f8">A laptop, a disassembler, and no documentation. The goal was narrow: get one model running on the NPU without the vendor runtime.</p>
+</div>
+<div style="border:1px solid rgba(93,158,194,.24);border-radius:12px;padding:28px;background:rgba(4,32,47,.6)">
+<div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;margin-bottom:12px">What it became</div>
+<p style="margin:0;font-size:14px;color:#a0d9f8">An inference engine covering five backends and 19 architecture classes, with a unified control plane, speculative decoding, image generation and a full local voice pipeline on top.</p>
+</div>
+</div>
+<div style="max-width:920px;margin:0 auto 96px;padding:0 24px">
+<div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#5d9ec2;border-bottom:1px solid rgba(93,158,194,.24);padding-bottom:12px;margin-bottom:20px">Why it is hard to copy</div>
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:14px">
+<div class="bh-card" style="border:1px solid rgba(93,158,194,.24);border-radius:12px;padding:20px;background:rgba(4,32,47,.6);transition:border-color .15s"><div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#00e5ff;margin-bottom:8px">the NPU path exists at all</div><p style="margin:0;font-size:13.5px;color:#a0d9f8">Recovered from a closed runtime and reimplemented in open C++. The engine is MAX-free by design; the <a href="https://github.com/1bit-systems/max-xdna-backend" style="color:#00e5ff;text-decoration:none">max-xdna-backend</a> repo stands as separate evidence that the chip can be driven from outside AMD tooling.</p></div>
+<div class="bh-card" style="border:1px solid rgba(93,158,194,.24);border-radius:12px;padding:20px;background:rgba(4,32,47,.6);transition:border-color .15s"><div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#ff9f1c;margin-bottom:8px">no python in the runtime</div><p style="margin:0;font-size:13.5px;color:#a0d9f8">Most of the field is a Python stack over vendor kernels. That is a deployment ceiling this engine does not have: one auditable binary, embeddable where a CUDA container cannot go.</p></div>
+<div class="bh-card" style="border:1px solid rgba(93,158,194,.24);border-radius:12px;padding:20px;background:rgba(4,32,47,.6);transition:border-color .15s"><div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#00e5ff;margin-bottom:8px">coverage compounds</div><p style="margin:0;font-size:13.5px;color:#a0d9f8">Class-level support means each new architecture is cheaper than the last, and every one widens the catalog permanently — including checkpoints that do not exist yet.</p></div>
+<div class="bh-card" style="border:1px solid rgba(93,158,194,.24);border-radius:12px;padding:20px;background:rgba(4,32,47,.6);transition:border-color .15s"><div style="font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:#ff9f1c;margin-bottom:8px">one artifact</div><p style="margin:0;font-size:13.5px;color:#a0d9f8">A single MIT-licensed engine, no runtime to install. Deployment is copying a file.</p></div>
+</div>
+</div>
+<footer style="text-align:center;padding:30px;font-size:12px;color:#5d9ec2;border-top:1px solid rgba(93,158,194,.2)">MIT License · github.com/1bit-MONSTER · "Sorry but not sorry."</footer>
 </div>
 </body>
 </html>


### PR DESCRIPTION
- Rebuild models/benchmarks/docs/story in the Bold Hero design to match the homepage (cyan #00e5ff / amber #ff9f1c on navy); homepage replaced with the Bold Hero version.
- Rename JARVIS → 1bit JARVIS across nav, titles and prose (ASCII-art diagrams untouched).
- 1bit.MONSTER brand mark links back to the homepage on every page.
- /models, /docs, /benchmarks (and legacy /docs/* stubs) route to the real pages instead of single-page # anchors.
- Remove the live page: nav links, sitemap entry, site/live.html.