### PR TITLE
build(npu): link zaya_decode.cpp into npu_engine_universal (both build paths)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -67,7 +67,7 @@ jobs:
             engine/npu/src/zaya_decode.cpp \
             engine/npu/src/gemm_npu_instructions.cpp \
             npu-infer/src/flm_bridge.cpp \
-            -Iengine/npu/include -Inpu-infer/include -Iinclude \
+            -Iengine/npu/include -Iengine/npu/generators -Inpu-infer/include -Iinclude \
             -I/opt/xrt/include -Iengine/npu -I. \
             -L/opt/xrt/lib -lxrt_coreutil -luuid -lm -ldl -lpthread -laiebu
 

--- a/engine/npu/CMakeLists.txt
+++ b/engine/npu/CMakeLists.txt
@@ -16,7 +16,13 @@ set(NPU_ENGINE_SOURCES
     ${NPU_SRC_DIR}/npu_engine_universal.cpp
     ${NPU_SRC_DIR}/dequant_q4nx.cpp
     ${NPU_SRC_DIR}/gemm_npu_instructions.cpp
+    ${NPU_SRC_DIR}/zaya_decode.cpp
 )
+# zaya_decode.cpp — the Zaya decode path (CCA attention on CPU, MoE FFN on
+# NPU, NPU_FUSED=1 fused GU->SiLU->D mode). npu_engine_universal dispatches
+# to zaya_decode_main when the model header contains "zaya", so it must be
+# linked in. Needs the generators/ include dir (silu_quant.h, the dual-
+# compiled fused-kernel contract) and -mavx2 (zaya_moe_cpu.h AVX2 host amax).
 # flm_bridge.cpp (FLM dlopen wrapper) was removed 2026-08-15: no engine code
 # calls FlmBridge — HybridFlmCtx generates instructions via the open-source
 # gemm_generate_sequence_i8_split(), and the pre-compiled .txt streams load
@@ -26,6 +32,7 @@ add_executable(npu_engine_universal ${NPU_ENGINE_SOURCES})
 
 target_include_directories(npu_engine_universal PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/generators
     ${CMAKE_CURRENT_SOURCE_DIR}/../../npu-infer/include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include   # npu_instr.hpp, npu_app.hpp
 )
@@ -59,7 +66,7 @@ target_link_libraries(npu_engine_universal
 )
 
 target_compile_options(npu_engine_universal PRIVATE
-    -O3 -ffast-math -march=native -funroll-loops -fno-math-errno
+    -O3 -ffast-math -march=native -funroll-loops -fno-math-errno -mavx2
     -Wno-unused-parameter -Wno-unused-variable -Wno-nan-infinity-disabled -Wno-implicit-const-int-float-conversion
 )
 

--- a/engine/npu/build_npu.sh
+++ b/engine/npu/build_npu.sh
@@ -9,9 +9,17 @@ DEQUANT="$SRCDIR/src/dequant_q4nx.cpp"
 DEQUANT_O="$BUILDDIR/dequant_q4nx.o"
 INSTR_GEN="$SRCDIR/src/gemm_npu_instructions.cpp"
 INSTR_GEN_O="$BUILDDIR/gemm_npu_instructions.o"
+# Zaya decode path (zaya_decode_main — CCA attention on CPU, MoE FFN on NPU,
+# NPU_FUSED=1 fused GU->SiLU->D mode). npu_engine_universal dispatches to it
+# when the model header contains "zaya", so it must be linked into every
+# variant. Requires the generators/ include dir (silu_quant.h) + -mavx2
+# (zaya_moe_cpu.h uses AVX2 for the host amax pass).
+ZAYA_DECODE="$SRCDIR/src/zaya_decode.cpp"
+ZAYA_DECODE_O="$BUILDDIR/zaya_decode.o"
 
 # XRT headers at /usr/include, libs at system default path
 XRT_INC="/usr/include"
+REPO_ROOT="$(cd "$SRCDIR/../.." && pwd)"
 
 # One-time: compile dequantizer
 if [ ! -f "$DEQUANT_O" ] || [ "$DEQUANT" -nt "$DEQUANT_O" ]; then
@@ -24,6 +32,15 @@ if [ ! -f "$INSTR_GEN_O" ] || [ "$INSTR_GEN" -nt "$INSTR_GEN_O" ]; then
     echo "g++ -c -std=c++23 -O3 -o $INSTR_GEN_O $INSTR_GEN"
     g++ -c -std=c++23 -O3 -fopenmp -I"$SRCDIR"/src -I"$SRCDIR"/include -I$XRT_INC \
         -o "$INSTR_GEN_O" "$INSTR_GEN"
+fi
+
+# One-time: compile the Zaya decode path
+if [ ! -f "$ZAYA_DECODE_O" ] || [ "$ZAYA_DECODE" -nt "$ZAYA_DECODE_O" ]; then
+    echo "g++ -c -std=c++23 -O3 -mavx2 -o $ZAYA_DECODE_O $ZAYA_DECODE"
+    g++ -c -std=c++23 -O3 -mavx2 -fopenmp -DONEBP_SUPPORT \
+        -I"$SRCDIR"/src -I"$SRCDIR"/include -I"$SRCDIR"/generators \
+        -I"$REPO_ROOT"/include -I$XRT_INC \
+        -o "$ZAYA_DECODE_O" "$ZAYA_DECODE"
 fi
 
 # Models to build
