### PR TITLE
seo: daily sync 2026-08-25 — arch strings 1,774 → 1,775 (kimik3 alias)

### DIFF
--- a/site/1bit-blog.html
+++ b/site/1bit-blog.html
@@ -208,7 +208,7 @@
             <span class="log-date">2026-08-24</span>
             <div class="log-body">
               <h3><a href="1bit-post-lemonade-v1170.html" class="log-link">Lemonade v11.7.0, and how we stay current with the SDK</a></h3>
-              <p>The embedded Lemonade server core is re-vendored to v11.7.0 — new models, register/options/stats/metrics endpoints live, and a repeatable re-vendor loop so every upstream release lands without touching engine code. The engine's own HF coverage stays at 100%: 552 architecture tokens, 1,774 HF arch strings, 317,310/317,310 checkpoints mapped.</p>
+              <p>The embedded Lemonade server core is re-vendored to v11.7.0 — new models, register/options/stats/metrics endpoints live, and a repeatable re-vendor loop so every upstream release lands without touching engine code. The engine's own HF coverage stays at 100%: 552 architecture tokens, 1,775 HF arch strings, 317,310/317,310 checkpoints mapped.</p>
               <div class="log-tags"><span class="log-tag">lemonade</span><span class="log-tag">upstream</span><span class="log-tag">sdk</span></div>
             </div>
           </article>

--- a/site/1bit-models.html
+++ b/site/1bit-models.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>1bit.MONSTER: One engine, Any model.</title>
-  <meta name="description" content="552 architecture tokens, 1,774 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability." />
+  <meta name="description" content="552 architecture tokens, 1,775 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability." />
   <style>
     /* ─── tokens ─────────────────────────────────────────────────────────
        Bound verbatim to the locked light modern-minimal + 1-bit identity.
@@ -243,7 +243,7 @@
         <p class="lead">The engine reads the model header, picks the architecture and kernel path, and runs. No config, no per-model glue, no registry to maintain.</p>
         <div class="stat-row" data-od-id="coverage-stats">
           <div class="stat" data-od-id="stat-tokens"><span class="n">552</span><span class="l">architecture tokens</span></div>
-          <div class="stat" data-od-id="stat-strings"><span class="n">1,774</span><span class="l">HF arch strings</span></div>
+          <div class="stat" data-od-id="stat-strings"><span class="n">1,775</span><span class="l">HF arch strings</span></div>
           <div class="stat" data-od-id="stat-coverage"><span class="n">100%</span><span class="l">checkpoints mapped</span></div>
         </div>
       </div>

--- a/site/1bit-monster-v2.html
+++ b/site/1bit-monster-v2.html
@@ -323,7 +323,7 @@ $<span class="caret"></span></code></pre>
             <div class="map-track"><span class="map-bar" style="width: 100%;"></span></div>
           </div>
           <div class="map-row" data-od-id="map-row-strings">
-            <div class="map-label"><span class="map-name">architecture strings</span><span class="map-count">1,774</span></div>
+            <div class="map-label"><span class="map-name">architecture strings</span><span class="map-count">1,775</span></div>
             <div class="map-track"><span class="map-bar" style="width: 58%;"></span></div>
           </div>
           <div class="map-row" data-od-id="map-row-tokens">

--- a/site/1bit-post-lemonade-v1170.html
+++ b/site/1bit-post-lemonade-v1170.html
@@ -143,7 +143,7 @@
         <p>The 1bit engine embeds <b>Lemonade's server core</b> in-process — all 14 backends and the policy router, compiled into the same <span class="mono">build/1bit</span> binary. That means upstream's release cadence is our release cadence: every time <span class="mono">lemonade-sdk/lemonade</span> ships, the engine inherits its new models, backends, and API surface the day we re-vendor. The relationship is documented in <code>docs/guides/Lemonade-Compat.md</code> and the vendoring rules live in <code>third_party/lemonade/UPSTREAM.md</code>.</p>
 
         <h2>v11.7.0: what came in</h2>
-        <p>This release brought new models, a management API, and observability — all now live in the embedded core. (The engine's own HF coverage is separate and larger: <b>552 architecture tokens / 1,774 HF arch strings, 317,310 of 317,310 arch-bearing text-gen checkpoints mapped — 100% of HuggingFace</b>. The numbers below are what the Lemonade core itself gained.)</p>
+        <p>This release brought new models, a management API, and observability — all now live in the embedded core. (The engine's own HF coverage is separate and larger: <b>552 architecture tokens / 1,775 HF arch strings, 317,310 of 317,310 arch-bearing text-gen checkpoints mapped — 100% of HuggingFace</b>. The numbers below are what the Lemonade core itself gained.)</p>
         <table>
           <thead><tr><th>Area</th><th>What landed</th></tr></thead>
           <tbody>


### PR DESCRIPTION
### **User description**
Automated daily SEO refresh (`scripts/seo_sync.py`).

Detected drift after #1848 merged (`kimik3` → `KIMI_K3` alias): the engine's `rcpp_arch_from_string` now maps **1,775** HF arch strings (site claimed 1,774).

Updated:
- `site/1bit-models.html` — meta description + stat (1,774 → 1,775)
- `site/1bit-blog.html` — blog card (1,774 → 1,775)
- `site/1bit-monster-v2.html` — map count (1,774 → 1,775)
- `site/1bit-post-lemonade-v1170.html` — coverage claim (1,774 → 1,775)


___

### **PR Type**
Documentation


___

### **Description**
- Refresh site coverage claims from 1,774 to 1,775 HF arch strings

- Update meta description, statistics, blog card, and post coverage numbers

- Reflect engine state after `kimik3` → `KIMI_K3` alias merged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["kimik3 alias added"] --> B["engine maps 1,775 arch strings"]
  B --> C["site/1bit-models.html"]
  B --> D["site/1bit-blog.html"]
  B --> E["site/1bit-monster-v2.html"]
  B --> F["site/1bit-post-lemonade-v1170.html"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>1bit-models.html</strong><dd><code>Update model page coverage stats to 1,775</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/1bit-models.html

<ul><li>Updated meta description coverage stat from 1,774 to 1,775 HF arch <br>strings<br> <li> Updated stat row "HF arch strings" count in the coverage stats section</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1853/files#diff-a903b0186fc3c43439874cf7d6feff4094a6338e719dff93ad748c2309aa9ee3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>1bit-blog.html</strong><dd><code>Refresh blog card coverage number</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/1bit-blog.html

<ul><li>Updated blog card paragraph arch string count from 1,774 to 1,775<br> <li> Kept the 100% checkpoint coverage claim unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1853/files#diff-bc701bd8bd62d9a63fc488c881b0ae6e4b6c2680e1b21fae947f2a2eaf38979a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>1bit-monster-v2.html</strong><dd><code>Update v2 coverage map string count</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/1bit-monster-v2.html

- Updated coverage map architecture strings count from 1,774 to 1,775


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1853/files#diff-660454a43550f83ec1a7072fd71caf420fb57f185d39b06424d8be01258beff3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>1bit-post-lemonade-v1170.html</strong><dd><code>Bump Lemonade post coverage claim</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/1bit-post-lemonade-v1170.html

<ul><li>Updated the Lemonade post coverage claim from 1,774 to 1,775 HF arch <br>strings</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1853/files#diff-8ed67592d5f7b63878893d1290c77d2a1ce7e2be17ab0d9fe5061c1e04033d82">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

