### PR TITLE
fix(csp): allow Cloudflare Web Analytics beacon

### DIFF
--- a/site/_headers
+++ b/site/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://img.shields.io https://github.com https://avatars.githubusercontent.com; font-src 'self'; connect-src 'self' https://1bit.monster; media-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://img.shields.io https://github.com https://avatars.githubusercontent.com; font-src 'self'; connect-src 'self' https://1bit.monster https://cloudflareinsights.com; media-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin


### PR DESCRIPTION
### **User description**
The `_headers` CSP (`script-src 'self' 'unsafe-inline'`) blocks the Web Analytics beacon (`static.cloudflareinsights.com`) whenever the site is served from Cloudflare Pages. Adds the beacon host to `script-src` + `connect-src`.


___

### **PR Type**
Bug fix


___

### **Description**
- Allow Cloudflare Web Analytics beacon via CSP

- Add `static.cloudflareinsights.com` to `script-src`

- Add `cloudflareinsights.com` to `connect-src`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CSP _headers"] -- "script-src + connect-src" --> B["static.cloudflareinsights.com allowed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_headers</strong><dd><code>Allow Cloudflare beacon hosts in CSP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/_headers

<ul><li>Extend <code>script-src</code> with <code>https://static.cloudflareinsights.com</code><br> <li> Extend <code>connect-src</code> with <code>https://cloudflareinsights.com</code><br> <li> Enables Cloudflare RUM beacon when served from Cloudflare Pages</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1859/files#diff-aa425049fdeab4ea6b94f164b358a4e51856cde1b52f7f4fba83a9b01146f1c3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

