### PR TITLE
Fix badge links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 ### 100% HF model coverage. Any hardware. One open-source, pure-C++ inference engine — NPU + GPU + CPU in a single engine. Model agnostic. Hardware agnostic. Zero Python.
 
-[![CI](https://raw.githubusercontent.com/1bit-MONSTER/1bit-MONSTER/main/site/assets/badges/ci.svg](https://github.com/1bit-MONSTER/1bit-MONSTER/actions/workflows/ci.yml)
+[![CI](https://raw.githubusercontent.com/1bit-MONSTER/1bit-MONSTER/main/site/assets/badges/ci.svg)](https://github.com/1bit-MONSTER/1bit-MONSTER/actions/workflows/ci.yml)
 [![License: MIT](https://raw.githubusercontent.com/1bit-MONSTER/1bit-MONSTER/main/site/assets/badges/license.svg)](LICENSE)
-[![HF coverage](https://raw.githubusercontent.com/1bit-MONSTER/1bit-MONSTER/main/site/assets/badges/hf-coverage.svg)](docs/model-families/README.md)
+[![HF_coverage](https://raw.githubusercontent.com/1bit-MONSTER/1bit-MONSTER/main/site/assets/badges/hf-coverage.svg)](docs/model-families/README.md)
 [![Hardware](https://raw.githubusercontent.com/1bit-MONSTER/1bit-MONSTER/main/site/assets/badges/hardware.svg)](docs/guides/architecture.md)
 [![Gates](https://raw.githubusercontent.com/1bit-MONSTER/1bit-MONSTER/main/site/assets/badges/gates.svg)](Testing/run_all.sh)
 [![Prefill](https://raw.githubusercontent.com/1bit-MONSTER/1bit-MONSTER/main/site/assets/badges/prefill.svg)](docs/wiki/performance.md)


### PR DESCRIPTION
## Description

The CI badge in the README's badge row was missing a closing parenthesis in its markdown image syntax, which broke rendering of the entire badge line on GitHub. This fixes the syntax so the CI, License, HF coverage, Hardware, Gates, Prefill, and Site badges all render correctly again.

## Type of Change

- [x] Documentation (`docs`)