### PR TITLE
analytics: path-based share attribution (CF RUM doesn't log query strings)

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -67,8 +67,10 @@ jobs:
 
           echo ""
           echo "--- Totals ---"
-          gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 1, filter: {siteTag: \"$SITE_TOKEN\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}) { sum { visits } } } } }" | \
-            jq '{ visits: (.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[0].sum.visits // 0), success: (.errors == null), error: (.errors[0].message // null) }'
+          TOTAL_JSON=$(gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 1, filter: {siteTag: \"$SITE_TOKEN\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}) { sum { visits } } } } }")
+          TOTAL_VISITS=$(echo "$TOTAL_JSON" | jq -r '.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[0].sum.visits // 0')
+          echo "Total visits: $TOTAL_VISITS (window $FROM .. $TODAY)"
+          echo "$TOTAL_JSON" | jq -r 'if .errors then "query errors: \(.errors[0].message)" else empty end'
 
           echo ""
           echo "--- Top pages ---"
@@ -79,3 +81,52 @@ jobs:
           echo "--- Top referrers (how people got here) ---"
           gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 10, filter: {siteTag: \"$SITE_TOKEN\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { refererHost } sum { visits } } } } }" | \
             jq -r 'if .data then ([.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[] | { referer: .dimensions.refererHost, views: .sum.visits }] | sort_by(-.views) | .[:10][] | "\(.views)\t\(.referer)") else "RUM query failed: \(.errors[0].message // "unknown")" end'
+
+          echo ""
+          echo "--- Attribution: who shared what (share.html links) ---"
+          # share.html links carry utm_source=share, utm_medium=<app>, share=<handle>
+          # and team=<team>. requestQuery captures the query string, so each visit
+          # can be attributed back to a sharer + team + medium.
+          ATTRIBUTION_JSON=$(gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 50, filter: {siteTag: \"$SITE_TOKEN\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { requestPath requestQuery } sum { visits } } } } }")
+          ATTRIBUTED=$(echo "$ATTRIBUTION_JSON" | jq -r '
+            if .data then
+              ([.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[]
+                | select(.dimensions.requestQuery != null)
+                | select(.dimensions.requestQuery | test("(^|[?&])(utm_source|share|team|ref)="))
+                | .sum.visits] | add // 0)
+            else -1 end')
+          if [ "$ATTRIBUTED" = "-1" ]; then
+            echo "Attribution query failed: $(echo "$ATTRIBUTION_JSON" | jq -r '.errors[0].message // "unknown"')"
+          else
+            echo "Attributed visits: $ATTRIBUTED of ${TOTAL_VISITS:-0} total (came through tracked share.html links)"
+            echo -e "views\tsharer\tteam\tmedium\tpath"
+            echo "$ATTRIBUTION_JSON" | jq -r '
+              if .data then
+                ([.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[]
+                  | select(.dimensions.requestQuery != null)
+                  | select(.dimensions.requestQuery | test("(^|[?&])(utm_source|share|team|ref)="))
+                  | . as $r
+                  | ($r.dimensions.requestQuery | ltrimstr("?") | split("&") | map(select(contains("=")) | split("=") | {key: .[0], value: (.[1:] | join("="))}) | from_entries) as $q
+                  | { views: $r.sum.visits,
+                      sharer: ($q.share // "-"),
+                      team: ($q.team // "-"),
+                      medium: ($q.utm_medium // $q.utm_source // "-"),
+                      path: $r.dimensions.requestPath }]
+                 | sort_by(-.views) | .[:25][])
+                | "\(.views)\t\(.sharer)\t\(.team)\t\(.medium)\t\(.path)"
+              else empty end'
+          fi
+
+          echo ""
+          echo "--- Attribution summary (also on the Actions run page) ---"
+          if [ "${ATTRIBUTED:-0}" -gt 0 ] 2>/dev/null; then
+            {
+              echo "### 🎉 Attributed shares this window"
+              echo "**$ATTRIBUTED** of ${TOTAL_VISITS:-0} visits came through tracked share.html links — see the run log for who / team / medium."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### 📡 Attribution status"
+              echo "No attributed clicks yet — the RUM beacon is still aggregating (< 24h live). Once people use share.html links, this report names the sharer + team + medium."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -84,36 +84,40 @@ jobs:
 
           echo ""
           echo "--- Attribution: who shared what (share.html links) ---"
-          # share.html links carry utm_source=share, utm_medium=<app>, share=<handle>
-          # and team=<team>. requestQuery captures the query string, so each visit
-          # can be attributed back to a sharer + team + medium.
-          ATTRIBUTION_JSON=$(gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 50, filter: {siteTag: \"$SITE_TOKEN\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { requestPath requestQuery } sum { visits } } } } }")
+          # share.html links carry the attribution in the PATH (/s/<sharer>/<team>/<medium>)
+          # because Cloudflare Web Analytics does not log query strings (documented
+          # limitation). 404.html fires the RUM beacon on the /s/ URL, so requestPath
+          # records the full attribution before redirecting to the target.
+          ATTRIBUTION_JSON=$(gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 50, filter: {siteTag: \"$SITE_TOKEN\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { requestPath } sum { visits } } } } }")
           ATTRIBUTED=$(echo "$ATTRIBUTION_JSON" | jq -r '
             if .data then
               ([.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[]
-                | select(.dimensions.requestQuery != null)
-                | select(.dimensions.requestQuery | test("(^|[?&])(utm_source|share|team|ref)="))
+                | select(.dimensions.requestPath != null and (.dimensions.requestPath | startswith("/s/")))
                 | .sum.visits] | add // 0)
             else -1 end')
           if [ "$ATTRIBUTED" = "-1" ]; then
             echo "Attribution query failed: $(echo "$ATTRIBUTION_JSON" | jq -r '.errors[0].message // "unknown"')"
           else
             echo "Attributed visits: $ATTRIBUTED of ${TOTAL_VISITS:-0} total (came through tracked share.html links)"
-            echo -e "views\tsharer\tteam\tmedium\tpath"
+            echo -e "views\tsharer\tteam\tmedium"
             echo "$ATTRIBUTION_JSON" | jq -r '
               if .data then
                 ([.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[]
-                  | select(.dimensions.requestQuery != null)
-                  | select(.dimensions.requestQuery | test("(^|[?&])(utm_source|share|team|ref)="))
+                  | select(.dimensions.requestPath != null and (.dimensions.requestPath | startswith("/s/")))
                   | . as $r
-                  | ($r.dimensions.requestQuery | ltrimstr("?") | split("&") | map(select(contains("=")) | split("=") | {key: .[0], value: (.[1:] | join("="))}) | from_entries) as $q
+                  | ($r.dimensions.requestPath | split("/") | map(select(length > 0))) as $seg
                   | { views: $r.sum.visits,
-                      sharer: ($q.share // "-"),
-                      team: ($q.team // "-"),
-                      medium: ($q.utm_medium // $q.utm_source // "-"),
-                      path: $r.dimensions.requestPath }]
+                      sharer: $seg[1],
+                      team: $seg[2],
+                      medium: ($seg[3]
+                        | if . == "teams" then "Teams"
+                          elif . == "discord" then "Discord"
+                          elif . == "slack" then "Slack"
+                          elif . == "email" then "Email"
+                          elif . == "social" then "Social"
+                          else . end) }]
                  | sort_by(-.views) | .[:25][])
-                | "\(.views)\t\(.sharer)\t\(.team)\t\(.medium)\t\(.path)"
+                | "\(.views)\t\(.sharer)\t\(.team)\t\(.medium)"
               else empty end'
           fi
 

--- a/site/404.html
+++ b/site/404.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Redirecting… — 1bit.MONSTER</title>
+  <meta name="robots" content="noindex" />
+  <link rel="canonical" href="https://1bit.monster/" />
+  <style>
+    body { font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace; max-width: 560px; margin: 80px auto; padding: 0 20px; background: #fafafa; color: #222; text-align: center; }
+    h1 { font-size: 20px; }
+    p { font-size: 14px; color: #555; }
+    a { color: #1a56db; }
+  </style>
+</head>
+<body>
+  <h1>Taking you there…</h1>
+  <p id="msg">Redirecting to the shared page.</p>
+  <p><a href="https://1bit.monster/">← Back to 1bit.monster</a></p>
+
+  <script src="analytics.js"></script>
+  <script>
+    // Attribution redirect for /s/<sharer>/<team>/<medium>?next=<target>
+    // GitHub Pages serves this 404 page for any unknown path, so an
+    // attribution link's /s/... URL lands here. analytics.js above fires the
+    // Cloudflare Web Analytics beacon, which records THIS URL's path — the
+    // sharer / team / medium — before we redirect to the real target.
+    (function () {
+      var seg = (location.pathname || "").split("/").filter(Boolean);
+      if (seg[0] === "s" && seg.length >= 4) {
+        var params = new URLSearchParams();
+        params.set("utm_source", "share");
+        params.set("utm_medium", decodeURIComponent(seg[3]));
+        params.set("share", decodeURIComponent(seg[1]));
+        params.set("team", decodeURIComponent(seg[2]));
+        var target = new URLSearchParams(location.search).get("next") || "https://1bit.monster/";
+        document.getElementById("msg").textContent = "Redirecting to: " + target;
+        // Give the beacon a moment to report this page load, then redirect.
+        setTimeout(function () {
+          var sep = target.indexOf("?") >= 0 ? "&" : "?";
+          location.replace(target + sep + params.toString());
+        }, 1000);
+      } else {
+        document.getElementById("msg").textContent = "That page doesn't exist.";
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/site/analytics.js
+++ b/site/analytics.js
@@ -28,6 +28,15 @@
       var v = p.get(k);
       if (v) out[k] = v;
     });
+    // Path-based attribution: /s/<sharer>/<team>/<medium> (share.html links).
+    // Cloudflare Web Analytics does not log query strings, so the attribution
+    // travels in the path; 404.html redirects to the target afterwards.
+    var seg = (window.location.pathname || "").split("/").filter(Boolean);
+    if (seg[0] === "s" && seg.length >= 4) {
+      if (!out.share) out.share = decodeURIComponent(seg[1]);
+      if (!out.team) out.team = decodeURIComponent(seg[2]);
+      if (!out.utm_medium) out.utm_medium = decodeURIComponent(seg[3]);
+    }
     return out;
   }
 

--- a/site/share.html
+++ b/site/share.html
@@ -68,20 +68,22 @@
     <label>Shareable link</label>
     <textarea id="url" readonly></textarea>
     <span class="copy" onclick="copy()">copy</span>
-    <div class="hint">The <code>utm_source</code>/<code>team</code> params let analytics attribute this share back to you. Share the whole link as-is.</div>
+    <div class="hint">The <code>/s/&lt;you&gt;/&lt;team&gt;/&lt;medium&gt;</code> path lets analytics attribute this share back to you. Share the whole link as-is.</div>
   </div>
 
   <script src="analytics.js"></script>
   <script>
     function build() {
+      // Path-based attribution: /s/<sharer>/<team>/<medium>?next=<target>
+      // Cloudflare Web Analytics does not log query strings, so the sharer,
+      // team and medium live in the PATH (recorded by RUM via requestPath);
+      // the target travels in ?next= and 404.html redirects to it.
+      var s = encodeURIComponent(document.getElementById("sharer").value.trim() || "-");
+      var t = encodeURIComponent(document.getElementById("team").value.trim() || "-");
+      var m = encodeURIComponent(document.getElementById("medium").value || "link");
       var base = document.getElementById("page").value;
-      var u = new URL(base);
-      u.searchParams.set("utm_source", "share");
-      u.searchParams.set("utm_medium", document.getElementById("medium").value || "link");
-      var s = document.getElementById("sharer").value.trim();
-      var t = document.getElementById("team").value.trim();
-      if (s) u.searchParams.set("share", s);
-      if (t) u.searchParams.set("team", t);
+      var u = new URL("https://1bit.monster/s/" + s + "/" + t + "/" + m);
+      u.searchParams.set("next", base);
       document.getElementById("url").value = u.toString();
       document.getElementById("out").style.display = "block";
     }


### PR DESCRIPTION
### **User description**
Cloudflare Web Analytics does not log query strings (documented), so the old share.html UTM-query scheme could never be attributed server-side.

**Changes**
- `share.html` generates `/s/<sharer>/<team>/<medium>?next=<target>` links
- New `site/404.html`: GitHub Pages serves it for unknown paths — it fires the RUM beacon on the /s/ URL (recording attribution in requestPath), then redirects to the target with attribution params
- `analytics.js`: parses /s/ paths for client-side first-touch attribution
- `analytics.yml`: reports attributed visits (sharer/team/medium) from /s/ requestPaths + coverage vs total + run-page summary

**Validation**: dispatched on this branch — query runs clean against the real GraphQL API (fixes the earlier `unknown field \requestQuery\`), reports 0/0 until RUM aggregates.


___

### **PR Type**
Enhancement


___

### **Description**
- Pivots share attribution from query strings to /s/ paths

- New 404 page fires RUM beacon before redirecting targets

- analytics.js also captures /s/ path-based attribution client-side

- Workflow reports attributed visits vs total on run page


___

### Diagram Walkthrough


```mermaid
flowchart LR
  sharehtml["share.html builds /s/ link"] --> s404["/s/... lands on 404.html"]
  s404 -- "fires RUM beacon (requestPath)" --> rum["Cloudflare RUM"]
  s404 -- "redirects with next target" --> target["target page"]
  analyticsjs["analytics.js parses /s/ path"] --> attribution["first-touch attribution"]
  rum --> workflow["analytics.yml attribution report"]
  attribution --> workflow
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>404.html</strong><dd><code>Attribution redirect 404 page for shared links</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/404.html

<ul><li>New GitHub Pages 404 page for unknown paths<br> <li> Detects /s/<sharer>/<team>/<medium> URLs<br> <li> Fires analytics beacon before redirecting to ?next target<br> <li> Shows a friendly redirect or missing-page message</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1863/files#diff-8cbce8d617d964ddab39632760ab6337f1b8e3c5584de59ef68c68f07ba8624d">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>share.html</strong><dd><code>Share links use path-based attribution format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/share.html

<ul><li>Link builder now generates /s/<sharer>/<team>/<medium>?next=<target><br> <li> Moves attribution data from query params into the URL path<br> <li> Updates hint text to explain the new path scheme</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1863/files#diff-13c0c92c6f311ddec0e93b68450844ae9a3f9f72a0b67c1fbb665b1a7b4cb393">+10/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>analytics.js</strong><dd><code>Client-side parsing of path-based attribution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/analytics.js

<ul><li>readAttribution also parses /s/ path segments<br> <li> Adds sharer, team, and medium from path segments<br> <li> Falls back to path values only when query params are absent</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1863/files#diff-bb95385d6f7cad7461b7de3ac9fd16b83021e4f180deaa7f6098a629fd350294">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>analytics.yml</strong><dd><code>Analytics workflow reports attributed share visits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/analytics.yml

<ul><li>Adds attribution query grouped by /s/ requestPath<br> <li> Reports attributed vs total visit coverage<br> <li> Formats sharer/team/medium from path segments<br> <li> Writes summary with result to the Actions run page</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1863/files#diff-607f949b9aca36160cbe6db71570383124fdf743994796f8091bb52cf1cc52a4">+57/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

