### PR TITLE
build: SANITIZE option + fix smoke-test after onebin consolidation (#1775)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,23 @@ if(USE_VART)
     endif()
 endif()
 
+# ── Optional: sanitizers (ASan + UBSan) — issue #1775 ──
+# The Zaya decode nondeterminism investigation (issue #1775) called for
+# ASan/UBSan runs of the engine; none existed. Enable with:
+#   cmake -B build-san -DSANITIZE=ON -DCMAKE_BUILD_TYPE=Debug
+# NOTES: (1) build WITHOUT -ffast-math — it implies -ffinite-math-only and
+# reassociation, hiding the float-UB class UBSan is meant to catch (see the
+# #1243 gate comment); (2) ASan only instruments host code — xrt BO memory
+# (bA/bC) is opaque to it, so a sanitizer-clean run does not prove the
+# NPU-side buffers are clean (that needs the strixhalo verification recipe);
+# (3) HIP targets may still add their own -ffast-math flags.
+option(SANITIZE "Build with AddressSanitizer + UndefinedBehaviorSanitizer" OFF)
+if(SANITIZE)
+    message(STATUS "SANITIZE=ON — adding -fsanitize=address,undefined -fno-sanitize-recover=all")
+    add_compile_options(-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer)
+    add_link_options(-fsanitize=address,undefined)
+endif()
+
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
 endif()


### PR DESCRIPTION
Two changes (both needed to land CI on current main):

1. **SANITIZE build option** (from the #1775 investigation): `-DSANITIZE=ON` → `-fsanitize=address,undefined -fno-sanitize-recover=all` for the engine. Docs the caveats: build without -ffast-math, ASan can't see xrt BO memory, HIP targets may add their own flags.

2. **Smoke-test fix** (pre-existing main bug, blocks any CMakeLists/server PR): `end-to-end-smoke.yml` still built `unified_server vision_server`, removed by the #1781 onebin consolidation → 'unknown target unified_server'. Now builds `onebin` and runs `./build/1bit unified|vision`.