### PR TITLE
feat(npu): bf16 path end-to-end + int8 GEMM weight-scale fix + FLM-parity instr header (S13) + HIP 1BP double-free fix

### DIFF
--- a/engine/npu/src/npu_engine_i8ctx_inc.h
+++ b/engine/npu/src/npu_engine_i8ctx_inc.h
@@ -74,10 +74,19 @@ struct I8Ctx {
         npu_sequence seq(device_npu2);
         gemm_generate_sequence_i8(&seq, (uint32_t)M, (uint32_t)K, (uint32_t)N,
                                   0, 0, false, 0, 0, 0);
-        seq.cmds2seq();
-        auto [dp, sz] = seq.dump();
-        std::vector<uint32_t> ins(dp, dp + sz / 4);
-        fprintf(stderr, "  generated %zu instr bytes (%zu words)\n", sz, ins.size());
+        // FLM-parity header (tools/gen_npu_insts.cpp): never cmds2seq() here —
+        // it appends a stale header AFTER the raw payload (bug S13).
+        std::vector<uint32_t>& raw = seq.raw_seq();
+        uint32_t ncmds = raw.back(); raw.pop_back();
+        std::vector<uint32_t> ins;
+        ins.reserve(raw.size() + 4);
+        ins.push_back(0x06040100);
+        ins.push_back(0x00000108);
+        ins.push_back(ncmds);
+        ins.push_back((uint32_t)(raw.size() * 4 + 16));
+        ins.insert(ins.end(), raw.begin(), raw.end());
+        fprintf(stderr, "  generated %zu instr bytes (%zu words)\n",
+                ins.size() * sizeof(uint32_t), ins.size());
 
         // Register xclbin
         try {
@@ -140,9 +149,15 @@ struct I8Ctx {
         npu_sequence seq(device_npu2);
         gemm_generate_sequence_i8(&seq, (uint32_t)M, (uint32_t)KD, (uint32_t)ND,
                                   0, 0, false, 0, 0, 0);
-        seq.cmds2seq();
-        auto [dp, sz] = seq.dump();
-        std::vector<uint32_t> ins(dp, dp + sz / 4);
+        std::vector<uint32_t>& raw = seq.raw_seq();
+        uint32_t ncmds = raw.back(); raw.pop_back();
+        std::vector<uint32_t> ins;
+        ins.reserve(raw.size() + 4);
+        ins.push_back(0x06040100);
+        ins.push_back(0x00000108);
+        ins.push_back(ncmds);
+        ins.push_back((uint32_t)(raw.size() * 4 + 16));
+        ins.insert(ins.end(), raw.begin(), raw.end());
         layerInstrData[0] = ins;
         memcpy(layerInstr[0]->map(), ins.data(), ins.size() * sizeof(uint32_t));
         layerInstr[0]->sync(XCL_BO_SYNC_BO_TO_DEVICE);

--- a/engine/npu/src/npu_engine_i8ctx_inc.h
+++ b/engine/npu/src/npu_engine_i8ctx_inc.h
@@ -245,24 +245,24 @@ struct I8Ctx {
     // K×N are the logical (unpadded) weight dims; the BO is KD×ND (padded to 128).
     // Zero-init ensures padded regions contribute zero to the GEMM output.
     void packB(int l, const float* w, int K, int N, float& sout) {
-        // Single per-tensor scale: the host dequant (dequant_only) applies ONE
-        // scalar to every output column, so the weight quantization must use
-        // that same single scale. Per-32-group scales were a precision attempt
-        // that broke correctness: dequant used mean(s_g) for all columns while
-        // weights were divided by s_g per group, distorting activations per
-        // K-channel by up to mean(s)/s_g (measured 0.53x-1.66x on Qwen3-0.6B).
+        // Per-output-column weight scales: each column j is quantized with its
+        // own amax_j/127 and dequantized with group_scales[l][j]. A single
+        // per-tensor scale packed low-magnitude columns (Qwen3 v_proj rms
+        // ~0.007 vs q/k ~0.02-0.03) onto ~10 int8 levels -> ~5% output error
+        // that compounds over 28 layers and flips the final token.
         auto* Bm = (int8_t*)layerB[l]->map();
         memset(Bm, 0, (size_t)KD * ND);
-        float t_amax = 0;
-        for (int j = 0; j < N; j++)
+        std::vector<float> col(N);
+        double ssum = 0;
+        for (int j = 0; j < N; j++) {
+            float amax = 0;
             for (int i = 0; i < K; i++) {
                 float a = fabsf(w[(size_t)i * N + j]);
-                if (std::isfinite(a) && a > t_amax) t_amax = a;
+                if (std::isfinite(a) && a > amax) amax = a;
             }
-        if (t_amax < 1e-12f) t_amax = 1.0f;
-        float ts = t_amax / 127.0f;
-        float tis = 127.0f / t_amax;
-        for (int j = 0; j < N; j++)
+            if (amax < 1e-12f) amax = 1.0f;
+            float ts = amax / 127.0f;
+            float tis = 127.0f / amax;
             for (int i = 0; i < K; i++) {
                 float v = w[(size_t)i * N + j];
                 if (!std::isfinite(v)) v = 0;
@@ -271,9 +271,12 @@ struct I8Ctx {
                 else if (x < -127) x = -127;
                 Bm[(size_t)i * ND + j] = (int8_t)x;
             }
+            col[j] = ts;
+            ssum += ts;
+        }
         layerB[l]->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        group_scales[l].assign((K + 31) / 32, ts);  // uniform: dequant mean == ts
-        sout = ts;
+        group_scales[l] = std::move(col);
+        sout = (float)(ssum / N);
     }
 
     // ── Quantize activations into bA ──
@@ -400,15 +403,13 @@ struct I8Ctx {
 
     inline void dequant_only(float* C, int am, int an, float ascale,
                              float Bscale, int layer = -1) {
+        const float* gs = nullptr;
         if (layer >= 0 && (size_t)layer < group_scales.size() &&
-            !group_scales[layer].empty()) {
-            float ssum = 0;
-            for (float s : group_scales[layer]) ssum += s;
-            Bscale = ssum / group_scales[layer].size();
-        }
-        float cs = ascale * Bscale;
+            (int)group_scales[layer].size() == an)
+            gs = group_scales[layer].data();
         for (int m = 0; m < am; m++)
             for (int n = 0; n < an; n++) {
+                float cs = ascale * (gs ? gs[n] : Bscale);
                 float val = (float)((int32_t)Cm[m * ND + n]) * cs;
                 if (!std::isfinite(val)) val = 0;
                 C[m * an + n] = val;
@@ -419,15 +420,13 @@ struct I8Ctx {
     inline void dequant_only_rows(float* C, int am, int an,
                                   const float* ascales, float Bscale,
                                   int layer = -1) {
+        const float* gs = nullptr;
         if (layer >= 0 && (size_t)layer < group_scales.size() &&
-            !group_scales[layer].empty()) {
-            float ssum = 0;
-            for (float s : group_scales[layer]) ssum += s;
-            Bscale = ssum / group_scales[layer].size();
-        }
+            (int)group_scales[layer].size() == an)
+            gs = group_scales[layer].data();
         for (int m = 0; m < am; m++) {
-            float cs = ascales[m] * Bscale;
             for (int n = 0; n < an; n++) {
+                float cs = ascales[m] * (gs ? gs[n] : Bscale);
                 float val = (float)((int32_t)Cm[m * ND + n]) * cs;
                 if (!std::isfinite(val)) val = 0;
                 C[m * an + n] = val;

--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -62,7 +62,7 @@ void gemm_generate_sequence_i8_split(
 extern "C" float* dequant_i8_to_float_ex(const uint8_t*,int,int,int*,int*);
 static inline float bf16f(uint16_t v){uint32_t b=v<<16;float f;memcpy(&f,&b,4);return f;}
 static inline float bf16g(uint16_t v){return(v&0x7F80)==0x7F80?0.0f:bf16f(v);}
-static inline uint16_t f32_to_bf16(float f){uint32_t b;memcpy(&b,&f,4);return (uint16_t)(b>>16);}
+static inline uint16_t f32_to_bf16(float f){uint32_t b;memcpy(&b,&f,4);return (uint16_t)((b+0x7FFF+((b>>16)&1))>>16);}
 // bfp16ebs8: 8 f32 -> 1 shared exponent byte + 8 x 7-bit mantissa bytes (9B/8vals)
 static inline void f32_to_bfp16ebs8(const float* in, int n, uint8_t* out){
     for(int b=0;b<n/8;b++){
@@ -753,6 +753,10 @@ int main(int argc,char**argv){
         return xd+"/final_i8_"+t+"_K"+std::to_string(K)+"_N"+std::to_string(N)+".xclbin";
     };
     auto ip=[&](const char*t){return xd+"/insts_i8_"+t+"_"+cfg.model_tag+".txt";};
+    // bf16 path (n1_core_placed.py: bf16 activations + v8bfp16ebs8 weights)
+    bool bf16_mode = getenv("NPU_BF16") != nullptr;
+    auto xpb=[&](const char*t, int K, int N){return xd+"/final_bf16_"+t+"_K"+std::to_string(K)+"_N"+std::to_string(N)+".xclbin";};
+    auto ipb=[&](const char*t, int K, int N){return xd+"/insts_bf16_"+t+"_K"+std::to_string(K)+"_N"+std::to_string(N)+".txt";};
 
     // FLM xclbin path: respect NPU_FLM_XCLBIN_DIR env var for explicit path,
     // or NPU_FLM_XCLBINS_ROOT for the root directory containing model subdirectories.
@@ -964,7 +968,9 @@ struct Bf16Ctx {
     }
 
     // pack weights: f32 [K,N] -> shuffled -> bfp16ebs8 (K*N/8*9 bytes)
-    void packB(int l, const float* w, int K, int N) {
+    // drop-in for FLM_PACKB: sout is unused (bf16 needs no per-group scale)
+    void packB(int l, const float* w, int K, int N, float& sout) {
+        sout = 1.0f;
         uint8_t* Bm=(uint8_t*)layerB[l]->map();
         static std::vector<float> shuf;
         shuf.resize((size_t)K*N);
@@ -973,46 +979,119 @@ struct Bf16Ctx {
         layerB[l]->sync(XCL_BO_SYNC_BO_TO_DEVICE);
     }
 
-    void quantize(const float* A, int am, int ak) {
+    inline int8_t* quantize_async(const float* A, int am, int ak, float ascale) {
         memset(Am,0,(size_t)am*KD*2);
         for(int m=0;m<am;m++) for(int k=0;k<ak;k++) Am[(size_t)m*KD+k]=f32_to_bf16(A[m*ak+k]);
+        return (int8_t*)Am;
     }
 
-    void go(int l, const float* A, int am, int ak, float* C, int an) {
-        quantize(A,am,ak);
+    inline xrt::run launch(int l) {
         bA->sync(XCL_BO_SYNC_BO_TO_DEVICE);
         ctrlpkts->sync(XCL_BO_SYNC_BO_TO_DEVICE); trace->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        auto r=(*k)((unsigned)3, *layerInstr, (unsigned)(instrData.size()), *bA, *layerB[l], *bC, *ctrlpkts, *trace);
+        return (*k)((unsigned)3, *layerInstr, (unsigned)(instrData.size()), *bA, *layerB[l], *bC, *ctrlpkts, *trace);
+    }
+
+    inline void dequant_only(float* C, int am, int an, float ascale, float Bscale, int layer = -1) {
+        for(int m=0;m<am;m++) for(int n=0;n<an;n++) C[m*an+n]=bf16g(Cm[(size_t)m*ND+n]);
+        if(getenv("NPU_BF16_DEBUG")){
+            double mx=0,ss=0; for(int i=0;i<am*an;i++){double v=C[i];ss+=v;if(v>mx)mx=v;}
+            fprintf(stderr,"[bf16-deq] am=%d an=%d C0..7=%.3f %.3f %.3f %.3f %.3f %.3f %.3f %.3f sum=%.2f max=%.2f\n",
+                am,an,C[0],C[1],C[2],C[3],C[4],C[5],C[6],C[7],ss,mx);
+        }
+    }
+
+    inline bool go(int l, const float* A, int am, int ak, float ascale, float Bscale, float* C, int an) {
+        quantize_async(A,am,ak,ascale);
+        auto r=launch(l);
         r.wait();
         bC->sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+        dequant_only(C,am,an,ascale,Bscale,l);
+        return true;
+    }
+
+    inline void sync_A(int) { bA->sync(XCL_BO_SYNC_BO_TO_DEVICE); }
+    inline xrt::run sync_and_launch(int l) { bA->sync(XCL_BO_SYNC_BO_TO_DEVICE); return launch(l); }
+    inline void wait_kernel(xrt::run& r) { r.wait(); }
+    inline void readback() { bC->sync(XCL_BO_SYNC_BO_FROM_DEVICE); }
+    inline int8_t* quantize_async_rows(const float* A, int am, int ak, const float* ascales) {
+        memset(Am,0,(size_t)am*KD*2);
+        for(int m=0;m<am;m++) for(int k=0;k<ak;k++) Am[(size_t)m*KD+k]=f32_to_bf16(A[m*ak+k]);
+        return (int8_t*)Am;
+    }
+    inline void dequant_only_rows(float* C, int am, int an, const float* ascales, float Bscale, int layer = -1) {
         for(int m=0;m<am;m++) for(int n=0;n<an;n++) C[m*an+n]=bf16g(Cm[(size_t)m*ND+n]);
+    }
+    inline void dequantize(xrt::run& r, float* C, int am, int an, float ascale, float Bscale, int layer = -1) {
+        r.wait(); readback(); dequant_only(C,am,an,ascale,Bscale,layer);
+    }
+    inline void sync_back_and_dequant(float* C, int am, int an, float ascale, float Bscale, int layer = -1) {
+        readback(); dequant_only(C,am,an,ascale,Bscale,layer);
+    }
+    inline bool go_rows(int l, const float* A, int am, int ak, const float* ascales_q, const float* ascales_d, float Bscale, float* C, int an) {
+        quantize_async_rows(A,am,ak,ascales_q);
+        auto r=sync_and_launch(l);
+        r.wait(); readback(); dequant_only_rows(C,am,an,ascales_d,Bscale,l);
+        return true;
+    }
+    inline xrt::run launch_async(int l, const float* A, int am, int ak, float ascale) {
+        quantize_async(A,am,ak,ascale); return sync_and_launch(l);
+    }
+    inline xrt::run launch_async_rows(int l, const float* A, int am, int ak, const float* ascales_q) {
+        quantize_async_rows(A,am,ak,ascales_q); return sync_and_launch(l);
+    }
+    inline void finish_async_rows(xrt::run& r, float* C, int am, int an, const float* ascales, float Bscale, int layer = -1) {
+        r.wait(); readback(); dequant_only_rows(C,am,an,ascales,Bscale,layer);
+    }
+    inline void finish_async(xrt::run& r, float* C, int am, int an, float ascale, float Bscale, int layer = -1) {
+        r.wait(); dequantize(r,C,am,an,ascale,Bscale,layer);
     }
 };
 
-#define FLM_GO(ctx, ...)         (flm_xclbin_available ? h##ctx->go(__VA_ARGS__) : ctx.go(__VA_ARGS__))
-#define FLM_PACKB(ctx, ...)      (flm_xclbin_available ? h##ctx->packB(__VA_ARGS__) : ctx.packB(__VA_ARGS__))
-#define FLM_LAUNCH_ASYNC(ctx, ...)  (flm_xclbin_available ? h##ctx->launch_async(__VA_ARGS__) : ctx.launch_async(__VA_ARGS__))
-#define FLM_FINISH_ASYNC(ctx, ...)  (flm_xclbin_available ? h##ctx->finish_async(__VA_ARGS__) : ctx.finish_async(__VA_ARGS__))
-#define FLM_LAUNCH_ASYNC_ROWS(ctx, ...) (flm_xclbin_available ? h##ctx->launch_async_rows(__VA_ARGS__) : ctx.launch_async_rows(__VA_ARGS__))
-#define FLM_FINISH_ASYNC_ROWS(ctx, ...) (flm_xclbin_available ? h##ctx->finish_async_rows(__VA_ARGS__) : ctx.finish_async_rows(__VA_ARGS__))
-#define FLM_GO_ROWS(ctx, ...) (flm_xclbin_available ? h##ctx->go_rows(__VA_ARGS__) : ctx.go_rows(__VA_ARGS__))
-#define FLM_LAUNCH(ctx, ...)     (flm_xclbin_available ? h##ctx->launch(__VA_ARGS__) : ctx.launch(__VA_ARGS__))
-#define FLM_QUANTIZE_ASYNC(ctx, ...) (flm_xclbin_available ? h##ctx->quantize_async(__VA_ARGS__) : ctx.quantize_async(__VA_ARGS__))
-#define FLM_SYNC_AND_LAUNCH(ctx, ...) (flm_xclbin_available ? h##ctx->sync_and_launch(__VA_ARGS__) : ctx.sync_and_launch(__VA_ARGS__))
-#define FLM_SYNC_A(ctx, ...)     (flm_xclbin_available ? h##ctx->sync_A(__VA_ARGS__) : ctx.sync_A(__VA_ARGS__))
-#define FLM_WAIT_KERNEL(ctx, ...) (flm_xclbin_available ? h##ctx->wait_kernel(__VA_ARGS__) : ctx.wait_kernel(__VA_ARGS__))
-#define FLM_DEQUANTIZE(ctx, ...) (flm_xclbin_available ? h##ctx->dequantize(__VA_ARGS__) : ctx.dequantize(__VA_ARGS__))
-#define FLM_READBACK(ctx)        (flm_xclbin_available ? h##ctx->readback() : ctx.readback())
-#define FLM_SYNC_BACK(ctx, ...)  (flm_xclbin_available ? h##ctx->sync_back_and_dequant(__VA_ARGS__) : ctx.sync_back_and_dequant(__VA_ARGS__))
-#define FLM_IS_READY(ctx)        (flm_xclbin_available ? h##ctx->isReady() : ctx.isReady())
+#define FLM_GO(ctx, ...)         (bf16_mode ? b##ctx->go(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->go(__VA_ARGS__) : ctx.go(__VA_ARGS__)))
+#define FLM_PACKB(ctx, ...)      (bf16_mode ? b##ctx->packB(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->packB(__VA_ARGS__) : ctx.packB(__VA_ARGS__)))
+#define FLM_LAUNCH_ASYNC(ctx, ...)  (bf16_mode ? b##ctx->launch_async(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->launch_async(__VA_ARGS__) : ctx.launch_async(__VA_ARGS__)))
+#define FLM_FINISH_ASYNC(ctx, ...)  (bf16_mode ? b##ctx->finish_async(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->finish_async(__VA_ARGS__) : ctx.finish_async(__VA_ARGS__)))
+#define FLM_LAUNCH_ASYNC_ROWS(ctx, ...) (bf16_mode ? b##ctx->launch_async_rows(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->launch_async_rows(__VA_ARGS__) : ctx.launch_async_rows(__VA_ARGS__)))
+#define FLM_FINISH_ASYNC_ROWS(ctx, ...) (bf16_mode ? b##ctx->finish_async_rows(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->finish_async_rows(__VA_ARGS__) : ctx.finish_async_rows(__VA_ARGS__)))
+#define FLM_GO_ROWS(ctx, ...) (bf16_mode ? b##ctx->go_rows(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->go_rows(__VA_ARGS__) : ctx.go_rows(__VA_ARGS__)))
+#define FLM_LAUNCH(ctx, ...)     (bf16_mode ? b##ctx->launch(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->launch(__VA_ARGS__) : ctx.launch(__VA_ARGS__)))
+#define FLM_QUANTIZE_ASYNC(ctx, ...) (bf16_mode ? b##ctx->quantize_async(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->quantize_async(__VA_ARGS__) : ctx.quantize_async(__VA_ARGS__)))
+#define FLM_SYNC_AND_LAUNCH(ctx, ...) (bf16_mode ? b##ctx->sync_and_launch(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->sync_and_launch(__VA_ARGS__) : ctx.sync_and_launch(__VA_ARGS__)))
+#define FLM_SYNC_A(ctx, ...)     (bf16_mode ? b##ctx->sync_A(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->sync_A(__VA_ARGS__) : ctx.sync_A(__VA_ARGS__)))
+#define FLM_WAIT_KERNEL(ctx, ...) (bf16_mode ? b##ctx->wait_kernel(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->wait_kernel(__VA_ARGS__) : ctx.wait_kernel(__VA_ARGS__)))
+#define FLM_DEQUANTIZE(ctx, ...) (bf16_mode ? b##ctx->dequantize(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->dequantize(__VA_ARGS__) : ctx.dequantize(__VA_ARGS__)))
+#define FLM_READBACK(ctx)        (bf16_mode ? b##ctx->readback() : (flm_xclbin_available ? h##ctx->readback() : ctx.readback()))
+#define FLM_SYNC_BACK(ctx, ...)  (bf16_mode ? b##ctx->sync_back_and_dequant(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->sync_back_and_dequant(__VA_ARGS__) : ctx.sync_back_and_dequant(__VA_ARGS__)))
+#define FLM_IS_READY(ctx)        (bf16_mode ? b##ctx->isReady() : (flm_xclbin_available ? h##ctx->isReady() : ctx.isReady()))
 // Unique_ptr variants (for cu_ptr which uses -> instead of .)
-#define FLM_GO_PTR(ctx, ...)         (flm_xclbin_available ? h##ctx->go(__VA_ARGS__) : ctx->go(__VA_ARGS__))
-#define FLM_GO_ROWS_PTR(ctx, ...)   (flm_xclbin_available ? h##ctx->go_rows(__VA_ARGS__) : ctx->go_rows(__VA_ARGS__))
-#define FLM_PACKB_PTR(ctx, ...)      (flm_xclbin_available ? h##ctx->packB(__VA_ARGS__) : ctx->packB(__VA_ARGS__))
-#define FLM_SYNC_AND_LAUNCH_PTR(ctx, ...) (flm_xclbin_available ? h##ctx->sync_and_launch(__VA_ARGS__) : ctx->sync_and_launch(__VA_ARGS__))
-#define FLM_DEQUANTIZE_PTR(ctx, ...) (flm_xclbin_available ? h##ctx->dequantize(__VA_ARGS__) : ctx->dequantize(__VA_ARGS__))
-#define FLM_QUANTIZE_ASYNC_PTR(ctx, ...) (flm_xclbin_available ? h##ctx->quantize_async(__VA_ARGS__) : ctx->quantize_async(__VA_ARGS__))
-#define FLM_IS_READY_PTR(ctx)    (flm_xclbin_available ? h##ctx->isReady() : ctx->isReady())
+#define FLM_GO_PTR(ctx, ...)         (bf16_mode ? b##ctx->go(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->go(__VA_ARGS__) : ctx->go(__VA_ARGS__)))
+#define FLM_GO_ROWS_PTR(ctx, ...)   (bf16_mode ? b##ctx->go_rows(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->go_rows(__VA_ARGS__) : ctx->go_rows(__VA_ARGS__)))
+#define FLM_PACKB_PTR(ctx, ...)      (bf16_mode ? b##ctx->packB(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->packB(__VA_ARGS__) : ctx->packB(__VA_ARGS__)))
+#define FLM_SYNC_AND_LAUNCH_PTR(ctx, ...) (bf16_mode ? b##ctx->sync_and_launch(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->sync_and_launch(__VA_ARGS__) : ctx->sync_and_launch(__VA_ARGS__)))
+#define FLM_DEQUANTIZE_PTR(ctx, ...) (bf16_mode ? b##ctx->dequantize(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->dequantize(__VA_ARGS__) : ctx->dequantize(__VA_ARGS__)))
+#define FLM_QUANTIZE_ASYNC_PTR(ctx, ...) (bf16_mode ? b##ctx->quantize_async(__VA_ARGS__) : (flm_xclbin_available ? h##ctx->quantize_async(__VA_ARGS__) : ctx->quantize_async(__VA_ARGS__)))
+#define FLM_IS_READY_PTR(ctx)    (bf16_mode ? b##ctx->isReady() : (flm_xclbin_available ? h##ctx->isReady() : ctx->isReady()))
+
+    // ── bf16 contexts (n1_core_placed.py xclbins) ──
+    std::unique_ptr<Bf16Ctx> bcq, bco, bcg, bcd, bcu_ptr;
+    if (bf16_mode) {
+        fprintf(stderr, "  === BF16 mode (n1_core_placed.py) ===\n");
+        auto init_bf16=[&](std::unique_ptr<Bf16Ctx>& c, const char* t, int K, int N) -> bool {
+            std::string xps=xpb(t,K,N), ips=ipb(t,K,N);
+            c=std::make_unique<Bf16Ctx>();
+            return c->init(dev, xps.c_str(), ips.c_str(), XM, K, N, NC);
+        };
+        if(!init_bf16(bcq,"QKV",cfg.xclbin_qkv_k,cfg.xclbin_qkv_n)){fprintf(stderr,"FAIL bf16 QKV\n");return 1;}
+        if(!init_bf16(bco,"O",cfg.xclbin_o_k,cfg.xclbin_o_n)){fprintf(stderr,"FAIL bf16 O\n");return 1;}
+        if(cfg.gu_split){
+            if(!init_bf16(bcg,"G",cfg.xclbin_g_k,cfg.xclbin_g_n)){fprintf(stderr,"FAIL bf16 G\n");return 1;}
+            if(!init_bf16(bcu_ptr,"U",cfg.xclbin_u_k,cfg.xclbin_u_n)){fprintf(stderr,"FAIL bf16 U\n");return 1;}
+        } else {
+            if(!init_bf16(bcg,"GU",cfg.xclbin_gu_k,cfg.xclbin_gu_n)){fprintf(stderr,"FAIL bf16 GU\n");return 1;}
+        }
+        if(!init_bf16(bcd,"D",cfg.xclbin_d_k,cfg.xclbin_d_n)){fprintf(stderr,"FAIL bf16 D\n");return 1;}
+        fprintf(stderr, "  bf16 contexts ready\n");
+    }
 
     // ── WS-11: per-token byte accounting (NPU_BYTE_STATS=1) ────────────────
     // Where bytes are copied on a q4nx decode: the 4 NPU GEMMs stream every
@@ -1183,7 +1262,7 @@ struct Bf16Ctx {
             // ~4x smaller than q/k, so one shared scale packs v onto ~10 int8
             // levels (~5% output error). q/k/v are packed with their own
             // scales and the QKV dequant applies them per section.
-            if (flm_xclbin_available) {
+            if (flm_xclbin_available || bf16_mode) {
                 FLM_PACKB(cq, l, w.data(), H, t, qsc[l]);
             } else {
                 if ((int)cq.sec_scales.size() < NC) cq.sec_scales.resize(NC);
@@ -2904,7 +2983,7 @@ struct Bf16Ctx {
         auto r_qkv=FLM_LAUNCH_ASYNC_ROWS(cq,l,h_b.data(),npt,H,qkv_ascales.data());
         // Phase 2: Wait QKV + dequant (CPU attention runs after) — per-section
         // scales when the QKV ctx was packed that way
-        if (!flm_xclbin_available && l < (int)cq.sec_scales.size() && cq.sec_scales[l].size() == 3)
+        if (!bf16_mode && !flm_xclbin_available && l < (int)cq.sec_scales.size() && cq.sec_scales[l].size() == 3)
             cq.dequant_qkv_rows(r_qkv, qo_b.data(), npt, qkv_n, qkv_ascales.data(), l);
         else
             FLM_FINISH_ASYNC_ROWS(cq,r_qkv,qo_b.data(),npt,qkv_n,qkv_ascales.data(),qsc[l],l);
@@ -3156,7 +3235,7 @@ struct Bf16Ctx {
             int mlp_out=cfg.gu_split?IM:2*IM;
 
             // ── QKV: wait + readback + dequant ──
-            if (!flm_xclbin_available && l < (int)cq.sec_scales.size() && cq.sec_scales[l].size() == 3) {
+            if (!bf16_mode && !flm_xclbin_available && l < (int)cq.sec_scales.size() && cq.sec_scales[l].size() == 3) {
                 std::vector<float> dsc_b(batch_size, cq_ascale);
                 cq.dequant_qkv_rows(r_cq, qo_b.data(), batch_size, qkv_n, dsc_b.data(), l);
             } else

--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -62,6 +62,7 @@ void gemm_generate_sequence_i8_split(
 extern "C" float* dequant_i8_to_float_ex(const uint8_t*,int,int,int*,int*);
 static inline float bf16f(uint16_t v){uint32_t b=v<<16;float f;memcpy(&f,&b,4);return f;}
 static inline float bf16g(uint16_t v){return(v&0x7F80)==0x7F80?0.0f:bf16f(v);}
+static inline uint16_t f32_to_bf16(float f){uint32_t b;memcpy(&b,&f,4);return (uint16_t)(b>>16);}
 extern "C" float* dequant_q8_0_to_float_ex(const uint8_t*,int,int,int*,int*);
 
 // ── Q4NX tile dequant matching the 1BP writer (gguf_to_onebp.cpp) ──
@@ -880,6 +881,86 @@ int main(int argc,char**argv){
     // based on flm_xclbin_available flag.
     // I8Ctx and HybridFlmCtx have the same method signatures, so each macro
     // dispatches to ctx.go(...) or h##ctx->go(...) based on the flag.
+// ── Bf16Ctx: bf16 twin of I8Ctx. Same kernel ("MLIR_AIE") + group IDs,
+// but A/B/C are bf16 and the instruction stream is the aiecc-generated
+// main_sequence.bin (embedded runtime sequence), not the FLM-parity stream.
+struct Bf16Ctx {
+    int MD, KD, ND, NL;
+    std::unique_ptr<xrt::xclbin> xc;
+    std::unique_ptr<xrt::hw_context> hc;
+    std::unique_ptr<xrt::kernel> k;
+    std::unique_ptr<xrt::bo> bA, bC;
+    std::vector<std::unique_ptr<xrt::bo>> layerB;
+    std::unique_ptr<xrt::bo> layerInstr;
+    std::vector<uint32_t> instrData;
+    uint16_t* Am; uint16_t* Cm;
+    bool initialized = false;
+
+    bool isReady() const { return initialized && k && bA && bC; }
+
+    bool init(xrt::device& d, const char* xp, const char* ip, int M, int K, int N, int nlayers) {
+        MD = M; KD = K; ND = N; NL = nlayers;
+        try {
+            xc = std::make_unique<xrt::xclbin>(std::string(xp));
+            d.register_xclbin(*xc);
+            hc = std::make_unique<xrt::hw_context>(d, xc->get_uuid());
+            k = std::make_unique<xrt::kernel>(*hc, "MLIR_AIE");
+        } catch (std::exception& ex) {
+            fprintf(stderr, "  Bf16Ctx: xclbin/kernel init failed: %s\n", ex.what());
+            return false;
+        }
+        int grp_a = k->group_id(3), grp_w = k->group_id(4), grp_c = k->group_id(5), grp_ins = k->group_id(1);
+        fprintf(stderr, "  Bf16Ctx::init xp=%s M=%d K=%d N=%d grp_a=%d grp_w=%d grp_c=%d grp_ins=%d\n",
+                xp, M, K, N, grp_a, grp_w, grp_c, grp_ins);
+        bA = std::make_unique<xrt::bo>(d, (size_t)MD * KD * 2, XRT_BO_FLAGS_HOST_ONLY, grp_a);
+        bC = std::make_unique<xrt::bo>(d, (size_t)MD * ND * 2, XRT_BO_FLAGS_HOST_ONLY, grp_c);
+        Am = (uint16_t*)bA->map();
+        Cm = (uint16_t*)bC->map();
+        layerB.resize(NL);
+        for (int l = 0; l < NL; l++)
+            layerB[l] = std::make_unique<xrt::bo>(d, (size_t)KD * ND * 2, XRT_BO_FLAGS_HOST_ONLY, grp_w);
+        FILE* f = fopen(ip, "rb");
+        if (!f) { fprintf(stderr, "  Bf16Ctx: fopen %s failed\n", ip); return false; }
+        fseek(f, 0, SEEK_END); long sz = ftell(f); fseek(f, 0, SEEK_SET);
+        instrData.resize(sz / 4);
+        if (fread(instrData.data(), 4, instrData.size(), f) != instrData.size()) { fclose(f); return false; }
+        fclose(f);
+        fprintf(stderr, "  Bf16Ctx: instr file %s size=%ld\n", ip, sz);
+        layerInstr = std::make_unique<xrt::bo>(d, instrData.size() * 4, XCL_BO_FLAGS_CACHEABLE, grp_ins);
+        memcpy(layerInstr->map(), instrData.data(), instrData.size() * 4);
+        layerInstr->sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        initialized = true;
+        return true;
+    }
+
+    void packB(int l, const float* w, int K, int N) {
+        uint16_t* Bm = (uint16_t*)layerB[l]->map();
+        memset(Bm, 0, (size_t)KD * ND * 2);
+        for (int i = 0; i < K; i++)
+            for (int j = 0; j < N; j++)
+                Bm[(size_t)i * ND + j] = f32_to_bf16(w[(size_t)i * N + j]);
+        layerB[l]->sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    }
+
+    void quantize(const float* A, int am, int ak) {
+        memset(Am, 0, (size_t)am * KD * 2);
+        for (int m = 0; m < am; m++)
+            for (int k = 0; k < ak; k++)
+                Am[(size_t)m * KD + k] = f32_to_bf16(A[m * ak + k]);
+    }
+
+    void go(int l, const float* A, int am, int ak, float* C, int an) {
+        quantize(A, am, ak);
+        bA->sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        auto r = (*k)((unsigned)3, *layerInstr, (unsigned)(instrData.size()), *bA, *layerB[l], *bC);
+        r.wait();
+        bC->sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+        for (int m = 0; m < am; m++)
+            for (int n = 0; n < an; n++)
+                C[m * an + n] = bf16g(Cm[(size_t)m * ND + n]);
+    }
+};
+
 #define FLM_GO(ctx, ...)         (flm_xclbin_available ? h##ctx->go(__VA_ARGS__) : ctx.go(__VA_ARGS__))
 #define FLM_PACKB(ctx, ...)      (flm_xclbin_available ? h##ctx->packB(__VA_ARGS__) : ctx.packB(__VA_ARGS__))
 #define FLM_LAUNCH_ASYNC(ctx, ...)  (flm_xclbin_available ? h##ctx->launch_async(__VA_ARGS__) : ctx.launch_async(__VA_ARGS__))

--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -63,6 +63,40 @@ extern "C" float* dequant_i8_to_float_ex(const uint8_t*,int,int,int*,int*);
 static inline float bf16f(uint16_t v){uint32_t b=v<<16;float f;memcpy(&f,&b,4);return f;}
 static inline float bf16g(uint16_t v){return(v&0x7F80)==0x7F80?0.0f:bf16f(v);}
 static inline uint16_t f32_to_bf16(float f){uint32_t b;memcpy(&b,&f,4);return (uint16_t)(b>>16);}
+// bfp16ebs8: 8 f32 -> 1 shared exponent byte + 8 x 7-bit mantissa bytes (9B/8vals)
+static inline void f32_to_bfp16ebs8(const float* in, int n, uint8_t* out){
+    for(int b=0;b<n/8;b++){
+        const float* v=in+b*8; uint8_t* o=out+b*9;
+        uint32_t maxExp=0;
+        for(int i=0;i<8;i++){uint32_t bits;memcpy(&bits,&v[i],4);uint32_t e=(bits>>23)&0xFF;if(e>maxExp)maxExp=e;}
+        for(int i=0;i<8;i++){
+            uint32_t bits;memcpy(&bits,&v[i],4);
+            uint32_t sign=bits&0x80000000, e=(bits>>23)&0xFF, m=bits&0x7FFFFF;
+            if(e) m|=0x800000;
+            m=sign?(~m+1):m;
+            uint8_t val=(uint8_t)(m>>(23-7+1));
+            if(maxExp-e>=32) val=sign?0xFF:0x00;
+            else val=(uint8_t)((int8_t)val>>(maxExp-e));
+            o[1+i]=val;
+        }
+        o[0]=(uint8_t)maxExp;
+    }
+}
+// B shuffle: layout_transpose_L1_1x2_8x8block (column-major L1 tiles, 1x2 8x8 col-major sub-blocks)
+static void shuffle_B_atb(const float* in, int K, int N, int l1k, int l1n, float* out){
+    int L1r=K/l1k, L1c=N/l1n, o=0;
+    for(int l1c=0;l1c<L1c;l1c++)
+        for(int l1r=0;l1r<L1r;l1r++){
+            for(int sbc=0;sbc<l1n/8;sbc+=2)
+                for(int sbr=0;sbr<l1k/8;sbr++)
+                    for(int bis=0;bis<2;bis++){
+                        int cb=sbc+bis;
+                        for(int cib=0;cib<8;cib++)
+                            for(int rib=0;rib<8;rib++)
+                                out[o++] = in[(l1r*l1k+sbr*8+rib)*N + (l1c*l1n+cb*8+cib)];
+                    }
+        }
+}
 extern "C" float* dequant_q8_0_to_float_ex(const uint8_t*,int,int,int*,int*);
 
 // ── Q4NX tile dequant matching the 1BP writer (gguf_to_onebp.cpp) ──
@@ -891,7 +925,7 @@ struct Bf16Ctx {
     std::unique_ptr<xrt::kernel> k;
     std::unique_ptr<xrt::bo> bA, bC;
     std::vector<std::unique_ptr<xrt::bo>> layerB;
-    std::unique_ptr<xrt::bo> layerInstr;
+    std::unique_ptr<xrt::bo> layerInstr, ctrlpkts, trace;
     std::vector<uint32_t> instrData;
     uint16_t* Am; uint16_t* Cm;
     bool initialized = false;
@@ -899,65 +933,59 @@ struct Bf16Ctx {
     bool isReady() const { return initialized && k && bA && bC; }
 
     bool init(xrt::device& d, const char* xp, const char* ip, int M, int K, int N, int nlayers) {
-        MD = M; KD = K; ND = N; NL = nlayers;
+        MD=M; KD=K; ND=N; NL=nlayers;
         try {
-            xc = std::make_unique<xrt::xclbin>(std::string(xp));
+            xc=std::make_unique<xrt::xclbin>(std::string(xp));
             d.register_xclbin(*xc);
-            hc = std::make_unique<xrt::hw_context>(d, xc->get_uuid());
-            k = std::make_unique<xrt::kernel>(*hc, "MLIR_AIE");
-        } catch (std::exception& ex) {
-            fprintf(stderr, "  Bf16Ctx: xclbin/kernel init failed: %s\n", ex.what());
-            return false;
-        }
-        int grp_a = k->group_id(3), grp_w = k->group_id(4), grp_c = k->group_id(5), grp_ins = k->group_id(1);
-        fprintf(stderr, "  Bf16Ctx::init xp=%s M=%d K=%d N=%d grp_a=%d grp_w=%d grp_c=%d grp_ins=%d\n",
-                xp, M, K, N, grp_a, grp_w, grp_c, grp_ins);
-        bA = std::make_unique<xrt::bo>(d, (size_t)MD * KD * 2, XRT_BO_FLAGS_HOST_ONLY, grp_a);
-        bC = std::make_unique<xrt::bo>(d, (size_t)MD * ND * 2, XRT_BO_FLAGS_HOST_ONLY, grp_c);
-        Am = (uint16_t*)bA->map();
-        Cm = (uint16_t*)bC->map();
+            hc=std::make_unique<xrt::hw_context>(d, xc->get_uuid());
+            k=std::make_unique<xrt::kernel>(*hc, "MLIR_AIE");
+        } catch(std::exception& ex){ fprintf(stderr,"  Bf16Ctx: xclbin init failed: %s\n",ex.what()); return false; }
+        int ga=k->group_id(3), gw=k->group_id(4), gc=k->group_id(5), gi=k->group_id(1);
+        int g6=k->group_id(6), g7=k->group_id(7);
+        fprintf(stderr,"  Bf16Ctx::init xp=%s M=%d K=%d N=%d grp a=%d w=%d c=%d ins=%d\n",xp,M,K,N,ga,gw,gc,gi);
+        bA=std::make_unique<xrt::bo>(d,(size_t)MD*KD*2, XRT_BO_FLAGS_HOST_ONLY, ga);
+        bC=std::make_unique<xrt::bo>(d,(size_t)MD*ND*2, XRT_BO_FLAGS_HOST_ONLY, gc);
+        Am=(uint16_t*)bA->map(); Cm=(uint16_t*)bC->map();
+        ctrlpkts=std::make_unique<xrt::bo>(d,8,XRT_BO_FLAGS_HOST_ONLY,g6);
+        trace=std::make_unique<xrt::bo>(d,1,XRT_BO_FLAGS_HOST_ONLY,g7);
         layerB.resize(NL);
-        for (int l = 0; l < NL; l++)
-            layerB[l] = std::make_unique<xrt::bo>(d, (size_t)KD * ND * 2, XRT_BO_FLAGS_HOST_ONLY, grp_w);
-        FILE* f = fopen(ip, "rb");
-        if (!f) { fprintf(stderr, "  Bf16Ctx: fopen %s failed\n", ip); return false; }
-        fseek(f, 0, SEEK_END); long sz = ftell(f); fseek(f, 0, SEEK_SET);
-        instrData.resize(sz / 4);
-        if (fread(instrData.data(), 4, instrData.size(), f) != instrData.size()) { fclose(f); return false; }
+        for(int l=0;l<NL;l++) layerB[l]=std::make_unique<xrt::bo>(d,(size_t)(KD*ND/8*9), XRT_BO_FLAGS_HOST_ONLY, gw);
+        FILE* f=fopen(ip,"rb");
+        if(!f){ fprintf(stderr,"  Bf16Ctx: fopen %s failed\n",ip); return false; }
+        fseek(f,0,SEEK_END); long sz=ftell(f); fseek(f,0,SEEK_SET);
+        instrData.resize(sz/4);
+        if(fread(instrData.data(),4,instrData.size(),f)!=(size_t)instrData.size()){ fclose(f); return false; }
         fclose(f);
-        fprintf(stderr, "  Bf16Ctx: instr file %s size=%ld\n", ip, sz);
-        layerInstr = std::make_unique<xrt::bo>(d, instrData.size() * 4, XCL_BO_FLAGS_CACHEABLE, grp_ins);
-        memcpy(layerInstr->map(), instrData.data(), instrData.size() * 4);
+        fprintf(stderr,"  Bf16Ctx: instr %s %ld bytes (%zu words, header incl)\n",ip,sz,instrData.size());
+        layerInstr=std::make_unique<xrt::bo>(d,instrData.size()*4,XCL_BO_FLAGS_CACHEABLE,gi);
+        memcpy(layerInstr->map(),instrData.data(),instrData.size()*4);
         layerInstr->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        initialized = true;
-        return true;
+        initialized=true; return true;
     }
 
+    // pack weights: f32 [K,N] -> shuffled -> bfp16ebs8 (K*N/8*9 bytes)
     void packB(int l, const float* w, int K, int N) {
-        uint16_t* Bm = (uint16_t*)layerB[l]->map();
-        memset(Bm, 0, (size_t)KD * ND * 2);
-        for (int i = 0; i < K; i++)
-            for (int j = 0; j < N; j++)
-                Bm[(size_t)i * ND + j] = f32_to_bf16(w[(size_t)i * N + j]);
+        uint8_t* Bm=(uint8_t*)layerB[l]->map();
+        static std::vector<float> shuf;
+        shuf.resize((size_t)K*N);
+        shuffle_B_atb(w, K, N, 64, 128, shuf.data());
+        f32_to_bfp16ebs8(shuf.data(), K*N, Bm);
         layerB[l]->sync(XCL_BO_SYNC_BO_TO_DEVICE);
     }
 
     void quantize(const float* A, int am, int ak) {
-        memset(Am, 0, (size_t)am * KD * 2);
-        for (int m = 0; m < am; m++)
-            for (int k = 0; k < ak; k++)
-                Am[(size_t)m * KD + k] = f32_to_bf16(A[m * ak + k]);
+        memset(Am,0,(size_t)am*KD*2);
+        for(int m=0;m<am;m++) for(int k=0;k<ak;k++) Am[(size_t)m*KD+k]=f32_to_bf16(A[m*ak+k]);
     }
 
     void go(int l, const float* A, int am, int ak, float* C, int an) {
-        quantize(A, am, ak);
+        quantize(A,am,ak);
         bA->sync(XCL_BO_SYNC_BO_TO_DEVICE);
-        auto r = (*k)((unsigned)3, *layerInstr, (unsigned)(instrData.size()), *bA, *layerB[l], *bC);
+        ctrlpkts->sync(XCL_BO_SYNC_BO_TO_DEVICE); trace->sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        auto r=(*k)((unsigned)3, *layerInstr, (unsigned)(instrData.size()), *bA, *layerB[l], *bC, *ctrlpkts, *trace);
         r.wait();
         bC->sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-        for (int m = 0; m < am; m++)
-            for (int n = 0; n < an; n++)
-                C[m * an + n] = bf16g(Cm[(size_t)m * ND + n]);
+        for(int m=0;m<am;m++) for(int n=0;n<an;n++) C[m*an+n]=bf16g(Cm[(size_t)m*ND+n]);
     }
 };
 

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -629,7 +629,7 @@ struct Hip1bpBackend : Backend {
     }
 
     void destroy()override{
-        auto hf=[](void*p){if(p)HIP_CHECK_D(hipFree(p));};
+        auto hf=[](auto*&p){if(p){HIP_CHECK_D(hipFree(p));p=nullptr;}};
         hf(d_embed);hf(d_final_norm);hf(d_output);
         for(auto&ll:L){hf(ll.wq);hf(ll.wk);hf(ll.wv);hf(ll.wo);hf(ll.w1);hf(ll.w2);hf(ll.w3);hf(ll.pn);hf(ll.pon);hf(ll.q_norm);hf(ll.k_norm);hf(ll.bq);hf(ll.bk);hf(ll.bv);}
         for (auto& pd : PD) { hf(pd.pq); hf(pd.pk); hf(pd.pv); hf(pd.po); hf(pd.p1); hf(pd.p2); hf(pd.p3); }


### PR DESCRIPTION
### **User description**
## Summary

Two bug fixes found and verified on the Strix Halo dev box.

### 1. HIP 1BP backend: double-free on model unload (`4e2355a6`)

`Hip1bpBackend::destroy()` ran twice on every unload — once via `Hip1bpBackendAdapter::unload_model()` (`destroy(); delete backend_;`) and again via `~Hip1bpBackend()`. The `hf` lambda freed without nulling the member pointer, so the second pass double-freed every device buffer, spamming `HIP error (dtor) invalid argument`.

**Fix:** null each pointer after `hipFree` so `destroy()` is idempotent.

**Verified:** dtor error spam drops from ~21/load to 0.

### 2. Native NPU engine: instruction-stream header emitted after payload (`58f96191`, S13)

`init_with_generator()` and `regen_insts()` called `seq.cmds2seq()` after `gemm_generate_sequence_i8()`. But `cmds2seq()` never clears `npu_seq` (reserve only) and iterates the empty `cmds` list, so it appended a stale 4-word header *after* the raw payload — the NPU parsed a payload word as its device header and produced degenerate output.

**Fix:** mirror `tools/gen_npu_insts.cpp` — pop the generator-stashed command count from the raw tail and prepend the hardcoded FLM-parity header `{0x06040100, 0x00000108, ncmds, nbytes}`.

**Verified byte-identical:** regenerated QKV (M=128, K=1024, N=4096) stream `cmp`-matches committed `insts_i8_QKV_qwen3_0_6b.txt` (131,216 bytes, 4,000 cmds).


___

### **PR Type**
Bug fix


___

### **Description**
- Fix HIP 1BP double-free on model unload

- Emit FLM-parity header before NPU instruction payload

- Replace stale post-payload header appended by cmds2seq()

- Verified byte-identical generated instruction streams


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hip1bpBackend::destroy()"] -- "null after hipFree" --> B["idempotent free"]
  C["gemm_generate_sequence_i8()"] -- "prepend FLM header" --> D["npu_engine_i8ctx_inc.h"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_hip_1bp.cpp</strong><dd><code>Null device pointers after free in destroy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_hip_1bp.cpp

<ul><li>Make <code>destroy()</code> free idempotent by nulling pointers after <code>hipFree</code><br> <li> Prevents double-free when <code>unload_model()</code> and destructor both run</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1756/files#diff-c4812ee96d278d2d2b452760b359c0521f1a016dce68e46c6668555b33eec182">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>npu_engine_i8ctx_inc.h</strong><dd><code>Emit FLM-parity header before NPU payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/npu_engine_i8ctx_inc.h

<ul><li>Replace <code>cmds2seq()</code> dump with FLM-parity header construction<br> <li> Prepend <code>{0x06040100, 0x00000108, ncmds, nbytes}</code> before raw payload<br> <li> Apply in <code>init_with_generator()</code> and <code>regen_insts()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1756/files#diff-00a304de6fc1ff0480e37d4ed288e548ef48a8b2cdde7652034ce7a3815b864c">+22/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

