### PR TITLE
chore(infra): one-off Cloudflare Pages rename helper workflow

### DIFF
--- a/.github/workflows/cf-project-rename.yml
+++ b/.github/workflows/cf-project-rename.yml
@@ -1,0 +1,99 @@
+name: CF pages rename (1bit-systems -> 1bit-monster)
+
+# One-off infra migration helper. Runs on dispatch; uses the repo's
+# CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID secrets. Modes:
+#   inspect        — read-only: whoami, project list, domain bindings
+#   create         — create the 1bit-monster Pages project (idempotent)
+#   migrate-domain — move 1bit.monster off 1bit-systems onto 1bit-monster
+#                    + first deploy of site/ to the new project (minimizes downtime)
+#   cleanup        — delete the old 1bit-systems project (requires confirm=YES)
+# Destructive steps require confirm=YES.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: inspect | create | migrate-domain | cleanup
+        required: true
+        default: inspect
+        type: choice
+        options: [inspect, create, migrate-domain, cleanup]
+      confirm:
+        description: 'type YES to allow destructive steps'
+        required: true
+        default: 'NO'
+        type: string
+
+env:
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+  OLD: 1bit-systems
+  NEW: 1bit-monster
+  DOMAIN: 1bit.monster
+
+jobs:
+  cf:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: main
+      - name: Install wrangler
+        run: npm i -g wrangler@4.125.0
+      - name: whoami
+        run: wrangler whoami
+
+      - name: Inspect
+        if: ${{ github.event.inputs.mode == 'inspect' }}
+        run: |
+          echo "== projects =="
+          wrangler pages project list
+          echo "== old project domains =="
+          curl -fsS -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$OLD/domains" \
+            | python3 -m json.tool
+          echo "== zone / DNS record for $DOMAIN =="
+          ZONE_ID=$(curl -fsS -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/zones?name=$DOMAIN" | python3 -c 'import json,sys; print(json.load(sys.stdin)["result"][0]["id"])')
+          curl -fsS -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records" \
+            | python3 -c 'import json,sys; [print(r["type"], r["name"], "->", r["content"], "proxied:", r["proxied"]) for r in json.load(sys.stdin)["result"]]'
+
+      - name: Create new project
+        if: ${{ github.event.inputs.mode == 'create' }}
+        run: wrangler pages project create "$NEW" --production-branch main
+
+      - name: Migrate custom domain + first deploy
+        if: ${{ github.event.inputs.mode == 'migrate-domain' }}
+        run: |
+          set -euo pipefail
+          [ "${{ github.event.inputs.confirm }}" = "YES" ] || { echo "abort: confirm=YES required"; exit 1; }
+          echo "== before: old project domains =="
+          curl -fsS -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$OLD/domains" | python3 -m json.tool
+          echo "== release domain from old project =="
+          curl -fsS -X DELETE -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$OLD/domains/$DOMAIN" | python3 -m json.tool
+          echo "== bind domain to new project =="
+          curl -fsS -X POST -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" -H "Content-Type: application/json" \
+            -d "{\"name\":\"$DOMAIN\"}" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$NEW/domains" | python3 -m json.tool
+          echo "== first deploy of site/ to new project =="
+          wrangler pages deploy site --project-name="$NEW"
+          echo "== after: new project domains =="
+          curl -fsS -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$NEW/domains" | python3 -m json.tool
+
+      - name: Cleanup old project
+        if: ${{ github.event.inputs.mode == 'cleanup' }}
+        run: |
+          set -euo pipefail
+          [ "${{ github.event.inputs.confirm }}" = "YES" ] || { echo "abort: confirm=YES required"; exit 1; }
+          echo "== domains still on old project (should be empty) =="
+          curl -fsS -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$OLD/domains" | python3 -m json.tool
+          echo "== deleting old project =="
+          wrangler pages project delete "$OLD"


### PR DESCRIPTION
### **User description**
Dispatch-only tooling to migrate the Pages project 1bit-systems -> 1bit-monster (inspect/create/migrate-domain/cleanup modes, destructive steps gated on confirm=YES). Uses repo Cloudflare secrets. Remove after migration.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds one-off workflow to migrate CF Pages project

- Modes: inspect, create, migrate-domain, cleanup

- Destructive steps gated on confirm=YES input

- Uses repo Cloudflare secrets, remove after migration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Dispatch["workflow_dispatch"] --> Inspect["inspect: read-only"]
  Dispatch --> Create["create: new project"]
  Dispatch --> Migrate["migrate-domain: move domain + deploy"]
  Dispatch --> Cleanup["cleanup: delete old project"]
  Migrate --> Confirm["confirm=YES required"]
  Cleanup --> Confirm
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cf-project-rename.yml</strong><dd><code>Add CF Pages rename migration workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/cf-project-rename.yml

<ul><li>Adds dispatch-only workflow with mode input<br> <li> Implements inspect, create, migrate-domain, cleanup steps<br> <li> Destructive steps require confirm=YES input<br> <li> Uses Cloudflare API token and account ID secrets</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1812/files#diff-4311db2465225baf113a2c0b29b016474c6f1980d77d6c0b606425051db761ef">+99/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