@@ -51,8 +68,8 @@ MODELS=(
 CXX="${CXX:-g++}"
 # XRT uses shared libs (must come AFTER source on command line)
 LIBS=(-lxrt_coreutil -lxrt_core -laiebu -luuid -lm -ldl)
-REPO_ROOT="$(cd "$SRCDIR/../.." && pwd)"
 CXXFLAGS=(-std=c++23 -O3 -fopenmp -DONEBP_SUPPORT -I"$SRCDIR/src" -I"$SRCDIR/include" -I"$REPO_ROOT/include" -I"$XRT_INC")
+ENGINE_OBJS=("$DEQUANT_O" "$INSTR_GEN_O" "$ZAYA_DECODE_O")
 
 echo "=== Building NPU engine variants ==="
 mkdir -p "$BUILDDIR"
@@ -61,14 +78,14 @@ for model in "${MODELS[@]}"; do
     binary="$BUILDDIR/npu_engine_$model"
     echo ""
     echo "--- $model -> $binary ---"
-    $CXX "-DMODEL_$model" "${CXXFLAGS[@]}" -o "$binary" "$SRC" "$DEQUANT_O" "$INSTR_GEN_O" "${LIBS[@]}"
+    $CXX "-DMODEL_$model" "${CXXFLAGS[@]}" -o "$binary" "$SRC" "${ENGINE_OBJS[@]}" "${LIBS[@]}"
     ls -lh "$binary"
 done
 
 # Also build a default (qwen3_0_6b) as npu_engine for backward compat
 echo ""
 echo "--- default (qwen3_0_6b) -> $BUILDDIR/npu_engine ---"
-$CXX -DMODEL_qwen3_0_6b "${CXXFLAGS[@]}" -o "$BUILDDIR/npu_engine" "$SRC" "$DEQUANT_O" "$INSTR_GEN_O" "${LIBS[@]}"
+$CXX -DMODEL_qwen3_0_6b "${CXXFLAGS[@]}" -o "$BUILDDIR/npu_engine" "$SRC" "${ENGINE_OBJS[@]}" "${LIBS[@]}"
 ls -lh "$BUILDDIR/npu_engine"
 
 echo ""


### PR DESCRIPTION
### **User description**
## Problem
`npu_engine_universal` dispatches to `zaya_decode_main` when the model header contains "zaya" (CCA attention on CPU, MoE FFN on NPU, `NPU_FUSED=1` fused GU→SiLU→D mode), but **neither build system compiled or linked `zaya_decode.cpp`**:
- `build_npu.sh` → `undefined reference to zaya_decode_main` at link
- CMake → engine binary silently lacked the Zaya path

Every prior zaya/NPU-verify run on strixhalo used an ad-hoc manual g++ command (including my own earlier verification), so the repo could not reproduce a working engine.

## Fix
- **`engine/npu/build_npu.sh`**: compile `zaya_decode.o` (with `-mavx2` for the `zaya_moe_cpu.h` AVX2 host-amax pass + `generators/` include for `silu_quant.h`) and link it into **every** `npu_engine_*` variant; `REPO_ROOT` hoisted above the one-time compiles.
- **`engine/npu/CMakeLists.txt`**: `zaya_decode.cpp` added to `NPU_ENGINE_SOURCES`, `generators/` added to the include path, `-mavx2` added to compile options.

## Verified on strixhalo (fused-perf worktree)
- `build_npu.sh` — all 18 variants + default build cleanly (exit 0)
- CMake `npu_engine_universal` target links cleanly; `zaya_decode_main` present (`nm -C | grep -c` = 10)
- `NPU_FUSED=1` decode with the **properly-built** engine:
  ```
  I8Ctx::init ... final_i8_MOE_FUSED_zaya.xclbin (instr 296528)
  fused resident experts packed (16 experts x 20 MoE layers)
  [MoE L1 fused dbg] corr=0.999528 maxdiff=0.047236
  [perf] 8 tokens in 729-818 ms (91-102 ms/tok, 9.8-11.0 tok/s)
  ```
- Timing varies with co-tenant load (3.7 tok/s once under load avg 5.75; 9.8-11.0 when quieter) — matches the page-cache/bandwidth variance already documented in #1776, not a build regression. Run-to-run token differences are the known #1775 ULP nondeterminism (corr-based validation unaffected).


___

### **PR Type**
Bug fix


___

### **Description**
- Fix missing `zaya_decode_main` in engine builds

- Compile and link `zaya_decode.cpp` in `build_npu.sh`

- Wire `zaya_decode.cpp` into CMake `npu_engine_universal`

- Add `generators/` include and `-mavx2` flags


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Z["zaya_decode.cpp"] -->|"build_npu.sh"| B["zaya_decode.o linked into all variants"]
  Z -->|"CMakeLists.txt"| C["npu_engine_universal target"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_npu.sh</strong><dd><code>Add zaya_decode.o to shell NPU builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/build_npu.sh

<ul><li>Add one-time <code>zaya_decode.o</code> compile with <code>-mavx2</code><br> <li> Link <code>zaya_decode.o</code> into every <code>npu_engine_*</code> variant<br> <li> Hoist <code>REPO_ROOT</code> above one-time compiles<br> <li> Introduce <code>ENGINE_OBJS</code> for shared object list</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1779/files#diff-df9125ffc6ce437fe924296c6404d5b9fa921303868bd2b694d67a6c59824f06">+20/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Wire zaya_decode.cpp into CMake engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/CMakeLists.txt

<ul><li>Add <code>zaya_decode.cpp</code> to <code>NPU_ENGINE_SOURCES</code><br> <li> Add <code>generators/</code> to include directories<br> <li> Add <code>-mavx2</code> to compile options</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1779/files#diff-4f95080e7d7ebc379f722aa653124aece9e5c4fd90b3c76601764141d56b8670">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

