### PR TITLE
feat(npu): int4 pack/unpack foundation for fused weight DMA (#1769, Phase 1)

### DIFF
--- a/engine/npu/generators/i4_pack.h
+++ b/engine/npu/generators/i4_pack.h
@@ -1,0 +1,61 @@
+// i4_pack.h — symmetric int4 (Q4NX-style) pack/unpack for the fused decode
+//             weight path (issue #1769).
+//
+// Compiled into BOTH the AIE kernel (mm_kernel_reference.cc / the future
+// int4 dequant stage, via the AIE2P Peano toolchain) AND the host-side CPU
+// reference (engine/npu/tests/test_i4_pack.cpp) so the exact bit-level
+// contract is pinned on x86 BEFORE the NPU round-trip — same dual-compile
+// discipline as silu_quant.h. NO AIE intrinsics, no <cmath>/libm — plain
+// scalar C the AIE2P scalar unit lowers to hardware instructions.
+//
+// ── Contract (Phase-1 MVP from the #1769 plan) ────────────────────────────
+//   Codes:       symmetric two's-complement int4, q ∈ [-8, 7].
+//   Pack:        q4 = clamp(round(x / 16), -8, 7); nibble = q4 & 0xF.
+//   Unpack:      int8 = sign-extend(nibble) << 4   (the ×16 is FOLDED into
+//                the existing per-column/per-group scales, so the kernel's
+//                dequant stage is a pure nibble→int8 expansion — byte-
+//                identical pipeline, zero extra metadata).
+//   Layout:      nibble pairs along the innermost (contiguous) axis;
+//                one byte holds elements (2j, 2j+1) with the EVEN element
+//                in the LOW nibble. For the fused B tiles this is the
+//                col-in-8 mmul axis (byte s = i0*1024 + i1*64 + i2*8 + i3,
+//                i3 = col-in-8): 8 elements → 4 bytes, exactly half the
+//                int8 streamed bytes (~12.6 MB → ~6.3 MB/layer).
+//
+//   round(x/16): x + (x >= 0 ? 8 : -8) then truncating /16 — symmetric
+//                round-half-away-from-zero, no float involved (int8→int4
+//                must not depend on FP rounding in the kernel).
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+// Pack n int8 values into n/2 bytes (n even). Consecutive pairs (x[2j],
+// x[2j+1]); x[2j] → low nibble, x[2j+1] → high nibble.
+static inline void pack_i8_to_i4(const int8_t* __restrict src, size_t n,
+                                 uint8_t* __restrict dst) {
+    for (size_t j = 0; j < n / 2; j++) {
+        int8_t a = src[2 * j];
+        int8_t b = src[2 * j + 1];
+        // clamp(round(x/16), -8, 7): round-half-away-from-zero in integers.
+        int qa = (a >= 0 ? (a + 8) : (a - 8)) / 16;
+        int qb = (b >= 0 ? (b + 8) : (b - 8)) / 16;
+        if (qa > 7) qa = 7; else if (qa < -8) qa = -8;
+        if (qb > 7) qb = 7; else if (qb < -8) qb = -8;
+        dst[j] = (uint8_t)((uint8_t)(qb & 0x0F) << 4) | (uint8_t)(qa & 0x0F);
+    }
+}
+
+// Unpack n/2 bytes back into n int8 values (n even). The ×16 scale fold
+// means unpacked = sign-extend(nibble) << 4 — the kernel consumes these
+// int8 values directly; the per-column scale absorbs the 1/16.
+static inline void unpack_i4_to_i8(const uint8_t* __restrict src, size_t n,
+                                   int8_t* __restrict dst) {
+    for (size_t j = 0; j < n / 2; j++) {
+        uint8_t byte = src[j];
+        int8_t a = (int8_t)((byte & 0x0F) << 4) >> 4;  // sign-extend low nibble
+        int8_t b = (int8_t)((byte >> 4) << 4) >> 4;    // sign-extend high nibble
+        dst[2 * j]     = (int8_t)(a << 4);
+        dst[2 * j + 1] = (int8_t)(b << 4);
+    }
+}

--- a/engine/npu/tests/test_i4_pack.cpp
+++ b/engine/npu/tests/test_i4_pack.cpp
@@ -1,0 +1,106 @@
+// test_i4_pack.cpp — int4 pack/unpack contract gate (issue #1769, Phase 1).
+//
+// Pins the exact bit-level contract of engine/npu/generators/i4_pack.h on
+// x86 BEFORE the AIE kernel round-trip (dual-compile discipline, same as
+// test_fused_silu.cpp ↔ silu_quant.h). Checks, all on plain int8:
+//
+//   1. Exhaustive: every x in [-128, 127] packs and unpacks to
+//      clamp(round(x/16), -8, 7) << 4 — i.e. |roundtrip(x) - x| <= 8
+//      (one 4-bit LSB), with the ×16 scale fold preserved exactly.
+//   2. Bit layout: byte = (q_b << 4) | q_a, even element in the LOW nibble.
+//   3. Float-reference: a Q4NX-style symmetric quantize of a pseudo-random
+//      weight tensor (scale = abs_max/127) roundtrips through int4 and the
+//      reconstructed float (q4 · scale, the folded scale) matches the int8
+//      quantized float within the 4-bit step (scale·8) — the ppl-gate
+//      proxy the kernel work will validate on zaya1-8b.q4nx.
+//   4. Determinism: two identical packs are byte-identical.
+//
+// Build (CPU only, no xrt):
+//   g++ -std=c++20 -O2 -I engine/npu/generators engine/npu/tests/test_i4_pack.cpp -o /tmp/test_i4_pack
+//   /tmp/test_i4_pack        # exit 0 = contract holds
+#include "i4_pack.h"
+
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <cmath>
+
+static int failures = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { \
+    fprintf(stderr, "FAIL: %s (line %d)\n", msg, __LINE__); failures++; } } while (0)
+
+// Reference: clamp(round(x/16), -8, 7) — integer round-half-away-from-zero.
+static int ref_q4(int x) {
+    int q = (x >= 0 ? (x + 8) : (x - 8)) / 16;
+    if (q > 7) q = 7;
+    if (q < -8) q = -8;
+    return q;
+}
+
+int main() {
+    // 1+2. Exhaustive roundtrip + bit layout. Pair each x with itself so no
+    // -x overflow (int8 min); layout is per-nibble so a same-value pair
+    // exercises both nibbles.
+    int8_t buf[2];
+    for (int x = -128; x <= 127; x++) {
+        int8_t in[2] = {(int8_t)x, (int8_t)x};
+        uint8_t packed;
+        pack_i8_to_i4(in, 2, &packed);
+        // bit layout: in[0] (even) = low nibble, in[1] (odd) = high nibble
+        int lo = packed & 0x0F, hi = (packed >> 4) & 0x0F;
+        CHECK(lo == (ref_q4(x) & 0x0F), "low nibble = even element code");
+        CHECK(hi == (ref_q4(x) & 0x0F), "high nibble = odd element code");
+        int8_t out[2];
+        unpack_i4_to_i8(&packed, 2, out);
+        int expect = ref_q4(x) << 4;
+        CHECK(out[0] == (int8_t)expect, "unpack even = signext<<4");
+        CHECK(out[1] == (int8_t)expect, "unpack odd = signext<<4");
+        // roundtrip is EXACTLY the clamped 4-bit grid value; the max |out-x|
+        // is 15 (x=127 → code 7 → 112), not 8 — the clamp at the top of the
+        // int8 range is part of the quantization, not the pack.
+        CHECK((int)out[0] == expect, "roundtrip exact on the 4-bit grid");
+        CHECK(std::abs((int)out[0] - x) <= 15, "roundtrip within 1 nibble step + clamp");
+    }
+
+    // 3. Float-reference roundtrip with folded scale.
+    const int N = 4096;
+    std::srand(12345);
+    float w[4096];
+    float amax = 0.0f;
+    for (int i = 0; i < N; i++) {
+        w[i] = (float)(std::rand() % 20001 - 10000) / 1000.0f;  // [-10, 10]
+        if (std::fabs(w[i]) > amax) amax = std::fabs(w[i]);
+    }
+    float scale = amax / 127.0f;                     // Q4NX-style symmetric
+    int8_t i8[4096], i8rt[4096];
+    for (int i = 0; i < N; i++) {
+        int q = (int)std::lround(w[i] / scale);
+        if (q > 127) q = 127; else if (q < -127) q = -127;
+        i8[i] = (int8_t)q;
+    }
+    uint8_t packed[2048];
+    pack_i8_to_i4(i8, N, packed);
+    unpack_i4_to_i8(packed, N, i8rt);
+    float worst = 0.0f;
+    for (int i = 0; i < N; i++) {
+        float ref_f  = (float)i8[i]  * scale;   // int8-quantized float
+        float rt_f   = (float)i8rt[i] * scale;  // int4-roundtripped (×16 folded)
+        float err = std::fabs(ref_f - rt_f);
+        if (err > worst) worst = err;
+    }
+    // 4-bit step on the quantized grid = 8 int8 LSBs = 8*scale; with the
+    // clamp at the top of the int8 range the worst error is 15 LSBs = 15*scale
+    // (x=127 → code 7 → 112). Check ≤ 16*scale for margin.
+    CHECK(worst <= 16.0f * scale, "float ref within one 4-bit step (+clamp)");
+
+    // 4. Determinism.
+    uint8_t p2[2048];
+    pack_i8_to_i4(i8, N, p2);
+    int same = 1;
+    for (int i = 0; i < 2048; i++) if (p2[i] != packed[i]) { same = 0; break; }
+    CHECK(same, "pack is deterministic");
+
+    if (failures == 0) { printf("i4 pack contract OK (exhaustive int8, float gate)\n"); return 0; }
+    fprintf(stderr, "%d failures\n", failures);
+    return 1;
+}


