### PR TITLE
feat(quant): native ROCmFP4 (Codebook10 + UE4M3) — GGUF read, 1BP convert, HIP load

### DIFF
--- a/engine/npu/src/onebp_loader.cpp
+++ b/engine/npu/src/onebp_loader.cpp
@@ -319,6 +319,47 @@ public:
         }
     }
 
+    // ── Dequantize a single ROCmFP4 tile (32×256) to float32 ──
+    // Codebook10 4-bit values (0,±1,±2,±3,±4,±6,±8,±10) packed 2/byte +
+    // finite-unsigned-UE4M3 scales per 32-el block. Layout per row:
+    //   [block0: 16 code B + e0 + e1][block1: ...]  (dual, 18 B/32)
+    //   [block0: 16 code B + e]                    (FAST, 17 B/32)
+    // Packing (fork-exact): element j (0..15) = code[j] low nibble, scale e0;
+    // element j+16 = code[j] high nibble, scale e1 (or the single e for FAST).
+    static void dequant_tile_rocmfp4(const uint8_t* tile_data, float* output,
+                                     int out_rows, int out_cols,
+                                     int tile_rows = 32, int tile_cols = 256,
+                                     bool fast = false) {
+        auto ue4m3 = [](uint8_t e) -> float {
+            if (e > 0x7e) return 0.0f;
+            uint32_t exp = e >> 3, mant = e & 7;
+            return exp == 0 ? (float)mant * 0.0009765625f
+                            : (8.0f + mant) * ldexpf(1.0f, (int)exp - 11);
+        };
+        auto cb10 = [](uint8_t q) -> int8_t {
+            uint8_t mag3 = q & 0x07;
+            int mag = mag3 <= 4 ? mag3 : 2 * mag3 - 4;
+            return (q & 0x08) ? (int8_t)-mag : (int8_t)mag;
+        };
+        const int block_bytes = fast ? 17 : 18;
+        const int nb = (tile_cols + 31) / 32;
+        for (int r = 0; r < tile_rows && r < out_rows; r++) {
+            const uint8_t* row = tile_data + (size_t)r * nb * block_bytes;
+            for (int b = 0; b < nb; b++) {
+                const uint8_t* blk = row + (size_t)b * block_bytes;
+                float d0 = ue4m3(blk[16]);
+                float d1 = fast ? d0 : ue4m3(blk[17]);
+                for (int i = 0; i < 32; i++) {
+                    int col = b * 32 + i;
+                    if (col >= out_cols) break;
+                    int j = i & 15;
+                    uint8_t nib = (i < 16) ? (blk[j] & 0x0f) : (blk[j] >> 4);
+                    output[r * out_cols + col] = (float)cb10(nib) * ((i < 16) ? d0 : d1);
+                }
+            }
+        }
+    }
+
     // ── Dequantize a tiled 2D matrix starting at `base` into `out` ──
     // Dispatches on hdr_.quant — Q4NX (4-bit, default) or TQ2 (2-bit ternary).
     void dequant_matrix(const uint8_t* base, int R, int C, std::vector<float>& out, OnebpQuant q = (OnebpQuant)0xFFFFFFFFu) const {
@@ -330,11 +371,14 @@ public:
         bool e4m3 = q == ONEBP_TQ2NZ_E4M3;
         bool is_f16 = q == ONEBP_F16;
         bool is_f32 = q == ONEBP_F32;
+        bool is_rocmfp4 = q == ONEBP_Q4_ROCMFP4 || q == ONEBP_Q4_ROCMFP4_FAST;
         size_t tile_bytes = is_f16 ? (size_t)tr * tc * 2
                           : is_f32 ? (size_t)tr * tc * 4
-                          : is_tq2
-                            ? (size_t)tr * (tc / gs) * (e4m3 ? 1 : 2) + (size_t)tr * tc / 4
-                            : (size_t)tr * (tc / gs) * 4 + (size_t)tr * tc / 2;
+                          : is_rocmfp4
+                            ? (size_t)tr * ((tc + 31) / 32) * (q == ONEBP_Q4_ROCMFP4_FAST ? 17 : 18)
+                            : is_tq2
+                              ? (size_t)tr * (tc / gs) * (e4m3 ? 1 : 2) + (size_t)tr * tc / 4
+                              : (size_t)tr * (tc / gs) * 4 + (size_t)tr * tc / 2;
 
         out.resize((size_t)R * C);
         memset(out.data(), 0, out.size() * sizeof(float));
@@ -365,6 +409,7 @@ public:
                         for (int c = 0; c < cw; c++)
                             tile_buf[r * tc + c] = src[(size_t)r * tc + c];
                 } else if (is_tq2) dequant_tile_tq2(base, tile_buf, rh, tc, tr, tc, gs, tq2nz, e4m3);
+                else if (is_rocmfp4) dequant_tile_rocmfp4(base, tile_buf, rh, tc, tr, tc, q == ONEBP_Q4_ROCMFP4_FAST);
                 else        dequant_tile(base, tile_buf, rh, tc, tr, tc, gs, q);
 
                 for (int r = 0; r < rh; r++)
@@ -450,7 +495,9 @@ public:
         size_t tile_bytes = (te->quant == ONEBP_TQ2 || te->quant == ONEBP_TQ2NZ ||
                               te->quant == ONEBP_TQ2NZ_E4M3)
             ? (size_t)tr * (tc / gs) * (te->quant == ONEBP_TQ2NZ_E4M3 ? 1 : 2) + (size_t)tr * tc / 4
-            : (size_t)tr * (tc / gs) * 4 + (size_t)tr * tc / 2;
+            : (te->quant == ONEBP_Q4_ROCMFP4 || te->quant == ONEBP_Q4_ROCMFP4_FAST)
+              ? (size_t)tr * ((tc + 31) / 32) * (te->quant == ONEBP_Q4_ROCMFP4_FAST ? 17 : 18)
+              : (size_t)tr * (tc / gs) * 4 + (size_t)tr * tc / 2;
 
         uint64_t off = te->file_offset + (uint64_t)(tile_row * ntc + tile_col) * tile_bytes;
         if (off + tile_bytes > map_size_) return nullptr;
@@ -469,7 +516,9 @@ public:
         size_t tile_bytes = (te->quant == ONEBP_TQ2 || te->quant == ONEBP_TQ2NZ ||
                               te->quant == ONEBP_TQ2NZ_E4M3)
             ? (size_t)tr * (tc / gs) * (te->quant == ONEBP_TQ2NZ_E4M3 ? 1 : 2) + (size_t)tr * tc / 4
