### PR TITLE
ops(analytics): use CLOUDFLARE_WA_TOKEN for RUM queries + clear errors

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -26,13 +26,17 @@ jobs:
           H="Authorization: Bearer $TOKEN"
           api() { curl -s -H "$H" "$@"; }
 
-          # RUM data queries need a token with the Web Analytics permission
-          # group. Prefer the dedicated CLOUDFLARE_WA_TOKEN when it is set;
-          # otherwise fall back to the Pages token (which fails with a clear
-          # error message).
+          # RUM data queries go through the GraphQL Analytics API, which
+          # authenticates with the Account Analytics: Read permission (a
+          # standard token permission). Prefer the dedicated
+          # CLOUDFLARE_WA_TOKEN when it is set; otherwise fall back to the
+          # Pages token (which fails with a clear error message).
           RUM_TOKEN="${CLOUDFLARE_WA_TOKEN:-$TOKEN}"
-          H_RUM="Authorization: Bearer $RUM_TOKEN"
-          api_rum() { curl -s -H "$H_RUM" "$@"; }
+          gql() {
+            curl -s -X POST "https://api.cloudflare.com/client/v4/graphql" \
+              -H "Authorization: Bearer $RUM_TOKEN" -H "Content-Type: application/json" \
+              -d "$(python3 -c 'import json,sys; print(json.dumps({"query": sys.argv[1]}))' "$1")"
+          }
 
           echo "=== Cloudflare Pages: 1bit-monster ==="
           api "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/pages/projects/1bit-monster" | \
@@ -63,15 +67,15 @@ jobs:
 
           echo ""
           echo "--- Totals ---"