### PR DESCRIPTION
### **User description**
CPU-tested **Phase-1 foundation** of the #1769 plan (full plan on the issue): the pack/unpack primitive that halves the fused-decode weight DMA (~12.6 MB → ~6.3 MB/layer, ~30 ms/tok).

**i4_pack.h** — dual-compiled (AIE kernel + x86 reference, silu_quant.h discipline, no libm):
- Symmetric two's-complement int4, q ∈ [-8, 7]
- Nibble pairs along the mmul innermost (col-in-8) axis; even element = low nibble
- q4 = clamp(round(x/16), -8, 7); unpack = sign-extend(nibble)<<4 with the **×16 folded into the existing per-column scales** — zero extra metadata, byte-identical pipeline

**test_i4_pack.cpp** — contract gate (g++-buildable, no xrt): exhaustive int8 roundtrip (exact on the 4-bit grid, |err|≤15 incl. top-of-range clamp), bit layout, Q4NX-style float-reference gate (≤16·scale), pack determinism. **Verified under ASan+UBSan.**

The in-kernel dequant stage (mm_kernel_reference.cc + n1_core_fused_gu_silu_d.py), the host B-tile packer, and the build_zaya_fused.sh #1777 signature updates (B-tile stride 8192→4096) are the hardware round — they land on the fused path (feat/npu-zaya-decode-perf, PR #1771) and need the aiecc/NPU2 loop on strixhalo.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add Q4NX-style symmetric int4 pack/unpack in `i4_pack.h`.

