### PR TITLE
fix(analytics): invalid jq escapes in zone/drift queries

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -96,7 +96,7 @@ jobs:
                        ([.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[] |
                          { tag: .dimensions.siteTag, path: .dimensions.requestPath, views: .sum.visits }]
                         | .[] | "\(.tag[0:8])…\t\(.views)\t\(.path)")
-                     else "health query failed: \(.errors[0].message // \"unknown\")" end'
+                     else "health query failed: \(.errors[0].message // "unknown")" end'
           else
             echo "Site token has data — no drift detected."
           fi
@@ -150,7 +150,7 @@ jobs:
                        ([.data.viewer.zones[0].httpRequests1dGroups[] |
                          { date: .dimensions.date, requests: .sum.requests, pageViews: .sum.pageViews }]
                         | .[] | "\(.date)\t\(.requests) req\t\(.pageViews) pv")
-                     else "zone analytics query failed: \(.errors[0].message // \"unknown\")" end'
+                     else "zone analytics query failed: \(.errors[0].message // "unknown")" end'
           else
             echo "Zone 1bit.monster not visible to the analytics token (need Zone: Read on the WA token)."
           fi


### PR DESCRIPTION
### **User description**
Follow-up to #1879: the zone-analytics and drift-detection jq used `\"unknown\"` inside `\( ... )` interpolation — jq rejects backslash-escaped quotes outside string literals, so the zone section crashed the step (exit 3, red daily run). Fixed to plain `"unknown"`; both programs verified locally.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix invalid `\"unknown\"` escapes in jq `\( )` interpolations

- Apply the fix to both drift-detection and zone-analytics queries

- Resolve jq parse failure that crashed the workflow step (exit 3)

- Verified both jq programs locally against realistic GraphQL responses


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["analytics.yml"] --> B["drift detection jq"]
  A --> C["zone analytics jq"]
  B --> D["invalid escapes"]
  C --> D
  D --> E["valid jq queries"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.yml</strong><dd><code>Fix invalid jq escapes in analytics workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/analytics.yml

<ul><li>Replaces <code>\"unknown\"</code> with <code>"unknown"</code> inside <code>\( )</code> interpolation in the <br>drift-detection health query<br> <li> Applies the same jq escape fix to the zone-analytics error message<br> <li> Prevents jq syntax rejection that caused the workflow step to exit <br>with code 3</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1880/files#diff-607f949b9aca36160cbe6db71570383124fdf743994796f8091bb52cf1cc52a4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

