### PR TITLE
chore(benchmarks): daily auto re-measure

### DIFF
--- a/benchmarks/latest.json
+++ b/benchmarks/latest.json
@@ -195,11 +195,11 @@
     "tolerance": 0.15
   },
   "benchmarks": {
-    "halo_gemv_gbps": 158.6,
-    "prefill_tflops_4h": 30.05,
-    "prefill_tflops_i8apre": 41.85,
-    "sherry_gemv_gbps": 155.3,
-    "tq1_gemv_gbps": 184.7
+    "halo_gemv_gbps": 149.5,
+    "prefill_tflops_4h": 26.96,
+    "prefill_tflops_i8apre": 38.84,
+    "sherry_gemv_gbps": 154.7,
+    "tq1_gemv_gbps": 184.9
   },
   "repo": {
     "forks": 4,

--- a/site/numbers.json
+++ b/site/numbers.json
@@ -1,7 +1,7 @@
 {
   "_warning": "Site data file. Headline perf numbers synced from benchmarks (source of truth). binary/ repo/ site/ keys are unique to this file.",
   "_missing": [],
-  "_benchmarks_remeasured": "2026-08-17, median of 3 runs on real gfx1151 hardware (bench_sherry, bench_prefill_variants) \u2014 see _sources.",
+  "_benchmarks_remeasured": "2026-08-18, median of 3 runs on real gfx1151 hardware (bench_sherry, bench_prefill_variants) \u2014 see _sources.",
   "binary": {
     "onebin_bytes": 70458416,
     "onebin_kb": 68807,
@@ -16,13 +16,13 @@
     "note": "ONE ELF (build/1bit): zaya_server + unified_server + unified_router + jarvis_server + vision_server + the agent CLI, dispatched by argv[0]/subcommand; legacy names ship as symlinks. zaya/unified entries kept as historical pre-merge sizes."
   },
   "benchmarks": {
-    "halo_gemv_gbps": 158.6,
-    "prefill_tflops_4h": 30.05,
-    "prefill_tflops_i8apre": 41.85,
-    "sherry_gemv_gbps": 155.3,
-    "tq1_gemv_gbps": 184.7,
-    "tflops": 41.85,
-    "note": "Auto re-measured 2026-08-17 by tools/validate_claims.py (bench_sherry, bench_prefill_variants, median of 3 runs, 1 warmup discarded). See benchmarks/latest.json for full history."
+    "halo_gemv_gbps": 149.5,
+    "prefill_tflops_4h": 26.96,
+    "prefill_tflops_i8apre": 38.84,
+    "sherry_gemv_gbps": 154.7,
+    "tq1_gemv_gbps": 184.9,
+    "tflops": 38.84,
+    "note": "Auto re-measured 2026-08-18 by tools/validate_claims.py (bench_sherry, bench_prefill_variants, median of 3 runs, 1 warmup discarded). See benchmarks/latest.json for full history."
   },
   "_sources": {
     "halo_gemv_gbps": "bench_sherry -- halo baseline kernel",
@@ -44,8 +44,8 @@
     "backends": 9,
     "models": 47
   },
-  "prefill_tflops_i8apre": 41.85,
-  "tflops": 41.85,
+  "prefill_tflops_i8apre": 38.84,
+  "tflops": 38.84,
   "blackmamba_1_5b_tok_s": 79.4,
   "blackmamba_2_8b_tok_s": 46.0,
   "engines": {


### PR DESCRIPTION
Automated daily re-measurement of the 5 hardware-verified benchmark claims (tools/validate_claims.py). This branch is force-pushed fresh off current main every run, so the diff always reflects the latest measurement — safe to merge whenever, or let tomorrow's run supersede it.