### PR TITLE
fix(build): verify_1bp uses NpuOnebpModel (issue #1833)

### DIFF
--- a/tools/verify_1bp.cpp
+++ b/tools/verify_1bp.cpp
@@ -43,7 +43,7 @@ int main(int argc, char** argv) {
 
     GgufReader gg;
     if (!gg.open(gg_path.c_str())) { fprintf(stderr, "cannot open GGUF %s\n", gg_path.c_str()); return 2; }
-    OnebpModel bp;
+    NpuOnebpModel bp;
     if (!bp.open(bp_path.c_str())) { fprintf(stderr, "cannot open 1BP %s\n", bp_path.c_str()); return 2; }
 
     int bad = 0, checked = 0;


### PR DESCRIPTION
### **User description**
**#1833** — `tools/verify_1bp.cpp` used `OnebpModel` but `onebp_loader.cpp` defines **`NpuOnebpModel`** (the `OnebpModel` in `include/onebp_loader.h` is a separate stub). verify_1bp includes the .cpp directly, so the class is `NpuOnebpModel`. Fixes the compile; verified builds.


___

### **PR Type**
Bug fix


___

### **Description**
- Rename `OnebpModel` to `NpuOnebpModel` in `tools/verify_1bp.cpp`.

- Fixes compile error because loader defines `NpuOnebpModel`.

- Keeps the 1BP verification tool buildable and usable.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  V["tools/verify_1bp.cpp"] -- "uses" --> N["NpuOnebpModel"]
  L["engine/npu/src/onebp_loader.cpp"] -- "defines" --> N
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>verify_1bp.cpp</strong><dd><code>Use NpuOnebpModel in verify_1bp tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/verify_1bp.cpp

<ul><li>Renamed <code>OnebpModel</code> to <code>NpuOnebpModel</code> in the verification tool.<br> <li> Fixes "OnebpModel was not declared" compile error.<br> <li> Uses the correct class name from <code>onebp_loader.cpp</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1877/files#diff-1e4d5c0469a40daca152bf147178ff672cbc06f19630abbf989323c13aa7fda0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

