### PR TITLE
ci(pr-agent): run PR-Agent natively on self-hosted runner (no Docker)

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -48,21 +48,32 @@ jobs:
           head -30 gitnexus-context.md
 
       - name: PR Agent
-        uses: The-PR-Agent/pr-agent@f6af7d77554ff8d26adffded077e6461329e92fa  # v0.42.0
-        with:
-          artifact_path: gitnexus-context.md
-          artifact_instructions: >
+        # Native runner: The-PR-Agent/pr-agent's Docker action is a thin
+        # wrapper around pr_agent.servers.github_action_runner, so we invoke
+        # the identical module directly (pip package pinned to the same
+        # version as the action SHA it replaces, v0.42.0). This removes the
+        # Docker dependency entirely — the job runs on any self-hosted runner.
+        # The venv is created on first use and reused across runs; the pip
+        # install is a fast no-op once the package is present.
+        run: |
+          if [ ! -x "$HOME/pr-agent-venv/bin/python" ]; then
+            python3 -m venv "$HOME/pr-agent-venv"
+          fi
+          "$HOME/pr-agent-venv/bin/pip" install --quiet "pr-agent==0.42.0"
+          "$HOME/pr-agent-venv/bin/python" -m pr_agent.servers.github_action_runner
+        env:
+          OPENAI_API_KEY: ${{ secrets.KIMI_API_KEY }}
+          OPENAI_API_BASE: https://api.moonshot.ai/v1
+          # SECURITY: GITHUB_TOKEN with contents:write scope is used by
+          # PR-Agent to post reviews/comments. Mitigation: the job-level `if`
+          # guard above restricts execution to same-repo PRs only; external
+          # forks are never processed. PR-Agent pinned to v0.42.0 (PyPI).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFIG_FILE: .pr_agent.toml
+          ARTIFACT_PATH: gitnexus-context.md
+          ARTIFACT_INSTRUCTIONS: >
             This is a GitNexus knowledge-graph analysis of the PR's changed
             symbols: blast radius (upstream dependants), affected execution
             flows, and risk level. Use it to prioritize review effort on
             high-risk changes and to verify the PR's impact claims against
             the repo's actual call graph.
-        env:
-          OPENAI_API_KEY: ${{ secrets.KIMI_API_KEY }}
-          OPENAI_API_BASE: https://api.moonshot.ai/v1
-          # SECURITY: GITHUB_TOKEN with contents:write scope is passed to the
-          # third-party action The-PR-Agent/pr-agent. Mitigation: the job-level
-          # `if` guard above restricts execution to same-repo PRs only;
-          # external forks are never processed. Action pinned to v0.41.0 SHA.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONFIG_FILE: .pr_agent.toml


### PR DESCRIPTION
## Problem

The `pr-agent.yml` workflow uses the `The-PR-Agent/pr-agent` **Docker action** (`runs-on: [self-hosted, pr-agent]`). The local self-hosted runner (`strixhalo-pr-agent`) cannot run Docker:

- No root/sudo on this box (`sudo` blocked by no-new-privileges)
- Rootless Docker is impossible without the setuid `newuidmap` helper (not installed, can't install)

Every PR Agent job currently fails with `docker: command not found`.

## Fix

The Docker action is a thin wrapper around `pr_agent.servers.github_action_runner` (pure Python). Replace the action step with a direct invocation of the identical module via a per-user venv, pinned to **`pr-agent==0.42.0`** — the same version as the action SHA it replaces (`f6af7d7...`, v0.42.0).

### Behavior parity
- Same env contract: `OPENAI_API_KEY`, `OPENAI_API_BASE`, `GITHUB_TOKEN`, `CONFIG_FILE`
- Same artifact injection: `ARTIFACT_PATH`/`ARTIFACT_INSTRUCTIONS` feed the GitNexus context report into `extra_instructions` (identical to the action's `artifact_path`/`artifact_instructions` inputs)
- Same event dispatch: the module itself handles `pull_request` (opened/reopened/ready_for_review/synchronize) and `issue_comment` responses — nothing else in the workflow changes

### Notes
- The venv is created on first run and reused; the `pip install` is a fast no-op afterwards
- Works on **any** self-hosted runner without a container runtime (also unblocks the `strix-halo-pr-agent` machine, which has Docker but no longer needs it)
- GitNexus steps, job-level `if` guard, and permissions are untouched

## Test plan
1. Merge → open/update a PR → confirm the `PR Agent` check runs green on `strixhalo-pr-agent`
2. Confirm a review comment lands on the PR (Kimi K3 via `KIMI_API_KEY` secret)