### PR TITLE
ops(analytics): read RUM site token from site/analytics.js

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
       - name: Fetch Cloudflare analytics
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -34,15 +36,17 @@ jobs:
 
           echo ""
           echo "=== Web Analytics (RUM) ==="
-          SITES=$(api "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/rum/site_info/list")
-          echo "$SITES" | jq -r '.result[]? | "site: \(.domain)  token: \(.site_token)"'
-
-          SITE_TOKEN=$(echo "$SITES" | jq -r '.result[]? | select(.domain == "1bit.monster") | .site_token // empty')
+          # The RUM site token is public by design (it ships inside the beacon on
+          # every page), so read it from the committed beacon loader instead of the
+          # rum/site_info/list API (which needs a token with the Web Analytics
+          # permission group that the Pages deploy token does not have).
+          SITE_TOKEN=$(sed -n 's/.*var TOKEN = "\([0-9a-f]\{32\}\)".*/\1/p' site/analytics.js | head -1)
 
           if [ -z "$SITE_TOKEN" ]; then
-            echo "No Web Analytics site for 1bit.monster yet — run the 'CF Web Analytics Bootstrap' workflow."
+            echo "No beacon token found in site/analytics.js — inject it first (see the CF Web Analytics Bootstrap workflow)."
             exit 0
           fi
+          echo "Site token: ${SITE_TOKEN:0:8}… (read from site/analytics.js)"
 
           TODAY=$(date -u +%Y-%m-%d)
           FROM=$(date -u -d "7 days ago" +%Y-%m-%d)


### PR DESCRIPTION
### **User description**
The `rum/site_info/list` endpoint needs a token with the **Web Analytics** permission group, which the Pages deploy token lacks (10000 auth error) — so the daily Site Analytics run never gets the site token. The RUM site token is **public by design** (it ships inside the beacon on every page), so this reads it from the committed `site/analytics.js` instead. Adds the missing checkout step.


___

### **PR Type**
Bug fix


___

### **Description**
- Read RUM site token from `site/analytics.js` instead of the failing `rum/site_info/list` API

- Add the missing `actions/checkout` step so the beacon file is available

- Improve fallback messaging when no beacon token is present


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["actions/checkout"] --> B["Fetch Cloudflare analytics"]
  B --> C["Read RUM token from site/analytics.js"]
  C --> D["Query analytics APIs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.yml</strong><dd><code>Read RUM site token from beacon file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/analytics.yml

<ul><li>Added <code>actions/checkout</code> step to make <code>site/analytics.js</code> available in the <br>runner<br> <li> Replaced <code>rum/site_info/list</code> API call with <code>sed</code> extraction of the public <br>RUM token from <code>site/analytics.js</code><br> <li> Updated the missing-token message to reference the CF Web Analytics <br>Bootstrap workflow<br> <li> Added a confirmation log printing the first 8 characters of the site <br>token</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1855/files#diff-607f949b9aca36160cbe6db71570383124fdf743994796f8091bb52cf1cc52a4">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

