### PR TITLE
feat(npu): AIE2P int4 weight unpack for the fused decode path (issue #1769 hardware round)

### DIFF
--- a/engine/npu/generators/mm_kernel_reference.cc
+++ b/engine/npu/generators/mm_kernel_reference.cc
@@ -685,4 +685,33 @@ extern "C" void silu_quant_i8_fused(int32_t *c1, const float *gs, int8_t *h2) {
     for (unsigned i = DIM_N / 2; i < DIM_M * (DIM_N / 2); i++) h2[i] = 0;
 }
 
+// ---- int4 weight unpack (issue #1769, Phase-1 hardware round) ----
+// AIE2P-native unpack for nibble-paired B tiles (i4_pack.h contract): byte
+// s' = i0*512 + i1*32 + i2*4 + i3/2, EVEN element in the LOW nibble. The
+// vldb.unpack intrinsic loads 32 bytes as 64 sign-extended int4 (sign=1);
+// four vector adds double it x16 so the mmul consumes the SAME int8 values
+// the host reference unpacks (q4<<4, scale unchanged) — bit-identical C1,
+// zero contract drift. Cost: 1 unpack + 4 vector adds per 64 elements
+// (~7 instructions) vs the ~4 KB of DMA saved per (64,128) tile.
+//
+// VERIFIED on strixhalo with a minimal probe xclbin (2026-08-23): a known
+// packed pattern unpacks byte-exact (even=low nibble, sign-extended, x16),
+// and the fused-decode GU GEMM is bit-identical to the host int4 emulation
+// (corr 1.000000). The remaining #1769 blocker is NOT the unpack — it is
+// quantization accuracy: per-column int4 re-quantization of the Q4NX weights
+// (scale uniform over K=2048) caps the MoE-FFN corr at ~0.972 vs float
+// (int8 fused: 0.9995), flipping tokens. The fused kernel's C1 accumulator
+// sums over K with a single scale, so it cannot carry the Q4NX per-
+// (32-col,row) scales a 4-bit grid needs; a per-group-scale kernel
+// restructure would be required.
+extern "C" void unpack_i4_b(const int8_t *__restrict packed,
+                            int8_t *__restrict out, unsigned n_bytes) {
+    for (unsigned i = 0; i + 32 <= n_bytes; i += 32) {
+        const v64int4 *p = (const v64int4 *)(packed + i);
+        v64int8 u = __builtin_aie2p_unpack_I512_I8_I4(*p, 1);  // sign-extend nibbles
+        u = u + u; u = u + u; u = u + u; u = u + u;            // x16 (fold-free)
+        *((v64int8 *)(out + 2 * i)) = u;
+    }
+}
+
 } // extern "C"


### PR DESCRIPTION
### **User description**
Completes the #1793 Phase-1 hardware round: the in-kernel int4 dequant stage for the fused GU/SiLU/D decode path.

## What

`unpack_i4_b` in mm_kernel_reference.cc uses the AIE2P `vldb.unpack` intrinsic (byte-packed nibbles, sign=1) + 4 vector adds to produce the exact q4<<4 int8 values the host reference unpacks (i4_pack.h contract) — bit-identical C1, zero contract drift, ~7 instructions per 64 elements vs ~4 KB DMA saved per tile.

## Verified on strixhalo (NPU2, real zaya1-8b q4nx)

- Minimal probe xclbin: known packed pattern unpacks byte-exact (even=low nibble, sign-extended, x16).
- Fused-decode GU GEMM with int4-packed weights: NPU output bit-identical to the host int4 emulation (corr 1.000000).

## Finding — why the full #1769 decode is NOT landed

Per-column int4 re-quantization of the Q4NX weights (scale uniform over K=2048) caps the MoE-FFN corr at **0.972** vs float (int8 fused: 0.9995) — tokens flip. The fused kernel C1 accumulator sums over K with a single scale, so it cannot carry the Q4NX per-(32-col,row) scales a 4-bit grid needs. A per-group-scale kernel restructure (e.g. per-K-chunk accumulation or on-chip group dequant) would be required to land the full DMA halving; this PR lands the proven unpack stage as the foundation.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `unpack_i4_b` AIE2P int4 unpack for fused decode

- `vldb.unpack` plus four adds yield exact q4<<4 int8

- Matches `i4_pack.h` byte-exact, zero contract drift

- Verified on strixhalo; int4 decode blocked by quant


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Packed["packed int4 B tile bytes"] -- "vldb.unpack + x16" --> Unpack["unpack_i4_b"]
  Unpack -- "q4<<4 int8" --> Int8["int8 values"]
  Int8 -- "mmul" --> K["fused GU/SiLU/D mmul"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mm_kernel_reference.cc</strong><dd><code>Add AIE2P int4 unpack for fused decode kernel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/mm_kernel_reference.cc

<ul><li>Add <code>unpack_i4_b</code> AIE2P unpack for packed int4 B tiles<br> <li> Use <code>vldb.unpack</code> sign-extension plus four vector adds (×16)<br> <li> Emit q4<<4 int8 values matching host <code>i4_pack.h</code> contract<br> <li> Document strixhalo verification and #1769 quantization blocker</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1813/files#diff-bfbf7dfd57573c1b95ed14f18638a299a33c1fe23d883599c3517bf08c68ae30">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

