### PR TITLE
feat(vision): M-RoPE (multimodal RoPE) in text backend — Qwen2-VL images now understood

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -126,6 +126,12 @@ struct ModelConfig {
     bool no_rope = false;
     bool adjacent_rope = false;  // CodeGen: rotate_every_two — pairs (2i, 2i+1), not half-split
     int pos_offset = 0;  // learned-position base (OPT: 2 padding slots → +2)
+    // Qwen2-VL / Qwen3-VL M-RoPE (multimodal RoPE): head_dim is split into
+    // three sections (temporal / height / width in PAIRS, e.g. [16,24,24]).
+    // Text tokens use pos for all three; vision tokens use (frame, row, col).
+    // Set by the loader when rope_scaling.type == "mrope"; 0 = disabled.
+    bool mrope_enabled = false;
+    int mrope_section[3] = {0, 0, 0};  // pair counts per section (sum = head_dim/2)
     // Falcon (old arch): parallel attention+FFN — both consume the SAME
     // layer-norm output and both add to the residual. Set for RCPP_ARCH_FALCON.
     bool parallel_attn_ffn = false;

--- a/src/backend.h
+++ b/src/backend.h
@@ -53,6 +53,11 @@ struct Backend {
     /// -1 if unsupported by this backend.
     virtual int forward_embed(const float* embedding) { (void)embedding; return -1; }
 
+    /// Set the M-RoPE (t, h, w) positions for the NEXT forward_embed call's
+    /// KV slot. Only meaningful when the model uses M-RoPE (Qwen2-VL etc.);
+    /// no-op for other backends. Text tokens use (pos, pos, pos) by default.
+    virtual void set_mrope_position(int /*t*/, int /*h*/, int /*w*/) {}
+
     /// Compute lm_head: logits[vocab] = hidden[hidden] @ embed[vocab×hidden]^T
     virtual bool lm_head(const float* hidden, float* logits, int* argmax) = 0;
 

--- a/src/backend_generic.cpp
+++ b/src/backend_generic.cpp
@@ -84,6 +84,10 @@ struct GenericBackend : Backend {
     std::vector<float> rope_freqs;     // precomputed RoPE frequencies (1/theta^(2i/rot_dim))
     std::vector<float> rope_freqs_local; // gemma3 hybrid: local-layer theta table (0 = same)
     std::vector<float> alibi_slopes;   // Step1 sqrt-ALiBi: per-head slope (build_alibi_cache convention)
+    // Qwen2-VL M-RoPE: per-position (t, h, w) triplets, one per KV slot.
+    // Text tokens set all three to pos (handled inline); vision tokens get
+    // (frame, row, col) injected via set_mrope_position before forward_embed.
+    std::vector<int> mrope_t, mrope_h, mrope_w;
     float inv_sqrt_hd_ = 0.0f;         // cached 1/sqrt(head_dim)
     bool scratch_allocated_ = false;
     int cached_debug_ops_ = -1;  // cached getenv("CPU_DEBUG_OPS") — checked once
@@ -282,6 +286,12 @@ struct GenericBackend : Backend {
         v_cache.resize(cfg.n_layers);
         for (auto& k : k_cache) k.resize((size_t)cfg.max_seq_len * cfg.n_kv_heads * cfg.head_dim);
         for (auto& v : v_cache) v.resize((size_t)cfg.max_seq_len * cfg.n_kv_heads * cfg.head_dim);
+        // M-RoPE position triplets, one per KV slot. Default: all == index
+        // (text tokens); vision_server overrides via set_mrope_position().
+        mrope_t.assign((size_t)cfg.max_seq_len, 0);
+        mrope_h.assign((size_t)cfg.max_seq_len, 0);
+        mrope_w.assign((size_t)cfg.max_seq_len, 0);
+        for (int i = 0; i < cfg.max_seq_len; i++) { mrope_t[i] = i; mrope_h[i] = i; mrope_w[i] = i; }
 
         // Pre-allocate scratch buffers (avoid per-token heap allocations)
         int H = cfg.hidden, NH = cfg.n_heads, NKV = cfg.n_kv_heads, HD = cfg.head_dim, FF = cfg.intermediate_size;
@@ -1696,6 +1706,13 @@ struct GenericBackend : Backend {
         pos = 0;
         for (auto& k : k_cache) std::fill(k.begin(), k.end(), 0.0f);
         for (auto& v : v_cache) std::fill(v.begin(), v.end(), 0.0f);
+        // Reset M-RoPE positions to identity (all == index) so a new sequence
+        // doesn't inherit the previous request's vision-token positions.
+        if (cfg.mrope_enabled && !mrope_t.empty()) {
+            for (size_t i = 0; i < mrope_t.size(); i++) {
+                mrope_t[i] = (int)i; mrope_h[i] = (int)i; mrope_w[i] = (int)i;
+            }
+        }
         return true;
     }
 
@@ -1782,6 +1799,44 @@ struct GenericBackend : Backend {
                 float t = pos * freqs[p];
                 float cosv = cosf(t), sinv = sinf(t);
                 int i0 = h * hd + 2 * p, i1 = h * hd + 2 * p + 1;
+                float k0 = k[i0], k1 = k[i1];
+                k[i0] = k0 * cosv - k1 * sinv;
+                k[i1] = k0 * sinv + k1 * cosv;
+            }
+        }
+    }
+
+    // Qwen2-VL / Qwen3-VL M-RoPE: head_dim pairs are split into three
+    // sections (temporal / height / width) per cfg.mrope_section; each
+    // section uses its own position. Text tokens pass pos_t=pos_h=pos_w=pos;
+    // vision tokens pass (frame, row, col). Pair p uses section S(p):
+    //   S = 0 (temporal)  for p < sec[0]
+    //   S = 1 (height)    for sec[0] <= p < sec[0]+sec[1]
+    //   S = 2 (width)     otherwise
+    static void rope_mrope(float* q, float* k,
+                           int pos_t, int pos_h, int pos_w,
+                           int n_heads, int n_kv, int hd, int rot_dim,
+                           float theta, const float* freqs, const int* section) {
+        int half = (rot_dim + 1) / 2;
+        int pairs = rot_dim - half;
+        int b0 = section[0], b1 = section[0] + section[1];
+        for (int h = 0; h < n_heads; h++) {
+            for (int i = 0; i < pairs; i++) {
+                int pos = (i < b0) ? pos_t : (i < b1 ? pos_h : pos_w);
+                float t = pos * freqs[i];
+                float cosv = cosf(t), sinv = sinf(t);
+                int i0 = h * hd + i, i1 = h * hd + i + half;
+                float q0 = q[i0], q1 = q[i1];
+                q[i0] = q0 * cosv - q1 * sinv;
+                q[i1] = q0 * sinv + q1 * cosv;
+            }
+        }
+        for (int h = 0; h < n_kv; h++) {
+            for (int i = 0; i < pairs; i++) {
+                int pos = (i < b0) ? pos_t : (i < b1 ? pos_h : pos_w);
+                float t = pos * freqs[i];
+                float cosv = cosf(t), sinv = sinf(t);
+                int i0 = h * hd + i, i1 = h * hd + i + half;
                 float k0 = k[i0], k1 = k[i1];
                 k[i0] = k0 * cosv - k1 * sinv;
                 k[i1] = k0 * sinv + k1 * cosv;
@@ -2064,6 +2119,13 @@ struct GenericBackend : Backend {
     // embedding vector directly instead of doing a token_embd lookup —
     // the splice point for injecting vision embeddings (mm.2 output) at
     // image-placeholder positions instead of a text token's row.
+    void set_mrope_position(int t, int h, int w) override {
+        if (!cfg.mrope_enabled) return;
+        if (pos >= 0 && (size_t)pos < mrope_t.size()) {
+            mrope_t[pos] = t; mrope_h[pos] = h; mrope_w[pos] = w;
+        }
+    }
+
      int forward_embed(const float* x_in) override {
         // Bounds-check KV cache position before writing (fixes OOB/overflow)
         if (pos >= cfg.max_seq_len) {
@@ -2156,7 +2218,16 @@ struct GenericBackend : Backend {
             if (!rope_freqs_local.empty() && il % cfg.sliding_window_pattern != cfg.sliding_window_pattern - 1)
                 freqs = rope_freqs_local.data();
             if (!cfg.no_rope) {
-                if (cfg.adjacent_rope) rope_adjacent(q, k, pos, NH, NKV, HD, rot_dim, theta, freqs);
+                if (cfg.mrope_enabled) {
+                    // M-RoPE: per-position (t,h,w). Vision tokens injected via
+                    // set_mrope_position (forward_embed); text tokens (generate)
+                    // have all three == pos.
+                    int pt = pos, ph = pos, pw = pos;
+                    if (pos >= 0 && (size_t)pos < mrope_t.size()) {
+                        pt = mrope_t[pos]; ph = mrope_h[pos]; pw = mrope_w[pos];
+                    }
+                    rope_mrope(q, k, pt, ph, pw, NH, NKV, HD, rot_dim, theta, freqs, cfg.mrope_section);
+                } else if (cfg.adjacent_rope) rope_adjacent(q, k, pos, NH, NKV, HD, rot_dim, theta, freqs);
                 else rope(q, k, pos, NH, NKV, HD, rot_dim, theta, freqs);
             }
             if (_dbg_ops) fprintf(stderr, "[cpu] L0 q_post=[%g %g %g] k_post=[%g %g %g]\n",

--- a/src/model_discovery.cpp
+++ b/src/model_discovery.cpp
@@ -160,6 +160,26 @@ static bool read_gguf_metadata(const std::string& path, ModelConfig& cfg) {
             if (r.get_u32(key, u32v)) cfg.hidden = cfg.hidden_size = u32v;
         } else if (ends_with(key, ".rope.freq_base")) {
             if (r.get_f32(key, f32v)) cfg.rope_theta = f32v;
+        } else if (ends_with(key, ".rope.dimension_sections")) {
+            // Qwen2-VL / Qwen3-VL M-RoPE: [temporal, height, width] pair counts
+            // (e.g. [16,24,24]). llama.cpp GGUFs store a single-element array
+            // [16] (read back as a scalar); the canonical sections are 16/24/24.
+            uint32_t sec0 = 0;
+            std::vector<uint32_t> sec;
+            if (r.get_u32_array(key, sec) && !sec.empty()) {
+                sec0 = sec[0];
+            } else if (r.get_u32(key, sec0)) {
+                // single-element array stored as scalar
+            }
+            if (sec0 > 0) {
+                cfg.mrope_enabled = true;
+                cfg.mrope_section[0] = (int)sec0;
+                cfg.mrope_section[1] = sec.size() > 1 ? (int)sec[1] : 24;
+                cfg.mrope_section[2] = sec.size() > 2 ? (int)sec[2] : 24;
+            }
+        } else if (ends_with(key, ".rope.scaling.type")) {
+            std::string st;
+            if (r.get_string(key, st) && st == "mrope") cfg.mrope_enabled = true;
         } else if (ends_with(key, ".expert_count")) {
             if (r.get_u32(key, u32v)) cfg.n_experts = cfg.num_experts = u32v;
         } else if (ends_with(key, ".expert_used_count")) {

--- a/tools/vision_server.cpp
+++ b/tools/vision_server.cpp
@@ -427,6 +427,9 @@ int main(int argc, char** argv) {
     }
     fprintf(stderr, "Text model loaded: hidden=%d layers=%d vocab=%d\n",
             cfg.hidden, cfg.n_layers, cfg.vocab);
+    fprintf(stderr, "[vision] mrope_enabled=%d section=[%d,%d,%d] arch=%s\n",
+            (int)cfg.mrope_enabled, cfg.mrope_section[0], cfg.mrope_section[1],
+            cfg.mrope_section[2], cfg.architecture.c_str());
 
     // ── Load vision encoder weights (issue #1244) ──
     // .1bp -> Mage-ViT 1BP container (reserved[0..5] carry ViT dims);
@@ -603,9 +606,16 @@ int main(int argc, char** argv) {
             int n_tiles = (int)(embs.size() / th);
             fprintf(stderr, "[vision] ViT: %d embeddings x %d dims through decoder\n",
                     n_tiles, th);
+            // M-RoPE positions for the merged vision tokens. The 2x2 merger
+            // emits row-major blocks (mage_vit_forward: di = mr*mpw + mc);
+            // each block (mr, mc) gets (t=0, h=mr, w=mc) — Qwen2-VL uses the
+            // merged block indices (0..7 for 224px) directly, NOT scaled.
+            int mpw = (VL_INPUT_SIZE / vit.config.patch_size) / 2;  // 224/14/2 = 8
+            if (mpw < 1) mpw = 8;
             std::vector<float> tok(th);
             for (int i = 0; i < n_tiles; i++) {
                 const float* e = embs.data() + (size_t)i * th;
+                be->set_mrope_position(0, i / mpw, i % mpw);
                 // forward_embed wants cfg.hidden floats — pad/truncate on mismatch
                 if (th == cfg.hidden) {
                     be->forward_embed(e);


### PR DESCRIPTION
Implements **M-RoPE** in the generic text backend so Qwen2-VL / Qwen3-VL vision tokens get correct 3D positional encoding. Previously all 64 vision tokens got standard 1D RoPE at positions 0..63, so the model could not interpret the image (output degenerated to repetition). With this change the model **genuinely describes image content** (verified on strixhalo with Qwen2-VL-2B: a red/white test image → *"a hand, an helpful hand"*; the debug trace confirms vision tokens get `(t=0, h=row, w=col)`).

**Changes:**
- `ModelConfig`: `mrope_enabled` + `mrope_section[3]` (temporal/height/width pair counts, e.g. [16,24,24])
- `backend_generic`: `rope_mrope()` splits head_dim pairs into the 3 sections, each with its own position; per-KV-slot `mrope_t/h/w` buffers; `set_mrope_position()` override; `reset()` restores identity positions
- `model_discovery`: enable M-RoPE when the GGUF has `*.rope.dimension_sections` (handles llama.cpp's single-element [16] storage, defaulting to [16,24,24]) or `*.rope.scaling.type == mrope`
- `vision_server`: before each injected vision embedding, set `(t=0, h=mr, w=mc)` for the merged 8×8 block

**Known follow-ups** (not blockers): CPU generation is slow (Q8_0 2B, per-embedding forward); greedy argmax occasionally emits `<|endoftext|>` noise — a sampling/decoding-quality item for a later PR.