### PR TITLE
fix(npu): attention kernel compiles on AIE2P (silu_roundf) + full design hardware-verified (issue #1776)

### DIFF
--- a/engine/npu/generators/build_attn.sh
+++ b/engine/npu/generators/build_attn.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
 # Build the GQA flash-attention xclbin (issue #1776).
 #
-# STATUS (2026-08-24): the design BUILDS (aiecc) and the kernel contract is
-# verified on x86 (test_attn.cpp — run it: g++ .../test_attn.cpp; PASS).
-# The generator is the FULL multi-phase core (QK^T → params → softmax → A2O →
-# PV → C2) with producer/consumer fifo counts balanced (9 A + 8 B per column,
-# both sides — see the core_body comment). Open on hardware: the last strixhalo
-# session measured C1 == 0 (QK^T mmul reads zero A/B fifo data) while every
-# pattern works in isolation — the next debugging step is the multi-fifo core
-# phase sequencing (per issue #1776 comment 2026-08-23).
+# STATUS (2026-08-24): the full multi-phase design is VERIFIED on strixhalo.
+# QK^T (c1a/c1b = 73984 exactly for the 0x11/0x22 pattern), softmax
+# (A2 = 127 for t < seq=200, 0 for t >= seq — causal mask + rows 1-7 zero),
+# and PV (C2 = 127·Σ_{t<200}(t%7+1) = 100838) all match the x86 contract
+# (test_attn.cpp — PASS). Hardware blockers found & fixed this round:
+#   - the i4 B-path used std::roundf, which the Peano libc++ cannot resolve
+#     ("reference to unresolved using declaration") — the attention kernel
+#     object failed to compile; fixed by using silu_roundf (no-libm, same
+#     round-half-away-from-zero semantics) in mm_kernel_reference.cc;
+#   - stale prebuilt kernel .o files (mm_32x64x128.o) from earlier probe
+#     sessions double-write their C result into the adjacent buffer,
+#     corrupting C1b (3 QK^T dots instead of 2) → wrong softmax max → all-zero
+#     A2. Always rebuild the kernel from source; do not reuse old .o files.
+# Run: bash build_attn.sh
 #
 # Usage: bash build_attn.sh
 set -euo pipefail

--- a/engine/npu/generators/build_attn.sh
+++ b/engine/npu/generators/build_attn.sh
@@ -43,8 +43,7 @@ $P/bin/ld.lld -r "$W/mm.o" "$W/softmax.o" -o "$W/attn_kernel.o"
 # 2. design
 $PYTHON "$G/n1_core_attn.py" -M 8 -K 128 -N 256 -m 8 -k 64 -n 128 -c 8 -b 2 \
     > "$W/design.mlir" 2>/dev/null
-cp "$W/attn_kernel.o" "$W/attn_kernel.o"  # link_with resolves from CWD
-cd "$W" && cp attn_kernel.o attn_kernel.o
+cd "$W"  # link_with resolves attn_kernel.o from CWD
 export PATH=/home/bcloud/Xilinx/2026.1/2026.1/Vitis/bin:/opt/xilinx/xrt/bin:$PATH
 export PYTHONPATH=/home/bcloud/mlir-aie/install_tmp/python:/home/bcloud/mlir-aie/.venv/lib/python3.14/site-packages
 export LD_LIBRARY_PATH=/home/bcloud/mlir-aie/install_tmp/python/aie/_mlir_libs

--- a/engine/npu/generators/mm_kernel_reference.cc
+++ b/engine/npu/generators/mm_kernel_reference.cc
@@ -716,7 +716,7 @@ extern "C" void matmul_i8_i32_i4(const int8_t *__restrict pA,
                 u = u + u; u = u + u; u = u + u; u = u + u;   // q4<<4
                 for (int e = 0; e < 64; e++) {
                     float v = (float)(int8_t)u[e] * ratio[e & 7];
-                    int x = (int)std::roundf(v);
+                    int x = silu_roundf(v);
                     Bb[jt][e] = (int8_t)(x > 127 ? 127 : x < -127 ? -127 : x);
                 }
             }


### PR DESCRIPTION
### **User description**
## Summary
The GQA flash-attention NPU kernel (issue #1776) previously could not even **compile** for AIE2P: the int4 B-path used `std::roundf`, which the Peano libc++ cannot resolve (`reference to unresolved using declaration`). This PR replaces it with `silu_roundf` — the existing no-libm round-half-away-from-zero helper in `silu_quant.h` already used by the silu path.

## Hardware verification (strixhalo, 0x11/0x22 pattern, seq=200)
With the kernel rebuilt from source, the full multi-phase core now matches the x86 contract (`test_attn.cpp`, PASS) end-to-end:

| Phase | Expected | Measured |
|---|---|---|
| QK^T c1a/c1b | 73984 | 73984 ✓ |
| Softmax A2 (t<200 / t≥200) | 127 / 0 | 127 / 0 ✓ (causal mask + rows 1-7 zero) |
| PV C2 | 127·Σ(t%7+1)=100838 | 100838 ✓ |

## Root cause of the earlier "C1 == 0" / all-zero A2 hardware readings
Stale prebuilt kernel `.o` files from earlier probe sessions (e.g. `mm_32x64x128.o`) **double-write their C result into the adjacent buffer**, so C1b accumulated 3 QK^T dots instead of 2 → wrong softmax max → all-zero A2. Rebuilding the kernel from source resolves it; `build_attn.sh` STATUS updated with this warning.

Fixes the compile blocker; the generator changes from #1840 are confirmed correct on hardware.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Replace `std::roundf` with `silu_roundf` in i4 B-path

- Fix AIE2P Peano libc++ compile failure

- Mark attention kernel hardware-verified in build status

- Warn against stale prebuilt kernel `.o` files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["i4 B-path: std::roundf"] -->|"replaced with"| B["silu_roundf (no-libm)"]
  B --> C["AIE2P kernel compiles"]
  C --> D["build_attn.sh: hardware-verified"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mm_kernel_reference.cc</strong><dd><code>Use silu_roundf to fix i4 B-path compile failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/mm_kernel_reference.cc

<ul><li>Replace <code>std::roundf</code> with <code>silu_roundf</code> in the i4 B-path<br> <li> Resolves Peano libc++ unresolved-declaration compile failure<br> <li> <code>silu_roundf</code> keeps round-half-away-from-zero semantics without libm</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1846/files#diff-bfbf7dfd57573c1b95ed14f18638a299a33c1fe23d883599c3517bf08c68ae30">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_attn.sh</strong><dd><code>Update build status with hardware-verification notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/build_attn.sh

<ul><li>Update STATUS to hardware-verified for the full multi-phase core<br> <li> Document stale <code>.o</code> files corrupting C1b (double-write)<br> <li> Advise rebuilding kernel from source; do not reuse old objects</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1846/files#diff-55d3bfab6f06b5d5667c5abb862021a7745181c5e394e9a01ecc657d15fe2e3a">+14/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

