### PR TITLE
fix(deploy): revert Cloudflare Pages project name to 1bit-systems

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy site --project-name=1bit-monster
+          command: pages deploy site --project-name=1bit-systems
 
   deploy-github-pages:
     runs-on: ubuntu-latest

--- a/site/wrangler.toml
+++ b/site/wrangler.toml
@@ -1,3 +1,3 @@
-name = "1bit-monster"
+name = "1bit-systems"
 compatibility_date = "2026-04-20"
 pages_build_output_dir = "."


### PR DESCRIPTION
#1810 renamed the repo-side deploy target to '1bit-monster', but the
actual Cloudflare Pages project is still '1bit-systems' — the rename
commit even warned not to merge until the Cloudflare project itself was
renamed and the 1bit.monster custom domain re-bound. As a result the
deploy job on main fails: 'The Pages project "1bit-monster" does not
exist.'

Revert both deploy.yml and site/wrangler.toml to 1bit-systems so deploys
go green against the live project. The full rename can be completed
later in the correct order: rename/create the Cloudflare project and
bind the custom domain first, then flip the repo back.