- Halve fused-decode weight DMA (~12.6 MB → ~6.3 MB/layer).

- Fold ×16 scale into existing per-column scales, zero metadata.

- Add CPU contract tests: exhaustive roundtrip, layout, float gate, determinism.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["int8 weights"] -- "pack_i8_to_i4" --> B["int4 bytes (n/2)"]
  B -- "unpack_i4_to_i8 (×16 folded)" --> C["int8 values for kernel"]
  C -- "test_i4_pack.cpp gate" --> D["exhaustive roundtrip / layout"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>i4_pack.h</strong><dd><code>Implement symmetric int4 pack/unpack header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/i4_pack.h

<ul><li>Add <code>pack_i8_to_i4</code> / <code>unpack_i4_to_i8</code> inline functions.<br> <li> Symmetric two's-complement int4 codes, q ∈ [-8, 7].<br> <li> Nibble pairs along innermost axis, even element in low nibble.<br> <li> No libm/AIE intrinsics; dual-compiled for AIE kernel and x86 <br>reference.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1793/files#diff-fc7197267160dd750ed8ec803cf194aa9985b3b699b59fe5ba5d574b8c6eff80">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_i4_pack.cpp</strong><dd><code>Add exhaustive int4 pack contract tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tests/test_i4_pack.cpp

<ul><li>New standalone CPU contract gate for <code>i4_pack.h</code>.<br> <li> Exhaustive int8 roundtrip plus bit-layout checks.<br> <li> Q4NX-style float-reference roundtrip within one 4-bit step.<br> <li> Determinism check; buildable with g++ (no xrt).</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1793/files#diff-bbdffe0e03bfa7ecb1af87c5a7f53ffeeb1f8b886bcc58f57eb3ceb5b90814f7">+106/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

