### PR TITLE
fix(seo): harden daily sync workflow (stale branch cleanup, clearer PR failure)

### DIFF
--- a/.github/workflows/seo-sync.yml
+++ b/.github/workflows/seo-sync.yml
@@ -50,6 +50,10 @@ jobs:
             echo "PR for $BRANCH already open — nothing to do"
             exit 0
           fi
+          # Clear a stale branch left by a previous failed run (no PR -> safe)
+          if git ls-remote --exit-code origin "$BRANCH" >/dev/null 2>&1; then
+            git push origin --delete "$BRANCH"
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
@@ -58,6 +62,16 @@ jobs:
           git push origin "$BRANCH"
 
           BODY="$(cat /tmp/seo_sync_out.txt)"
+
+          _pr_fail() {
+            if grep -q "not permitted to create" /tmp/pr_err.txt; then
+              echo "::error::GitHub Actions is not permitted to create pull requests. Enable Settings → Actions → General → Workflow permissions → 'Allow GitHub Actions to create and approve pull requests', then re-run."
+            else
+              cat /tmp/pr_err.txt >&2
+            fi
+            exit 1
+          }
+
           if echo "$BODY" | grep -q '^NEW:'; then
             # Generated lemonade post: release specifics need a human/PR-agent pass.
             {
@@ -67,9 +81,11 @@ jobs:
               echo "$BODY"
               echo '```'
             } > /tmp/seo_pr_body.md
-            gh pr create --base main --head "$BRANCH" --draft \
+            if ! gh pr create --base main --head "$BRANCH" --draft \
               --title "seo: daily sync $DATE (lemonade bump)" \
-              --body-file /tmp/seo_pr_body.md
+              --body-file /tmp/seo_pr_body.md >/tmp/pr_url.txt 2>/tmp/pr_err.txt; then
+              _pr_fail
+            fi
           else
             {
               echo "Automated daily SEO refresh (scripts/seo_sync.py). Changes detected:"
@@ -78,7 +94,10 @@ jobs:
               echo "$BODY"
               echo '```'
             } > /tmp/seo_pr_body.md
-            gh pr create --base main --head "$BRANCH" \
+            if ! gh pr create --base main --head "$BRANCH" \
               --title "seo: daily sync $DATE" \
-              --body-file /tmp/seo_pr_body.md
+              --body-file /tmp/seo_pr_body.md >/tmp/pr_url.txt 2>/tmp/pr_err.txt; then
+              _pr_fail
+            fi
           fi
+          echo "PR: $(cat /tmp/pr_url.txt)"


### PR DESCRIPTION
### **User description**
Two failure modes seen during today's manual run of the SEO sync:\n\n1. A previous run pushed `seo/daily-<date>` but failed at `gh pr create` (repo blocks Actions from creating PRs) — the next run then hit a non-fast-forward push on the leftover branch. The workflow now deletes a stale remote branch when no PR is open for it.\n\n2. When PR creation is blocked, the run now prints an actionable ::error:: pointing at Settings → Actions → General → Workflow permissions → 'Allow GitHub Actions to create and approve pull requests' (that toggle must be enabled for the daily PR to open itself).\n\nAlso: bash syntax + YAML validated locally.


___

### **PR Type**
Bug fix


___

### **Description**
- Delete stale remote branch when no PR exists

- Add actionable error for blocked PR creation

- Handle `gh pr create` failure in both paths

- Print created PR URL on success


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Daily SEO sync"] --> B{"PR open?"}
  B -- "yes" --> C["Exit: nothing to do"]
  B -- "no" --> D{"Stale remote branch?"}
  D -- "yes" --> E["Delete stale branch"]
  D -- "no" --> F["Create branch and push"]
  E --> F
  F --> G{"gh pr create"}
  G -- "success" --> H["Print PR URL"]
  G -- "permission denied" --> I["::error:: enable Actions PR permission"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>seo-sync.yml</strong><dd><code>Harden SEO sync workflow cleanup and PR failure handling</code>&nbsp; </dd></summary>
<hr>

.github/workflows/seo-sync.yml

<ul><li>Deletes leftover remote branch when no PR is open for <code>seo/daily-*</code>, <br>preventing non-fast-forward push<br> <li> Adds <code>_pr_fail</code> helper emitting an actionable <code>::error::</code> message when <br>Actions lacks PR creation permission<br> <li> Wraps both draft and normal <code>gh pr create</code> calls to capture failures and <br>print the resulting PR URL<br> <li> Allows the daily workflow to recover from stale state and report <br>blocked PR creation clearly</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1854/files#diff-66c40869f524c6864276cb1e5de5acc7b0166fbc4a10bfdcd3b81ffcfc364275">+23/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

