### PR TITLE
security: fix CodeQL alerts from triage #1825

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,6 +18,9 @@ on:
       - 'engine/npu/kernel/**'
       - 'engine/npu/xclbins/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: bench-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/npu-reset.yml
+++ b/.github/workflows/npu-reset.yml
@@ -1,6 +1,8 @@
 name: NPU Driver Reset + Benchmark
 on:
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   reset-and-bench:
     runs-on: [self-hosted, strix-halo]

--- a/engine/npu/tests/test_i4_grouped_fused.cpp
+++ b/engine/npu/tests/test_i4_grouped_fused.cpp
@@ -437,7 +437,7 @@ int main(int argc, char** argv) {
     const uint64_t gu_off = off, gu_size = size;
     int gu_i8_rows = (n_exp * 2 * n_ff / 32) * (H / 256);
     auto gu = load_i8(D, off, size, gu_i8_rows, H);   // [n_exp*2*n_ff, H] float
-    fprintf(stderr, "GU dequant rows=%zu cols=%zu\n", gu.size() / H, H);
+    fprintf(stderr, "GU dequant rows=%zu cols=%zu\n", gu.size() / H, (size_t)H);
 
     // Expert E's GU block: gate = rows [E*2n_ff, E*2n_ff+n_ff), up = +n_ff.
     const float* gblk = &gu[(size_t)E * 2 * n_ff * H];

--- a/site/1bit-store.html
+++ b/site/1bit-store.html
@@ -2637,7 +2637,7 @@
               '<div class="cart-item-foot">' +
                 '<span class="cart-qty">' +
                   '<button type="button" data-dec aria-label="decrease">-</button>' +
-                  '<span>' + it.q + '</span>' +
+                  '<span>' + esc(it.q) + '</span>' +
                   '<button type="button" data-inc aria-label="increase">+</button>' +
                 '</span>' +
                 '<span class="cart-item-price">' + money(line) + '</span>' +


### PR DESCRIPTION
### **User description**
Closes #1825.

Fixes the 4 actionable CodeQL alerts; the other 47 (cpp/integer-multiplication-cast-to-long) were dismissed as deliberate int16/int32 SIMD arithmetic + vendored third-party code.

- **2870 (error, cpp/wrong-type-format-argument)** — `%zu` with `int H` in `engine/npu/tests/test_i4_grouped_fused.cpp`; cast to `size_t`.
- **2861 (js/xss-through-dom)** — unescaped cart quantity in `site/1bit-store.html` innerHTML; now routed through the existing `esc()`.
- **2862 / 1481 (actions/missing-workflow-permissions)** — `contents: read` added to bench.yml and npu-reset.yml.


___

### **PR Type**
Bug fix, Other


___

### **Description**
- Fix four actionable CodeQL alerts

- Fix format arg by casting H to size_t

- Escape cart quantity with esc() in store

- Add contents:read permission to two workflows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CodeQL alerts (triage 1825)"] --> B["NPU test cast H to size_t"]
  A --> C["Store escape cart quantity"]
  A --> D["Workflows add contents read"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_i4_grouped_fused.cpp</strong><dd><code>Cast H to size_t in GU dequant log</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tests/test_i4_grouped_fused.cpp

<ul><li>Cast <code>H</code> to <code>size_t</code> in <code>fprintf</code> for GU dequant rows/cols<br> <li> Fixes <code>cpp/wrong-type-format-argument</code> CodeQL error</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1828/files#diff-28ec10319e31fcfd7653c668b97e8ae5a29a36f9a5d7443152209d950a95d7e9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>1bit-store.html</strong><dd><code>Escape cart quantity to prevent XSS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/1bit-store.html

<ul><li>Escape cart quantity <code>it.q</code> with <code>esc()</code> in cart item HTML<br> <li> Fixes <code>js/xss-through-dom</code> CodeQL alert</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1828/files#diff-b8903d5c92e9f4fb38d6b6737fa6b27b1786b17121fa2fda128d4ba3467d0fcb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bench.yml</strong><dd><code>Add read permissions to bench workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/bench.yml

<ul><li>Add <code>permissions: contents: read</code> top-level to workflow<br> <li> Satisfies <code>actions/missing-workflow-permissions</code> CodeQL alert</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1828/files#diff-a5e740be96415373789689f814583e93ff2a8f05eae6481e94505fd6cb6bc6a7">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>npu-reset.yml</strong><dd><code>Add read permissions to npu-reset workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/npu-reset.yml

<ul><li>Add <code>permissions: contents: read</code> to workflow_dispatch<br> <li> Fixes <code>actions/missing-workflow-permissions</code> alert</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1828/files#diff-747047dddc37307f23b9cc4551344e0672a8e76868593468c7cae89194af7392">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