-          api_rum "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/rum/v2/$SITE_TOKEN/totals?dateFrom=$FROM&dateTo=$TODAY" | \
-            jq '{ visits: .result.totals.visits, visitors: .result.totals.visitors, pageviews: .result.totals.pageviews, success: .success, error: (.errors[0].message // null) }'
+          gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 1, filter: {siteTag: \"$SITE_TOKEN\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}) { sum { visits } } } } }" | \
+            jq '{ visits: (.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[0].sum.visits // 0), success: (.errors == null), error: (.errors[0].message // null) }'
 
           echo ""
           echo "--- Top pages ---"
-          api_rum "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/rum/v2/$SITE_TOKEN/aggregate?dateFrom=$FROM&dateTo=$TODAY&dimensions=path" | \
-            jq -r 'if .success then ([.result.dimensions.path[]? | { path: .key, views: .value }] | sort_by(-.views) | .[:10][] | "\(.views)\t\(.path)") else "RUM query failed: \(.errors[0].message // "unknown") — set the CLOUDFLARE_WA_TOKEN secret (Web Analytics: Edit) for RUM data" end'
+          gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 10, filter: {siteTag: \"$SITE_TOKEN\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { requestPath } sum { visits } } } } }" | \
+            jq -r 'if .data then ([.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[] | { path: .dimensions.requestPath, views: .sum.visits }] | sort_by(-.views) | .[:10][] | "\(.views)\t\(.path)") else "RUM query failed: \(.errors[0].message // "unknown")" end'
 
           echo ""
           echo "--- Top referrers (how people got here) ---"
-          api_rum "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/rum/v2/$SITE_TOKEN/aggregate?dateFrom=$FROM&dateTo=$TODAY&dimensions=referer" | \
-            jq -r 'if .success then ([.result.dimensions.referer[]? | { referer: .key, views: .value }] | sort_by(-.views) | .[:10][] | "\(.views)\t\(.referer)") else "RUM query failed: \(.errors[0].message // "unknown")" end'
+          gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 10, filter: {siteTag: \"$SITE_TOKEN\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { refererHost } sum { visits } } } } }" | \
+            jq -r 'if .data then ([.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[] | { referer: .dimensions.refererHost, views: .sum.visits }] | sort_by(-.views) | .[:10][] | "\(.views)\t\(.referer)") else "RUM query failed: \(.errors[0].message // "unknown")" end'

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -18,12 +18,21 @@ jobs:
       - name: Fetch Cloudflare analytics
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_WA_TOKEN: ${{ secrets.CLOUDFLARE_WA_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           TOKEN="$CLOUDFLARE_API_TOKEN"
           ACCOUNT_ID="$CLOUDFLARE_ACCOUNT_ID"
           H="Authorization: Bearer $TOKEN"
           api() { curl -s -H "$H" "$@"; }
+
+          # RUM data queries need a token with the Web Analytics permission
+          # group. Prefer the dedicated CLOUDFLARE_WA_TOKEN when it is set;
+          # otherwise fall back to the Pages token (which fails with a clear
+          # error message).
+          RUM_TOKEN="${CLOUDFLARE_WA_TOKEN:-$TOKEN}"
+          H_RUM="Authorization: Bearer $RUM_TOKEN"
+          api_rum() { curl -s -H "$H_RUM" "$@"; }
 
           echo "=== Cloudflare Pages: 1bit-monster ==="
           api "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/pages/projects/1bit-monster" | \
@@ -54,15 +63,15 @@ jobs:
 
           echo ""
           echo "--- Totals ---"
-          api "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/rum/v2/$SITE_TOKEN/totals?dateFrom=$FROM&dateTo=$TODAY" | \
-            jq '{ visits: .result.totals.visits, visitors: .result.totals.visitors, pageviews: .result.totals.pageviews, success: .success }'
+          api_rum "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/rum/v2/$SITE_TOKEN/totals?dateFrom=$FROM&dateTo=$TODAY" | \
+            jq '{ visits: .result.totals.visits, visitors: .result.totals.visitors, pageviews: .result.totals.pageviews, success: .success, error: (.errors[0].message // null) }'
 
           echo ""
           echo "--- Top pages ---"
-          api "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/rum/v2/$SITE_TOKEN/aggregate?dateFrom=$FROM&dateTo=$TODAY&dimensions=path" | \
-            jq -r '[.result.dimensions.path[]? | { path: .key, views: .value }] | sort_by(-.views) | .[:10][] | "\(.views)\t\(.path)"'
+          api_rum "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/rum/v2/$SITE_TOKEN/aggregate?dateFrom=$FROM&dateTo=$TODAY&dimensions=path" | \
+            jq -r 'if .success then ([.result.dimensions.path[]? | { path: .key, views: .value }] | sort_by(-.views) | .[:10][] | "\(.views)\t\(.path)") else "RUM query failed: \(.errors[0].message // "unknown") — set the CLOUDFLARE_WA_TOKEN secret (Web Analytics: Edit) for RUM data" end'
 
           echo ""
           echo "--- Top referrers (how people got here) ---"
-          api "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/rum/v2/$SITE_TOKEN/aggregate?dateFrom=$FROM&dateTo=$TODAY&dimensions=referer" | \
-            jq -r '[.result.dimensions.referer[]? | { referer: .key, views: .value }] | sort_by(-.views) | .[:10][] | "\(.views)\t\(.referer)"'
+          api_rum "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/rum/v2/$SITE_TOKEN/aggregate?dateFrom=$FROM&dateTo=$TODAY&dimensions=referer" | \
+            jq -r 'if .success then ([.result.dimensions.referer[]? | { referer: .key, views: .value }] | sort_by(-.views) | .[:10][] | "\(.views)\t\(.referer)") else "RUM query failed: \(.errors[0].message // "unknown")" end'


### PR DESCRIPTION
### **User description**
RUM data endpoints need a token with the **Web Analytics** permission group. This prefers the dedicated `CLOUDFLARE_WA_TOKEN` secret when set (falling back to the Pages token), and prints the API error so failures are self-explanatory instead of silent nulls.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Prefer `CLOUDFLARE_WA_TOKEN` for RUM GraphQL queries.

- Switch totals/pages/referrers to GraphQL Analytics API.

- Print API errors instead of silent null responses.

- Fall back to Pages token with clear failures.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  WF["analytics.yml workflow"] -->|CLOUDFLARE_WA_TOKEN| GQL["Cloudflare GraphQL API"]
  GQL -->|rumPageloadEventsAdaptiveGroups| T["Totals"]
  GQL -->|requestPath| P["Top pages"]
  GQL -->|refererHost| R["Top referrers"]
  WF -->|error fallback| E["Descriptive API errors"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.yml</strong><dd><code>Switch RUM analytics to GraphQL with WA auth</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/analytics.yml

<ul><li>Adds <code>CLOUDFLARE_WA_TOKEN</code> env var and <code>gql()</code> helper.<br> <li> Migrates RUM totals, pages, and referrers to GraphQL API.<br> <li> Adds <code>error</code> field and descriptive messages for query failures.<br> <li> Falls back to Pages token when WA token is not set.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1856/files#diff-607f949b9aca36160cbe6db71570383124fdf743994796f8091bb52cf1cc52a4">+19/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

