### PR TITLE
fix(npu): misaligned bf16 loads in q4nx loaders (UB, issue #1775)

### DIFF
--- a/engine/npu/src/dequant_q4nx.cpp
+++ b/engine/npu/src/dequant_q4nx.cpp
@@ -31,6 +31,15 @@ static inline float bf16_to_float(uint16_t v) {
     float f; std::memcpy(&f, &bits, sizeof(f)); return f;
 }
 
+// The .q4nx tile buffer is not guaranteed 2-byte aligned (tensor data can
+// start at an odd byte in the mapped file), so reading the bf16 scales/zps
+// through a (const uint16_t*) cast is a misaligned load — UB flagged by
+// UBSan and a hard fault on ARM/AIE targets (issue #1775 sanitizer run).
+// Read the two bytes explicitly instead.
+static inline uint16_t load_bf16_bytes(const uint8_t* p) {
+    return (uint16_t)(p[0]) | ((uint16_t)(p[1]) << 8);
+}
+
 /**
  * Dequantize an I8 tensor (torch2aie Q4NX chunk format) to float.
  * Output: [out_rows, out_cols] row-major float array (caller must free).
@@ -68,8 +77,8 @@ extern "C" float* dequant_i8_to_float_ex(const uint8_t* data, int i8_rows, int i
         int tile_row = ir / n_tile_cols;
         int tile_col = ir % n_tile_cols;
 
-        const uint16_t* scales = (const uint16_t*)(rd);
-        const uint16_t* zeros  = (const uint16_t*)(rd + 512);
+        const uint8_t* scales = rd;
+        const uint8_t* zeros  = rd + 512;
         const uint8_t* packed  = rd + 1024;
 
         for (int lr = 0; lr < TILE_ROWS; lr++) {
@@ -82,8 +91,8 @@ extern "C" float* dequant_i8_to_float_ex(const uint8_t* data, int i8_rows, int i
 
             for (int col = 0; col < TILE_COLS; col++) {
                 int group = col / 32;
-                float scale = bf16_to_float(scales[group * 32 + lr]);
-                float zp = bf16_to_float(zeros[group * 32 + lr]);
+                float scale = bf16_to_float(load_bf16_bytes(scales + (group * 32 + lr) * 2));
+                float zp = bf16_to_float(load_bf16_bytes(zeros + (group * 32 + lr) * 2));
                 if (!std::isfinite(scale) || std::fabs(scale) > 100.0f) scale = 0.0f;
                 if (!std::isfinite(zp) || std::fabs(zp) > 100.0f) zp = 0.0f;
 
@@ -125,8 +134,8 @@ extern "C" float* dequant_i8_signed_to_float_ex(const uint8_t* data, int i8_rows
         const uint8_t* rd = data + ir * 5120;
         int tile_row = ir / n_tile_cols;
         int tile_col = ir % n_tile_cols;
-        const uint16_t* scales = (const uint16_t*)(rd);
-        const uint16_t* zeros  = (const uint16_t*)(rd + 512);
+        const uint8_t* scales = rd;
+        const uint8_t* zeros  = rd + 512;
         const uint8_t* packed  = rd + 1024;
         for (int lr = 0; lr < TILE_ROWS; lr++) {
             int lane = lr / 16;
@@ -138,8 +147,8 @@ extern "C" float* dequant_i8_signed_to_float_ex(const uint8_t* data, int i8_rows
                 int group = col / 32;
                 // Zaya converter (convert_float32_bins_to_q4nx.py) stores scales
                 // row-major: scales_flat[row*8 + group] (NOT group-major g*32+r).
-                float scale = bf16_to_float(scales[lr * 8 + group]);
-                float zp = bf16_to_float(zeros[lr * 8 + group]);
+                float scale = bf16_to_float(load_bf16_bytes(scales + (lr * 8 + group) * 2));
+                float zp = bf16_to_float(load_bf16_bytes(zeros + (lr * 8 + group) * 2));
                 if (!std::isfinite(scale) || std::fabs(scale) > 100.0f) scale = 0.0f;
                 if (!std::isfinite(zp) || std::fabs(zp) > 100.0f) zp = 0.0f;
                 // nibble layout (parallel_size=16): byte = lane*2048 + col*8 + (row%16)/2, low nibble = even row
@@ -173,13 +182,13 @@ extern "C" float* dequant_q8_0_to_float_ex(const uint8_t* data, int i8_rows, int
         int tile_row = ir / n_tile_cols;
         int tile_col = ir % n_tile_cols;
 
-        const uint16_t* scales = (const uint16_t*)(rd);
+        const uint8_t* scales = rd;
         const int8_t*   values = (const int8_t*)(rd + 512);  // signed INT8
 
         for (int lr = 0; lr < TILE_ROWS; lr++) {
             for (int col = 0; col < TILE_COLS; col++) {
                 int group = col / 32;
-                float scale = bf16_to_float(scales[group * 32 + lr]);
+                float scale = bf16_to_float(load_bf16_bytes(scales + (group * 32 + lr) * 2));
                 if (!std::isfinite(scale) || std::fabs(scale) > 100.0f) scale = 0.0f;
 
                 // Signed INT8: row-major layout

--- a/engine/npu/src/zaya_decode.cpp
+++ b/engine/npu/src/zaya_decode.cpp
@@ -68,9 +68,13 @@ static bool get_offsets(const char* js, size_t jl, const char* key,
 
 static std::vector<float> load_bf16(const uint8_t* data, uint64_t off, uint64_t size) {
     std::vector<float> v(size / 2);
-    const uint16_t* p = (const uint16_t*)(data + off);
+    // The .q4nx data section starts at an odd file offset (8 + JSON-header
+    // size is odd), so (const uint16_t*)(data+off) is a misaligned load —
+    // UB flagged by the issue #1775 UBSan run, and a hard fault on
+    // ARM/AIE targets. Read the two bytes explicitly (little-endian).
+    const uint8_t* p = data + off;
     for (size_t i = 0; i < v.size(); i++) {
-        uint32_t bits = (uint32_t)p[i] << 16;
+        uint32_t bits = (uint32_t)((uint16_t)p[2 * i] | ((uint16_t)p[2 * i + 1] << 8)) << 16;
         float f; memcpy(&f, &bits, 4); v[i] = f;
     }
     return v;

--- a/engine/npu/tools/zaya_cpu_runner.cpp
+++ b/engine/npu/tools/zaya_cpu_runner.cpp
@@ -51,9 +51,13 @@ static bool get_offsets(const char* js, size_t jl, const char* key,
 
 static std::vector<float> load_bf16(const uint8_t* data, uint64_t off, uint64_t size) {
     std::vector<float> v(size / 2);
-    const uint16_t* p = (const uint16_t*)(data + off);
+    // The .q4nx data section starts at an odd file offset (8 + JSON-header
+    // size is odd), so (const uint16_t*)(data+off) is a misaligned load —
+    // UB flagged by the issue #1775 UBSan run, and a hard fault on
+    // ARM/AIE targets. Read the two bytes explicitly (little-endian).
+    const uint8_t* p = data + off;
     for (size_t i = 0; i < v.size(); i++) {
-        uint32_t bits = (uint32_t)p[i] << 16;
+        uint32_t bits = (uint32_t)((uint16_t)p[2 * i] | ((uint16_t)p[2 * i + 1] << 8)) << 16;
         float f; memcpy(&f, &bits, 4); v[i] = f;
     }
     return v;

--- a/engine/npu/tools/zaya_npu_runner.cpp
+++ b/engine/npu/tools/zaya_npu_runner.cpp
@@ -69,9 +69,13 @@ static bool get_offsets(const char* js, size_t jl, const char* key,
 
 static std::vector<float> load_bf16(const uint8_t* data, uint64_t off, uint64_t size) {
     std::vector<float> v(size / 2);
-    const uint16_t* p = (const uint16_t*)(data + off);
+    // The .q4nx data section starts at an odd file offset (8 + JSON-header
+    // size is odd), so (const uint16_t*)(data+off) is a misaligned load —
+    // UB flagged by the issue #1775 UBSan run, and a hard fault on
+    // ARM/AIE targets. Read the two bytes explicitly (little-endian).
+    const uint8_t* p = data + off;
     for (size_t i = 0; i < v.size(); i++) {
-        uint32_t bits = (uint32_t)p[i] << 16;
+        uint32_t bits = (uint32_t)((uint16_t)p[2 * i] | ((uint16_t)p[2 * i + 1] << 8)) << 16;
         float f; memcpy(&f, &bits, 4); v[i] = f;
     }
     return v;


### PR DESCRIPTION
### **User description**
First results from the issue #1775 ASan/UBSan effort (SANITIZE option landed via #1787). Running the fused CPU contract test (test_fused_silu, real zaya1-8b.q4nx weights) under UBSan found a **systemic misaligned-load UB**:

**Root cause:** the .q4nx file's data section starts at file offset 232423 — 8-byte size prefix + odd-sized JSON header — so **every** bf16 tensor begins at an odd byte. All loaders cast to `(const uint16_t*)` and index `uint16_t` values → misaligned load (UB). Silently works on x86 (unaligned loads allowed) but faults on ARM/AIE targets.

Fixed (byte-wise little-endian reads):
- engine/npu/src/dequant_q4nx.cpp (3 dequant functions — scales/zeros)
- engine/npu/src/zaya_decode.cpp, tools/zaya_cpu_runner.cpp, tools/zaya_npu_runner.cpp (load_bf16)

Verified: the fused contract test now runs UBSan-clean on real weights (link to the run in the issue). The branch's test_fused_silu.cpp has the same pattern and is fixed by the #1771 refresh.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix misaligned bf16 loads flagged by UBSan

- Add byte-wise load_bf16_bytes helper in dequant_q4nx

- Replace misaligned uint16_t casts with byte reads

- Removes UB; prevents hard faults on ARM/AIE


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Q4NX["q4nx file odd-offset tensor"] -- "uint16_t cast" --> UB["misaligned-load UB"]
  UB -- "fix" --> BYTE["byte-wise load_bf16_bytes"]
  BYTE --> SAFE["aligned little-endian reads"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dequant_q4nx.cpp</strong><dd><code>Add byte-wise bf16 load helper for dequant scales</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/dequant_q4nx.cpp

<ul><li>Add <code>load_bf16_bytes</code> helper for explicit little-endian byte reads<br> <li> Replace <code>(const uint16_t*)</code> casts in all three dequant functions<br> <li> Fixes misaligned-load UB on odd-offset q4nx tensor data</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1792/files#diff-167e72e29afa5b8071129772dd74ca48711ff82f88aaa242030639200098f331">+19/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zaya_decode.cpp</strong><dd><code>Read bf16 tensors byte-wise in decode loader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/zaya_decode.cpp

<ul><li>Replace misaligned <code>uint16_t*</code> cast in <code>load_bf16</code> with byte-wise reads<br> <li> Document odd .q4nx data-section offset as root cause<br> <li> Fixes UBSan-flagged UB and ARM/AIE hard-fault risk</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1792/files#diff-03d765f3c907f9bbf3b9e72824d9f24105ec11666aacb7a9b57702d5254669ae">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zaya_cpu_runner.cpp</strong><dd><code>Read bf16 byte-wise in zaya_cpu_runner loader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tools/zaya_cpu_runner.cpp

<ul><li>Replace misaligned <code>uint16_t*</code> cast in <code>load_bf16</code> with byte-wise reads<br> <li> Document odd .q4nx data-section offset as root cause<br> <li> Fixes UBSan-flagged UB and ARM/AIE hard-fault risk</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1792/files#diff-82f9676c4542062db8b170457404c4e6b696d090dfdddbf6ccf94390a7a5a612">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zaya_npu_runner.cpp</strong><dd><code>Read bf16 byte-wise in zaya_npu_runner loader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tools/zaya_npu_runner.cpp

<ul><li>Replace misaligned <code>uint16_t*</code> cast in <code>load_bf16</code> with byte-wise reads<br> <li> Document odd .q4nx data-section offset as root cause<br> <li> Fixes UBSan-flagged UB and ARM/AIE hard-fault risk</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1792/files#diff-e851b1dd70bdec298e2f8866205621888aca3cb1f5db9b106ef1649bdc9c481a">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

