### PR TITLE
feat(npu): host wiring for the fused int4 GU path (#1769)

### DIFF
--- a/engine/npu/src/gu_i4_pack.h
+++ b/engine/npu/src/gu_i4_pack.h
@@ -56,6 +56,20 @@ static inline uint16_t f32_to_bf16(float f) {
 //   raw   full gate_up tensor [n_exp*2*n_ff, H] raw (expert rows
 //         [E*2*n_ff, (E+1)*2*n_ff): gate rows [0,n_ff), up rows [n_ff, 2n_ff))
 //   H     hidden (K reduction), n_ff per-expert FFN width
+// ── BO layout writer (regions A/B/C; D = gs header follows, unchanged) ──
+static inline size_t gu_i4_bo_size(int K, int N) {
+    return (size_t)K * N / 2 + (size_t)(K / 32) * N * 2 + (size_t)N * 2;
+}
+
+static inline void write_gu_i4_bo(uint8_t* bo, const GuI4Pack& p) {
+    size_t a = p.nibbles.size();
+    size_t b = p.row_scales.size() * 2;
+    size_t c = p.scol_bf16.size() * 2;
+    std::memcpy(bo, p.nibbles.data(), a);
+    std::memcpy(bo + a, p.row_scales.data(), b);
+    std::memcpy(bo + a + b, p.scol_bf16.data(), c);
+}
+
 static inline GuI4Pack pack_gu_fused_i4(const RawQ4Tensor& raw, int expert,
                                         int H, int n_ff) {
     const size_t N = 2 * (size_t)n_ff;

--- a/engine/npu/src/npu_engine_i8ctx_inc.h
+++ b/engine/npu/src/npu_engine_i8ctx_inc.h
@@ -23,6 +23,10 @@
 #include <xrt/xrt_bo.h>
 #include <xrt/xrt_kernel.h>
 
+// Raw Q4NX + int4 fused GU packing (issue #1769, ws09).
+#include "q4nx_raw.h"
+#include "gu_i4_pack.h"
+
 // Include npu_sequence for init_with_generator (may already be included by caller)
 #if __has_include("npu_utils/npu_instr_utils.hpp")
 #include "npu_utils/npu_instr_utils.hpp"
@@ -746,6 +750,60 @@ struct I8Ctx {
                             + cg * FUSED_GS_SLICE, &gsec0[cg], 4);
         bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
         col_out = std::move(col);
+    }
+
+    // ── Fused int4 GU (issue #1769, ws09): raw-Q4NX packing ──
+    // Regions A/B/C are the int4 layout (gu_i4_pack.h): nibbles [0, K*N/2),
+    // row scales [(K/32)*N*2), S_col [N*2) — then the gs-header region
+    // (unchanged, per-token ag/qn_s fold). The kernel's B-path dequant stage
+    // consumes A/B/C and feeds the unchanged int8 mmul.
+    std::unique_ptr<xrt::bo> make_fused_weight_bo_i4(xrt::device& d, int K, size_t n_cols) {
+        int grp_w = k->group_id(4);
+        uint32_t fl = XRT_BO_FLAGS_HOST_ONLY;
+        if (const char* f = getenv("NPU_WBO_FLAGS")) {
+            int v = atoi(f);
+            if (v == 0) fl = 0;
+            else if (v == 1) fl = XRT_BO_FLAGS_CACHEABLE;
+            else if (v == 2) fl = XRT_BO_FLAGS_SVM;
+        }
+        size_t sz = gu_i4_bo_size(K, (int)n_cols) + FUSED_AIE_COLS * FUSED_GS_TILE + FUSED_GS_SLACK;
+        return std::make_unique<xrt::bo>(d, sz, fl, grp_w);
+    }
+
+    // Pack one expert's interleaved GU from RAW Q4NX into the int4 regions.
+    // col_out = S_col (per-column int8 scales — the amax pass's guGs),
+    // row_out = B_shadow (exact int8 reconstruction — the amax pass's guB).
+    void packB_into_fused_i4(xrt::bo& bo, const RawQ4Tensor& raw, int expert,
+                             int H, int n_ff, std::vector<float>& col_out,
+                             std::vector<int8_t>& row_out) {
+        auto pack = pack_gu_fused_i4(raw, expert, H, n_ff);
+        uint8_t* Bm = (uint8_t*)bo.map();
+        write_gu_i4_bo(Bm, pack);
+        // gs-header region: the int4 path's SiLU uses the per-token folded
+        // per-column scales (region C rewritten per token); the legacy
+        // section header region is unused — zero it for determinism.
+        memset(Bm + gu_i4_bo_size(H, 2 * n_ff), 0,
+               FUSED_AIE_COLS * FUSED_GS_TILE + FUSED_GS_SLACK);
+        bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+        col_out = pack.scol;
+        row_out = std::move(pack.B_shadow);
+    }
+
+    // Per-token fold of the int4 SiLU scales (the int4 analogue of
+    // update_fused_header): S'[2p] = ag*S_col[2p] (gate), S'[2p+1] =
+    // ag*qn_s*S_col[2p+1] (up), written into the gs-header region (unused by
+    // the int4 path — its 1 MB is plenty for the 16 KB per-column array).
+    // Region C keeps the STATIC S_col for the kernel's B-path dequant. The
+    // kernel's silu stage reads S'[j] per column instead of gs[0]/gs[4].
+    void update_fused_header_i4(xrt::bo& bo, const std::vector<float>& scol,
+                                int n_ff, float ag, float qn_s, int N) {
+        size_t a = (size_t)KD * N / 2 + (size_t)(KD / 32) * N * 2;  // regions A+B
+        float* dst = (float*)((uint8_t*)bo.map() + a + (size_t)N * 2);
+        for (int p = 0; p < n_ff; p++) {
+            dst[2 * p]     = ag * scol[2 * p];
+            dst[2 * p + 1] = ag * qn_s * scol[2 * p + 1];
+        }
+        bo.sync(XCL_BO_SYNC_BO_TO_DEVICE, (size_t)N * 4, a + (size_t)N * 2);
     }
 
     // Fused D weights: per-column quant (like packB_into) but tile-contiguous

--- a/engine/npu/src/zaya_decode.cpp
+++ b/engine/npu/src/zaya_decode.cpp
@@ -16,6 +16,7 @@
 
 #include "model_config.h"
 #include "dequant_q4nx.h"
+#include "q4nx_raw.h"
 #include "zaya_cca_attn_cpu.h"
 #include "zaya_moe_cpu.h"
 #include "npu_engine_i8ctx_inc.h"
@@ -146,6 +147,8 @@ int zaya_decode_main(int argc, char** argv) {
         zaya_cca::CcaWeights cw; zaya_cca::CcaState cs;
         zaya_moe::RouterWeights rw;
         std::vector<float> gu, dn, nw, pahss, pahsb, parss, parsb, pmhss, pmhsb, pmrss, pmrsb;
+        uint64_t gu_off = 0, gu_size = 0;   // raw Q4NX bytes (NPU_FUSED_I4)
+        int gu_i8_rows = 0;
     };
     std::vector<Layer> L(NC);
     char key[256];
@@ -191,7 +194,9 @@ int zaya_decode_main(int argc, char** argv) {
             if (s_ == 2) s_ = (uint64_t)m.rtr_h * 2;
             w.rw.eda = load_bf16(D, o_, s_);
         } }
-        snprintf(key, sizeof key, "model.layers.%d.mlp.experts.gate_up_proj.weight", l); GETI8(key, w.gu, (m.n_exp*2*m.n_ff/32)*(d.H/256), d.H);
+        snprintf(key, sizeof key, "model.layers.%d.mlp.experts.gate_up_proj.weight", l);
+        GETI8(key, w.gu, (m.n_exp*2*m.n_ff/32)*(d.H/256), d.H);
+        { uint64_t o_, s_; if (get_offsets(js, jl, key, &o_, &s_)) { w.gu_off = o_; w.gu_size = s_; w.gu_i8_rows = (m.n_exp*2*m.n_ff/32)*(d.H/256); } }
         snprintf(key, sizeof key, "model.layers.%d.mlp.experts.down_proj.weight", l); GETI8(key, w.dn, (m.n_exp*d.H/32)*(m.n_ff/256), m.n_ff);
         #undef GET
         #undef GETI8
@@ -232,6 +237,10 @@ int zaya_decode_main(int argc, char** argv) {
     // gu BO header. Contract validated on x86 (test_fused_silu.cpp): corr
     // 0.9993–0.9996 vs float, argmax parity.
     const bool FUSED = getenv("NPU_FUSED") && atoi(getenv("NPU_FUSED")) == 1;
+    // Fused int4 GU (issue #1769, ws09): pack from the RAW Q4NX bytes (halved
+    // weight DMA). Requires the kernel's B-path dequant stage — build with
+    // the ws09 int4 xclbins; until then this is host-side only.
+    const bool FUSED_I4 = FUSED && getenv("NPU_FUSED_I4") && atoi(getenv("NPU_FUSED_I4")) == 1;
     I8Ctx fused_ctx, fused_ctx_p2;   // split launch (issue #1775): p1 GU->SiLU->h2, p2 D-from-h2
     std::vector<std::vector<std::unique_ptr<xrt::bo>>> fgu_bo, fd_bo;
     std::vector<std::vector<std::vector<float>>> fgu_cs, fd_cs;
@@ -281,7 +290,15 @@ int zaya_decode_main(int argc, char** argv) {
                     }
                 }
                 fgu_bo[l][e] = fused_ctx.make_fused_weight_bo(dev, 2 * m.n_ff);
-                fused_ctx.packB_into_fused(*fgu_bo[l][e], guI.data(), d.H, 2 * m.n_ff, fgu_cs[l][e], fgu_row[l][e]);
+                if (FUSED_I4) {
+                    // Raw-Q4NX int4 pack (regions A/B/C, see gu_i4_pack.h).
+                    auto raw_gu = read_q4nx_raw(D, w.gu_off, w.gu_i8_rows, d.H);
+                    fgu_bo[l][e] = fused_ctx.make_fused_weight_bo_i4(dev, d.H, 2 * m.n_ff);
+                    fused_ctx.packB_into_fused_i4(*fgu_bo[l][e], raw_gu, e, d.H, m.n_ff,
+                                                  fgu_cs[l][e], fgu_row[l][e]);
+                } else {
+                    fused_ctx.packB_into_fused(*fgu_bo[l][e], guI.data(), d.H, 2 * m.n_ff, fgu_cs[l][e], fgu_row[l][e]);
+                }
                 const float* dnp = &w.dn[(size_t)e * d.H * m.n_ff];
                 #pragma omp parallel for schedule(static)
                 for (int j = 0; j < m.n_ff; j++)
@@ -417,7 +434,10 @@ int zaya_decode_main(int argc, char** argv) {
                         fused_ctx.Am, fgu_row[l][e].data(),
                         fgu_cs[l][e].data(), d.H, m.n_ff, ag);
                     auto tb0 = std::chrono::steady_clock::now();
-                    fused_ctx.update_fused_header(*fgu_bo[l][e], fgu_cs[l][e], m.n_ff, ag, qn_s, 2 * m.n_ff);
+                    if (FUSED_I4)
+                        fused_ctx.update_fused_header_i4(*fgu_bo[l][e], fgu_cs[l][e], m.n_ff, ag, qn_s, 2 * m.n_ff);
+                    else
+                        fused_ctx.update_fused_header(*fgu_bo[l][e], fgu_cs[l][e], m.n_ff, ag, qn_s, 2 * m.n_ff);
                     auto tb1 = std::chrono::steady_clock::now();
                     // P1: GU->SiLU->h2 writeback.
                     auto frun = fused_ctx.launch_fused(*fgu_bo[l][e], *fd_bo[l][e], *h2_bo[l],

--- a/engine/npu/tests/test_i4_grouped_fused.cpp
+++ b/engine/npu/tests/test_i4_grouped_fused.cpp
@@ -587,6 +587,20 @@ int main(int argc, char** argv) {
             }
         fprintf(stderr, "  [packer] B'' byte-identity vs B_shadow: %d/%d exact\n", neq, ntot);
         if (neq != ntot) { fprintf(stderr, "FAIL: packer/kernel-dequant mismatch\n"); return 1; }
+        // BO layout writer roundtrip: write regions A/B/C, read back, verify
+        // the region offsets and content.
+        size_t bo_sz = gu_i4_bo_size(H, (int)Np);
+        std::vector<uint8_t> bo(bo_sz);
+        write_gu_i4_bo(bo.data(), pack);
+        size_t a = pack.nibbles.size(), b = pack.row_scales.size() * 2;
+        int bo_ok = 1;
+        if (std::memcmp(bo.data(), pack.nibbles.data(), a) != 0) bo_ok = 0;
+        if (std::memcmp(bo.data() + a, pack.row_scales.data(), b) != 0) bo_ok = 0;
+        if (std::memcmp(bo.data() + a + b, pack.scol_bf16.data(), (size_t)Np * 2) != 0) bo_ok = 0;
+        if (bo_sz != a + b + (size_t)Np * 2) bo_ok = 0;
+        fprintf(stderr, "  [packer] BO layout writer regions A/B/C: %s (size %zu)\n",
+                bo_ok ? "exact" : "MISMATCH", bo_sz);
+        if (!bo_ok) { fprintf(stderr, "FAIL: BO layout writer\n"); return 1; }
     }
     if (getenv("NPU_I4_DBG")) {
         {

--- a/research/ws09-int4-grouped/README.md
+++ b/research/ws09-int4-grouped/README.md
@@ -120,6 +120,22 @@ contract for the kernel round.
   hooks to dump real MoE inputs for the gate.
 - Existing (already merged): `i4_pack.h` (#1793), `unpack_i4_b` (#1813).
 
+## Kernel interface (for the strixhalo round)
+
+1. **B-tile loads**: replace the int8 B tap with (a) the int4 nibble tile
+   (region A, stride 4096 B) + (b) the row-scale tap (region B, 512 B/tile) →
+   on-chip dequant `B'' = sat8(round(q4·s_row/S_col[j]))` → the existing mmul.
+   `unpack_i4_b` (#1813) already proved the nibble load.
+2. **S_col taps**: region C carries the STATIC per-column scale (for the B
+   dequant). The per-token folded header (ag for gate, ag·qn_s for up — the
+   same fold `update_fused_header` does today, at per-column granularity) is
+   what the SiLU stage reads: `g = C1[2p]·S'[2p], u = C1[2p+1]·S'[2p+1]`.
+3. **silu stage**: replaces the gs[0]/gs[4] per-section reads with per-column
+   S'[j] — the only arithmetic change to `silu_quant_i8_fused`.
+4. **amax pass unchanged**: `host_h2_amax_qn_s` works with
+   `guB = pack.B_shadow` (the exact int8 reconstruction) + `guGs = pack.scol`.
+5. **#1777 signatures**: B-tile stride 8192 → 4096 + the region B/C tap offsets.
+
 ## Risks / next steps
 
 - **aiecc lowering** of the scale-multiply + requant in the B path (the #1813


### PR DESCRIPTION
### **User description**
## Host integration of the ws09 int4 GU design — complete + CPU-validated

Follows #1818 (design) and #1820 (byte-pinned packer). This wires the host end:

- **`gu_i4_pack.h`**: BO layout writer (regions A/B/C at pinned offsets) + `gu_i4_bo_size` — the gate readbacks all three regions **byte-exact**.
- **`npu_engine_i8ctx_inc.h`**: `make_fused_weight_bo_i4`, `packB_into_fused_i4` (packs from raw Q4NX; `col_out` = S_col, `row_out` = B_shadow for the amax pass), `update_fused_header_i4` (per-token ag/qn_s fold at per-column granularity into the unused gs-header region; region C stays static for the B-dequant).
- **`zaya_decode.cpp`**: `NPU_FUSED_I4=1` packs each expert from the raw Q4NX bytes and uses the i4 header fold per token.
- **`research/ws09-int4-grouped/README.md`**: kernel-interface spec for the strixhalo round (B-path dequant taps, S_col taps, per-column silu read, #1777 signature updates).

**Status**: host side complete, CPU gate still green (GATE PASSED, byte-identity 8,388,608/8,388,608). The xrt-dependent wiring compiles on strixhalo (no xrt headers on ryzen) — next is the kernel round there.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Host wiring for fused int4 GU path (#1769) complete

- Adds raw-Q4NX packer, BO layout writer, i4 header fold

- CPU gate validates byte-identity of regions A/B/C

- Kernel-interface spec documents strixhalo B-path dequant


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ZD["zaya_decode.cpp NPU_FUSED_I4"] -- "read_q4nx_raw" --> PK["packB_into_fused_i4"]
  PK -- "regions A/B/C" --> BO["gu_i4_pack.h write_gu_i4_bo"]
  BO -- "byte-exact readback" --> GT["test_i4_grouped_fused.cpp gate"]
  PK -- "per-token S' fold" --> HF["update_fused_header_i4"]
  BO -- "kernel contract" --> RD["ws09 README kernel interface"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zaya_decode.cpp</strong><dd><code>Wire NPU_FUSED_I4 int4 GU path in decode runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/zaya_decode.cpp

<ul><li>Includes q4nx_raw.h and tracks raw Q4NX GU offsets/size per layer<br> <li> Adds NPU_FUSED_I4 env flag gating the int4 pack path<br> <li> Packs experts via make_fused_weight_bo_i4/packB_into_fused_i4<br> <li> Uses per-token i4 header fold (update_fused_header_i4)</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1821/files#diff-03d765f3c907f9bbf3b9e72824d9f24105ec11666aacb7a9b57702d5254669ae">+23/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gu_i4_pack.h</strong><dd><code>Add int4 BO layout writer and size helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/gu_i4_pack.h

<ul><li>Adds gu_i4_bo_size calculating regions A/B/C size<br> <li> Adds write_gu_i4_bo writing nibbles, row scales, S_col</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1821/files#diff-9b71d224944bb6e7af40f37e35eac50e26579074eeed27dac15d1f42ec285f87">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>npu_engine_i8ctx_inc.h</strong><dd><code>Add i4 fused BO creation, packing, header fold</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/npu_engine_i8ctx_inc.h

<ul><li>Includes q4nx_raw.h and gu_i4_pack.h for int4 packing<br> <li> Adds make_fused_weight_bo_i4 with host-only BO options<br> <li> Adds packB_into_fused_i4 writing regions and shadows<br> <li> Adds update_fused_header_i4 per-token per-column fold</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1821/files#diff-00a304de6fc1ff0480e37d4ed288e548ef48a8b2cdde7652034ce7a3815b864c">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_i4_grouped_fused.cpp</strong><dd><code>Gate BO layout writer byte-exactness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tests/test_i4_grouped_fused.cpp

<ul><li>Adds BO layout writer roundtrip test for regions A/B/C<br> <li> Verifies region offsets and content byte-exact against pack<br> <li> Checks gu_i4_bo_size matches A+B+C total</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1821/files#diff-28ec10319e31fcfd7653c668b97e8ae5a29a36f9a5d7443152209d950a95d7e9">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document kernel interface for int4 GU round</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

research/ws09-int4-grouped/README.md

<ul><li>Documents kernel interface for strixhalo B-path dequant<br> <li> Specifies B-tile loads, S_col taps, silu per-column read<br> <li> Lists amax pass usage and #1777 signature updates</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1821/files#diff-b55d9c34af2bc4420b53457aa5ff76e7a49464708adfa6a2fe18fbb35bef12a2">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

