### PR TITLE
docs: drop dead max-xdna-backend link, point to in-repo AIE2P evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ No cloud, no Python in the hot path.
 - **[The engineering journey](docs/journey.md)** · **[Roadmap](docs/guides/roadmap.md)**
 - **[Contributing](CONTRIBUTING.md)**
 
-> **[MAX XDNA backend](https://github.com/1bit-systems/max-xdna-backend)** — secondary evidence repo (MIT): proves the XDNA 2 NPU can be driven from outside AMD tooling. The engine itself is MAX-free by design.
+> **XDNA 2 NPU, driven from outside AMD tooling** — the measured evidence lives in-repo: [AIE2P hardware facts](engine/npu/AIE2P-FACTS.md) (bf16 RNI rounding, dispatch costs) and the [NPU backend](engine/npu/). The engine itself is MAX-free by design.
 
 ## License
 


### PR DESCRIPTION
### **User description**
Closes the dead link reported in https://github.com/1bit-systems/max-xdna-backend (404 — repo was never public; the org renamed to 1bit-MONSTER).

The claim (XDNA 2 NPU driven from outside AMD tooling) is real, but the evidence lives in-repo: `engine/npu/AIE2P-FACTS.md` (bf16 RNI rounding, dispatch costs) and `engine/npu/`. The engine is MAX-free by design.


___

### **PR Type**
Documentation


___

### **Description**
- Drop dead `max-xdna-backend` link from README

- Point to in-repo AIE2P evidence and NPU backend

- Clarify MAX-free engine claim with local references


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dead external link"] -- "replace" --> B["In-repo evidence links"]
  B --> C["AIE2P-FACTS.md"]
  B --> D["engine/npu/"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Fix dead link with in-repo evidence references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Removed dead link to <code>max-xdna-backend</code> GitHub repo<br> <li> Added in-repo links to AIE2P hardware facts and NPU backend<br> <li> Updated description to cite local evidence for MAX-free engine</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1784/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

