### PR TITLE
feat(readme): #ff9f1c gradient badges for license, hardware, prefill

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 ### 100% HF model coverage. Any hardware. One open-source, pure-C++ inference engine — NPU + GPU + CPU in a single engine. Model agnostic. Hardware agnostic. Zero Python.
 
 [![CI](https://github.com/1bit-MONSTER/1bit-MONSTER/actions/workflows/ci.yml/badge.svg)](https://github.com/1bit-MONSTER/1bit-MONSTER/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/license-MIT-00e5ff?style=flat-square&labelColor=021621)](LICENSE)
+[![License: MIT](https://raw.githubusercontent.com/1bit-MONSTER/1bit-MONSTER/main/site/assets/badges/license.svg)](LICENSE)
 [![HF coverage](https://img.shields.io/badge/HF%20coverage-100%25-00e5ff?style=flat-square&labelColor=021621)](docs/model-families/README.md)
-[![Hardware](https://img.shields.io/badge/hardware-NPU%20%C2%B7%20HIP%20%C2%B7%20Vulkan%20%C2%B7%20CUDA%20%C2%B7%20Metal%20%C2%B7%20CPU-ff9f1c?style=flat-square&labelColor=021621)](docs/guides/architecture.md)
+[![Hardware](https://raw.githubusercontent.com/1bit-MONSTER/1bit-MONSTER/main/site/assets/badges/hardware.svg)](docs/guides/architecture.md)
 [![Gates](https://img.shields.io/badge/gates-17%2F17%20green-00e5ff?style=flat-square&labelColor=021621)](Testing/run_all.sh)
-[![Prefill](https://img.shields.io/badge/prefill-43.2%20TFLOPS-ff9f1c?style=flat-square&labelColor=021621)](docs/wiki/performance.md)
+[![Prefill](https://raw.githubusercontent.com/1bit-MONSTER/1bit-MONSTER/main/site/assets/badges/prefill.svg)](docs/wiki/performance.md)
 [![Site](https://img.shields.io/badge/site-1bit.monster-00e5ff?style=flat-square&labelColor=021621)](https://1bit.monster)
 
 **[Website](https://1bit.monster)** · **[Docs](docs/README.md)** · **[Model families](docs/model-families/README.md)** · **[Benchmarks](docs/wiki/performance.md)** · **[JARVIS](docs/jarvis.md)** · **[The story](docs/journey.md)** · **[Roadmap](docs/guides/roadmap.md)**

--- a/site/assets/badges/hardware.svg
+++ b/site/assets/badges/hardware.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="281" height="20" role="img" aria-label="hardware: NPU · HIP · Vulkan · CUDA · Metal · CPU">
+  <title>hardware: NPU · HIP · Vulkan · CUDA · Metal · CPU</title>
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ff9f1c"/>
+      <stop offset="1" stop-color="#d97f00"/>
+    </linearGradient>
+  </defs>
+  <rect width="59" height="20" fill="#021621"/>
+  <rect x="59" width="222" height="20" fill="url(#g)"/>
+  <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">
+    <text x="29.5" y="14">hardware</text>
+    <text x="170.0" y="14">NPU · HIP · Vulkan · CUDA · Metal · CPU</text>
+  </g>
+</svg>

--- a/site/assets/badges/license.svg
+++ b/site/assets/badges/license.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="73" height="20" role="img" aria-label="license: MIT">
+  <title>license: MIT</title>
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ff9f1c"/>
+      <stop offset="1" stop-color="#d97f00"/>
+    </linearGradient>
+  </defs>
+  <rect width="46" height="20" fill="#021621"/>
+  <rect x="46" width="27" height="20" fill="url(#g)"/>
+  <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">
+    <text x="23.0" y="14">license</text>
+    <text x="59.5" y="14">MIT</text>
+  </g>
+</svg>

--- a/site/assets/badges/prefill.svg
+++ b/site/assets/badges/prefill.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="116" height="20" role="img" aria-label="prefill: 43.2 TFLOPS">
+  <title>prefill: 43.2 TFLOPS</title>
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#ff9f1c"/>
+      <stop offset="1" stop-color="#d97f00"/>
+    </linearGradient>
+  </defs>
+  <rect width="39" height="20" fill="#021621"/>
+  <rect x="39" width="77" height="20" fill="url(#g)"/>
+  <g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">
+    <text x="19.5" y="14">prefill</text>
+    <text x="77.5" y="14">43.2 TFLOPS</text>
+  </g>
+</svg>


### PR DESCRIPTION
Swaps the License, Hardware, and Prefill shields.io badges for repo-hosted SVGs with a #ff9f1c → #d97f00 gradient (shields.io has no gradient support).