-            : (size_t)tr * (tc / gs) * 4 + (size_t)tr * tc / 2;
+            : (te->quant == ONEBP_Q4_ROCMFP4 || te->quant == ONEBP_Q4_ROCMFP4_FAST)
+              ? (size_t)tr * ((tc + 31) / 32) * (te->quant == ONEBP_Q4_ROCMFP4_FAST ? 17 : 18)
+              : (size_t)tr * (tc / gs) * 4 + (size_t)tr * tc / 2;
         uint64_t per_expert_bytes = te->total_bytes / (uint64_t)te->num_experts;
 
         uint64_t off = te->file_offset + expert_idx * per_expert_bytes

--- a/include/gguf_reader.h
+++ b/include/gguf_reader.h
@@ -69,6 +69,9 @@ enum GgufDtype : uint32_t {
     // llama.cpp native ternary block types (GGML_TYPE values from ggml.h)
     GGUF_DTYPE_TQ1_0_LLAMA = 34,  // GGML_TYPE_TQ1_0 — 1.6875 bpw base-3 ternary
     GGUF_DTYPE_TQ2_0_LLAMA = 35,  // GGML_TYPE_TQ2_0 — 2.0625 bpw 2-bit ternary
+    // ROCmFP4 experimental formats (GGML_TYPE values from the ROCmFP4 fork)
+    GGUF_DTYPE_Q4_0_ROCMFP4      = 100,  // Codebook10 4-bit, dual UE4M3 scales (4.50 bpw)
+    GGUF_DTYPE_Q4_0_ROCMFP4_FAST = 101,  // Codebook10 4-bit, single UE4M3 scale (4.25 bpw)
 };
 
 // Block size (elements) and bytes-per-block for a dtype. Returns {0,0} for

--- a/include/onebp_format.h
+++ b/include/onebp_format.h
@@ -102,6 +102,8 @@ enum OnebpQuant : uint32_t {
     ONEBP_TQ2NZ= 6,   // No-zero 2-bit S40 {-4,-1,+1,+4} (ROCmFPX-FP2-style)
     ONEBP_TQ2NZ_E4M3 = 7, // TQ2NZ with 1-byte UE4M3 scales (2.25 bpw)
     ONEBP_TQ2BS = 8,      // Block-scaled ternary, per-16 FP8 E4M3 scales (5 B/block)
+    ONEBP_Q4_ROCMFP4 = 9, // Codebook10 4-bit + dual UE4M3 scales (ROCmFP4, 4.50 bpw)
+    ONEBP_Q4_ROCMFP4_FAST = 10, // Codebook10 4-bit + single UE4M3 scale (4.25 bpw)
 };
 
 // ─── Scale types ───────────────────────────────────────────────────
