### PR TITLE
ci(codeql): drop submodule checkout — analyze first-party source only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,8 +36,11 @@ jobs:
             build-mode: none
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          submodules: recursive
+      # NOTE: no submodule checkout — all languages use build-mode: none (no
+      # build happens), and analyzing the vendored llama.cpp submodule filed
+      # 20 third-party alerts (ggml-hexagon HTP, kimi/minimax models, mtmd)
+      # in code this repo neither owns nor builds. Excluding it keeps CodeQL
+      # scoped to first-party source.
       - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         with:
           languages: ${{ matrix.language }}


### PR DESCRIPTION
Fixes #1718 (security triage: 20 open code-scanning alerts).

## Triage result

All 20 open `cpp/integer-multiplication-cast-to-long` alerts are in `third_party/llama.cpp` — the Qualcomm Hexagon HTP backend (`ggml-hexagon/htp/*`), unused model implementations (kimi-k3, minimax-01/m3), and mtmd tools. Zero alerts in this repo's own source.

Why they fired: the CodeQL workflow checked out `submodules: recursive`, and every matrix language runs `build-mode: none` — nothing builds, so the submodule checkout exists purely for analysis, and CodeQL dutifully analyzed the vendored llama.cpp code this project neither owns nor builds.

## Fix

Remove the spurious submodule checkout from the CodeQL job (`ci.yml`/`release.yml` keep theirs — those actually build). With no submodule in the workspace, the third-party files are not analyzed and the 20 alerts auto-close on the next default-branch analysis.

Also verified while triaging: dependabot = 0 open (protobufjs medium already fixed), secret scanning = 0.