### PR TITLE
fix(site): gradient bar under brand on landing pages — match jarvis

### DIFF
--- a/site/benchmarks.html
+++ b/site/benchmarks.html
@@ -49,12 +49,15 @@
   .bh-nav a:hover{color:#ff9f1c}
   .bh-cta-ghost:hover{border-color:#00e5ff;color:#00e5ff}
   .bh-row:hover{background:rgba(0,229,255,.04)}
+
+  .brand-logo{position:relative}
+  .brand-logo::after{content:"";position:absolute;left:0;right:0;bottom:-8px;height:3px;border-radius:999px;background:linear-gradient(90deg,#00e5ff,#ff9f1c)}
 </style>
 </head>
 <body>
 <div style="background:radial-gradient(1200px 600px at 15% -10%, rgba(0,229,255,.12), transparent 60%),radial-gradient(1000px 550px at 90% 0%, rgba(255,159,28,.10), transparent 60%),#021621;color:#e7f6fd;font-family:'DM Mono',ui-monospace,Menlo,monospace;line-height:1.6;min-height:100vh">
 <nav style="display:flex;align-items:center;justify-content:space-between;max-width:1100px;margin:0 auto;padding:28px 24px">
-<div style="display:flex;flex-direction:column;align-items:flex-start"><a href="index.html" style="display:inline-flex;align-items:center;gap:10px;font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><img src="/assets/logo-mark.svg" alt="1bit MONSTER" style="width:30px;height:30px;border-radius:999px;box-shadow:0 0 10px rgba(255,159,28,.35);flex:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a><div style="height:3px;border-radius:999px;background:linear-gradient(90deg,#00e5ff,#ff9f1c);margin-top:5px"></div></div>
+<a href="index.html" class="brand-logo" style="position:relative;display:inline-flex;align-items:center;gap:10px;font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><img src="/assets/logo-mark.svg" alt="1bit MONSTER" style="width:30px;height:30px;border-radius:999px;box-shadow:0 0 10px rgba(255,159,28,.35);flex:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a>
 <div class="bh-nav" style="display:flex;gap:28px;font-size:13px;color:#a0d9f8;flex-wrap:wrap;justify-content:flex-end">
 <a href="models.html" style="color:inherit;text-decoration:none">Models</a>
 <a href="benchmarks.html" style="color:#00e5ff;text-decoration:none">Benchmarks</a>

--- a/site/docs.html
+++ b/site/docs.html
@@ -49,12 +49,15 @@
   .bh-nav a:hover{color:#ff9f1c}
   .bh-cta-ghost:hover{border-color:#00e5ff;color:#00e5ff}
   .bh-link:hover{color:#e7f6fd}
+
+  .brand-logo{position:relative}
+  .brand-logo::after{content:"";position:absolute;left:0;right:0;bottom:-8px;height:3px;border-radius:999px;background:linear-gradient(90deg,#00e5ff,#ff9f1c)}
 </style>
 </head>
 <body>
 <div style="background:radial-gradient(1200px 600px at 15% -10%, rgba(0,229,255,.12), transparent 60%),radial-gradient(1000px 550px at 90% 0%, rgba(255,159,28,.10), transparent 60%),#021621;color:#e7f6fd;font-family:'DM Mono',ui-monospace,Menlo,monospace;line-height:1.6;min-height:100vh">
 <nav style="display:flex;align-items:center;justify-content:space-between;max-width:1100px;margin:0 auto;padding:28px 24px">
-<div style="display:flex;flex-direction:column;align-items:flex-start"><a href="index.html" style="display:inline-flex;align-items:center;gap:10px;font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><img src="/assets/logo-mark.svg" alt="1bit MONSTER" style="width:30px;height:30px;border-radius:999px;box-shadow:0 0 10px rgba(255,159,28,.35);flex:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a><div style="height:3px;border-radius:999px;background:linear-gradient(90deg,#00e5ff,#ff9f1c);margin-top:5px"></div></div>
+<a href="index.html" class="brand-logo" style="position:relative;display:inline-flex;align-items:center;gap:10px;font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><img src="/assets/logo-mark.svg" alt="1bit MONSTER" style="width:30px;height:30px;border-radius:999px;box-shadow:0 0 10px rgba(255,159,28,.35);flex:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a>
 <div class="bh-nav" style="display:flex;gap:28px;font-size:13px;color:#a0d9f8;flex-wrap:wrap;justify-content:flex-end">
 <a href="models.html" style="color:inherit;text-decoration:none">Models</a>
 <a href="benchmarks.html" style="color:inherit;text-decoration:none">Benchmarks</a>

--- a/site/index.html
+++ b/site/index.html
@@ -75,12 +75,15 @@
   .bh-cta-primary:hover{filter:brightness(1.08)}
   .bh-hw:hover{border-color:#00e5ff}
   .bh-hw.bh-hw-untested:hover{border-color:#ff9f1c}
+
+  .brand-logo{position:relative}
+  .brand-logo::after{content:"";position:absolute;left:0;right:0;bottom:-8px;height:3px;border-radius:999px;background:linear-gradient(90deg,#00e5ff,#ff9f1c)}
 </style>
 </head>
 <body>
 <div style="background:radial-gradient(1200px 600px at 15% -10%, rgba(0,229,255,.12), transparent 60%),radial-gradient(1000px 550px at 90% 0%, rgba(255,159,28,.10), transparent 60%),#021621;color:#e7f6fd;font-family:'DM Mono',ui-monospace,Menlo,monospace;line-height:1.6;min-height:100vh">
 <nav style="display:flex;align-items:center;justify-content:space-between;max-width:1100px;margin:0 auto;padding:28px 24px">
-<div style="display:flex;flex-direction:column;align-items:flex-start"><a href="index.html" style="display:inline-flex;align-items:center;gap:10px;font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><img src="/assets/logo-mark.svg" alt="1bit MONSTER" style="width:30px;height:30px;border-radius:999px;box-shadow:0 0 10px rgba(255,159,28,.35);flex:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a><div style="height:3px;border-radius:999px;background:linear-gradient(90deg,#00e5ff,#ff9f1c);margin-top:5px"></div></div>
+<a href="index.html" class="brand-logo" style="position:relative;display:inline-flex;align-items:center;gap:10px;font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><img src="/assets/logo-mark.svg" alt="1bit MONSTER" style="width:30px;height:30px;border-radius:999px;box-shadow:0 0 10px rgba(255,159,28,.35);flex:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a>
 <div class="bh-nav" style="display:flex;gap:28px;font-size:13px;color:#a0d9f8;flex-wrap:wrap;justify-content:flex-end">
 <a href="models.html" style="color:inherit;text-decoration:none">Models</a>
 <a href="benchmarks.html" style="color:inherit;text-decoration:none">Benchmarks</a>

--- a/site/models.html
+++ b/site/models.html
@@ -49,12 +49,15 @@
   .bh-nav a:hover{color:#ff9f1c}
   .bh-cta-ghost:hover{border-color:#00e5ff;color:#00e5ff}
   .bh-row:hover{background:rgba(0,229,255,.04)}
+
+  .brand-logo{position:relative}
+  .brand-logo::after{content:"";position:absolute;left:0;right:0;bottom:-8px;height:3px;border-radius:999px;background:linear-gradient(90deg,#00e5ff,#ff9f1c)}
 </style>
 </head>
 <body>
 <div style="background:radial-gradient(1200px 600px at 15% -10%, rgba(0,229,255,.12), transparent 60%),radial-gradient(1000px 550px at 90% 0%, rgba(255,159,28,.10), transparent 60%),#021621;color:#e7f6fd;font-family:'DM Mono',ui-monospace,Menlo,monospace;line-height:1.6;min-height:100vh">
 <nav style="display:flex;align-items:center;justify-content:space-between;max-width:1100px;margin:0 auto;padding:28px 24px">
-<div style="display:flex;flex-direction:column;align-items:flex-start"><a href="index.html" style="display:inline-flex;align-items:center;gap:10px;font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><img src="/assets/logo-mark.svg" alt="1bit MONSTER" style="width:30px;height:30px;border-radius:999px;box-shadow:0 0 10px rgba(255,159,28,.35);flex:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a><div style="height:3px;border-radius:999px;background:linear-gradient(90deg,#00e5ff,#ff9f1c);margin-top:5px"></div></div>
+<a href="index.html" class="brand-logo" style="position:relative;display:inline-flex;align-items:center;gap:10px;font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><img src="/assets/logo-mark.svg" alt="1bit MONSTER" style="width:30px;height:30px;border-radius:999px;box-shadow:0 0 10px rgba(255,159,28,.35);flex:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a>
 <div class="bh-nav" style="display:flex;gap:28px;font-size:13px;color:#a0d9f8;flex-wrap:wrap;justify-content:flex-end">
 <a href="models.html" style="color:#00e5ff;text-decoration:none">Models</a>
 <a href="benchmarks.html" style="color:inherit;text-decoration:none">Benchmarks</a>

--- a/site/story.html
+++ b/site/story.html
@@ -50,12 +50,15 @@
   .bh-cta-ghost:hover{border-color:#00e5ff;color:#00e5ff}
   .bh-cta-primary:hover{filter:brightness(1.08)}
   .bh-card:hover{border-color:#00e5ff}
+
+  .brand-logo{position:relative}
+  .brand-logo::after{content:"";position:absolute;left:0;right:0;bottom:-8px;height:3px;border-radius:999px;background:linear-gradient(90deg,#00e5ff,#ff9f1c)}
 </style>
 </head>
 <body>
 <div style="background:radial-gradient(1200px 600px at 15% -10%, rgba(0,229,255,.12), transparent 60%),radial-gradient(1000px 550px at 90% 0%, rgba(255,159,28,.10), transparent 60%),#021621;color:#e7f6fd;font-family:'DM Mono',ui-monospace,Menlo,monospace;line-height:1.6;min-height:100vh">
 <nav style="display:flex;align-items:center;justify-content:space-between;max-width:1100px;margin:0 auto;padding:28px 24px">
-<div style="display:flex;flex-direction:column;align-items:flex-start"><a href="index.html" style="display:inline-flex;align-items:center;gap:10px;font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><img src="/assets/logo-mark.svg" alt="1bit MONSTER" style="width:30px;height:30px;border-radius:999px;box-shadow:0 0 10px rgba(255,159,28,.35);flex:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a><div style="height:3px;border-radius:999px;background:linear-gradient(90deg,#00e5ff,#ff9f1c);margin-top:5px"></div></div>
+<a href="index.html" class="brand-logo" style="position:relative;display:inline-flex;align-items:center;gap:10px;font-family:'DM Serif Display',Georgia,serif;font-size:20px;color:#e7f6fd;text-decoration:none"><img src="/assets/logo-mark.svg" alt="1bit MONSTER" style="width:30px;height:30px;border-radius:999px;box-shadow:0 0 10px rgba(255,159,28,.35);flex:none"><span style="color:#00e5ff">1bit</span>.MONSTER</a>
 <div class="bh-nav" style="display:flex;gap:28px;font-size:13px;color:#a0d9f8;flex-wrap:wrap;justify-content:flex-end">
 <a href="models.html" style="color:inherit;text-decoration:none">Models</a>
 <a href="benchmarks.html" style="color:inherit;text-decoration:none">Benchmarks</a>


### PR DESCRIPTION
### **User description**
### Description
Fixes the gradient bar under the site brand on the landing pages (index, benchmarks, docs, models, story).

The earlier rollout wrapped the brand in a flex-column div, which collapsed the bar to zero width (`align-items:flex-start` + empty div), so the main page showed no gradient line and the nav looked misaligned. The landing pages now use a `.brand-logo::after` rule — identical to `.site-nav .brand::after` in `monster.css` used by jarvis/blog/demo/store — restoring the original nav layout with the cyan→amber gradient bar sitting under the 1bm mark + wordmark.

No engine code, no content changes.

### Files
- `site/index.html`, `site/benchmarks.html`, `site/docs.html`, `site/models.html`, `site/story.html` — brand markup + `.brand-logo::after` rule


___

### **PR Type**
Bug fix


___

### **Description**
- Replace collapsed flex-column brand wrapper with `.brand-logo::after`.

- Apply rule across all five landing pages.

- Restore cyan→amber bar under brand/wordmark.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old markup: flex-column wrapper + empty div"] -- "gradient bar collapses to zero width" --> B["Bar missing on landing pages"]
  B -- "fix: shared .brand-logo::after rule" --> C["Gradient bar restored under brand"]
  C -- "applied to pages" --> D["index, benchmarks, docs, models, story"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>benchmarks.html</strong><dd><code>Restore brand gradient bar via ::after rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/benchmarks.html

<ul><li>Removes flex-column wrapper and empty gradient div around brand link.<br> <li> Adds <code>.brand-logo</code> class and <code>.brand-logo::after</code> gradient rule.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1740/files#diff-0ebc731d3211b2c8d5b4e0aca643b9e71ba0835fee02005d46a909d9b0a18cc5">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docs.html</strong><dd><code>Restore brand gradient bar via ::after rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/docs.html

<ul><li>Removes flex-column wrapper and empty gradient div around brand link.<br> <li> Adds <code>.brand-logo</code> class and <code>.brand-logo::after</code> gradient rule.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1740/files#diff-2c2006a93db42e2539dc84b76c08aafdeca0560d2c4362f78f9c482bbf188198">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Restore brand gradient bar via ::after rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/index.html

<ul><li>Removes flex-column wrapper and empty gradient div around brand link.<br> <li> Adds <code>.brand-logo</code> class and <code>.brand-logo::after</code> gradient rule.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1740/files#diff-aef9cf1e2772f3835b32360da3eb558ecc9624843d3a91fe6a2c7e64b7a2c5e6">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>models.html</strong><dd><code>Restore brand gradient bar via ::after rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/models.html

<ul><li>Removes flex-column wrapper and empty gradient div around brand link.<br> <li> Adds <code>.brand-logo</code> class and <code>.brand-logo::after</code> gradient rule.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1740/files#diff-de1a2d08f7c96efae3c99e698ea646ce8a169fc088bd657ff1683381b2cdf97b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>story.html</strong><dd><code>Restore brand gradient bar via ::after rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/story.html

<ul><li>Removes flex-column wrapper and empty gradient div around brand link.<br> <li> Adds <code>.brand-logo</code> class and <code>.brand-logo::after</code> gradient rule.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1740/files#diff-be6367ef0c22744ca2e2b6fed4bc2601e953e85ba29b63b8611282b15ff41a16">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

