### PR TITLE
ci(pr-agent): switch PR-Agent model to DeepSeek deepseek-v4-flash

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -58,8 +58,11 @@ jobs:
             high-risk changes and to verify the PR's impact claims against
             the repo's actual call graph.
         env:
-          OPENAI_API_KEY: ${{ secrets.KIMI_API_KEY }}
-          OPENAI_API_BASE: https://api.moonshot.ai/v1
+          # PR-Agent talks to DeepSeek via litellm's deepseek provider
+          # (model deepseek/deepseek-v4-flash in .pr_agent.toml). The
+          # provider default base (https://api.deepseek.com) is used, so no
+          # OPENAI_API_BASE override is needed here.
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           # SECURITY: GITHUB_TOKEN with contents:write scope is passed to the
           # third-party action The-PR-Agent/pr-agent. Mitigation: the job-level
           # `if` guard above restricts execution to same-repo PRs only;

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,6 +1,6 @@
 [pr_agent]
-model = "openai/kimi-k3"
-model_turbo = "openai/kimi-k3"
+model = "deepseek/deepseek-v4-flash"
+model_turbo = "deepseek/deepseek-v4-flash"
 fallback_models = []
 verbosity_level = 2
 publish_output = true
@@ -34,17 +34,18 @@ push_changelog_changes = true
 enable_help_text = false
 
 [config]
-model = "openai/kimi-k3"
+model = "deepseek/deepseek-v4-flash"
 fallback_models = []
 ignore_pr_labels = []
-# 2026-08-12: deepseek-v4-flash replaced by Kimi K3 via OpenAI-compatible
-# endpoint (api.moonshot.ai/v1, OPENAI_API_KEY/OPENAI_API_BASE in workflow).
-# Deepseek key expired -> silent failures. K3 note: temperature/top_p are
-# FIXED server-side; do not add sampling params here or requests 400.
+# 2026-08-18: Kimi K3 replaced by DeepSeek deepseek-v4-flash (litellm
+# deepseek provider, api.deepseek.com). Key: DEEPSEEK_API_KEY repo secret
+# (set 2026-08-18; the Aug-12-era DeepSeek key had expired, and the Kimi K3
+# key also went invalid -> "Incorrect API key" auth errors on every run).
+# v4-flash is a reasoning model (reasoning_content), like K3.
 custom_model_max_tokens = 128000
-# K3 allows ONLY temperature=1 (server-pinned). drop_params doesn't strip it
-# because litellm treats openai/* as temperature-capable. Send 1 explicitly.
-temperature = 1
-# K3 runs thinking=max by default; 120s default times out on real diffs
-# (litellm.Timeout in run 31629721723).
+# DeepSeek supports temperature (unlike K3's server-pinned 1). Slightly low
+# for more deterministic code reviews.
+temperature = 0.3
+# Reasoning models can take a while on real diffs; keep a generous timeout
+# (litellm.Timeout in run 31629721723 with the default 120s).
 ai_timeout = 600


### PR DESCRIPTION
## Problem

Every PR Agent run fails with `litellm.AuthenticationError: OpenAIException - Incorrect API key provided` — the **Kimi K3 key** (`KIMI_API_KEY`, `api.moonshot.ai/v1`) is invalid/expired. (Same silent-failure mode that killed the earlier DeepSeek key on Aug 12.)

## Fix

Switch PR-Agent to **DeepSeek `deepseek-v4-flash`** (a reasoning model, verified working against `api.deepseek.com`):

- **`.pr_agent.toml`**: `model` → `deepseek/deepseek-v4-flash` (litellm deepseek provider); `temperature` 1 → 0.3 (DeepSeek supports sampling; lower = more deterministic reviews); comments refreshed
- **`pr-agent.yml`**: env `OPENAI_API_KEY: secrets.KIMI_API_KEY` + `OPENAI_API_BASE: api.moonshot.ai/v1` → `DEEPSEEK_API_KEY: secrets.DEEPSEEK_API_KEY` (provider default base; no override needed)
- **`DEEPSEEK_API_KEY`** repo secret set (2026-08-18), key verified with a live chat-completions call

Everything else (GitNexus artifact injection, event dispatch, guards) is untouched.

## Test plan
1. Merge → this PR's own `PR Agent` check runs on `strixhalo-pr-agent` with the new config → expect a real review comment (not 'Failed to generate...')
2. Then re-run one of the previously-failed runs to see a full DeepSeek review