### PR TITLE
build(npu): harden stale /tmp design handling in existing xclbin build scripts (#1777)

### DIFF
--- a/engine/npu/generators/build_moe_v27.sh
+++ b/engine/npu/generators/build_moe_v27.sh
@@ -13,15 +13,27 @@ XCLBIN_DIR="$(cd "$(dirname "$0")/../xclbins" && pwd)"
 GENERATOR_DIR="$(cd "$(dirname "$0")" && pwd)"
 TAG=qwen3.6-moe_35b
 
+# PID-unique workdir (issue #1777): a fixed /tmp path for the design OR the
+# kernel .o could be clobbered by a co-tenant process between generation and
+# aiecc, and the build would silently consume the stale file. $$ = PID.
+workdir="/tmp/zaya_moe_v27_build.$$"
+mkdir -p "$workdir"
+trap 'rm -rf "$workdir"' EXIT
+
 build_one() {
     local proj="$1" K="$2" N="$3" cols="$4"
-    local design="/tmp/design_${proj}_moe.mlir"
+    local design="$workdir/design_${proj}_moe.mlir"
     local xclbin="$XCLBIN_DIR/final_i8_${proj}_${TAG}.xclbin"
     echo "═══ ${proj} K=${K} N=${N} cols=${cols} ═══"
     $PYTHON "$GENERATOR_DIR/n1_core_i8_v27.py" -M 128 -K "$K" -N "$N" \
         -m 32 -k 64 -n 128 -c "$cols" -r 4 -b 5 2>/dev/null > "$design"
-    cp "$KERNEL_O" /tmp/mm_32x64x128.o
-    cd /tmp
+    if [ ! -s "$design" ]; then
+        echo "ERROR: ${proj}: design generation produced an empty file" >&2
+        rm -rf "$workdir"
+        exit 1
+    fi
+    cp "$KERNEL_O" "$workdir/mm_32x64x128.o"
+    cd "$workdir"
     $AIECC --peano="$PEANO" --aietools="$AIETOOLS" \
         --alloc-scheme=basic-sequential --no-xchesscc --no-xbridge \
         --aie-generate-xclbin --no-compile-host --unified --dynamic-objFifos \

--- a/engine/npu/generators/build_moe_v28.sh
+++ b/engine/npu/generators/build_moe_v28.sh
@@ -16,15 +16,27 @@ XCLBIN_DIR="$(cd "$(dirname "$0")/../xclbins" && pwd)"
 GENERATOR_DIR="$(cd "$(dirname "$0")" && pwd)"
 TAG=qwen3.6-moe_35b
 
+# PID-unique workdir (issue #1777): a fixed /tmp path for the design OR the
+# kernel .o could be clobbered by a co-tenant process between generation and
+# aiecc, and the build would silently consume the stale file. $$ = PID.
+workdir="/tmp/zaya_moe_v28_build.$$"
+mkdir -p "$workdir"
+trap 'rm -rf "$workdir"' EXIT
+
 build_one() {
     local proj="$1" K="$2" N="$3" cols="$4"
-    local design="/tmp/design_${proj}_moe.mlir"
+    local design="$workdir/design_${proj}_moe.mlir"
     local xclbin="$XCLBIN_DIR/final_i8_${proj}_${TAG}.xclbin"
     echo "═══ ${proj} K=${K} N=${N} cols=${cols} ═══"
     $PYTHON "$GENERATOR_DIR/n1_core_i8_v27.py" -M 128 -K "$K" -N "$N" \
         -m 32 -k 64 -n 128 -c "$cols" -r 4 -b 5 2>/dev/null > "$design"
-    cp "$KERNEL_O" /tmp/mm_32x64x128.o
-    cd /tmp
+    if [ ! -s "$design" ]; then
+        echo "ERROR: ${proj}: design generation produced an empty file" >&2
+        rm -rf "$workdir"
+        exit 1
+    fi
+    cp "$KERNEL_O" "$workdir/mm_32x64x128.o"
+    cd "$workdir"
     $AIECC --peano="$PEANO" --aietools="$AIETOOLS" \
         --alloc-scheme=basic-sequential --no-xchesscc --no-xbridge \
         --aie-generate-xclbin --no-compile-host --unified --dynamic-objFifos \

--- a/engine/npu/generators/run_build.sh
+++ b/engine/npu/generators/run_build.sh
@@ -57,7 +57,14 @@ SHAPES=(
 
 build_one() {
     local tag="$1" proj="$2" K="$3" N="$4" cols="$5"
-    local design="/tmp/design_${proj}_${tag}.mlir"
+    # PID-unique workdir (issue #1777): a fixed /tmp path for the design OR
+    # the kernel .o could be clobbered by a co-tenant process between
+    # generation and aiecc, and the build would silently consume the stale
+    # file. $$ = PID. aiecc needs the kernel .o in its CWD, so the design and
+    # the kernel are staged together here.
+    local workdir="/tmp/build_${proj}_${tag}.$$"
+    mkdir -p "$workdir"
+    local design="$workdir/design.mlir"
     local xclbin="$XCLBIN_DIR/final_i8_${proj}_${tag}.xclbin"
     local insts_dir="$XCLBIN_DIR"   # engine reads insts_i8_<op>_<tag>.txt from the xclbin dir
     mkdir -p "$insts_dir"
@@ -73,9 +80,12 @@ build_one() {
     $PYTHON "$GENERATOR_DIR/n1_core_i8_v27.py" \
         -M 128 -K "$K" -N "$N" -m 32 -k 64 -n 128 -c "$cols" -r 4 -b 5 \
         2>/dev/null > "$design"
+    if [ ! -s "$design" ]; then
+        echo "  ❌ ${proj} ${tag}: design generation produced an empty file" >&2
+        rm -rf "$workdir"
+        return 1
+    fi
     
-    # aiecc needs kernel .o in CWD and runs from the design directory
-    local workdir; workdir=$(dirname "$design")
     cp "$KERNEL_O" "$workdir/mm_32x64x128.o" 2>/dev/null || true
     
     cd "$workdir"
@@ -87,6 +97,7 @@ build_one() {
         --npu-insts-name="$insts_dir/insts_i8_${proj}_${tag}.txt" \
         "$design" 2>&1 | tail -1
     cd "$GENERATOR_DIR"
+    rm -rf "$workdir"
     
     if [ -f "$xclbin" ]; then
         local size; size=$(stat -c%s "$xclbin" 2>/dev/null)


### PR DESCRIPTION
### **User description**
Lands the reviewed #1777 hardening (PR #1778) for build scripts already on main: PID-unique workdir isolation for design + kernel .o and a loud empty-design failure in build_moe_v27.sh, build_moe_v28.sh, run_build.sh. The fused Zaya build script + full-BD verifier remain on feat/npu-zaya-decode-perf (PR #1771).


___

### **PR Type**
Bug fix


___

### **Description**
- PID-unique workdirs stop co-tenant /tmp clobbering

- Empty generated designs now fail loudly before aiecc

- Kernel .o staged in isolated workdir with cleanup


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Fixed /tmp path hazard"] --> B["PID-unique workdir"]
  B --> C["Generate MLIR design"]
  C --> D{"Design non-empty?"}
  D -- "empty" --> E["Fail loudly"]
  D -- "ok" --> F["Stage kernel .o + aiecc"]
  F --> G["Cleanup workdir"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_moe_v27.sh</strong><dd><code>Isolate MoE v27 build in PID-unique workdir</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/build_moe_v27.sh

<ul><li>Introduces PID-unique workdir <code>/tmp/zaya_moe_v27_build.$$</code> with trap <br>cleanup<br> <li> Stages design and kernel <code>.o</code> in the workdir instead of fixed <code>/tmp</code> paths<br> <li> Fails loudly if design generation produces an empty file</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1785/files#diff-192df5ffec2956a31a8dafa278fc6d50db17edb45fdcde18e295baa7a3814b92">+15/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build_moe_v28.sh</strong><dd><code>Isolate MoE v28 build in PID-unique workdir</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/build_moe_v28.sh

<ul><li>Introduces PID-unique workdir <code>/tmp/zaya_moe_v28_build.$$</code> with trap <br>cleanup<br> <li> Stages design and kernel <code>.o</code> in the workdir instead of fixed <code>/tmp</code> paths<br> <li> Fails loudly if design generation produces an empty file</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1785/files#diff-7aa987598a7495d8dc8f9ceee9664a16cddd0d1f5afd76be0f923adcc9db5980">+15/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run_build.sh</strong><dd><code>Harden run_build with PID workdir and empty-design guard</code>&nbsp; </dd></summary>
<hr>

engine/npu/generators/run_build.sh

<ul><li>Uses per-build PID-unique workdir for design and kernel <code>.o</code><br> <li> Adds non-empty design guard that fails before aiecc<br> <li> Cleans up workdir after aiecc completes</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1785/files#diff-fa74e9b6eac7fea4f8421a83249b9b9ab220e1fcb2d53d3a415ae0dc29f6b1f9">+14/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