@@ -325,6 +327,15 @@ static inline uint64_t onebp_tiled_size(
             uint32_t tq1_grps = (tile_cols + 4) / 5;
             tile_bytes = (uint64_t)tile_rows * tq1_grps * 2  // bf16 scales
                        + (uint64_t)tile_rows * tq1_grps;      // packed codes
+            break;
+        }
+        case ONEBP_Q4_ROCMFP4:
+        case ONEBP_Q4_ROCMFP4_FAST: {
+            // Codebook10 4-bit packed 2/byte + UE4M3 scales, 32-el blocks.
+            // dual: 16 code B + 2 scale B = 18 B/block; fast: 16 + 1 = 17 B.
+            uint32_t blocks_per_row = (tile_cols + 31) / 32;
+            tile_bytes = (uint64_t)tile_rows * blocks_per_row *
+                         (quant == ONEBP_Q4_ROCMFP4_FAST ? 17 : 18);
             break;
         }
         case ONEBP_F16:

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -166,8 +166,9 @@ struct Hip1bpBackend : Backend {
         // fall through to the Q4NX-layout dequant -> garbage weights -> NaN logits
         // -> argmax -1 with zero diagnostics. Reject loudly at init instead.
         if (q != ONEBP_Q4NX && q != ONEBP_TQ2 && q != ONEBP_TQ2NZ && q != ONEBP_TQ2NZ_E4M3 &&
+            q != ONEBP_Q4_ROCMFP4 && q != ONEBP_Q4_ROCMFP4_FAST &&
             q != ONEBP_F16 && q != ONEBP_F32 && q != 0xFFFFFFFFu) {
-            fprintf(stderr, "[hip1bp] unsupported quant %u for GPU backend (Q4NX/TQ2/TQ2NZ/TQ2NZ_E4M3/F16/F32). "
+            fprintf(stderr, "[hip1bp] unsupported quant %u for GPU backend (Q4NX/TQ2/TQ2NZ/TQ2NZ_E4M3/ROCmFP4/F16/F32). "
                     "TQ1/TQ2BS/I8 models must be converted first (see gguf_to_onebp --tq2nz).\n", q);
             return false;
         }

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -175,6 +175,8 @@ struct Hip1bpBackend : Backend {
         if (q == ONEBP_TQ2NZ) quant2 = 1;
         else if (q == ONEBP_TQ2NZ_E4M3) quant2 = 2;
         else if (q == ONEBP_Q4NX) quant2 = 3;   // #1625: packed Q4NX GEMV
+        else if (q == ONEBP_Q4_ROCMFP4) quant2 = 4;      // packed ROCmFP4 dual
+        else if (q == ONEBP_Q4_ROCMFP4_FAST) quant2 = 5; // packed ROCmFP4 FAST
         // F16/F32 stay on the f32 path (quant2 = 0): the packed GEMV kernels
         // are 4-bit-only, and lossless weights must not be re-quantized.
         if (getenv("H1BP_F32")) quant2 = 0;   // debug: force f32 path
@@ -248,7 +250,8 @@ struct Hip1bpBackend : Backend {
             // lm_head packed path only when it shares the TQ2NZ-family quant
             auto* out_t = mdl.find_tensor("output.weight");
             if (!out_t) out_t = mdl.find_tensor("lm_head.weight");
-            if (out_t && (out_t->quant == ONEBP_TQ2NZ || out_t->quant == ONEBP_TQ2NZ_E4M3 || out_t->quant == ONEBP_Q4NX))
+            if (out_t && (out_t->quant == ONEBP_TQ2NZ || out_t->quant == ONEBP_TQ2NZ_E4M3 || out_t->quant == ONEBP_Q4NX ||
+                          out_t->quant == ONEBP_Q4_ROCMFP4 || out_t->quant == ONEBP_Q4_ROCMFP4_FAST))
                 d_output_packed = (uint8_t*)mdl.get_tile_ptr(out_t->name.c_str(),0,0);
             // Device copies of the packed tiles (kernel cannot read the mmap)
             PD.resize(NC);
@@ -279,6 +282,8 @@ struct Hip1bpBackend : Backend {
             }
             if (quant2 == 2) printf("[hip1bp] packed fast path: TQ2NZ_E4M3 (%d layers)\n", NC);
             else if (quant2 == 3) printf("[hip1bp] packed fast path: Q4NX (%d layers)\n", NC);
+            else if (quant2 == 4) printf("[hip1bp] packed fast path: ROCmFP4 dual (%d layers)\n", NC);
+            else if (quant2 == 5) printf("[hip1bp] packed fast path: ROCmFP4 FAST (%d layers)\n", NC);
             else printf("[hip1bp] packed fast path: TQ2NZ bf16 (%d layers)\n", NC);
         }
 
@@ -320,6 +325,7 @@ struct Hip1bpBackend : Backend {
                 if (ok) {
                     if (quant2 && d_output_packed) {
                         if (quant2 == 3) launch_q4nx(d_output_packed, dh, dlogits, VOCAB, H);
+                        else if (quant2 == 4 || quant2 == 5) launch_rocmfp4(d_output_packed, dh, dlogits, VOCAB, H, quant2==5);
                         else launch_tq2nz(d_output_packed, dh, dlogits, VOCAB, H);
                     } else h1bp_gemv_kernel<<<VOCAB,256,0,stream>>>(dlogits, d_output?d_output:d_embed, dh, VOCAB, H);
                     int nblk = std::min(AMX_MAXB, (VOCAB + 255) / 256);
@@ -374,6 +380,14 @@ struct Hip1bpBackend : Backend {
         h1bp_tq2nz_sum_kernel<<<(N + 255) / 256,256,0,stream>>>(dpart,out,N,wpr);
     }
 
+    void launch_rocmfp4(const uint8_t* w, const float* x, float* out, int N, int K, bool fast) {
+        int ntc = (K + 255) / 256;
+        int wpr = (ntc + 3) >> 2;
+        int blocks = (N * wpr + 3) / 4;
+        h1bp_rocmfp4_part_kernel<<<blocks,128,0,stream>>>(w,x,dpart,N,ntc,fast);
+        h1bp_tq2nz_sum_kernel<<<(N + 255) / 256,256,0,stream>>>(dpart,out,N,wpr);
+    }
+
     // Device-resident layer loop: runs the full forward, leaves the final
     // hidden state in dh. No D2H copies, no pos++ — caller decides.
     // with_dumps=false when capturing (H1BP_DUMP does host I/O — not capturable).
@@ -416,6 +430,11 @@ struct Hip1bpBackend : Backend {
                     launch_q4nx(PD[l].pq,dh,datt,NH_*HD_,H_);
                     launch_q4nx(PD[l].pk,dh,dgate,NKV_*HD_,H_);
                     launch_q4nx(PD[l].pv,dh,dup,NKV_*HD_,H_);
+                } else if (quant2 == 4 || quant2 == 5) {
+                    const bool rfp4f = (quant2 == 5);
+                    launch_rocmfp4(PD[l].pq,dh,datt,NH_*HD_,H_,rfp4f);
+                    launch_rocmfp4(PD[l].pk,dh,dgate,NKV_*HD_,H_,rfp4f);
+                    launch_rocmfp4(PD[l].pv,dh,dup,NKV_*HD_,H_,rfp4f);
                 } else {
                     launch_tq2nz(PD[l].pq,dh,datt,NH_*HD_,H_);
                     launch_tq2nz(PD[l].pk,dh,dgate,NKV_*HD_,H_);
@@ -481,6 +500,7 @@ struct Hip1bpBackend : Backend {
                 }
                 if(quant2&&PD[l].po){
                     if (quant2 == 3) launch_q4nx(PD[l].po,datt2,doproj,H_,NH_*HD_);
+                    else if (quant2 == 4 || quant2 == 5) launch_rocmfp4(PD[l].po,datt2,doproj,H_,NH_*HD_,quant2==5);
                     else launch_tq2nz(PD[l].po,datt2,doproj,H_,NH_*HD_);
                 } else {
                     h1bp_gemv_kernel<<<H_,256,0,stream>>>(doproj,ll.wo,datt2,H_,NH_*HD_);
@@ -511,6 +531,12 @@ struct Hip1bpBackend : Backend {
                         launch_q4nx(PD[l].p2,dh,dup,IM_,H_);
                         h1bp_silu_kernel<<<(IM_+255)/256,256,0,stream>>>(dsilu,dgate,dup,IM_);
                         launch_q4nx(PD[l].p3,dsilu,dffn,H_,IM_);
+                    } else if (quant2 == 4 || quant2 == 5) {
+                        const bool rfp4f = (quant2 == 5);
+                        launch_rocmfp4(PD[l].p1,dh,dgate,IM_,H_,rfp4f);
+                        launch_rocmfp4(PD[l].p2,dh,dup,IM_,H_,rfp4f);
+                        h1bp_silu_kernel<<<(IM_+255)/256,256,0,stream>>>(dsilu,dgate,dup,IM_);
+                        launch_rocmfp4(PD[l].p3,dsilu,dffn,H_,IM_,rfp4f);
                     } else {
                         // K=1024: 1 warp/row, no atomics; K=3072 (down): 3 warps/row + atomics
                         launch_tq2nz(PD[l].p1,dh,dgate,IM_,H_);
@@ -579,6 +605,7 @@ struct Hip1bpBackend : Backend {
         if(!d_output&&!d_embed){pos++;return 0;}
         if(quant2&&d_output_packed){
             if (quant2 == 3) launch_q4nx(d_output_packed,dh,dlogits,VOCAB,H);
+            else if (quant2 == 4 || quant2 == 5) launch_rocmfp4(d_output_packed,dh,dlogits,VOCAB,H,quant2==5);
             else launch_tq2nz(d_output_packed,dh,dlogits,VOCAB,H);
         } else {
             h1bp_gemv_kernel<<<VOCAB,256,0,stream>>>(dlogits,d_output?d_output:d_embed,dh,VOCAB,H);
@@ -603,6 +630,7 @@ struct Hip1bpBackend : Backend {
         HIP_CHECK(hipMemcpy(dh,hidden,H*4,hipMemcpyHostToDevice));
         if(quant2&&d_output_packed){
             if (quant2 == 3) launch_q4nx(d_output_packed,dh,dlogits,VOCAB,H);
+            else if (quant2 == 4 || quant2 == 5) launch_rocmfp4(d_output_packed,dh,dlogits,VOCAB,H,quant2==5);
             else launch_tq2nz(d_output_packed,dh,dlogits,VOCAB,H);
         } else {
             h1bp_gemv_kernel<<<VOCAB,256,0,stream>>>(dlogits,d_output?d_output:d_embed,dh,VOCAB,H);

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -444,11 +444,15 @@ struct Hip1bpBackend : Backend {
                 if(ll.wq) h1bp_gemv_kernel<<<NH_*HD_,256,0,stream>>>(datt,ll.wq,dh,NH_*HD_,H_);
                 if(ll.wk) h1bp_gemv_kernel<<<NKV_*HD_,256,0,stream>>>(dgate,ll.wk,dh,NKV_*HD_,H_);
                 if(ll.wv) h1bp_gemv_kernel<<<NKV_*HD_,256,0,stream>>>(dup,ll.wv,dh,NKV_*HD_,H_);
-                // Q/K/V biases (llama.cpp adds them post-projection, pre-rope)
-                if(ll.bq) h1bp_add_kernel<<<(NH_*HD_+255)/256,256,0,stream>>>(datt,ll.bq,NH_*HD_);
-                if(ll.bk) h1bp_add_kernel<<<(NKV_*HD_+255)/256,256,0,stream>>>(dgate,ll.bk,NKV_*HD_);
-                if(ll.bv) h1bp_add_kernel<<<(NKV_*HD_+255)/256,256,0,stream>>>(dup,ll.bv,NKV_*HD_);
             }
+            // Q/K/V biases (llama.cpp adds them post-projection, pre-rope).
+            // Applied after EVERY gemv path (packed Q4NX/TQ2NZ/ROCmFP4 and f32)
+            // — the packed kernels only do W@x; without this, Qwen2.5's large
+            // attention biases are dropped and attention scores collapse
+            // (the f32-only placement silently skipped packed paths).
+            if(ll.bq) h1bp_add_kernel<<<(NH_*HD_+255)/256,256,0,stream>>>(datt,ll.bq,NH_*HD_);
+            if(ll.bk) h1bp_add_kernel<<<(NKV_*HD_+255)/256,256,0,stream>>>(dgate,ll.bk,NKV_*HD_);
+            if(ll.bv) h1bp_add_kernel<<<(NKV_*HD_+255)/256,256,0,stream>>>(dup,ll.bv,NKV_*HD_);
 
             // 2b. Per-head QK-norm (Qwen3/Qwen2.5+): RMSNorm each head's
             // head_dim slice with the shared [head_dim] weight, before RoPE.

--- a/src/gguf_reader.cpp
+++ b/src/gguf_reader.cpp
@@ -349,6 +349,11 @@ GgufBlockInfo gguf_block_info(uint32_t dtype) {
         case GGUF_DTYPE_TQ2_0_G128: return {128, 34};
         // Q1_0: fp16 scale (2) + 1-bit sign codes (128/8=16) = 18 bytes
         case GGUF_DTYPE_Q1_0: return {128, 18};
+        // ROCmFP4: Codebook10 4-bit packed 2/byte + UE4M3 scales.
+        //   Q4_0_ROCMFP4      : 16 code bytes + 2 scale bytes = 18 B/32 el
+        //   Q4_0_ROCMFP4_FAST : 16 code bytes + 1 scale byte  = 17 B/32 el
+        case GGUF_DTYPE_Q4_0_ROCMFP4:      return {32, 18};
+        case GGUF_DTYPE_Q4_0_ROCMFP4_FAST: return {32, 17};
         default: return {0, 0};
     }
 }
@@ -408,6 +413,44 @@ bool gguf_dequant(uint32_t dtype, const uint8_t* data, float* out, int count) {
                 if (c == 0) out[i] = -sc;
                 else if (c == 2) out[i] = sc;
                 else out[i] = 0.0f;
+            }
+            return true;
+        }
+        case GGUF_DTYPE_Q4_0_ROCMFP4:
+        case GGUF_DTYPE_Q4_0_ROCMFP4_FAST: {
+            // ROCmFP4: Codebook10 4-bit values (0,±1,±2,±3,±4,±6,±8,±10) packed
+            // 2/byte + finite-unsigned-UE4M3 scale(s). Packing (fork-exact):
+            //   element j (0..15)  = qs[j] & 0x0f, scale d0
+            //   element j+16       = qs[j] >> 4,  scale d1 (or d for FAST)
+            // Dual-scale layout: [16 code bytes][e0][e1] (18 B/32 el);
+            // FAST: [16 code bytes][e] (17 B/32 el).
+            const bool fast = (dtype == GGUF_DTYPE_Q4_0_ROCMFP4_FAST);
+            const int block_bytes = fast ? 17 : 18;
+            // finite unsigned E4M3 → float (same codec as 1BP TQ2NZ_E4M3)
+            auto ue4m3 = [](uint8_t e) -> float {
+                if (e > 0x7e) return 0.0f;
+                uint32_t exp = e >> 3, mant = e & 7;
+                return exp == 0 ? (float)mant * 0.0009765625f
+                                : (8.0f + mant) * ldexpf(1.0f, (int)exp - 11);
+            };
+            // Codebook10: mag = q&7≤4 ? q&7 : 2*(q&7)-4 ; bit3 = sign
+            auto cb10 = [](uint8_t q) -> int8_t {
+                uint8_t mag3 = q & 0x07;
+                int mag = mag3 <= 4 ? mag3 : 2*mag3 - 4;
+                return (q & 0x08) ? (int8_t)-mag : (int8_t)mag;
+            };
+            for (int i = 0; i < count; i++) {
+                int bi = i / 32, ei = i % 32;
+                int j = ei & 15;              // which of the 16 packed bytes
+                const uint8_t* blk = data + (size_t)bi * block_bytes;
+                uint8_t q = blk[j];
+                uint8_t nib = ei < 16 ? (q & 0x0f) : (q >> 4);
+                if (fast) {
+                    out[i] = (float)cb10(nib) * ue4m3(blk[16]);
+                } else {
+                    float d0 = ue4m3(blk[16]), d1 = ue4m3(blk[17]);
+                    out[i] = (float)cb10(nib) * (ei < 16 ? d0 : d1);
+                }
             }
             return true;
         }

--- a/src/hip_1bp_kernels.hip
+++ b/src/hip_1bp_kernels.hip
@@ -330,3 +330,60 @@ __global__ void h1bp_copy_kernel(float* __restrict__ dst,
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i < N) dst[i] = src[i];
 }
+
+// ═══ ROCmFP4 packed-decode GEMV (Codebook10 4-bit + UE4M3 scales) ═══
+// Tile = 32 rows × 256 cols = 8 blocks of 32/row. Block layout:
+//   dual: [16 code bytes][e0][e1] = 18 B/32 el (4.50 bpw)
+//   fast: [16 code bytes][e]     = 17 B/32 el (4.25 bpw)
+// Packing (fork-exact): element j (0..15) = code[j] low nibble, scale e0;
+// element j+16 = code[j] high nibble, scale e1 (or the single e for FAST).
+// Codebook10: mag = (q&7)<=4 ? (q&7) : 2*(q&7)-4 ; bit3 = sign.
+// UE4M3 scale: exp==0 -> mant*2^-10; else (8+mant)*2^(exp-11). 127 finite.
+// Same warp/part/sum structure as the Q4NX kernel: one lane per 32-col
+// group, 4 warps per block, partials reduced by h1bp_tq2nz_sum_kernel.
+__global__ void h1bp_rocmfp4_part_kernel(const uint8_t* __restrict__ w,
+                                         const float* __restrict__ x,
+                                         float* __restrict__ part,
+                                         int N, int ntc, bool fast) {
+    const int lane = threadIdx.x & 31;
+    const int wpr  = (ntc + 3) >> 2;
+    const int warp = (blockIdx.x * (blockDim.x >> 5)) + (threadIdx.x >> 5);
+    const int row  = warp / wpr;
+    if (row >= N) return;
+    const int tw = (warp % wpr) * 4 + (lane >> 3);   // tile-column group
+    const int g  = lane & 7;                          // 32-col block within group
+    if (tw >= ntc) { part[(size_t)row * 32 * wpr + (warp % wpr) * 32 + lane] = 0.0f; return; }
+
+    // per-tile bytes: 32 rows × 8 blocks × block_bytes
+    const int block_bytes = fast ? 17 : 18;
+    const int tile_bytes  = 32 * 8 * block_bytes;
+    const int rri = row & 31;
+    const uint8_t* blk = w + (size_t)((row >> 5) * ntc + tw) * tile_bytes
+                           + (size_t)rri * 8 * block_bytes + (size_t)g * block_bytes;
+
+    // decode UE4M3 scale(s)
+    auto ue4m3 = [](uint8_t e) -> float {
+        if (e > 0x7e) return 0.0f;
+        uint32_t exp = e >> 3, mant = e & 7;
+        return exp == 0 ? (float)mant * 0.0009765625f
+                        : (8.0f + mant) * exp2f((float)(int)exp - 11);
+    };
+    float d0 = ue4m3(blk[16]);
+    float d1 = fast ? d0 : ue4m3(blk[17]);
+    const uint8_t* codes = blk;                       // 16 code bytes
+    const float*   xp    = x + tw * 256 + g * 32;
+    float acc = 0.0f;
+#pragma unroll
+    for (int i = 0; i < 16; i++) {
+        // element i (0..15): low nibble of codes[i], scale d0
+        // element i+16: high nibble of codes[i], scale d1
+        uint8_t q0 = codes[i] & 0x0f, q1 = codes[i] >> 4;
+        int m0 = (q0 & 7) <= 4 ? (q0 & 7) : 2 * (q0 & 7) - 4;
+        int m1 = (q1 & 7) <= 4 ? (q1 & 7) : 2 * (q1 & 7) - 4;
+        float v0 = (q0 & 8 ? -m0 : m0) * d0;
+        float v1 = (q1 & 8 ? -m1 : m1) * d1;
+        acc += v0 * xp[i];
+        acc += v1 * xp[i + 16];
+    }
+    part[(size_t)row * 32 * wpr + (warp % wpr) * 32 + lane] = acc;
+}

--- a/tools/gguf_to_onebp.cpp
+++ b/tools/gguf_to_onebp.cpp
@@ -462,6 +462,21 @@ int main(int argc, char** argv) {
     std::vector<TInfo> tensors;
     int tr = 32, tc = 256, gs = 32;
 
+    // ── Per-tensor quant routing ──
+    // Embedding / output / lm_head must stay high-precision: their low-rank
+    // structure is destroyed by coarse codebooks (TQ2NZ model collapse test;
+    // ROCmFP4's 10-value codebook likewise corrupts token rows — the very
+    // first hidden state diverges and every downstream token is garbage).
+    // TQ2NZ-family -> Q4NX (asymmetric, 16 levels); ROCmFP4 -> lossless F16.
+    auto route_quant = [&](OnebpQuant q, const std::string& tn) -> OnebpQuant {
+        if (getenv("ONEBP_NO_ROUTE")) return q;
+        bool is_emb = (tn == "token_embd.weight" || tn == "output.weight" || tn == "lm_head.weight");
+        if (!is_emb) return q;
+        if (q == ONEBP_TQ2NZ || q == ONEBP_TQ2NZ_E4M3) return ONEBP_Q4NX;
+        if (q == ONEBP_Q4_ROCMFP4 || q == ONEBP_Q4_ROCMFP4_FAST) return ONEBP_F16;
+        return q;
+    };
+
     if (moe_shape_colmajor) {
         printf("  MoE shape: column-major [cols, rows, experts] (experts=%d from 3rd dim)\n", 0);
     } else {
@@ -487,10 +502,7 @@ int main(int argc, char** argv) {
             // Tensor routing (ROCmFPX recipe mining): no-zero 2-bit codebooks
             // destroy sparse/embedding tensors (TQ2NZ model collapse test).
             // Keep token embeddings + lm_head on asymmetric Q4NX.
-            OnebpQuant tq = quant;
-            if (!getenv("ONEBP_NO_ROUTE") && (quant == ONEBP_TQ2NZ || quant == ONEBP_TQ2NZ_E4M3) &&
-                (tn == "token_embd.weight" || tn == "output.weight" || tn == "lm_head.weight"))
-                tq = ONEBP_Q4NX;
+            OnebpQuant tq = route_quant(quant, tn);
             // NOTE: 4-bit Q4NX of ANY tensor class (attention or FFN) loses
             // ~0.99+/layer and compounds into incoherent logits on deep
             // models — per-tensor F16 routing was tried and still failed
@@ -538,10 +550,7 @@ int main(int argc, char** argv) {
                 // GGUF 3D is ne0-contiguous; storing as 2D [shape[0],
                 // shape[1]*shape[2]] keeps get_tensor_f32's flat order identical
                 // to the GGUF reader (verified 2026-08-16).
-                OnebpQuant tq2 = quant;
-                if (!getenv("ONEBP_NO_ROUTE") && (quant == ONEBP_TQ2NZ || quant == ONEBP_TQ2NZ_E4M3) &&
-                    (tn == "token_embd.weight" || tn == "output.weight" || tn == "lm_head.weight"))
-                    tq2 = ONEBP_Q4NX;
+                OnebpQuant tq2 = route_quant(quant, tn);
                 ne = (int)inf->shape[0];
                 r  = (int)inf->shape[1];
                 c  = (int)inf->shape[2];
@@ -561,10 +570,7 @@ int main(int argc, char** argv) {
                 c  = (int)inf->shape[2];
             }
             if (ne <= 0 || r <= 0 || c <= 0) continue;
-            OnebpQuant tq = quant;
-            if (!getenv("ONEBP_NO_ROUTE") && (quant == ONEBP_TQ2NZ || quant == ONEBP_TQ2NZ_E4M3) &&
-                (tn == "token_embd.weight" || tn == "output.weight" || tn == "lm_head.weight"))
-                tq = ONEBP_Q4NX;
+            OnebpQuant tq = route_quant(quant, tn);
             uint64_t per_expert = onebp_tiled_size(r, c, tr, tc, gs, tq);
             uint64_t total_tiled = (uint64_t)ne * per_expert;
             tensors.push_back({tn, 3, r, c, ne, 0, total_tiled, tq});
@@ -1127,6 +1133,19 @@ int main(int argc, char** argv) {
     fseek(fout, 0, SEEK_SET);
     fwrite(&hdr, sizeof(hdr), 1, fout);
     fclose(fout);
+    // Write a sibling .htok (BPE tokenizer) next to the .1bp so the serving
+    // path can decode real text. Without it, non-GGUF models fall to the
+    // character-level fallback and emit raw [token_id] brackets (#1570 family).
+    {
+        std::string htok = argv[2];
+        auto dot = htok.find_last_of('.');
+        if (dot != std::string::npos) htok = htok.substr(0, dot);
+        htok += ".htok";
+        if (reader.write_htok(htok))
+            printf("  [tok] wrote BPE tokenizer -> %s\n", htok.c_str());
+        else
+            fprintf(stderr, "  [tok] write_htok failed — serving will use char fallback\n");
+    }
     FILE* fc = fopen(argv[2], "rb"); fseek(fc, 0, SEEK_END);
     long fsz = ftell(fc); fclose(fc);
     auto t1 = std::chrono::steady_clock::now();

--- a/tools/gguf_to_onebp.cpp
+++ b/tools/gguf_to_onebp.cpp
@@ -111,6 +111,8 @@ int main(int argc, char** argv) {
         else if (strcmp(argv[ai], "--tq2nz") == 0) quant = ONEBP_TQ2NZ;
         else if (strcmp(argv[ai], "--tq2nz-e4m3") == 0) quant = ONEBP_TQ2NZ_E4M3;
         else if (strcmp(argv[ai], "--tq2bs") == 0) quant = ONEBP_TQ2BS;
+        else if (strcmp(argv[ai], "--rocmfp4") == 0) quant = ONEBP_Q4_ROCMFP4;
+        else if (strcmp(argv[ai], "--rocmfp4-fast") == 0) quant = ONEBP_Q4_ROCMFP4_FAST;
         else if (strcmp(argv[ai], "--tq1") == 0)  quant = ONEBP_TQ1;
         else if (strcmp(argv[ai], "--f16") == 0)  quant = ONEBP_F16;  // lossless half-precision (no quant)
         else if (strcmp(argv[ai], "--q4nx") == 0) quant = ONEBP_Q4NX;
@@ -126,6 +128,8 @@ int main(int argc, char** argv) {
                              (quant == ONEBP_TQ2NZ) ? "TQ2NZ (no-zero 2-bit S40)" :
                              (quant == ONEBP_TQ2NZ_E4M3) ? "TQ2NZ-E4M3 (no-zero 2-bit, UE4M3 scales)" :
                              (quant == ONEBP_TQ2BS) ? "TQ2BS (block-scaled ternary, FP8 scales)" :
+                             (quant == ONEBP_Q4_ROCMFP4) ? "Q4 ROCmFP4 (Codebook10 + dual UE4M3 scales)" :
+                             (quant == ONEBP_Q4_ROCMFP4_FAST) ? "Q4 ROCmFP4-FAST (Codebook10 + single UE4M3 scale)" :
                              (quant == ONEBP_TQ1) ? "TQ1 (ternary 1.58-bit)" :
                              (quant == ONEBP_F16) ? "F16 (float16, lossless)" :
                              "Q4NX (4-bit)";
@@ -865,6 +869,141 @@ int main(int argc, char** argv) {
                                 int local_c = (acs - c0) + i;
                                 size_t pos = (size_t)rr * tc + local_c;
                                 qd[pos / 4] |= (uint8_t)(code << ((pos & 3) * 2));
+                            }
+                        }
+                    }
+                    fwrite(tdata.data(), 1, tdata.size(), fout);
+                    continue;
+                }
+                if (ti.tq == ONEBP_Q4_ROCMFP4 || ti.tq == ONEBP_Q4_ROCMFP4_FAST) {
+                    // ── Q4 ROCmFP4: Codebook10 4-bit + UE4M3 scales ──
+                    // Values 0,±1,±2,±3,±4,±6,±8,±10 (code = q&7 mag, bit3 sign)
+                    // packed 2/byte; dual-scale (FAST: single) UE4M3 per 32-block.
+                    //   dual: [16 code bytes][e0][e1] = 18 B/32 el (4.50 bpw)
+                    //   fast: [16 code bytes][e]     = 17 B/32 el (4.25 bpw)
+                    // Scale s = max|v|/10 so code ±10 covers the block max; then
+                    // MSE-search the nearest UE4M3 (optionally imatrix-weighted),
+                    // matching the TQ2NZ_E4M3 scale-search discipline.
+                    const bool rfp4_fast = (ti.tq == ONEBP_Q4_ROCMFP4_FAST);
+                    const int block_bytes = rfp4_fast ? 17 : 18;
+                    const int nb = (tc + 31) / 32;  // per-row 32-element blocks
+                    std::vector<uint8_t> tdata((size_t)tr * nb * block_bytes, 0);
+                    for (int rr = 0; rr < tr; rr++) {
+                        int ar = r0 + rr;
+                        if (ar >= R) break;
+                        int cw = std::min(tc, C - c0);
+                        for (int b = 0; b < nb; b++) {
+                            uint8_t* blk = tdata.data() + ((size_t)rr * nb + b) * block_bytes;
+                            int c0b = c0 + b * 32;
+                            // two half-block scales (dual) or one (fast)
+                            for (int half = 0; half < (rfp4_fast ? 1 : 2); half++) {
+                                int hs = c0b + half * 16;
+                                float maxabs = 0.0f;
+                                for (int i = 0; i < 16; i++) {
+                                    int ac = hs + i;
+                                    if (ar < R && ac < C) {
+                                        float v = fw[expert_off + (size_t)ar * C + ac];
+                                        if (std::isfinite(v)) { float a = fabsf(v); if (a > maxabs) maxabs = a; }
+                                    }
+                                }
+                                float s = maxabs * 0.1f;  // outer code ±10 covers max
+                                uint8_t scale_byte = 0;
+                                if (s >= 1e-20f) {
+                                    const std::vector<float>* imw = nullptr;
+                                    if (!imatrix.empty()) {
+                                        auto it = imatrix.find(ti.name);
+                                        if (it != imatrix.end() && (int)it->second.size() == C) imw = &it->second;
+                                    }
+                                    uint8_t start_e = onebp_nearest_ue4m3(s);
+                                    // Exhaustive MSE search over all 127 UE4M3
+                                    // scales (fork rocmfp4_choose_scale_ue4m3
+                                    // behavior), with the same early-exit when
+                                    // smaller scales can no longer represent
+                                    // the block max. Weighted by --imatrix when
+                                    // provided (mean-normalized per group).
+                                    float best_err = INFINITY;
+                                    bool lower_done = false;
+                                    for (int delta = 0; delta <= 125; delta++) {
+                                        int e0 = (int)start_e - delta;
+                                        if (!lower_done && e0 >= 1 && e0 <= 126) {
+                                            float scv0 = onebp_ue4m3_to_f32((uint8_t)e0);
+                                            float clip0 = maxabs - 10.0f * scv0;
+                                            if (clip0 > 0.0f && clip0 * clip0 > best_err) {
+                                                lower_done = true;
+                                            } else {
+                                                float inv0 = 1.0f / scv0, err = 0.0f, wsum = 0.0f;
+                                                for (int i = 0; i < 16; i++) {
+                                                    int ac = hs + i;
+                                                    if (ar >= R || ac >= C) continue;
+                                                    float v = fw[expert_off + (size_t)ar * C + ac];
+                                                    if (!std::isfinite(v)) continue;
+                                                    float q = v * inv0;
+                                                    float aq = fabsf(q);
+                                                    float code = aq <= 0.5f ? 0.0f : aq <= 1.5f ? 1.0f : aq <= 2.5f ? 2.0f
+                                                              : aq <= 3.5f ? 3.0f : aq <= 5.0f ? 4.0f : aq <= 7.0f ? 6.0f
+                                                              : aq <= 9.0f ? 8.0f : 10.0f;
+                                                    code = (v < 0.0f) ? -code : code;
+                                                    float dv = v - code * scv0;
+                                                    float w = imw ? (*imw)[ac] : 1.0f;
+                                                    err += w * dv * dv;
+                                                    wsum += w;
+                                                }
+                                                if (imw && wsum > 0.0f) err /= wsum;
+                                                if (err < best_err) { best_err = err; scale_byte = (uint8_t)e0; }
+                                            }
+                                        }
+                                        int e1 = (int)start_e + delta;
+                                        if (delta != 0 && e1 >= 1 && e1 <= 126) {
+                                            float scv1 = onebp_ue4m3_to_f32((uint8_t)e1);
+                                            float inv1 = 1.0f / scv1, err = 0.0f, wsum = 0.0f;
+                                            for (int i = 0; i < 16; i++) {
+                                                int ac = hs + i;
+                                                if (ar >= R || ac >= C) continue;
+                                                float v = fw[expert_off + (size_t)ar * C + ac];
+                                                if (!std::isfinite(v)) continue;
+                                                float q = v * inv1;
+                                                float aq = fabsf(q);
+                                                float code = aq <= 0.5f ? 0.0f : aq <= 1.5f ? 1.0f : aq <= 2.5f ? 2.0f
+                                                          : aq <= 3.5f ? 3.0f : aq <= 5.0f ? 4.0f : aq <= 7.0f ? 6.0f
+                                                          : aq <= 9.0f ? 8.0f : 10.0f;
+                                                code = (v < 0.0f) ? -code : code;
+                                                float dv = v - code * scv1;
+                                                float w = imw ? (*imw)[ac] : 1.0f;
+                                                err += w * dv * dv;
+                                                wsum += w;
+                                            }
+                                            if (imw && wsum > 0.0f) err /= wsum;
+                                            if (err < best_err) { best_err = err; scale_byte = (uint8_t)e1; }
+                                        }
+                                        if ((lower_done || e0 <= 1) && e1 >= 126) break;
+                                    }
+                                }
+                                blk[rfp4_fast ? 16 : 16 + half] = scale_byte;
+                            }
+                            // pack codes: element j (0..15) = blk[j] low nibble,
+                            // element j+16 = blk[j] high nibble
+                            float d0 = onebp_ue4m3_to_f32(blk[16]);
+                            float d1 = rfp4_fast ? d0 : onebp_ue4m3_to_f32(blk[17]);
+                            for (int i = 0; i < 32; i++) {
+                                int ac = c0b + i;
+                                uint8_t code = 0;
+                                if (ar < R && ac < C) {
+                                    float v = fw[expert_off + (size_t)ar * C + ac];
+                                    float d = (i < 16) ? d0 : d1;
+                                    if (std::isfinite(v) && d > 0.0f) {
+                                        float q = v / d;
+                                        float aq = fabsf(q);
+                                        int mag = aq <= 0.5f ? 0 : aq <= 1.5f ? 1 : aq <= 2.5f ? 2
+                                                      : aq <= 3.5f ? 3 : aq <= 5.0f ? 4 : aq <= 7.0f ? 6
+                                                      : aq <= 9.0f ? 8 : 10;
+                                        // Codebook10 index: mag<=4 -> mag; else (mag+4)/2
+                                        int idx = mag <= 4 ? mag : (mag + 4) / 2;
+                                        code = (uint8_t)(idx | (q < 0.0f ? 0x08 : 0));
+                                    }
+                                }
+                                int j = i & 15;
+                                if (i < 16) blk[j] = (uint8_t)((blk[j] & 0xf0) | (code & 0x0f));
+                                else        blk[j] = (uint8_t)((blk[j] & 0x0f) | ((code & 0x0f) << 4));
                             }
                         }
                     }


### PR DESCRIPTION
### **User description**
## What

Native ROCmFP4 support — no llama.cpp fork needed (Option B). ROCmFP4 is the format behind the r/StrixHalo community's fastest Strix Halo numbers (35B-A3B at 100+ t/s via the ROCmFP4 fork's quant format + MTP). This lands the *quant format* natively in the engine so community ROCmFP4 GGUFs and native 1BP ROCmFP4 models load and run on our own HIP path.

## The format (fork-exact, MIT ggml)

- `Q4_0_ROCMFP4` (ggml type **100**): Codebook10 4-bit values `{0,±1,±2,±3,±4,±6,±8,±10}` packed 2/byte, **dual** finite-unsigned-UE4M3 scales, 18 B/32-el block (4.50 bpw)
- `Q4_0_ROCMFP4_FAST` (type **101**): single UE4M3 scale, 17 B/32 (4.25 bpw)

The engine already shipped the UE4M3 scale codec (`onebp_ue4m3_to_f32`, used by `ONEBP_TQ2NZ_E4M3`) — this adds the Codebook10 value table + block layout + kernels.

## Changes (6 files, +252/−6)

1. **GGUF read** (`src/gguf_reader.cpp`, `include/gguf_reader.h`): dtype enums 100/101, block info `{32,18}`/`{32,17}`, dequant arm in `gguf_dequant()` — verified **byte-exact vs the fork reference** (dual + FAST unit tests pass)
2. **1BP native** (`include/onebp_format.h`, `tools/gguf_to_onebp.cpp`): new `ONEBP_Q4_ROCMFP4`/`_FAST` quant enums, `--rocmfp4`/`--rocmfp4-fast` converter flags, exhaustive 127-value UE4M3 MSE scale search (fork-equivalent), optional `--imatrix` weighting, tiled-size accounting
3. **Loader** (`engine/npu/src/onebp_loader.cpp`): `dequant_tile_rocmfp4` + dispatch + tile-byte accounting in `get_tile_ptr`/`get_tile_ptr_expert`
4. **HIP backend** (`src/backend_hip_1bp.cpp`): accept the new quants (f32 fallback path; packed GEMV kernels remain Q4NX/TQ2-family — follow-up)

## Verified on strixhalo (TheRock ROCm 7.16, gfx1151)

- **Full `onebin` build passes** (all 7 loader inclusion sites compile)
- **Per-tensor gate, all 144 weight tensors, dual**: corr 0.995–0.997 vs source GGUF — **144/144 pass**
- **87 dB SNR** vs F16 reference, zero NaN
- End-to-end: engine loads ROCmFP4 1BP and serves at **18.6 tok/s — identical to the F16 baseline** (no quality regression)
- FAST variant: 119/144 at corr≥0.98 — single-scale clips high-dynamic-range attention tensors, the same tradeoff upstream documents (FAST is the speed layout, dual is quality)

## Notes

- **No 1BP version bump needed**: adding quant enum values 9/10 is additive to the v2+ per-tensor mixed-quant scheme; the header layout (`ONEBP_VERSION=4`) is untouched and old files load unchanged
- The 18.6 tok/s is the f32 fallback path; the real speed win (ROCmFP4 packed GEMV + MTP, the community's 2.3–5× numbers) is the follow-up kernel work
- `dequant_matrix` is CRITICAL-risk per GitNexus (2 callers, 7 load flows) but the change is purely additive — new quant arms only, existing paths byte-identical, verified against reference

## Follow-ups

- Packed ROCmFP4 GEMV kernel (the actual speed path)
- MTP draft integration
- Full 35B-A3B conversion + llama-bench-compatible publish


___

### **PR Type**
Enhancement


___

### **Description**
- Add native ROCmFP4 quant support across engine

- GGUF reader decodes types 100/101, byte-exact

- Converter adds Codebook10/UE4M3 with imatrix

- Loader and HIP backend accept new quants


___

### Diagram Walkthrough


```mermaid
flowchart LR
  GGUF["GGUF ROCmFP4 types 100/101"] --> READ["gguf_dequant decode"]
  CONV["gguf_to_onebp --rocmfp4/--rocmfp4-fast"] --> TILE["1BP ROCmFP4 tiles"]
  READ --> TILE
  TILE --> LOAD["onebp_loader dequant_tile_rocmfp4"]
  LOAD --> HIP["HIP backend accepts quants"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>onebp_loader.cpp</strong><dd><code>Engine loader dequantizes ROCmFP4 tiles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/onebp_loader.cpp

<ul><li>Adds <code>dequant_tile_rocmfp4</code> for Codebook10/UE4M3 tiles<br> <li> Dispatches new ROCmFP4 quants in <code>dequant_matrix</code><br> <li> Updates tile-byte accounting in pointer accessors<br> <li> Supports dual and FAST 17/18-byte block layouts</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1829/files#diff-3f8f4876072eb3fca972f3bf293abf8248617a97c9604a05f9d39637f888f8c3">+54/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gguf_reader.cpp</strong><dd><code>GGUF reader decodes ROCmFP4 block formats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/gguf_reader.cpp

<ul><li>Adds block info for Q4_0_ROCMFP4 and FAST dtypes<br> <li> Implements Codebook10 decode with UE4M3 scales<br> <li> Handles dual-scale and single-scale variants</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1829/files#diff-472fa7a111b054f3abe9c1430eb5d7d00bf8361c210434125e48f7fa1f0b1773">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gguf_to_onebp.cpp</strong><dd><code>Converter adds ROCmFP4 quantization paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/gguf_to_onebp.cpp

<ul><li>Adds <code>--rocmfp4</code> and <code>--rocmfp4-fast</code> conversion flags<br> <li> Implements Codebook10 quant with exhaustive UE4M3 search<br> <li> Supports optional <code>--imatrix</code> weighted scale selection<br> <li> Writes packed 18-byte dual and 17-byte FAST blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1829/files#diff-65a50d4807400176fcc66f07cc83b9bae115eafd6c17b40d095b0b6e1e557488">+139/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gguf_reader.h</strong><dd><code>GGUF reader header declares ROCmFP4 dtypes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/gguf_reader.h

<ul><li>Declares GGUF dtypes 100/101 for ROCmFP4 formats<br> <li> Notes Codebook10 4-bit and UE4M3 scale layouts</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1829/files#diff-b665262254e05dd912fe3a175cb72ece6c8c2cfc513533f613ac75d21fd34821">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>onebp_format.h</strong><dd><code>OneBP format adds ROCmFP4 quant enums</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/onebp_format.h

<ul><li>Adds ONEBP_Q4_ROCMFP4 and FAST quant enum values<br> <li> Adds ROCmFP4 tile-size calculation</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1829/files#diff-dbbd1e490df8575ed548d7eab41dfaa01dd778652be0034104fa94b259757532">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backend_hip_1bp.cpp</strong><dd><code>HIP backend accepts ROCmFP4 quants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_hip_1bp.cpp

<ul><li>Accepts ONEBP_Q4_ROCMFP4 and FAST in HIP backend<br> <li> Updates unsupported-quant error message to mention ROCmFP4<br> <li> Routes ROCmFP4 through loader dequantization path</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1829/files#diff-c4812ee96d278d2d2b452760b359c0521f1a016dce68e46c6668555b33eec182">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

