### PR TITLE
chore(deps): bump codeql-action init+analyze to v4.37.7 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,10 +41,10 @@ jobs:
       # 20 third-party alerts (ggml-hexagon HTP, kimi/minimax models, mtmd)
       # in code this repo neither owns nor builds. Excluding it keeps CodeQL
       # scoped to first-party source.
-      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
### **User description**
Bumps `github/codeql-action/init` **and** `analyze` to v4.37.7 together.

Dependabot opened separate PRs (#1745 analyze, #1748 init); each alone fails CI because CodeQL requires `init` and `analyze` to run the **same** version — mixing 4.37.6 init with 4.37.7 analyze (and vice versa) errors with "Loaded a configuration file for version '4.37.6', but running version '4.37.7'". Both dependabot PRs were closed; this single change keeps the two steps in lockstep.

Release note: v4.37.7 updates the default CodeQL bundle to 2.26.3 (no user-facing changes).


___

### **PR Type**
Other


___

### **Description**
- Bump init and analyze to v4.37.7

- Update commit refs to ff2f1c6

- Keep versions in lockstep to avoid CI mismatch

- No user-facing changes; bundle 2.26.3


___

### Diagram Walkthrough


```mermaid
flowchart LR
  InitOld["init v4.37.6"] -->|bump| InitNew["init v4.37.7"]
  AnalyzeOld["analyze v4.37.6"] -->|bump| AnalyzeNew["analyze v4.37.7"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codeql.yml</strong><dd><code>Update CodeQL actions to v4.37.7</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/codeql.yml

<ul><li>Bump <code>github/codeql-action/init</code> from v4.37.6 to v4.37.7<br> <li> Bump <code>github/codeql-action/analyze</code> from v4.37.6 to v4.37.7<br> <li> Update commit hashes from <code>5595ccaf</code> to <code>ff2f1c6</code> for both steps<br> <li> Keeps init and analyze in lockstep per CodeQL requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1774/files#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

