### PR TITLE
build(npu): harden stale /tmp design handling in xclbin build scripts (#1777)

### DIFF
--- a/engine/npu/generators/build_moe_v27.sh
+++ b/engine/npu/generators/build_moe_v27.sh
@@ -15,11 +15,15 @@ TAG=qwen3.6-moe_35b
 
 build_one() {
     local proj="$1" K="$2" N="$3" cols="$4"
-    local design="/tmp/design_${proj}_moe.mlir"
+    # PID-unique design path (issue #1777): a fixed /tmp path could be
+    # clobbered by a co-tenant process between generation and aiecc, and the
+    # build would silently consume the stale file.
+    local design="/tmp/design_${proj}_moe.$$.mlir"
     local xclbin="$XCLBIN_DIR/final_i8_${proj}_${TAG}.xclbin"
     echo "═══ ${proj} K=${K} N=${N} cols=${cols} ═══"
     $PYTHON "$GENERATOR_DIR/n1_core_i8_v27.py" -M 128 -K "$K" -N "$N" \
         -m 32 -k 64 -n 128 -c "$cols" -r 4 -b 5 2>/dev/null > "$design"
+    [ -s "$design" ] || { echo "ERROR: ${proj}: design generation produced an empty file" >&2; exit 1; }
     cp "$KERNEL_O" /tmp/mm_32x64x128.o
     cd /tmp
     $AIECC --peano="$PEANO" --aietools="$AIETOOLS" \
@@ -31,6 +35,7 @@ build_one() {
         "$design" 2>&1 | tail -1
     cd "$GENERATOR_DIR"
     ls -la "$xclbin" "$XCLBIN_DIR/insts_i8_${proj}_${TAG}.txt"
+    rm -f "$design"; rm -rf "$design.prj"
 }
 
 build_one MOE_GU 2048 8192 8

--- a/engine/npu/generators/build_moe_v27.sh
+++ b/engine/npu/generators/build_moe_v27.sh
@@ -13,19 +13,27 @@ XCLBIN_DIR="$(cd "$(dirname "$0")/../xclbins" && pwd)"
 GENERATOR_DIR="$(cd "$(dirname "$0")" && pwd)"
 TAG=qwen3.6-moe_35b
 
+# PID-unique workdir (issue #1777): a fixed /tmp path for the design OR the
+# kernel .o could be clobbered by a co-tenant process between generation and
+# aiecc, and the build would silently consume the stale file. $$ = PID.
+workdir="/tmp/zaya_moe_v27_build.$$"
+mkdir -p "$workdir"
+trap 'rm -rf "$workdir"' EXIT
+
 build_one() {
     local proj="$1" K="$2" N="$3" cols="$4"
-    # PID-unique design path (issue #1777): a fixed /tmp path could be
-    # clobbered by a co-tenant process between generation and aiecc, and the
-    # build would silently consume the stale file.
-    local design="/tmp/design_${proj}_moe.$$.mlir"
+    local design="$workdir/design_${proj}_moe.mlir"
     local xclbin="$XCLBIN_DIR/final_i8_${proj}_${TAG}.xclbin"
     echo "═══ ${proj} K=${K} N=${N} cols=${cols} ═══"
     $PYTHON "$GENERATOR_DIR/n1_core_i8_v27.py" -M 128 -K "$K" -N "$N" \
         -m 32 -k 64 -n 128 -c "$cols" -r 4 -b 5 2>/dev/null > "$design"
-    [ -s "$design" ] || { echo "ERROR: ${proj}: design generation produced an empty file" >&2; exit 1; }
-    cp "$KERNEL_O" /tmp/mm_32x64x128.o
-    cd /tmp
+    if [ ! -s "$design" ]; then
+        echo "ERROR: ${proj}: design generation produced an empty file" >&2
+        rm -rf "$workdir"
+        exit 1
+    fi
+    cp "$KERNEL_O" "$workdir/mm_32x64x128.o"
+    cd "$workdir"
     $AIECC --peano="$PEANO" --aietools="$AIETOOLS" \
         --alloc-scheme=basic-sequential --no-xchesscc --no-xbridge \
         --aie-generate-xclbin --no-compile-host --unified --dynamic-objFifos \
@@ -35,7 +43,6 @@ build_one() {
         "$design" 2>&1 | tail -1
     cd "$GENERATOR_DIR"
     ls -la "$xclbin" "$XCLBIN_DIR/insts_i8_${proj}_${TAG}.txt"
-    rm -f "$design"; rm -rf "$design.prj"
 }
 
 build_one MOE_GU 2048 8192 8

--- a/engine/npu/generators/build_moe_v28.sh
+++ b/engine/npu/generators/build_moe_v28.sh
@@ -16,19 +16,27 @@ XCLBIN_DIR="$(cd "$(dirname "$0")/../xclbins" && pwd)"
 GENERATOR_DIR="$(cd "$(dirname "$0")" && pwd)"
 TAG=qwen3.6-moe_35b
 
+# PID-unique workdir (issue #1777): a fixed /tmp path for the design OR the
+# kernel .o could be clobbered by a co-tenant process between generation and
+# aiecc, and the build would silently consume the stale file. $$ = PID.
+workdir="/tmp/zaya_moe_v28_build.$$"
+mkdir -p "$workdir"
+trap 'rm -rf "$workdir"' EXIT
+
 build_one() {
     local proj="$1" K="$2" N="$3" cols="$4"
-    # PID-unique design path (issue #1777): a fixed /tmp path could be
-    # clobbered by a co-tenant process between generation and aiecc, and the
-    # build would silently consume the stale file.
-    local design="/tmp/design_${proj}_moe.$$.mlir"
+    local design="$workdir/design_${proj}_moe.mlir"
     local xclbin="$XCLBIN_DIR/final_i8_${proj}_${TAG}.xclbin"
     echo "═══ ${proj} K=${K} N=${N} cols=${cols} ═══"
     $PYTHON "$GENERATOR_DIR/n1_core_i8_v27.py" -M 128 -K "$K" -N "$N" \
         -m 32 -k 64 -n 128 -c "$cols" -r 4 -b 5 2>/dev/null > "$design"
-    [ -s "$design" ] || { echo "ERROR: ${proj}: design generation produced an empty file" >&2; exit 1; }
-    cp "$KERNEL_O" /tmp/mm_32x64x128.o
-    cd /tmp
+    if [ ! -s "$design" ]; then
+        echo "ERROR: ${proj}: design generation produced an empty file" >&2
+        rm -rf "$workdir"
+        exit 1
+    fi
+    cp "$KERNEL_O" "$workdir/mm_32x64x128.o"
+    cd "$workdir"
     $AIECC --peano="$PEANO" --aietools="$AIETOOLS" \
         --alloc-scheme=basic-sequential --no-xchesscc --no-xbridge \
         --aie-generate-xclbin --no-compile-host --unified --dynamic-objFifos \
@@ -41,7 +49,6 @@ build_one() {
     ln -sf "final_i8_${proj}_${TAG}.xclbin" "$XCLBIN_DIR/final_i8_${proj}_qwen3_6_35b_a3b.xclbin"
     ln -sf "insts_i8_${proj}_${TAG}.txt"   "$XCLBIN_DIR/insts_i8_${proj}_qwen3_6_35b_a3b.txt"
     ls -la "$xclbin" "$XCLBIN_DIR/insts_i8_${proj}_${TAG}.txt"
-    rm -f "$design"; rm -rf "$design.prj"
 }
 
 build_one MOE_GUSGU 2048 9216 8

--- a/engine/npu/generators/build_moe_v28.sh
+++ b/engine/npu/generators/build_moe_v28.sh
@@ -18,11 +18,15 @@ TAG=qwen3.6-moe_35b
 
 build_one() {
     local proj="$1" K="$2" N="$3" cols="$4"
-    local design="/tmp/design_${proj}_moe.mlir"
+    # PID-unique design path (issue #1777): a fixed /tmp path could be
+    # clobbered by a co-tenant process between generation and aiecc, and the
+    # build would silently consume the stale file.
+    local design="/tmp/design_${proj}_moe.$$.mlir"
     local xclbin="$XCLBIN_DIR/final_i8_${proj}_${TAG}.xclbin"
     echo "═══ ${proj} K=${K} N=${N} cols=${cols} ═══"
     $PYTHON "$GENERATOR_DIR/n1_core_i8_v27.py" -M 128 -K "$K" -N "$N" \
         -m 32 -k 64 -n 128 -c "$cols" -r 4 -b 5 2>/dev/null > "$design"
+    [ -s "$design" ] || { echo "ERROR: ${proj}: design generation produced an empty file" >&2; exit 1; }
     cp "$KERNEL_O" /tmp/mm_32x64x128.o
     cd /tmp
     $AIECC --peano="$PEANO" --aietools="$AIETOOLS" \
@@ -37,6 +41,7 @@ build_one() {
     ln -sf "final_i8_${proj}_${TAG}.xclbin" "$XCLBIN_DIR/final_i8_${proj}_qwen3_6_35b_a3b.xclbin"
     ln -sf "insts_i8_${proj}_${TAG}.txt"   "$XCLBIN_DIR/insts_i8_${proj}_qwen3_6_35b_a3b.txt"
     ls -la "$xclbin" "$XCLBIN_DIR/insts_i8_${proj}_${TAG}.txt"
+    rm -f "$design"; rm -rf "$design.prj"
 }
 
 build_one MOE_GUSGU 2048 9216 8

--- a/engine/npu/generators/build_zaya_fused.sh
+++ b/engine/npu/generators/build_zaya_fused.sh
@@ -7,6 +7,15 @@
 # Shape: A = residual [1×2048], GU [2048×4096 interleaved], D [2048×2048].
 # Single core row (r=1), M=8 1x4 vectorized mmul (bit-identical to M=16/128).
 #
+# Stale-design hardening (issue #1777): the design is written to a PID-unique
+# /tmp path (no fixed path a co-tenant process can clobber between generation
+# and aiecc), byte-compared against a fresh regeneration (the generator is
+# deterministic), and content-checked for the fused-kernel markers + the
+# exact h2-writeback [8K, K, 8, 1] and B-tile (ki·32 + n_tile)·8192 DMA
+# signatures BEFORE aiecc consumes it. Any mismatch fails the build loudly
+# instead of silently emitting a corrupt xclbin (the 08-22 incident: stale
+# file → wrong B offsets / h2-writeback strides, corr 0.374).
+#
 # REQUIRES the mlir-aie toolchain (aiecc) + an NPU2 device for verification —
 # this machine only has the CPU-side contract validation
 # (engine/npu/tests/test_fused_silu.cpp).
@@ -40,11 +49,155 @@ $P/bin/clang++ --target=aie2p-none-unknown-elf --std=c++20 -O2 \
 cp /tmp/mm_8x64x128_fused.o /tmp/mm_32x64x128.o
 
 echo "═══ fused GU→SiLU→D  M=8 K=2048 N_GU=4096 N_D=2048 ═══"
-design="/tmp/design_fused_gu_silu_d.mlir"
+
+# 2. Generate the design to a PID-unique path (issue #1777 fix #2). The old
+#    fixed /tmp/design_fused_gu_silu_d.mlir could be overwritten by a
+#    co-tenant process (or a leftover build) between generation and aiecc,
+#    and the build silently consumed whatever was there. $$ = this shell's
+#    PID, so no two builds share a path; the trap removes our files on exit
+#    so no stale /tmp designs accumulate.
+design="/tmp/design_fused_gu_silu_d.$$.mlir"
+design_ref="/tmp/design_fused_gu_silu_d.$$.ref.mlir"
+# aiecc also creates <design>.prj/ beside the design; the trap removes
+# everything we own so no stale /tmp artifacts accumulate.
+trap 'rm -f "$design" "$design_ref"; rm -rf "$design.prj" "$design_ref.prj"' EXIT
+
+gen_design() {  # $1 = output path
+    $PYTHON "$GENERATOR_DIR/n1_core_fused_gu_silu_d.py" -M 8 -K 2048 \
+        -N_GU 4096 -N_D 2048 -m 8 -k 64 -n 128 -c 8 -b 2 2>/dev/null > "$1"
+}
+
+gen_design "$design"
+[ -s "$design" ] || { echo "ERROR: design generation produced an empty file" >&2; exit 1; }
+
+# 3. Verify BEFORE aiecc (issue #1777 fix #1). The generator is deterministic
+#    — a fresh run always yields the correct design — so:
+#    (a) the design must be byte-identical to a fresh regeneration (catches a
+#        stale/tampered file, the exact 08-22 failure mode);
+#    (b) the design must carry the fused-kernel markers and the exact DMA
+#        signatures the stale file got wrong (B offsets (ki·32+n_tile)·8192,
+#        h2-writeback strides [8K, K, 8, 1] = [16384, 2048, 8, 1]).
+gen_design "$design_ref"
+if ! cmp -s "$design" "$design_ref"; then
+    echo "ERROR: design differs from a fresh regeneration — stale/tampered design or" >&2
+    echo "       nondeterministic generator. Refusing to build (issue #1777)." >&2
+    diff -u "$design_ref" "$design" | head -40 >&2 || true
+    exit 1
+fi
+
+"$PYTHON" - "$design" <<'PYEOF' || { echo "ERROR: design verification FAILED — refusing to build (issue #1777)" >&2; exit 1; }
+import re, sys
+
+path = sys.argv[1]
+text = open(path, encoding="utf-8", errors="replace").read()
+K = 2048  # build_zaya_fused.sh fixed shape
+errors = []
+
+# Fused-design markers: a stale GU/D-only or moe design lacks these.
+for marker in ("silu_quant_i8_fused", "mm_32x64x128.o"):
+    if marker not in text:
+        errors.append(f"missing marker {marker!r} — not the fused design?")
+
+ops = []  # (fifo, offset, sizes, strides)
+
+# Format A — this repo's mlir-aie version (verified on strixhalo):
+#   %N = aiex.dma_configure_task_for @FIFO {
+#     aie.dma_bd(%mem : memref<16384xi8>, 0, 512, [<size = 1, stride = 16384>, ...]) {burst_length = 0 : i32}
+for m in re.finditer(r"aiex\.dma_configure_task_for @(\w+)\s*\{\s*aie\.dma_bd\(([^)]*)\)", text):
+    fifo = m.group(1)
+    body = m.group(2)
+    mm = re.match(r"%\w+\s*:\s*memref<[^>]*>,\s*(\d+),\s*(\d+),\s*\[(.*)\]", body)
+    if not mm:
+        continue
+    offset = int(mm.group(1))
+    sizes, strides = [], []
+    for dm in re.finditer(r"<size\s*=\s*(\d+),\s*stride\s*=\s*(\d+)>", mm.group(3)):
+        sizes.append(int(dm.group(1)))
+        strides.append(int(dm.group(2)))
+    ops.append((fifo, offset, sizes, strides))
+
+# Format B — newer mlir-aie main fallback:
+#   aiex.npu.dma_memcpy_nd (%mem[offsets][sizes][strides]) {metadata = @fifo} : memref<...>
+if not ops:
+    for m in re.finditer(r"aiex\.npu\.dma_memcpy_nd\s*\(([^)]*)\)\s*\{([^}]*)\}", text):
+        body, attrs = m.group(1), m.group(2)
+        fm = re.search(r"metadata\s*=\s*@(\w+)", attrs)
+        fifo = fm.group(1) if fm else ""
+        groups = re.findall(r"\[([^\]]*)\]", body)
+        if len(groups) < 3:
+            continue
+
+        def nums(group):
+            out = []
+            for tok in group.split(","):
+                tok = tok.strip()
+                cm = re.match(r"%c(\d+)", tok)   # SSA constant ref, e.g. %c16384_i64
+                if cm:
+                    out.append(int(cm.group(1)))
+                elif re.match(r"\d+$", tok):    # inline literal
+                    out.append(int(tok))
+                else:
+                    out.append(None)
+            return out
+
+        offs, sizes, strides = (nums(g) for g in groups[-3:])
+        if None in offs or None in sizes or None in strides:
+            continue
+        ops.append((fifo, (offs[0] if offs else 0), sizes, strides))
+
+if not ops:
+    errors.append("no DMA bd ops found — design empty or printer format changed")
+
+h2_ok = a_ok = b_ok = False
+n_b_off_bad = 0
+seen = set()
+for fifo, offset, sizes, strides in ops:
+    if fifo.startswith("H2_S"):  # h2 writeback — the bug signature
+        if strides == [8 * K, K, 8, 1]:
+            h2_ok = True
+        else:
+            msg = f"H2_S tap strides {strides}, expected [8K, K, 8, 1] = {[8*K, K, 8, 1]}"
+            if msg not in seen:
+                errors.append(msg); seen.add(msg)
+    elif fifo.startswith("A_C"):  # A broadcast tap
+        if strides == [8 * K, 8, K, 1]:
+            a_ok = True
+        else:
+            msg = f"A_C tap strides {strides}, expected [8K, 8, K, 1] = {[8*K, 8, K, 1]}"
+            if msg not in seen:
+                errors.append(msg); seen.add(msg)
+    elif fifo.startswith("B_S"):  # linear B tiles: (ki*32 + n_tile)*8192
+        if sizes == [1, 1, 1, 8192] and strides == [1, 1, 1, 1]:
+            b_ok = True
+            if offset % 8192 != 0:
+                n_b_off_bad += 1
+                msg = f"B_S tap offset {offset} not a multiple of 8192 (expected (ki*32+n_tile)*8192)"
+                if msg not in seen:
+                    errors.append(msg); seen.add(msg)
+        else:
+            msg = f"B_S tap sizes {sizes} strides {strides}, expected linear 8192-byte tile"
+            if msg not in seen:
+                errors.append(msg); seen.add(msg)
+
+if not h2_ok:
+    errors.append("no H2_S writeback with strides [8K, K, 8, 1] — the h2-writeback bug signature")
+if not a_ok:
+    errors.append("no A tap with strides [8K, 8, K, 1]")
+if not b_ok:
+    errors.append("no linear B tile (sizes [1,1,1,8192], strides [1,1,1,1])")
+if n_b_off_bad:
+    errors.append(f"{n_b_off_bad} B-tile offset(s) not 8192-multiples")
+
+if errors:
+    print("fused design verification FAILED:", file=sys.stderr)
+    for e in errors:
+        print("  - " + e, file=sys.stderr)
+    sys.exit(1)
+print(f"fused design verification OK: {len(ops)} DMA bd ops, h2 [8K,K,8,1] + A [8K,8,K,1] + B 8192-step tiles")
+PYEOF
+
 xclbin="$XCLBIN_DIR/final_i8_MOE_FUSED_zaya.xclbin"
 insts="$XCLBIN_DIR/insts_i8_MOE_FUSED_zaya.txt"
-$PYTHON "$GENERATOR_DIR/n1_core_fused_gu_silu_d.py" -M 8 -K 2048 \
-    -N_GU 4096 -N_D 2048 -m 8 -k 64 -n 128 -c 8 -b 2 2>/dev/null > "$design"
 cd /tmp
 $AIECC --peano="$P" --aietools="$AIETOOLS" \
     --alloc-scheme=basic-sequential --no-xchesscc --no-xbridge \

--- a/engine/npu/generators/build_zaya_fused.sh
+++ b/engine/npu/generators/build_zaya_fused.sh
@@ -36,31 +36,33 @@ GENERATOR_DIR="$(cd "$(dirname "$0")" && pwd)"
 XCLBIN_DIR="$GENERATOR_DIR/../xclbins"
 mkdir -p "$XCLBIN_DIR"
 
+# 2. PID-unique workdir (issue #1777). The old build used fixed /tmp paths
+#    (/tmp/design_fused_gu_silu_d.mlir AND /tmp/mm_32x64x128.o) that a
+#    co-tenant process or leftover build could overwrite between generation
+#    and aiecc, silently producing a corrupt xclbin (wrong B offsets /
+#    h2-writeback strides, corr 0.374). $$ = this shell's PID, so no two
+#    builds share a workdir; the trap removes it on exit so no stale /tmp
+#    artifacts accumulate (design, <design>.prj/, kernel .o included).
+workdir="/tmp/zaya_fused_build.$$"
+mkdir -p "$workdir"
+trap 'rm -rf "$workdir"' EXIT
+
 # 1. Compile the DIM_M=8 kernel (1x4 mmul + the fused silu_quant_i8_fused
-#    entry from silu_quant.h — the on-core SiLU+quant step).
+#    entry from silu_quant.h — the on-core SiLU+quant step) INTO the workdir.
 $P/bin/clang++ --target=aie2p-none-unknown-elf --std=c++20 -O2 \
     -DDIM_M=8 -DDIM_K=64 -DDIM_N=128 -Di8_i32_ONLY -DM8_VECTORIZED \
     -isystem $P/include/c++/v1 \
     -I /home/bcloud/Xilinx/2025.2/Vitis/aietools/include \
     -I $M/include/aie_kernels/aie2p \
-    -c "$GENERATOR_DIR/mm_kernel_reference.cc" -o /tmp/mm_8x64x128_fused.o
+    -c "$GENERATOR_DIR/mm_kernel_reference.cc" -o "$workdir/mm_8x64x128_fused.o"
 
 # The MLIR references the kernel object by the fixed name mm_32x64x128.o.
-cp /tmp/mm_8x64x128_fused.o /tmp/mm_32x64x128.o
+cp "$workdir/mm_8x64x128_fused.o" "$workdir/mm_32x64x128.o"
 
 echo "═══ fused GU→SiLU→D  M=8 K=2048 N_GU=4096 N_D=2048 ═══"
 
-# 2. Generate the design to a PID-unique path (issue #1777 fix #2). The old
-#    fixed /tmp/design_fused_gu_silu_d.mlir could be overwritten by a
-#    co-tenant process (or a leftover build) between generation and aiecc,
-#    and the build silently consumed whatever was there. $$ = this shell's
-#    PID, so no two builds share a path; the trap removes our files on exit
-#    so no stale /tmp designs accumulate.
-design="/tmp/design_fused_gu_silu_d.$$.mlir"
-design_ref="/tmp/design_fused_gu_silu_d.$$.ref.mlir"
-# aiecc also creates <design>.prj/ beside the design; the trap removes
-# everything we own so no stale /tmp artifacts accumulate.
-trap 'rm -f "$design" "$design_ref"; rm -rf "$design.prj" "$design_ref.prj"' EXIT
+design="$workdir/design_fused_gu_silu_d.mlir"
+design_ref="$workdir/design_fused_gu_silu_d.ref.mlir"
 
 gen_design() {  # $1 = output path
     $PYTHON "$GENERATOR_DIR/n1_core_fused_gu_silu_d.py" -M 8 -K 2048 \
@@ -98,23 +100,38 @@ for marker in ("silu_quant_i8_fused", "mm_32x64x128.o"):
     if marker not in text:
         errors.append(f"missing marker {marker!r} — not the fused design?")
 
-ops = []  # (fifo, offset, sizes, strides)
+ops = []  # (fifo, offset, sizes, strides) — one entry per aie.dma_bd
 
 # Format A — this repo's mlir-aie version (verified on strixhalo):
 #   %N = aiex.dma_configure_task_for @FIFO {
 #     aie.dma_bd(%mem : memref<16384xi8>, 0, 512, [<size = 1, stride = 16384>, ...]) {burst_length = 0 : i32}
-for m in re.finditer(r"aiex\.dma_configure_task_for @(\w+)\s*\{\s*aie\.dma_bd\(([^)]*)\)", text):
+#     ...
+#   }
+# A task may carry several aie.dma_bd descriptors; capture the whole
+# brace-balanced task body and inspect EVERY descriptor (a wrong offset or
+# stride hidden in a later BD must not slip through).
+for m in re.finditer(r"aiex\.dma_configure_task_for @(\w+)\s*\{", text):
     fifo = m.group(1)
-    body = m.group(2)
-    mm = re.match(r"%\w+\s*:\s*memref<[^>]*>,\s*(\d+),\s*(\d+),\s*\[(.*)\]", body)
-    if not mm:
-        continue
-    offset = int(mm.group(1))
-    sizes, strides = [], []
-    for dm in re.finditer(r"<size\s*=\s*(\d+),\s*stride\s*=\s*(\d+)>", mm.group(3)):
-        sizes.append(int(dm.group(1)))
-        strides.append(int(dm.group(2)))
-    ops.append((fifo, offset, sizes, strides))
+    start = m.end()
+    depth, i = 1, start
+    while depth and i < len(text):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+        i += 1
+    task_body = text[start:i - 1] if depth == 0 else text[start:]
+    for bdm in re.finditer(r"aie\.dma_bd\(([^)]*)\)", task_body):
+        body = bdm.group(1)
+        mm = re.match(r"%\w+\s*:\s*memref<[^>]*>,\s*(\d+),\s*(\d+),\s*\[(.*)\]", body)
+        if not mm:
+            continue
+        offset = int(mm.group(1))
+        sizes, strides = [], []
+        for dm in re.finditer(r"<size\s*=\s*(\d+),\s*stride\s*=\s*(\d+)>", mm.group(3)):
+            sizes.append(int(dm.group(1)))
+            strides.append(int(dm.group(2)))
+        ops.append((fifo, offset, sizes, strides))
 
 # Format B — newer mlir-aie main fallback:
 #   aiex.npu.dma_memcpy_nd (%mem[offsets][sizes][strides]) {metadata = @fifo} : memref<...>
@@ -143,7 +160,9 @@ if not ops:
         offs, sizes, strides = (nums(g) for g in groups[-3:])
         if None in offs or None in sizes or None in strides:
             continue
-        ops.append((fifo, (offs[0] if offs else 0), sizes, strides))
+        # B-tile offset may be spread over several offset dims; verify EVERY
+        # dim is an 8192-multiple so a 512-step offset in any dim is caught.
+        ops.append((fifo, offs, sizes, strides))
 
 if not ops:
     errors.append("no DMA bd ops found — design empty or printer format changed")
@@ -169,9 +188,13 @@ for fifo, offset, sizes, strides in ops:
     elif fifo.startswith("B_S"):  # linear B tiles: (ki*32 + n_tile)*8192
         if sizes == [1, 1, 1, 8192] and strides == [1, 1, 1, 1]:
             b_ok = True
-            if offset % 8192 != 0:
-                n_b_off_bad += 1
-                msg = f"B_S tap offset {offset} not a multiple of 8192 (expected (ki*32+n_tile)*8192)"
+            # Format A passes offset as a scalar (int); Format B as a list.
+            # Normalize to a list and verify EVERY offset dim is an 8192-multiple.
+            offs = offset if isinstance(offset, list) else [offset]
+            bad = [o for o in offs if o % 8192 != 0]
+            if bad:
+                n_b_off_bad += len(bad)
+                msg = f"B_S tap offset(s) {bad} not 8192-multiples (expected (ki*32+n_tile)*8192)"
                 if msg not in seen:
                     errors.append(msg); seen.add(msg)
         else:
@@ -198,7 +221,7 @@ PYEOF
 
 xclbin="$XCLBIN_DIR/final_i8_MOE_FUSED_zaya.xclbin"
 insts="$XCLBIN_DIR/insts_i8_MOE_FUSED_zaya.txt"
-cd /tmp
+cd "$workdir"
 $AIECC --peano="$P" --aietools="$AIETOOLS" \
     --alloc-scheme=basic-sequential --no-xchesscc --no-xbridge \
     --aie-generate-xclbin --no-compile-host --unified --dynamic-objFifos \

--- a/engine/npu/generators/build_zaya_m16.sh
+++ b/engine/npu/generators/build_zaya_m16.sh
@@ -35,12 +35,16 @@ cp /tmp/mm_16x64x128.o /tmp/mm_32x64x128.o
 
 build_one() {
     local proj="$1" K="$2" N="$3"
-    local design="/tmp/design_${proj}_m16.mlir"
+    # PID-unique design path (issue #1777): a fixed /tmp path could be
+    # clobbered by a co-tenant process between generation and aiecc, and the
+    # build would silently consume the stale file.
+    local design="/tmp/design_${proj}_m16.$$.mlir"
     local xclbin="$XCLBIN_DIR/final_i8_MOE_${proj}_zaya_m16.xclbin"
     local insts="$XCLBIN_DIR/insts_i8_MOE_${proj}_zaya_m16.txt"
     echo "═══ ${proj} M=16 K=${K} N=${N} ═══"
     $PYTHON "$GENERATOR_DIR/n1_core_i8_v27.py" -M 16 -K "$K" -N "$N" \
         -m 16 -k 64 -n 128 -c 8 -r 1 -b 5 2>/dev/null > "$design"
+    [ -s "$design" ] || { echo "ERROR: ${proj}: design generation produced an empty file" >&2; exit 1; }
     cd /tmp
     $AIECC --peano="$P" --aietools="$AIETOOLS" \
         --alloc-scheme=basic-sequential --no-xchesscc --no-xbridge \
@@ -50,6 +54,7 @@ build_one() {
         "$design" 2>&1 | tail -1
     cd "$GENERATOR_DIR"
     ls -la "$xclbin" "$insts"
+    rm -f "$design"; rm -rf "$design.prj"
 }
 
 build_one GU 2048 4096

--- a/engine/npu/generators/build_zaya_m16.sh
+++ b/engine/npu/generators/build_zaya_m16.sh
@@ -22,30 +22,35 @@ GENERATOR_DIR="$(cd "$(dirname "$0")" && pwd)"
 XCLBIN_DIR="$GENERATOR_DIR/../xclbins"
 mkdir -p "$XCLBIN_DIR"
 
-# 1. Compile the DIM_M=16 microkernel (vectorized mmul, single core-row slice).
+# PID-unique workdir (issue #1777): a fixed /tmp path for the design OR the
+# kernel .o could be clobbered by a co-tenant process between generation and
+# aiecc, and the build would silently consume the stale file. $$ = PID.
+workdir="/tmp/zaya_m16_build.$$"
+mkdir -p "$workdir"
+trap 'rm -rf "$workdir"' EXIT
+
+# 1. Compile the DIM_M=16 microkernel (vectorized mmul, single core-row slice)
+#    INTO the workdir.
 $P/bin/clang++ --target=aie2p-none-unknown-elf --std=c++20 -O2 \
     -DDIM_M=16 -DDIM_K=64 -DDIM_N=128 -Di8_i32_ONLY \
     -isystem $P/include/c++/v1 \
     -I /home/bcloud/Xilinx/2025.2/Vitis/aietools/include \
     -I $M/include/aie_kernels/aie2p \
-    -c "$GENERATOR_DIR/mm_kernel_reference.cc" -o /tmp/mm_16x64x128.o
+    -c "$GENERATOR_DIR/mm_kernel_reference.cc" -o "$workdir/mm_16x64x128.o"
 
 # The MLIR references the kernel object by the fixed name mm_32x64x128.o.
-cp /tmp/mm_16x64x128.o /tmp/mm_32x64x128.o
+cp "$workdir/mm_16x64x128.o" "$workdir/mm_32x64x128.o"
 
 build_one() {
     local proj="$1" K="$2" N="$3"
-    # PID-unique design path (issue #1777): a fixed /tmp path could be
-    # clobbered by a co-tenant process between generation and aiecc, and the
-    # build would silently consume the stale file.
-    local design="/tmp/design_${proj}_m16.$$.mlir"
+    local design="$workdir/design_${proj}_m16.mlir"
     local xclbin="$XCLBIN_DIR/final_i8_MOE_${proj}_zaya_m16.xclbin"
     local insts="$XCLBIN_DIR/insts_i8_MOE_${proj}_zaya_m16.txt"
     echo "═══ ${proj} M=16 K=${K} N=${N} ═══"
     $PYTHON "$GENERATOR_DIR/n1_core_i8_v27.py" -M 16 -K "$K" -N "$N" \
         -m 16 -k 64 -n 128 -c 8 -r 1 -b 5 2>/dev/null > "$design"
     [ -s "$design" ] || { echo "ERROR: ${proj}: design generation produced an empty file" >&2; exit 1; }
-    cd /tmp
+    cd "$workdir"
     $AIECC --peano="$P" --aietools="$AIETOOLS" \
         --alloc-scheme=basic-sequential --no-xchesscc --no-xbridge \
         --aie-generate-xclbin --no-compile-host --unified --dynamic-objFifos \
@@ -54,7 +59,6 @@ build_one() {
         "$design" 2>&1 | tail -1
     cd "$GENERATOR_DIR"
     ls -la "$xclbin" "$insts"
-    rm -f "$design"; rm -rf "$design.prj"
 }
 
 build_one GU 2048 4096

--- a/engine/npu/generators/build_zaya_m8.sh
+++ b/engine/npu/generators/build_zaya_m8.sh
@@ -37,12 +37,16 @@ cp /tmp/mm_8x64x128.o /tmp/mm_32x64x128.o
 
 build_one() {
     local proj="$1" K="$2" N="$3"
-    local design="/tmp/design_${proj}_m8.mlir"
+    # PID-unique design path (issue #1777): a fixed /tmp path could be
+    # clobbered by a co-tenant process between generation and aiecc, and the
+    # build would silently consume the stale file.
+    local design="/tmp/design_${proj}_m8.$$.mlir"
     local xclbin="$XCLBIN_DIR/final_i8_MOE_${proj}_zaya_m8.xclbin"
     local insts="$XCLBIN_DIR/insts_i8_MOE_${proj}_zaya_m8.txt"
     echo "═══ ${proj} M=8 K=${K} N=${N} ═══"
     $PYTHON "$GENERATOR_DIR/n1_core_i8_v27.py" -M 8 -K "$K" -N "$N" \
         -m 8 -k 64 -n 128 -c 8 -r 1 -b 5 2>/dev/null > "$design"
+    [ -s "$design" ] || { echo "ERROR: ${proj}: design generation produced an empty file" >&2; exit 1; }
     cd /tmp
     $AIECC --peano="$P" --aietools="$AIETOOLS" \
         --alloc-scheme=basic-sequential --no-xchesscc --no-xbridge \
@@ -52,6 +56,7 @@ build_one() {
         "$design" 2>&1 | tail -1
     cd "$GENERATOR_DIR"
     ls -la "$xclbin" "$insts"
+    rm -f "$design"; rm -rf "$design.prj"
 }
 
 build_one GU 2048 4096

--- a/engine/npu/generators/build_zaya_m8.sh
+++ b/engine/npu/generators/build_zaya_m8.sh
@@ -23,31 +23,35 @@ GENERATOR_DIR="$(cd "$(dirname "$0")" && pwd)"
 XCLBIN_DIR="$GENERATOR_DIR/../xclbins"
 mkdir -p "$XCLBIN_DIR"
 
+# PID-unique workdir (issue #1777): a fixed /tmp path for the design OR the
+# kernel .o could be clobbered by a co-tenant process between generation and
+# aiecc, and the build would silently consume the stale file. $$ = PID.
+workdir="/tmp/zaya_m8_build.$$"
+mkdir -p "$workdir"
+trap 'rm -rf "$workdir"' EXIT
+
 # 1. Compile the DIM_M=8 kernel (1x4 mmul expansion; M8_VECTORIZED bypasses the
-#    DIM_M < 16 scalar alias).
+#    DIM_M < 16 scalar alias) INTO the workdir.
 $P/bin/clang++ --target=aie2p-none-unknown-elf --std=c++20 -O2 \
     -DDIM_M=8 -DDIM_K=64 -DDIM_N=128 -Di8_i32_ONLY -DM8_VECTORIZED \
     -isystem $P/include/c++/v1 \
     -I /home/bcloud/Xilinx/2025.2/Vitis/aietools/include \
     -I $M/include/aie_kernels/aie2p \
-    -c "$GENERATOR_DIR/mm_kernel_reference.cc" -o /tmp/mm_8x64x128.o
+    -c "$GENERATOR_DIR/mm_kernel_reference.cc" -o "$workdir/mm_8x64x128.o"
 
 # The MLIR references the kernel object by the fixed name mm_32x64x128.o.
-cp /tmp/mm_8x64x128.o /tmp/mm_32x64x128.o
+cp "$workdir/mm_8x64x128.o" "$workdir/mm_32x64x128.o"
 
 build_one() {
     local proj="$1" K="$2" N="$3"
-    # PID-unique design path (issue #1777): a fixed /tmp path could be
-    # clobbered by a co-tenant process between generation and aiecc, and the
-    # build would silently consume the stale file.
-    local design="/tmp/design_${proj}_m8.$$.mlir"
+    local design="$workdir/design_${proj}_m8.mlir"
     local xclbin="$XCLBIN_DIR/final_i8_MOE_${proj}_zaya_m8.xclbin"
     local insts="$XCLBIN_DIR/insts_i8_MOE_${proj}_zaya_m8.txt"
     echo "═══ ${proj} M=8 K=${K} N=${N} ═══"
     $PYTHON "$GENERATOR_DIR/n1_core_i8_v27.py" -M 8 -K "$K" -N "$N" \
         -m 8 -k 64 -n 128 -c 8 -r 1 -b 5 2>/dev/null > "$design"
     [ -s "$design" ] || { echo "ERROR: ${proj}: design generation produced an empty file" >&2; exit 1; }
-    cd /tmp
+    cd "$workdir"
     $AIECC --peano="$P" --aietools="$AIETOOLS" \
         --alloc-scheme=basic-sequential --no-xchesscc --no-xbridge \
         --aie-generate-xclbin --no-compile-host --unified --dynamic-objFifos \
@@ -56,7 +60,6 @@ build_one() {
         "$design" 2>&1 | tail -1
     cd "$GENERATOR_DIR"
     ls -la "$xclbin" "$insts"
-    rm -f "$design"; rm -rf "$design.prj"
 }
 
 build_one GU 2048 4096

--- a/engine/npu/generators/run_build.sh
+++ b/engine/npu/generators/run_build.sh
@@ -57,7 +57,10 @@ SHAPES=(
 
 build_one() {
     local tag="$1" proj="$2" K="$3" N="$4" cols="$5"
-    local design="/tmp/design_${proj}_${tag}.mlir"
+    # PID-unique design path (issue #1777): a fixed /tmp path could be
+    # clobbered by a co-tenant process between generation and aiecc, and the
+    # build would silently consume the stale file.
+    local design="/tmp/design_${proj}_${tag}.$$.mlir"
     local xclbin="$XCLBIN_DIR/final_i8_${proj}_${tag}.xclbin"
     local insts_dir="$XCLBIN_DIR"   # engine reads insts_i8_<op>_<tag>.txt from the xclbin dir
     mkdir -p "$insts_dir"
@@ -73,6 +76,7 @@ build_one() {
     $PYTHON "$GENERATOR_DIR/n1_core_i8_v27.py" \
         -M 128 -K "$K" -N "$N" -m 32 -k 64 -n 128 -c "$cols" -r 4 -b 5 \
         2>/dev/null > "$design"
+    [ -s "$design" ] || { echo "  ❌ ${proj} ${tag}: design generation produced an empty file"; return 1; }
     
     # aiecc needs kernel .o in CWD and runs from the design directory
     local workdir; workdir=$(dirname "$design")
@@ -87,6 +91,7 @@ build_one() {
         --npu-insts-name="$insts_dir/insts_i8_${proj}_${tag}.txt" \
         "$design" 2>&1 | tail -1
     cd "$GENERATOR_DIR"
+    rm -f "$design"; rm -rf "$design.prj"
     
     if [ -f "$xclbin" ]; then
         local size; size=$(stat -c%s "$xclbin" 2>/dev/null)

--- a/engine/npu/generators/run_build.sh
+++ b/engine/npu/generators/run_build.sh
@@ -57,10 +57,14 @@ SHAPES=(
 
 build_one() {
     local tag="$1" proj="$2" K="$3" N="$4" cols="$5"
-    # PID-unique design path (issue #1777): a fixed /tmp path could be
-    # clobbered by a co-tenant process between generation and aiecc, and the
-    # build would silently consume the stale file.
-    local design="/tmp/design_${proj}_${tag}.$$.mlir"
+    # PID-unique workdir (issue #1777): a fixed /tmp path for the design OR
+    # the kernel .o could be clobbered by a co-tenant process between
+    # generation and aiecc, and the build would silently consume the stale
+    # file. $$ = PID. aiecc needs the kernel .o in its CWD, so the design and
+    # the kernel are staged together here.
+    local workdir="/tmp/build_${proj}_${tag}.$$"
+    mkdir -p "$workdir"
+    local design="$workdir/design.mlir"
     local xclbin="$XCLBIN_DIR/final_i8_${proj}_${tag}.xclbin"
     local insts_dir="$XCLBIN_DIR"   # engine reads insts_i8_<op>_<tag>.txt from the xclbin dir
     mkdir -p "$insts_dir"
@@ -76,10 +80,12 @@ build_one() {
     $PYTHON "$GENERATOR_DIR/n1_core_i8_v27.py" \
         -M 128 -K "$K" -N "$N" -m 32 -k 64 -n 128 -c "$cols" -r 4 -b 5 \
         2>/dev/null > "$design"
-    [ -s "$design" ] || { echo "  ❌ ${proj} ${tag}: design generation produced an empty file"; return 1; }
+    if [ ! -s "$design" ]; then
+        echo "  ❌ ${proj} ${tag}: design generation produced an empty file" >&2
+        rm -rf "$workdir"
+        return 1
+    fi
     
-    # aiecc needs kernel .o in CWD and runs from the design directory
-    local workdir; workdir=$(dirname "$design")
     cp "$KERNEL_O" "$workdir/mm_32x64x128.o" 2>/dev/null || true
     
     cd "$workdir"
@@ -91,7 +97,7 @@ build_one() {
         --npu-insts-name="$insts_dir/insts_i8_${proj}_${tag}.txt" \
         "$design" 2>&1 | tail -1
     cd "$GENERATOR_DIR"
-    rm -f "$design"; rm -rf "$design.prj"
+    rm -rf "$workdir"
     
     if [ -f "$xclbin" ]; then
         local size; size=$(stat -c%s "$xclbin" 2>/dev/null)


### PR DESCRIPTION
### **User description**
Closes #1777.

## Problem
`build_zaya_fused.sh` wrote its MLIR design to a fixed `/tmp/design_fused_gu_silu_d.mlir` and aiecc silently consumed whatever was there. A co-tenant process or leftover build overwrote it between generation and aiecc, producing xclbins with wrong B-tile offsets and h2-writeback strides (corr 0.374) that looked plausible — hours of debugging.

## Fix (`build_zaya_fused.sh`)
1. **PID-unique design path** (`/tmp/design_fused_gu_silu_d.$$.mlir`) — no fixed path left for another process to clobber; a `trap` removes our files (incl. the `<design>.prj/` dir aiecc creates) on exit.
2. **Byte-compare vs fresh regeneration** before aiecc — the generator is deterministic (verified byte-identical), so any difference = stale/tampered file or nondeterministic generator → fail loudly with a diff.
3. **Content verification** (embedded Python, parses both the strixhalo `aiex.dma_configure_task_for`/`aie.dma_bd` form and the upstream `aiex.npu.dma_memcpy_nd` fallback):
   - fused markers `silu_quant_i8_fused` + `mm_32x64x128.o` present
   - h2-writeback strides must be `[8K, K, 8, 1]` = `[16384, 2048, 8, 1]` (the bug signature)
   - B-tile offsets must be multiples of 8192 (`(ki*32 + n_tile)*8192`)
   - A-tap strides `[8K, 8, K, 1]` sanity check

## Sibling scripts (same fixed-`/tmp/design_*.mlir` hazard)
`build_zaya_m8.sh`, `build_zaya_m16.sh`, `build_moe_v27.sh`, `build_moe_v28.sh`, `run_build.sh`: PID-unique design paths + non-empty-file guard before aiecc + cleanup of design and `<design>.prj` after success.

## Validation (real toolchain on strixhalo, `fused-perf` worktree)
- Correct design → `verification OK: 1808 DMA bd ops, h2 [8K,K,8,1] + A [8K,8,K,1] + B 8192-step tiles`
- Buggy h2 writeback (strides `[16384, 8, 2048, 1]`) → fails with the bug-signature message
- Buggy B-tile offset (512) → fails with the B-offset message
- Stale non-fused design → fails on missing `silu_quant_i8_fused`
- Full build ran clean end-to-end: kernel compile → verify → aiecc → `final_i8_MOE_FUSED_zaya.xclbin` (83872 B, matches known-good build); no `/tmp` leftovers after

Note: the earlier comment on #1777 assumed `aiex.npu.dma_memcpy_nd`; the real strixhalo mlir-aie prints `aiex.dma_configure_task_for`/`aie.dma_bd` — the verifier handles both.


___

### **PR Type**
Bug fix


___

### **Description**
- PID-unique /tmp paths stop co-tenant clobbering

- Fused build byte-compares and content-verifies designs

- Empty-file guards and cleanup added to sibling scripts

- Corrupt designs now fail loudly before aiecc


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Generate MLIR design"] --> B["PID-unique /tmp path"]
  B --> C{"Non-empty? Byte-compare?"}
  C -- "fail" --> D["Abort build loudly"]
  C -- "pass" --> E["Content verify DMA signatures"]
  E -- "fail" --> D
  E -- "pass" --> F["aiecc builds xclbin"]
  F --> G["Cleanup design + .prj"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_zaya_fused.sh</strong><dd><code>Verify fused design before aiecc consumption</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/build_zaya_fused.sh

<ul><li>PID-unique design path and trap-based cleanup<br> <li> Byte-compare against fresh regeneration before aiecc<br> <li> Embedded Python verifies fused markers and DMA signatures<br> <li> Fail-fast on any mismatch instead of silent corruption</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1778/files#diff-f6ec6841f068c4fa0a10ebb9acab8a8b93cfe12ac21b44f6c4efbdf813098012">+156/-3</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build_moe_v27.sh</strong><dd><code>Harden MoE v27 build against stale designs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/build_moe_v27.sh

<ul><li>PID-unique design path prevents co-tenant clobbering<br> <li> Non-empty file guard fails build early<br> <li> Removes design and .prj after success</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1778/files#diff-192df5ffec2956a31a8dafa278fc6d50db17edb45fdcde18e295baa7a3814b92">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build_moe_v28.sh</strong><dd><code>Harden MoE v28 build against stale designs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/build_moe_v28.sh

<ul><li>PID-unique design path prevents co-tenant clobbering<br> <li> Non-empty file guard fails build early<br> <li> Removes design and .prj after success</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1778/files#diff-7aa987598a7495d8dc8f9ceee9664a16cddd0d1f5afd76be0f923adcc9db5980">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build_zaya_m8.sh</strong><dd><code>Harden Zaya M8 build against stale designs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/build_zaya_m8.sh

<ul><li>PID-unique design path prevents co-tenant clobbering<br> <li> Non-empty file guard fails build early<br> <li> Removes design and .prj after success</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1778/files#diff-21b892077472b78b55699922aba0de97528b75dfb6617a95f1daa207c0460958">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build_zaya_m16.sh</strong><dd><code>Harden Zaya M16 build against stale designs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/build_zaya_m16.sh

<ul><li>PID-unique design path prevents co-tenant clobbering<br> <li> Non-empty file guard fails build early<br> <li> Removes design and .prj after success</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1778/files#diff-655640b48cbcd7b20f6dfb0783197c23d42ee4785915dc101126327e2fdb3653">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run_build.sh</strong><dd><code>Harden generic run_build against stale designs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/run_build.sh

<ul><li>PID-unique design path prevents co-tenant clobbering<br> <li> Empty design now returns failure instead of proceeding<br> <li> Removes design and .prj after successful build</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1778/files#diff-fa74e9b6eac7fea4f8421a83249b9b9ab220e1fcb2d53d3a415ae0dc29f6b1f9">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

