### PR TITLE
fix(npu): zero-pad all MD rows of bA in quantize_async (#1775)

### DIFF
--- a/engine/npu/src/npu_engine_i8ctx_inc.h
+++ b/engine/npu/src/npu_engine_i8ctx_inc.h
@@ -273,7 +273,12 @@ struct I8Ctx {
     // ── Quantize activations into bA ──
     inline int8_t* quantize_async(const float* A, int am, int ak, float ascale) {
         float ais = 1.0f / ascale;
-        memset(Am, 0, (size_t)am * KD);
+        // Zero-pad ALL MD rows (issue #1775): the M=128 stream reads rows
+        // [am, MD) every launch; zeroing only rows [0, am) left stale BO
+        // memory (the previous launch's A) in [am, MD) — an
+        // uninitialized-read-class hazard for any kernel with cross-row
+        // interaction.
+        memset(Am, 0, (size_t)MD * KD);
         for (int m = 0; m < am; m++)
             for (int k = 0; k < ak; k++) {
                 float v = A[m * ak + k];
@@ -291,7 +296,7 @@ struct I8Ctx {
     // use the matching per-row scale (dequant_only_rows).
     inline int8_t* quantize_async_rows(const float* A, int am, int ak,
                                        const float* ascales) {
-        memset(Am, 0, (size_t)am * KD);
+        memset(Am, 0, (size_t)MD * KD);
         for (int m = 0; m < am; m++) {
             float ais = 1.0f / ascales[m];
             for (int k = 0; k < ak; k++) {


### PR DESCRIPTION
### **User description**
Part of the #1775 (ULP nondeterminism) investigation. `quantize_async`/\_rows memset only rows [0, am) of the bA BO, but the M=128 stream reads rows [am, MD) every launch, so those rows held the previous launch's activations — an uninitialized-read-class hazard. Latent today (kernels are row-independent), but it matches the issue's 'uninitialized-memory read' suspect and must be fixed before any kernel with cross-row interaction lands. Full investigation notes are on the issue.


___

### **PR Type**
Bug fix


___

### **Description**
- Zero-pad all MD rows of bA in both `quantize_async` and `quantize_async_rows`

- Eliminates uninitialized-read hazard from stale BO memory in rows [am, MD)

- Matches documented zero-pad contract and the Bm handling

- Addresses issue #1775 ULP nondeterminism investigation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["quantize_async / quantize_async_rows"] -- "memset(Am, 0, MD*KD)" --> B["All MD rows zeroed"]
  B -- "write rows [0, am)" --> C["bA BO fully initialized"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>npu_engine_i8ctx_inc.h</strong><dd><code>Zero-pad all MD rows of bA buffer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/npu_engine_i8ctx_inc.h

<ul><li>Changed <code>quantize_async</code> to memset <code>MD * KD</code> bytes instead of <code>am * KD</code><br> <li> Changed <code>quantize_async_rows</code> to memset <code>MD * KD</code> bytes instead of <code>am * KD</code><br> <li> Prevents stale activations from previous launches in rows [am, MD)<br> <li> Removes uninitialized-read-class hazard for future cross-row kernels</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1786/files#diff-00a304de6fc1ff0480e37d4ed288e548ef48a8b2cdde7652034ce7a3815b864c">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

