### PR TITLE
fix(npu): attention generator — A-frame layout, params source, writeback offsets (issue #1776)

### DIFF
--- a/engine/npu/generators/n1_core_attn.py
+++ b/engine/npu/generators/n1_core_attn.py
@@ -44,6 +44,7 @@ def main():
 def my_attn(M, K, N, m, k, n, n_aie_cols=8, BATCH_SIZE=2):
     dtype_in = np.int8
     dtype_out = np.int32
+    K_FRAME = 2048   # fused-style A-frame K (the small-K 4D tap fails on AIE2P)
     assert M % m == 0 and K % k == 0 and N % n == 0
     n_k = K // k            # QK^T K-chunks (hd/64 = 2)
     n_n = N // n            # QK^T N-tiles (MAX_SEQ/128 = 2)
@@ -121,11 +122,11 @@ def my_attn(M, K, N, m, k, n, n_aie_cols=8, BATCH_SIZE=2):
                     C2_c[c].release(ObjectFifoPort.Produce, 1)
 
         @runtime_sequence(
-            np.ndarray[(16 * K,), np.dtype[dtype_in]],       # q (bo0)
+            np.ndarray[(16 * K_FRAME,), np.dtype[dtype_in]],  # q (bo0, fused A-frame)
             np.ndarray[(nkv * K * N,), np.dtype[dtype_in]],  # K^T (bo1)
             np.ndarray[(M * K,), np.dtype[dtype_out]],       # C2 (bo2)
             np.ndarray[(nkv * N * K,), np.dtype[dtype_in]],  # V (bo3)
-            np.ndarray[(8 + M * N,), np.dtype[dtype_in]],    # scratch (bo4)
+            np.ndarray[(32 + n_aie_cols * M * N,), np.dtype[dtype_in]],  # scratch (bo4)
         )
         def seq(Q, KT, C2, V, SCR):
             # QK^T phase: per (ki, nt): A = q row c chunk ki (offset c*K+ki*k,
@@ -135,9 +136,12 @@ def my_attn(M, K, N, m, k, n, n_aie_cols=8, BATCH_SIZE=2):
                 for nt in range(n_n):
                     at_list, bt_list = [], []
                     for c in range(n_aie_cols):
+                        # A in the fused M×Kframe layout: K_frame=2048 (the
+                        # small-K 4D tap pattern does not deliver on AIE2P).
                         at = shim_dma_single_bd_task(
-                            A_s[c], Q, offset=c * K + ki * k,
-                            sizes=[1, k // 8, 8, 8], strides=[8 * K, 8, K, 1], issue_token=True)
+                            A_s[c], Q, offset=c * K_FRAME + ki * k,
+                            sizes=[1, k // 8, 8, 8], strides=[8 * K_FRAME, 8, K_FRAME, 1],
+                            issue_token=True)
                         dma_start_task(at); at_list.append(at)
                     for cc in range(n_aie_cols):
                         kvv = cc // 4
@@ -152,15 +156,17 @@ def my_attn(M, K, N, m, k, n, n_aie_cols=8, BATCH_SIZE=2):
             # tile — the floats in the first 32 bytes (A-layout row 0).
             pt_list = []
             for c in range(n_aie_cols):
-                pt = shim_dma_single_bd_task(A_s[c], SCR, offset=0,
-                                             sizes=[1, 1, 1, 64], strides=[1, 1, 1, 1],
+                # params ride the A stream from the q BO's padding (row 15
+                # of the A-frame — never read by the head taps).
+                pt = shim_dma_single_bd_task(A_s[c], Q, offset=15 * K_FRAME,
+                                             sizes=[1, 1, 1, 512], strides=[1, 1, 1, 1],
                                              issue_token=True)
                 dma_start_task(pt); pt_list.append(pt)
             # A2 writeback: core A2 (A-layout, r*N + (t/8)*8 + t%8) → bo4[64..]
             a2_list = []
             for c in range(n_aie_cols):
                 a2t = shim_dma_single_bd_task(
-                    A2o_s[c], SCR, offset=8 + c * (M * N // 8),
+                    A2o_s[c], SCR, offset=32 + c * (M * N),
                     sizes=[1, 1, 1, M * N], strides=[1, 1, 1, 1], issue_token=True)
                 dma_start_task(a2t); a2_list.append(a2t)
             # the PV reads the A2 back — the writebacks MUST be visible first.
@@ -171,7 +177,7 @@ def my_attn(M, K, N, m, k, n, n_aie_cols=8, BATCH_SIZE=2):
                 at_list, bt_list = [], []
                 for c in range(n_aie_cols):
                     at = shim_dma_single_bd_task(
-                        A_s[c], SCR, offset=8 + c * (M * N // 8) + ki * k,
+                        A_s[c], SCR, offset=32 + c * (M * N) + ki * k,
                         sizes=[1, k // 8, 8, 8], strides=[8 * N, 8, N, 1], issue_token=True)
                     dma_start_task(at); at_list.append(at)
                 for cc in range(n_aie_cols):


### PR DESCRIPTION
### **User description**
Hardware findings + fixes from the strixhalo bring-up (2026-08-23). Each item was isolated with a minimal probe xclbin on the real NPU:

## Fixes

1. **A-tap pattern**: the (8,64) 4D tap with K=128 strides (`[1024,8,128,1]`) does NOT deliver on the AIE2P shim; the fused-style K=2048 frame (`[16384,8,2048,1]`) does. The q BO is now laid out in the fused M×Kframe (each head at row·2048) and the A taps use the fused pattern.
2. **Params source**: the params rode the scratch region and overlapped the A2 writeback; they now live in the q BO padding (row 15 of the A-frame).
3. **A2 head stride**: was M·N//8=256 but each head is M·N=2048 bytes — writebacks overlapped. Fixed; the SCR is now 32 + NQ·M·N.
4. **Writebacks flat**: the 4D writeback pattern permutes the data (measured via probe); flat `[1,1,1,N]` + a linear readback is consistent.

## Open item (documented on #1776)

The multi-phase core (QK^T → params → softmax → A2O → PV → C2) still delivers **zero A/B fifo data to the QK^T mmul (C1 == 0)** while every individual pattern works in isolation (probe-verified). The next step is the multi-fifo core phase sequencing.


___

### **PR Type**
Bug fix


___

### **Description**
- Switch q A-taps to fused K=2048 A-frame layout (small-K 4D tap fails on AIE2P)

- Move attention params to q BO padding row 15 instead of scratch

- Fix A2 writeback head stride and scratch sizing (`M*N` per head)

- Update PV reads and flat writeback offsets for A2/C2 consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  QBO["q BO fused M×Kframe (K=2048)"] -- "A taps" --> QKT["QK^T mmul"]
  QBO -- "params row 15" --> ASTREAM["A stream"]
  ASTREAM --> QKT
  QKT -- "A2 writeback flat" --> SCR["scratch 32 + NQ*M*N"]
  SCR -- "PV reads" --> PV["PV phase"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>n1_core_attn.py</strong><dd><code>Fix NPU attention A-frame layout, params, and writeback offsets</code></dd></summary>
<hr>

engine/npu/generators/n1_core_attn.py

<ul><li>Introduced <code>K_FRAME = 2048</code> and switch q BO to fused M×Kframe layout, <br>with matching A-tap strides<br> <li> Relocated attention params to q BO padding (row 15) and enlarged the <br>params BD to 512 bytes<br> <li> Fixed A2 head stride from <code>M*N//8</code> to <code>M*N</code> and resized scratch to <code>32 + </code><br><code>n_aie_cols*M*N</code><br> <li> Updated PV-phase A2 read offsets to use the new <code>32 + c*M*N</code> base</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1819/files#diff-1038f0d1f2badc6c34c19aaa73daa63a6ef0c69a3f13b41189fb323868480ce8">+14/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

