### PR TITLE
community: version Fluxer ops scripts

### DIFF
--- a/.github/workflows/scope-guard.yml
+++ b/.github/workflows/scope-guard.yml
@@ -70,6 +70,7 @@ jobs:
             .abacusai .claude  # agent-tooling files removed from repo (2026-08) — removal-only, machine-local agent config + GitNexus skill docs
             .nojekyll CNAME apple-touch-icon.png assets favicon.ico favicon.svg
             index.html site.webmanifest  # 1bit.monster landing page, served via GitHub Pages from repo root — public-facing site scope
+            community  # Fluxer community ops scripts (Discord #support + role theming) — 1bit.MONSTER community operations, product-adjacent ops tooling (see PR #1797)
           '
 
           CHANGED="$(git diff --name-only "$BASE" "$HEAD" | sed 's#/.*##' | sort -u)"

--- a/community/fluxer/README.md
+++ b/community/fluxer/README.md
@@ -1,0 +1,31 @@
+# Fluxer community ops
+
+Idempotent scripts for managing the official `1bit.MONSTER` Fluxer community
+(`1540334785874886656`, invite `https://fluxer.gg/USDRI0qz`).
+
+They read all config from the environment or `./.env`. **Commit nothing secret** —
+`.env` is gitignored; set `FLUXER_TOKEN`, `FLUXER_TOKEN_TYPE`, `FLUXER_API_BASE_URL`,
+and `FLUXER_HOME_GUILD_ID` locally. These scripts never need the token in git.
+
+## Scripts
+
+`add-support-channel.mjs`
+: Create the `#support` channel (idempotent) under the Text Channels category and
+  seed a one-time welcome message. `--fresh` recreates the channel.
+
+```bash
+node add-support-channel.mjs            # create + seed (no-op if present)
+node add-support-channel.mjs --fresh    # delete + recreate
+```
+
+`theme-roles.mjs`
+: Apply the site brand palette to the guild roles — Admin `#1779e1`, Moderator
+  `#008048`, everyone `#0e1217`. Dry-run by default.
+
+```bash
+node theme-roles.mjs                    # dry run (prints what it would do)
+node theme-roles.mjs --apply            # write the colors
+```
+
+Both reuse the same `.env` precedence as `fluxer-mcp` (env var, then `./.env`),
+so the token is never passed on the command line or committed to git.

