### PR TITLE
fix(npu): router EDA OOB heap read is the run-to-run nondeterminism (issue #1799, #1775)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -64,6 +64,7 @@ jobs:
           g++ -std=c++23 -O3 -march=native -fopenmp -ffast-math \
             -o engine/npu/build/npu_engine_v12 \
             engine/npu/src/npu_engine_universal.cpp engine/npu/build/dequant_q4nx.o \
+            engine/npu/src/zaya_decode.cpp \
             engine/npu/src/gemm_npu_instructions.cpp \
             npu-infer/src/flm_bridge.cpp \
             -Iengine/npu/include -Inpu-infer/include -Iinclude \

--- a/engine/npu/src/zaya_decode.cpp
+++ b/engine/npu/src/zaya_decode.cpp
@@ -181,7 +181,15 @@ int zaya_decode_main(int argc, char** argv) {
         snprintf(key, sizeof key, "model.layers.%d.mlp.gate.router_mlp.fc2.bias", l); GET(key, w.rw.rf2b);
         snprintf(key, sizeof key, "model.layers.%d.mlp.gate.router_mlp.out_proj.weight", l); GET(key, w.rw.rout);
         snprintf(key, sizeof key, "model.layers.%d.mlp.gate.balancing_biases", l); GET(key, w.rw.bb);
-        snprintf(key, sizeof key, "model.layers.%d.mlp.gate.router_states_scale", l); GET(key, w.rw.eda);
+        snprintf(key, sizeof key, "model.layers.%d.mlp.gate.router_states_scale", l);
+        { uint64_t o_, s_; if (get_offsets(js, jl, key, &o_, &s_)) {
+            // Issue #1799 root cause: the manifest declares this tensor as
+            // shape [1] (2 bytes) but the blob holds the full rtr_h=256
+            // per-channel EDA scale; the 2-byte load left the router's EDA
+            // loop reading OOB heap (run-to-run expert flips at layers 3+).
+            if (s_ == 2) s_ = (uint64_t)m.rtr_h * 2;
+            w.rw.eda = load_bf16(D, o_, s_);
+        } }
         snprintf(key, sizeof key, "model.layers.%d.mlp.experts.gate_up_proj.weight", l); GETI8(key, w.gu, (m.n_exp*2*m.n_ff/32)*(d.H/256), d.H);
         snprintf(key, sizeof key, "model.layers.%d.mlp.experts.down_proj.weight", l); GETI8(key, w.dn, (m.n_exp*d.H/32)*(m.n_ff/256), m.n_ff);
         #undef GET

--- a/engine/npu/src/zaya_moe_cpu.h
+++ b/engine/npu/src/zaya_moe_cpu.h
@@ -85,8 +85,18 @@ inline int router(const MoeDims& d, const RouterWeights& w,
         rs[i] = s;
     }
     // 2. EDA (recurrent, before norm): rs += prev_router * eda
-    if (!prev_router.empty())
-        for (int i = 0; i < rtr_h; i++) rs[i] += prev_router[i] * w.eda[i];
+    // Issue #1799 root cause: the q4nx manifest declares router_states_scale
+    // as shape [1] (2 bytes) although the blob holds the full rtr_h=256
+    // per-channel scale — a 2-byte load left w.eda with 1 element and this
+    // loop read OOB heap (run-to-run expert flips at layers 3+). Bound by the
+    // smallest of the three so a short eda can never read OOB; the load-side
+    // fix (load_eda_size correction in each caller) restores the full tensor.
+    if (!prev_router.empty() && !w.eda.empty()) {
+        int n = rtr_h;
+        if ((int)prev_router.size() < n) n = (int)prev_router.size();
+        if ((int)w.eda.size() < n) n = (int)w.eda.size();
+        for (int i = 0; i < n; i++) rs[i] += prev_router[i] * w.eda[i];
+    }
     prev_router = rs;  // store BEFORE norm
 
     // 3. RMSNorm

--- a/engine/npu/tools/zaya_cpu_runner.cpp
+++ b/engine/npu/tools/zaya_cpu_runner.cpp
@@ -176,7 +176,15 @@ int main(int argc, char** argv) {
         snprintf(key, sizeof key, "model.layers.%d.mlp.gate.router_mlp.fc2.bias", l); GET(key, w.rw.rf2b);
         snprintf(key, sizeof key, "model.layers.%d.mlp.gate.router_mlp.out_proj.weight", l); GET(key, w.rw.rout);
         snprintf(key, sizeof key, "model.layers.%d.mlp.gate.balancing_biases", l); GET(key, w.rw.bb);
-        snprintf(key, sizeof key, "model.layers.%d.mlp.gate.router_states_scale", l); GET(key, w.rw.eda);
+        snprintf(key, sizeof key, "model.layers.%d.mlp.gate.router_states_scale", l);
+        { uint64_t o_, s_; if (get_offsets(js, jl, key, &o_, &s_)) {
+            // Issue #1799 root cause: the manifest declares this tensor as
+            // shape [1] (2 bytes) but the blob holds the full rtr_h=256
+            // per-channel EDA scale; the 2-byte load left the router's EDA
+            // loop reading OOB heap (run-to-run expert flips at layers 3+).
+            if (s_ == 2) s_ = (uint64_t)m.rtr_h * 2;
+            w.rw.eda = load_bf16(D, o_, s_);
+        } }
         // experts. gate_up: [n_exp*2*n_ff, H]; down: [n_exp*H, n_ff].
         snprintf(key, sizeof key, "model.layers.%d.mlp.experts.gate_up_proj.weight", l); GETI8(key, w.gu, (m.n_exp*2*m.n_ff/32)*(d.H/256), d.H);
         snprintf(key, sizeof key, "model.layers.%d.mlp.experts.down_proj.weight", l); GETI8(key, w.dn, (m.n_exp*d.H/32)*(m.n_ff/256), m.n_ff);

--- a/engine/npu/tools/zaya_npu_runner.cpp
+++ b/engine/npu/tools/zaya_npu_runner.cpp
@@ -182,7 +182,15 @@ int main(int argc, char** argv) {
         snprintf(key, sizeof key, "model.layers.%d.mlp.gate.router_mlp.fc2.bias", l); GET(key, w.rw.rf2b);
         snprintf(key, sizeof key, "model.layers.%d.mlp.gate.router_mlp.out_proj.weight", l); GET(key, w.rw.rout);
         snprintf(key, sizeof key, "model.layers.%d.mlp.gate.balancing_biases", l); GET(key, w.rw.bb);
-        snprintf(key, sizeof key, "model.layers.%d.mlp.gate.router_states_scale", l); GET(key, w.rw.eda);
+        snprintf(key, sizeof key, "model.layers.%d.mlp.gate.router_states_scale", l);
+        { uint64_t o_, s_; if (get_offsets(js, jl, key, &o_, &s_)) {
+            // Issue #1799 root cause: the manifest declares this tensor as
+            // shape [1] (2 bytes) but the blob holds the full rtr_h=256
+            // per-channel EDA scale; the 2-byte load left the router's EDA
+            // loop reading OOB heap (run-to-run expert flips at layers 3+).
+            if (s_ == 2) s_ = (uint64_t)m.rtr_h * 2;
+            w.rw.eda = load_bf16(D, o_, s_);
+        } }
         snprintf(key, sizeof key, "model.layers.%d.mlp.experts.gate_up_proj.weight", l); GETI8(key, w.gu, (m.n_exp*2*m.n_ff/32)*(d.H/256), d.H);
         snprintf(key, sizeof key, "model.layers.%d.mlp.experts.down_proj.weight", l); GETI8(key, w.dn, (m.n_exp*d.H/32)*(m.n_ff/256), m.n_ff);
         #undef GET


### PR DESCRIPTION
### **User description**
## Summary

Fixes issue #1799 — and with it the layers-3+ run-to-run nondeterminism from #1775. **Root cause: a host-side heap-buffer-overflow in the router's EDA term, not the S2MM-writeback visibility race previously hypothesized.**

The q4nx manifest declares `mlp.gate.router_states_scale` as `shape [1]` (data_offsets span = 2 bytes), so `load_bf16` populated `w.rw.eda` with **1 element**. The router's EDA recurrence (`rs += prev_router * eda`, `rtr_h=256` iterations) then read `eda[1..255]` **out of bounds** on every MoE layer after L1. The heap bytes past the 4-byte allocation are sometimes sane-looking, sometimes garbage (−3.4e25, −inf) → the razor-thin L3 expert tie (gap ~5.7e-6) flips run-to-run. L1 is immune because `prev_router` is empty there (no EDA) — exactly why layer-1 output was bit-identical in every #1775 experiment.

The blob actually holds the full **256-value per-channel EDA scale** at the declared blob-relative offset (means ≈0.99, range [0.0996, 1.06], all finite, every layer) — the manifest size is simply wrong.

## How it was found (all evidence in #1799)

- `run_determinism_probe.sh` (on the decode-perf branch, #1804): 19 controlled runs with xrt-smi/dmesg/load telemetry — discrete token outcomes, **zero** health issues at any load → firmware-degradation hypothesis disproven.
- `NPU_DBG_FP=1` fingerprints: L1 bit-identical every run; first divergence at **L3's router expert** with L0–L2 `h` and the router residual bit-identical.
- `[fp-r]` dumps: `prev_router[2]` = −3.4e25 / +2.3e33 / −inf vs clean 0.300147 — a single garbage word in the EDA state.
- **ASan** (from #1787): `heap-buffer-overflow READ of size 4` at `zaya_moe_cpu.h:99` — the EDA loop — in every run.

## Changes

| File | Change |
|---|---|
| `engine/npu/src/zaya_moe_cpu.h` | Bound the EDA loop by `min(rtr_h, prev_router.size(), w.eda.size())` — no OOB read regardless of tensor shape |
| `engine/npu/tools/zaya_npu_runner.cpp` | Load the full `rtr_h*2`-byte tensor when the manifest says 2 bytes |
| `engine/npu/src/zaya_decode.cpp` | Same loader fix |
| `engine/npu/tools/zaya_cpu_runner.cpp` | Same loader fix |

(`test_fused_silu.cpp` gets the identical fix when the decode-perf branch lands, tracked by #1804.)

## Verification (strixhalo, real hardware, same model/prompt)

- **Main runner (this PR):** 3/3 runs → identical tokens `10239 62914` (was 4+ discrete outcomes).
- **Decode-perf runner:** 6/6 runs → identical tokens `177138 251882`, all fingerprints bit-identical.
- **ASan:** clean (was: abort every run).
- **CPU reference runner:** deterministic, now with correct EDA.
- L1 NPU corr unchanged (0.999568) — MoE math untouched.

## Follow-ups

- #1806's "cleared finding" that EDA had "no OOB, no UB" is corrected on the issue — the runner was never ASan'd (only the fused contract test was).
- The model file's manifest is malformed (2-byte span for a 512-byte tensor). Converter fix + model regeneration is the remaining workaround-eliminating follow-up — worth a dedicated issue.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix router EDA OOB read causing MoE nondeterminism (#1799)
  - Manifest declared `router_states_scale` as 2 bytes; EDA loop read heap OOB
  - Bound EDA recurrence and load full `rtr_h*2` tensor in all loaders
  - Verified 6/6 probe runs bit-identical, ASan clean

- Restyle merch generator to live 1-bit identity
  - Paper/ink/gray palette, Inter fonts, relay mark, new op helpers
  - Add 50 TOPS and LOCAL AI stickers plus `--stickers` flag

- Add sticker gallery HTML page
  - Lists 10 single designs and pack sheets with asset links


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MAN["manifest shape [1]"] --> LOAD["eda loaded as 2 bytes"]
  LOAD --> OOB["EDA loop reads heap OOB"]
  OOB --> FLIP["layers 3+ tokens flip"]
  FIX["bound loop + load full rtr_h*2"] -- "fixes" --> FLIP
  MERCH["merch generator"] --> PALETTE["restyle to 1-bit identity"]
  PALETTE --> GALLERY["new sticker gallery"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zaya_decode.cpp</strong><dd><code>Correct router EDA tensor size in decode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/zaya_decode.cpp

<ul><li>Replace direct <code>GET</code>/<code>load_bf16</code> with explicit offsets+size load for <br><code>router_states_scale</code><br> <li> Treat manifest size of 2 bytes as the full <code>rtr_h*2</code> EDA tensor<br> <li> Fixes the issue #1799 heap OOB read in decode paths</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1807/files#diff-03d765f3c907f9bbf3b9e72824d9f24105ec11666aacb7a9b57702d5254669ae">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zaya_cpu_runner.cpp</strong><dd><code>Load full EDA scale in CPU runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tools/zaya_cpu_runner.cpp

<ul><li>Apply the same <code>router_states_scale</code> size correction as the decode path<br> <li> Load full <code>rtr_h*2</code>-byte EDA tensor when manifest reports 2 bytes<br> <li> Keeps CPU reference runner deterministic and ASan clean</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1807/files#diff-82f9676c4542062db8b170457404c4e6b696d090dfdddbf6ccf94390a7a5a612">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zaya_npu_runner.cpp</strong><dd><code>Load full EDA scale in NPU runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tools/zaya_npu_runner.cpp

<ul><li>Apply the same <code>router_states_scale</code> size correction as the decode path<br> <li> Load full <code>rtr_h*2</code>-byte EDA tensor when manifest reports 2 bytes<br> <li> Fixes run-to-run MoE expert flips at layers 3+</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1807/files#diff-e851b1dd70bdec298e2f8866205621888aca3cb1f5db9b106ef1649bdc9c481a">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zaya_moe_cpu.h</strong><dd><code>Bound router EDA loop against short tensors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/zaya_moe_cpu.h

<ul><li>Bound the router EDA recurrence by <code>min(rtr_h, prev_router.size(), </code><br><code>w.eda.size())</code><br> <li> Skip EDA recurrence entirely when <code>w.eda</code> is empty<br> <li> Prevents OOB heap reads regardless of tensor shape</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1807/files#diff-d27455585cde047cf27cb0bee9971fb55f1c527378721d1c3109f43c412d4abd">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate_merch.py</strong><dd><code>Restyle merch generator to 1-bit identity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/merch/generate_merch.py

<ul><li>Restyle sticker designs from navy theme to live 1-bit identity palette <br>(paper/ink/gray, Inter)<br> <li> Add <code>arcpoly</code>/<code>dotring</code> ops and helpers <code>_tick_ring</code>, <code>_lockup</code>, <code>_roundel</code>, <br><code>_relay_mark</code><br> <li> Rework preview cards as soft dot-grid store tiles; add <code>--stickers</code> flag<br> <li> Add two new sticker designs: 50 TOPS and LOCAL AI</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1807/files#diff-a21f282b3abfcc1aca1db5181a9c16cd710d2da1d07e2178ff8a15938e484ec0">+260/-111</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sticker-gallery.html</strong><dd><code>Add sticker gallery HTML page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sticker-gallery.html

<ul><li>Add standalone sticker gallery page for the merch line<br> <li> Show 10 single sticker designs plus 3pack and mega pack cards<br> <li> Link each card to preview PNG, print-ready PNG, and SVG assets</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1807/files#diff-926057790a40e03f906da72207ad0e5c35c5821646f9a26e83513ad48c4b347f">+81/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

