### PR TITLE
fix(build): remove dangling #endif in onebp_loader example main (#1833)

### DIFF
--- a/engine/npu/src/onebp_loader.cpp
+++ b/engine/npu/src/onebp_loader.cpp
@@ -530,7 +530,6 @@ public:
 
 // ─── Example usage ─────────────────────────────────────────────────
 #ifdef ONEBP_LOADER_MAIN
-#ifdef ONEBP_LOADER_MAIN
 int main(int argc, char** argv) {
     if (argc < 2) {
         fprintf(stderr, "Usage: %s model.1bp [tensor_name]\n", argv[0]);
@@ -579,6 +578,5 @@ int main(int argc, char** argv) {
         printf("    ... and %d more\n", model.tensor_count() - 10);
 
     return 0;
-#endif
 }
 #endif


### PR DESCRIPTION
### **User description**
Completes #1833 (the compile half was fixed by #1877's `NpuOnebpModel` rename).

`tools/verify_1bp.cpp` includes `engine/npu/src/onebp_loader.cpp` directly. The example-main block had `1 x #ifdef ONEBP_LOADER_MAIN` but `2 x #endif`, so the translation unit failed with `#endif without #if`. Removed the dangling `#endif`.

Verified: `g++ -std=c++23 -O2 -Iinclude -Iengine/npu/include -I. tools/verify_1bp.cpp src/gguf_reader.cpp` builds a working binary (usage message prints).


___

### **PR Type**
Bug fix


___

### **Description**
- Remove duplicate `ONEBP_LOADER_MAIN` guard in onebp_loader.

- Delete dangling `#endif` that broke verify_1bp compilation.

- Restore single guarded example-main block in loader.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["engine/npu/src/onebp_loader.cpp"] -- "remove duplicate #ifdef + dangling #endif" --> B["Single ONEBP_LOADER_MAIN block"]
  B -- "enables" --> C["tools/verify_1bp.cpp compiles"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>onebp_loader.cpp</strong><dd><code>Deduplicate ONEBP_LOADER_MAIN guard and fix #endif</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/onebp_loader.cpp

<ul><li>Removed duplicate <code>#ifdef ONEBP_LOADER_MAIN</code> in example-main block.<br> <li> Removed extra <code>#endif</code> that made <code>verify_1bp.cpp</code> fail to compile.<br> <li> Left a single balanced <code>#ifdef</code>/<code>#endif</code> around <code>main()</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1881/files#diff-3f8f4876072eb3fca972f3bf293abf8248617a97c9604a05f9d39637f888f8c3">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