--- a/community/fluxer/add-support-channel.mjs
+++ b/community/fluxer/add-support-channel.mjs
@@ -70,14 +70,17 @@ async function api(method, path, body) {
     try { data = JSON.parse(text); } catch { data = text; }
   }
   if (!res.ok) {
-    throw new Error(`${method} ${path} -> HTTP ${res.status}: ${JSON.stringify(data)}`);
+    // Never embed the token or IDs in errors: log method + status + a short
+    // response snippet only (the request path can carry env-derived IDs).
+    const snippet = String(data ?? '').replace(/\s+/g, ' ').slice(0, 200);
+    throw new Error(`${method} -> HTTP ${res.status}: ${snippet}`);
   }
   return data;
 }
 
 async function main() {
   const fresh = process.argv.includes('--fresh');
-  console.log(`Preparing #${SUPPORT_NAME} in guild ${GUILD_ID} ...`);
+  console.log(`Preparing #${SUPPORT_NAME} ...`);
 
   const channels = await api('GET', `/guilds/${GUILD_ID}/channels`);
   let support = channels.find((c) => c.name.toLowerCase() === SUPPORT_NAME && c.type === 0);
@@ -109,7 +112,7 @@ async function main() {
     console.log(`• channel already has messages; not re-seeding`);
   }
 
-  console.log(`\nDone. #${SUPPORT_NAME} is ready in guild ${GUILD_ID}.`);
+  console.log(`\nDone. #${SUPPORT_NAME} is ready.`);
 }
 
 main().catch((e) => {

--- a/community/fluxer/add-support-channel.mjs
+++ b/community/fluxer/add-support-channel.mjs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+//
+// Adds the official 1bit.MONSTER #support channel (idempotent) and seeds a
+// short welcome message. Reuses fluxer-mcp's own .env config loader so the
+// token never has to be passed on the command line or printed.
+//
+// Usage:
+//   node scripts/add-support-channel.mjs
+//   node scripts/add-support-channel.mjs --fresh   # delete + recreate instead of reuse
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ── config (same .env precedence as dist/config.js) ─────────────────────────
+const ENV = { ...process.env };
+if (!ENV.FLUXER_TOKEN) {
+  for (const file of ['.env', resolve(process.cwd(), '.env'), resolve(import.meta.dirname, '..', '.env')]) {
+    if (!existsSync(file)) continue;
+    for (const line of readFileSync(file, 'utf8').split('\n')) {
+      const t = line.trim();
+      if (!t || t.startsWith('#')) continue;
+      const eq = t.indexOf('=');
+      if (eq === -1) continue;
+      const k = t.slice(0, eq).trim();
+      const v = t.slice(eq + 1).trim().replace(/^["']|["']$/g, '');
+      if (k && !(k in ENV)) ENV[k] = v;
+    }
+  }
+}
+
+const TOKEN = ENV.FLUXER_TOKEN;
+const TOKEN_TYPE = ENV.FLUXER_TOKEN_TYPE ?? 'session';
+const BASE = (ENV.FLUXER_API_BASE_URL ?? 'https://api.fluxer.app/v1').replace(/\/+$/, '');
+
+// The 1bit.MONSTER guild + its Text Channels category (from the okf reference).
+const GUILD_ID = ENV.FLUXER_HOME_GUILD_ID ?? '1540334785874886656';
+const TEXT_CATEGORY_ID = '1540334785874886657';
+const SUPPORT_NAME = 'support';
+const SUPPORT_TOPIC = 'Official 1bit.MONSTER support. Ask here, get answers from the engine team.';
+
+const WELCOME =
+  'Welcome to 1bit.MONSTER support. One engine, any model, zero Python.\n' +
+  'Post a question and an engineer (or a bot) will pick it up. Before you ask:\n' +
+  '• Check the docs: https://1bit.monster/docs\n' +
+  '• Known issue numbers: https://github.com/1bit-MONSTER/1bit-MONSTER/issues\n' +
+  'Great first message = what you ran, what you expected, what happened.';
+
+if (!TOKEN) {
+  console.error('FLUXER_TOKEN is required (set it in .env or the environment).');
+  process.exit(1);
+}
+
+const AUTH =
+  TOKEN_TYPE === 'bot' ? `Bot ${TOKEN}` : TOKEN_TYPE === 'bearer' ? `Bearer ${TOKEN}` : TOKEN;
+
+async function api(method, path, body) {
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: AUTH,
+      'Content-Type': 'application/json',
+      'User-Agent': 'fluxer-add-support',
+      Accept: 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  let data = null;
+  if (text) {
+    try { data = JSON.parse(text); } catch { data = text; }
+  }
+  if (!res.ok) {
+    throw new Error(`${method} ${path} -> HTTP ${res.status}: ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+async function main() {
+  const fresh = process.argv.includes('--fresh');
+  console.log(`Preparing #${SUPPORT_NAME} in guild ${GUILD_ID} ...`);
+
+  const channels = await api('GET', `/guilds/${GUILD_ID}/channels`);
+  let support = channels.find((c) => c.name.toLowerCase() === SUPPORT_NAME && c.type === 0);
+
+  if (support && fresh) {
+    await api('DELETE', `/channels/${support.id}`);
+    support = undefined;
+    console.log(`• deleted existing #${SUPPORT_NAME}`);
+  }
+
+  if (!support) {
+    support = await api('POST', `/guilds/${GUILD_ID}/channels`, {
+      name: SUPPORT_NAME,
+      type: 0,
+      topic: SUPPORT_TOPIC,
+      parent_id: TEXT_CATEGORY_ID,
+    });
+    console.log(`✔ created #${SUPPORT_NAME} (${support.id})`);
+  } else {
+    console.log(`• channel #${SUPPORT_NAME} already exists (${support.id})`);
+  }
+
+  // Seed a welcome message; skip if we'd be adding to an existing populated thread.
+  const messages = await api('GET', `/channels/${support.id}/messages?limit=4`);
+  if (!Array.isArray(messages) || messages.length === 0) {
+    await api('POST', `/channels/${support.id}/messages`, { content: WELCOME });
+    console.log(`✔ seeded welcome message`);
+  } else {
+    console.log(`• channel already has messages; not re-seeding`);
+  }
+
+  console.log(`\nDone. #${SUPPORT_NAME} is ready in guild ${GUILD_ID}.`);
+}
+
+main().catch((e) => {
+  console.error('Failed:', e.message);
+  process.exit(1);
+});

--- a/community/fluxer/theme-roles.mjs
+++ b/community/fluxer/theme-roles.mjs
@@ -1,0 +1,69 @@
+// Applies the site brand palette to the 1bit.MONSTER guild roles via Fluxer.
+// Dry-run by default: pass `--apply` to actually PATCH.
+//   node scripts/theme-roles.mjs            # dry run (prints what it would do)
+//   node scripts/theme-roles.mjs --apply    # write the colors
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ENV = { ...process.env };
+if (!ENV.FLUXER_TOKEN) {
+  for (const file of ['.env', resolve(process.cwd(), '.env'), resolve(import.meta.dirname, '..', '.env')]) {
+    if (!existsSync(file)) continue;
+    for (const line of readFileSync(file, 'utf8').split('\n')) {
+      const t = line.trim();
+      if (!t || t.startsWith('#')) continue;
+      const eq = t.indexOf('=');
+      if (eq === -1) continue;
+      const k = t.slice(0, eq).trim();
+      const v = t.slice(eq + 1).trim().replace(/^["']|["']$/g, '');
+      if (k && !(k in ENV)) ENV[k] = v;
+    }
+  }
+}
+const TOKEN = ENV.FLUXER_TOKEN;
+const TOKEN_TYPE = ENV.FLUXER_TOKEN_TYPE ?? 'session';
+const BASE = (ENV.FLUXER_API_BASE_URL ?? 'https://api.fluxer.app/v1').replace(/\/+$/, '');
+const GUILD_ID = ENV.FLUXER_HOME_GUILD_ID ?? '1540334785874886656';
+if (!TOKEN) { console.error('FLUXER_TOKEN required'); process.exit(1); }
+const AUTH = TOKEN_TYPE === 'bot' ? `Bot ${TOKEN}` : TOKEN_TYPE === 'bearer' ? `Bearer ${TOKEN}` : TOKEN;
+
+const apply = process.argv.includes('--apply');
+
+async function api(method, path, body) {
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers: { Authorization: AUTH, 'Content-Type': 'application/json', Accept: 'application/json', 'User-Agent': 'fluxer-theme-roles' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  let data = null;
+  if (text) { try { data = JSON.parse(text); } catch { data = text; } }
+  if (!res.ok) throw new Error(`${method} ${path} -> HTTP ${res.status}: ${JSON.stringify(data)}`);
+  return data;
+}
+
+// Site palette (hex -> Fluxer int). accent & status from the locked oklch tokens.
+const PALETTE = {
+  'Admin':       { color: 0x1779e1, label: 'accent blue #1779e1' },  // --accent
+  'Moderator':   { color: 0x008048, label: 'status green #008048' },  // --status
+  '@everyone':   { color: 0x0e1217, label: 'ink #0e1217' },           // --fg
+};
+
+const roles = await api('GET', `/guilds/${GUILD_ID}/roles`);
+let changed = 0;
+for (const { id, name, color } of roles) {
+  const target = PALETTE[name];
+  if (!target) continue;
+  if ((color ?? 0) === target.color) {
+    console.log(`• ${name} already ${target.label}`);
+    continue;
+  }
+  if (!apply) {
+    console.log(`dry-run: would set ${name} -> ${target.label} (was color=${color ?? 0})`);
+    continue;
+  }
+  await api('PATCH', `/guilds/${GUILD_ID}/roles/${id}`, { color: target.color });
+  console.log(`✔ ${name} -> ${target.label}`);
+  changed++;
+}
+console.log(apply ? `\nApplied ${changed} role color(s).` : `\nDry run only. Run with --apply to write.`);


### PR DESCRIPTION
### **User description**
Adds idempotent support-channel + role-theme scripts for the 1bit.MONSTER Fluxer community. Config via env or ./.env (gitignored); no secrets committed.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add idempotent Fluxer community ops scripts for 1bit.MONSTER

- Create `#support` channel with welcome message via `add-support-channel.mjs`

- Apply brand role colors via `theme-roles.mjs` with dry-run default

- Document usage and `.env` config in `community/fluxer/README.md`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["community/fluxer scripts"] --> B["add-support-channel.mjs"]
  A --> C["theme-roles.mjs"]
  B --> D["Create #support channel"]
  B --> E["Seed welcome message"]
  C --> F["Apply role colors"]
  F --> G["dry-run / --apply"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document Fluxer ops scripts usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

community/fluxer/README.md

<ul><li>Documents both ops scripts and their CLI flags<br> <li> Explains idempotency and <code>--fresh</code> / <code>--apply</code> behavior<br> <li> Describes <code>.env</code> config precedence and secret handling</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1797/files#diff-a76e7e8ff6a6ae14780bbcbb33ab2d791bde0895639797e74c549e5cc437c3c2">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>add-support-channel.mjs</strong><dd><code>Add idempotent support channel script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

community/fluxer/add-support-channel.mjs

<ul><li>Adds idempotent <code>#support</code> channel creation under Text Channels category<br> <li> Supports <code>--fresh</code> to delete and recreate the channel<br> <li> Seeds a welcome message only if channel is empty<br> <li> Loads config from env or <code>.env</code> with same precedence as <code>fluxer-mcp</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1797/files#diff-c10dcdc87346f2767431bb8cc9b4be63babf7f17ece32cb688048d359ad36fdd">+118/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>theme-roles.mjs</strong><dd><code>Add role theme script with dry-run</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

community/fluxer/theme-roles.mjs

<ul><li>Applies brand palette colors to Admin, Moderator, and @everyone roles<br> <li> Dry-run by default; <code>--apply</code> writes role colors via PATCH<br> <li> Reuses shared env/token loading pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1797/files#diff-02ed1b360f921071d73c8e7e399fd76a0fe36ea9a71654f9025714f88754388b">+69/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

