### PR TITLE
fix(npu): root-cause and harden the xrt teardown wedge in the Zaya runners (#1762)

### DIFF
--- a/engine/npu/AIE2P-FACTS.md
+++ b/engine/npu/AIE2P-FACTS.md
@@ -76,6 +76,25 @@ def rni_bf16(x):  # x: fp32 ndarray -> uint16 bf16 values, RNI rounding
   (the single-core-row vs multi-row WARN). Verify tokens vs the CPU engine
   before trusting any speedup.
 
+## 3c. Teardown wedge (issue #1762) — xrt destructors hang after decode
+
+- `zaya_decode.cpp` / `zaya_npu_runner.cpp` end with `_exit(0)` (was `exit(0)`)
+  because running the xrt destructor chain after a decode session wedges the NPU
+  (process hangs after the last token). Same family as journey.md UPDATE 32/33.
+- Root cause: NOT a BO sync on destroy (every launch is `r.wait()`ed before the
+  next; `xrt::bo` never syncs on destruction — sync is always explicit) and NOT
+  an ordering bug (reverse-declaration order BOs → kernel → hw_context → device
+  is correct). After a session's hundreds of DPU executions the AIE firmware
+  context is degraded/fatal (DPU PC stuck at 0xffffffff; "every mailbox call
+  fails"), and the hwctx/BO release path (dma-buf/IOMMU free + context teardown)
+  issues mailbox calls to the dead firmware that never return. The driver's
+  `aie2_hw_reset()` self-heal only fires on job timeouts, not release-path ioctl
+  hangs — recovery is reboot-only.
+- Fix: default teardown flushes stdio explicitly then `_exit(0)` (no atexit /
+  static dtors — same pattern as npu_engine_universal and the #1426 fix). Set
+  `NPU_CLEAN_TEARDOWN=1` to run the real destructors and return normally (safe
+  on a fresh boot with a healthy driver; will hang if the firmware is degraded).
+
 ## 4. XRT dispatch protocol (matches what engine/npu already does)
 
 - Kernel name in mlir-aie xclbins: `MLIR_AIE`; metadata args

--- a/engine/npu/src/zaya_decode.cpp
+++ b/engine/npu/src/zaya_decode.cpp
@@ -352,5 +352,27 @@ int zaya_decode_main(int argc, char** argv) {
     fflush(stdout);
     fprintf(stderr, "[cache] hits=%zu misses=%zu (%.1f%% hit)\n", cache_hits, cache_misses,
             cache_hits + cache_misses ? 100.0 * cache_hits / (cache_hits + cache_misses) : 0.0);
-    exit(0);  // skip xrt destructors (NPU wedges on teardown)
+
+    // ── Teardown (issue #1762) ──────────────────────────────────────────────
+    // Root cause: the xrt destructors wedge the NPU — NOT a BO sync on destroy
+    // (every launch is r.wait()ed before the next and xrt::bo never syncs on
+    // destruction; sync is always explicit) and NOT an ordering bug (reverse-
+    // declaration order is correct: BOs -> kernel -> hw_context -> device). The
+    // wedge is the same firmware-fatal family as journey.md UPDATE 32/33: after
+    // a decode session's hundreds of DPU executions the AIE firmware context is
+    // degraded/fatal (DPU PC stuck at 0xffffffff), and the hwctx/BO release
+    // path issues mailbox calls to the dead firmware that never return. The
+    // driver's aie2_hw_reset() self-heal only fires on job timeouts, not
+    // release-path ioctl hangs — recovery is reboot-only.
+    //
+    // Default: _exit(0) — flush explicitly, skip the destructor chain, let the
+    // OS reclaim everything (same pattern as npu_engine_universal and the #1426
+    // _exit() fix; exit(0) also runs atexit/static dtors and double-flushes).
+    // NPU_CLEAN_TEARDOWN=1: run the real destructors and return normally — use
+    // only when the driver/firmware is known healthy (e.g. a fresh boot).
+    fflush(stdout);
+    fflush(stderr);
+    if (getenv("NPU_CLEAN_TEARDOWN") && atoi(getenv("NPU_CLEAN_TEARDOWN")) == 1)
+        return 0;
+    _exit(0);
 }

--- a/engine/npu/tools/zaya_npu_runner.cpp
+++ b/engine/npu/tools/zaya_npu_runner.cpp
@@ -393,5 +393,27 @@ int main(int argc, char** argv) {
     fflush(stdout);
     fprintf(stderr, "[cache] hits=%zu misses=%zu (%.1f%% hit)\n", cache_hits, cache_misses,
             cache_hits + cache_misses ? 100.0 * cache_hits / (cache_hits + cache_misses) : 0.0);
-    exit(0);  // skip xrt destructors (NPU wedges on teardown)
+
+    // ── Teardown (issue #1762) ──────────────────────────────────────────────
+    // Root cause: the xrt destructors wedge the NPU — NOT a BO sync on destroy
+    // (every launch is r.wait()ed before the next and xrt::bo never syncs on
+    // destruction; sync is always explicit) and NOT an ordering bug (reverse-
+    // declaration order is correct: BOs -> kernel -> hw_context -> device). The
+    // wedge is the same firmware-fatal family as journey.md UPDATE 32/33: after
+    // a decode session's hundreds of DPU executions the AIE firmware context is
+    // degraded/fatal (DPU PC stuck at 0xffffffff), and the hwctx/BO release
+    // path issues mailbox calls to the dead firmware that never return. The
+    // driver's aie2_hw_reset() self-heal only fires on job timeouts, not
+    // release-path ioctl hangs — recovery is reboot-only.
+    //
+    // Default: _exit(0) — flush explicitly, skip the destructor chain, let the
+    // OS reclaim everything (same pattern as npu_engine_universal and the #1426
+    // _exit() fix; exit(0) also runs atexit/static dtors and double-flushes).
+    // NPU_CLEAN_TEARDOWN=1: run the real destructors and return normally — use
+    // only when the driver/firmware is known healthy (e.g. a fresh boot).
+    fflush(stdout);
+    fflush(stderr);
+    if (getenv("NPU_CLEAN_TEARDOWN") && atoi(getenv("NPU_CLEAN_TEARDOWN")) == 1)
+        return 0;
+    _exit(0);
 }

--- a/research/ws01-npu-attention/ZAYA-CCA-CPU-PORT.md
+++ b/research/ws01-npu-attention/ZAYA-CCA-CPU-PORT.md
@@ -438,8 +438,10 @@ the engine's `I8Ctx` (from `npu_engine_i8ctx_inc.h`) + `gemm_npu_instructions.cp
 
 - M=128 instruction stream reused for M=1 decode (`am=1` zero-pads rows 1..127);
   `regen_insts(1)` hangs the M=128-baked microkernel — do not call it.
-- `exit(0)` at the end (not `return 0`) — the xrt destructors wedge the NPU on
-  teardown.
+- `_exit(0)` at the end by default (not `return 0`) — the xrt destructors wedge
+  the NPU on teardown (firmware-fatal family, journey.md UPDATE 32/33: the
+  hwctx/BO release path mailboxes a dead firmware; reboot-only recovery — issue
+  #1762). `NPU_CLEAN_TEARDOWN=1` runs the real destructor chain instead.
 
 Verified on `zaya1-8b-fresh.q4nx`, prompt "2+2=":
 - CPU runner (float MoE):  logits rms 4.32, min -22.5, max 31.1


### PR DESCRIPTION
### **User description**
Resolves **#1762** — root-causes the xrt teardown wedge in the Zaya runners and replaces the bare `exit(0)` skip with a principled teardown.

## Root cause

**Not** a BO sync on destroy (every launch is `r.wait()`ed before the next, and `xrt::bo` never syncs on destruction — sync is always explicit in XRT) and **not** an ordering bug (reverse-declaration order BOs → kernel → hw_context → device is correct).

It is the **firmware-fatal family** from journey.md UPDATE 32/33: after a decode session's hundreds of DPU executions the AIE firmware context is degraded/fatal (DPU PC stuck at `0xffffffff`; every mailbox call fails). At teardown, the hwctx/BO release path (dma-buf/IOMMU free + context teardown) issues mailbox calls to the dead firmware that never return → hang. The driver's `aie2_hw_reset()` self-heal only fires on job timeouts, not release-path ioctl hangs — recovery is reboot-only, so no userspace teardown can be made reliably safe on a degraded firmware. Consistent with `npu_engine_universal` also skipping teardown (its comment blames "XRT dma-buf teardown") and the #1426 `_exit()` fix.

## Changes

- **`engine/npu/src/zaya_decode.cpp`**, **`engine/npu/tools/zaya_npu_runner.cpp`** — replace `exit(0)` with explicit `fflush(stdout/stderr)` + `_exit(0)` default (skips atexit/static dtors, no double-flush; same pattern as `npu_engine_universal` / #1426), and gate the **real destructor chain** behind `NPU_CLEAN_TEARDOWN=1` (`return 0`) for runs on a healthy driver/firmware (e.g. fresh boot).
- **`engine/npu/AIE2P-FACTS.md`** — new §3c documenting the root cause and the env knob.
- **`research/ws01-npu-attention/ZAYA-CCA-CPU-PORT.md`** — §17 note updated.

## Verification

- Syntax-checked with stubbed XRT headers — no errors reference the new teardown block (full compile needs the XRT/NPU toolchain, not present on this box).
- Default behavior unchanged for production runs (process still exits 0 after the last token, just via `_exit` instead of `exit`); `NPU_CLEAN_TEARDOWN=1` opts into real teardown when the driver is known healthy.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Replace exit(0) with fflush and _exit(0) in runners

- Gate destructor chain behind NPU_CLEAN_TEARDOWN=1

- Document firmware-fatal mailbox hang root cause in docs

- Skip static/atexit destructors via _exit(0) default


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Zaya runners"] --> B["fflush stdout/stderr"]
  B --> C{"NPU_CLEAN_TEARDOWN=1?"}
  C -- "yes" --> D["return 0: xrt destructors"]
  C -- "no" --> E["_exit(0): kernel reclaim"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zaya_decode.cpp</strong><dd><code>Harden decode teardown with flush and _exit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/zaya_decode.cpp

<ul><li>Replace exit(0) with explicit fflush + _exit(0) default<br> <li> Add NPU_CLEAN_TEARDOWN=1 gate for real destructor chain<br> <li> Document firmware-fatal mailbox root cause in comments</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1773/files#diff-03d765f3c907f9bbf3b9e72824d9f24105ec11666aacb7a9b57702d5254669ae">+23/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zaya_npu_runner.cpp</strong><dd><code>Harden runner teardown with flush and _exit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tools/zaya_npu_runner.cpp

<ul><li>Replace exit(0) with explicit fflush + _exit(0) default<br> <li> Add NPU_CLEAN_TEARDOWN=1 gate for real destructor chain<br> <li> Document firmware-fatal mailbox root cause in comments</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1773/files#diff-e851b1dd70bdec298e2f8866205621888aca3cb1f5db9b106ef1649bdc9c481a">+23/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AIE2P-FACTS.md</strong><dd><code>Document NPU teardown wedge root cause</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/AIE2P-FACTS.md

<ul><li>Add §3c documenting teardown wedge root cause<br> <li> Explain NOT BO sync or ordering bug<br> <li> Document NPU_CLEAN_TEARDOWN=1 knob</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1773/files#diff-8d0b584287d9c7f40e7f6ed75aa8849e74b0aa8ce7b55cb85b1b80dd6a01931d">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ZAYA-CCA-CPU-PORT.md</strong><dd><code>Update research note on teardown behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

research/ws01-npu-attention/ZAYA-CCA-CPU-PORT.md

<ul><li>Update §17 note to _exit(0) default<br> <li> Reference issue #1762 and NPU_CLEAN_TEARDOWN=1</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1773/files#diff-f799ad2dc2e32ecd11cdac73fc0062c262879510f4181dad91affd3c437d8f76">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

