### PR TITLE
ci: fix end-to-end smoke test for one-binary layout

### DIFF
--- a/.github/workflows/end-to-end-smoke.yml
+++ b/.github/workflows/end-to-end-smoke.yml
@@ -29,7 +29,11 @@ jobs:
         run: |
           source env.sh
           cmake -B build -G Ninja
-          cmake --build build --target unified_server vision_server -j$(nproc)
+          # One binary: unified_server + vision_server live inside build/1bit
+          # (ONE_BIN_DISPATCH), dispatched by subcommand. No standalone
+          # unified_server / vision_server executables since the one-binary
+          # consolidation.
+          cmake --build build --target onebin -j$(nproc)
 
       - name: Download test model
         # Model files are git-ignored (symlinked to HF cache locally).
@@ -56,15 +60,15 @@ jobs:
           sudo systemctl stop 1bit-systems.service || true
           # Also kill stray manual servers (vision_server etc.) that can
           # squat on 8099 and answer health checks with the wrong schema.
-          pkill -f "[v]ision_server.*8099" || true
+          pkill -f "[v]ision_server.*8099|[v]ision .*8099" || true
           # -9 fallback: a wedged instance can survive SIGTERM and squat on 8099
           # with the wrong health schema (issue #1257 incident class).
-          pkill -9 -f "[v]ision_server.*8099" || true
+          pkill -9 -f "[v]ision_server.*8099|[v]ision .*8099" || true
           # Stray unified_server instances from manual runs/dev agents on this
           # shared box answer health with the right schema but die mid-test
           # (curl 56), or hold the port so our server can't bind.
-          pkill -f "[u]nified_server.*8099" || true
-          pkill -9 -f "[u]nified_server.*8099" || true
+          pkill -f "[u]nified_server.*8099|[u]nified .*8099" || true
+          pkill -9 -f "[u]nified_server.*8099|[u]nified .*8099" || true
           # Any other process squatting on 8099 (llama-server, dev agents,
           # manual curl-test servers) answers /v1/health with the wrong
           # schema and makes the test "pass" against the squatter while the
@@ -77,7 +81,7 @@ jobs:
       - name: Start server
         run: |
           rm -f /tmp/unified_server.lock
-          ./build/unified_server --port 8099 --weights models/ \
+          ./build/1bit unified --port 8099 --weights models/ \
             --gen-timeout-ms 10000 --quick &>/tmp/smoke_server.log &
           echo "pid=$!"
           # Wait for startup (GPU init can take ~90s on Strix Halo)
@@ -193,9 +197,9 @@ jobs:
             exit 0
           fi
           # Free the GPU for the VL stack.
-          pkill -f "unified_server.*8099" 2>/dev/null || true
+          pkill -f "unified_server.*8099|unified .*8099" 2>/dev/null || true
           sleep 2
-          ./build/vision_server --port 8099 --mmproj "$VIT" --model "$MM" \
+          ./build/1bit vision --port 8099 --mmproj "$VIT" --model "$MM" \
             &>/tmp/smoke_vision_server.log &
           echo "pid=$!"
           for i in $(seq 1 60); do
@@ -220,11 +224,11 @@ jobs:
           assert 'data' in d and len(d['data']) > 0, 'no models listed'
           print('OK: vision_server models endpoint:', d['data'][0].get('id'))
           "
-          pkill -f "vision_server.*8099" 2>/dev/null || true
+          pkill -f "vision_server.*8099|vision .*8099" 2>/dev/null || true
       - name: Cleanup
         if: always()
         run: |
-          pkill -f "unified_server.*8099" 2>/dev/null || true
-          pkill -f "[v]ision_server.*8099" 2>/dev/null || true
+          pkill -f "unified_server.*8099|unified .*8099" 2>/dev/null || true
+          pkill -f "[v]ision_server.*8099|[v]ision .*8099" 2>/dev/null || true
           rm -f /tmp/unified_server.lock
           sudo systemctl start 1bit-systems.service || true


### PR DESCRIPTION
Fixes the end-to-end smoke test, which has been failing on **every** branch with `ninja: error: unknown target 'unified_server'`.

**Root cause:** the workflow still built `--target unified_server vision_server`, but those standalone executables no longer exist since the one-binary consolidation — everything lives in `build/1bit` (ONE_BIN_DISPATCH), dispatched by subcommand.

**Changes:**
- Build: `--target onebin` (produces `build/1bit`)
- Run: `./build/1bit unified ...` and `./build/1bit vision ...`
- `pkill` patterns cover both legacy binary names and the new subcommand form

Verified working on the strixhalo self-hosted runner (this failure was found while validating the rebrand PR #1788).