### PR TITLE
hw(1bit-llm): land RTL source + U250 Vivado flow; drop generated sim artifacts

### DIFF
--- a/.github/workflows/scope-guard.yml
+++ b/.github/workflows/scope-guard.yml
@@ -61,6 +61,7 @@ jobs:
             experimental research hackathon fastflowlm_analysis npu-infer
             integrations themes
             npu_smoke.py  # pyxrt NPU engine smoke test (CI/bench harness on strix-halo runner) — engine scope
+            hw  # 1bit-LLM FPGA accelerator RTL (ternary GEMV decode engine for the 1-bit box) — engine hardware scope, see hw/1bit-llm/DESIGN.md
             .gitmodules .gitignore .gitnexusignore third_party  # embedded Lemonade server core — engine scope; .gitnexusignore = GitNexus index exclusions (agent tooling, like .gitignore)
             .clang-format  # engine C++23 style config — engine scope
             .superpowers  # agent-tooling task docs (SDD dispatch/brief/report) — same category as .claude/.abacusai

--- a/.gitignore
+++ b/.gitignore
@@ -163,4 +163,6 @@ build-asan/
 x86simulator_output/
 Work/
 build-1715/
+# ── hw/1bit-llm generated sim/build outputs (DESIGN.md §6: gitignored) ──
+hw/1bit-llm/sim/
 .gitnexus/

--- a/hw/1bit-llm/DESIGN.md
+++ b/hw/1bit-llm/DESIGN.md
@@ -1,0 +1,217 @@
+# 1bit-LLM — Ternary LLM Decode Accelerator (RTL)
+
+**Status:** wiring pass 1 — skeleton datapath, simulation-verified
+**Target:** open-source 7-series flow (iverilog sim → yosys synth_xilinx → nextpnr-xilinx + prjxray)
+**Portability note:** the Alveo U250 (the eventual box per journey UPDATE 32) is UltraScale+ and has
+no open-source bitstream path, so the RTL is written in portable Verilog-2001 with **no vendor
+primitives** — only inferred BRAMs. The same RTL can be dropped into a Vivado U250 project later;
+the open-source flow keeps the 7-series (Artix/Kintex-7) honest for free.
+
+---
+
+## 1. What this is
+
+A first, wired, *correct* slice of the "1-bit FPGA LLM box": the decode-time workhorse — a
+**ternary (1.58-bit) GEMV engine**. BitNet-style LLMs quantize weights to {-1, 0, +1}, which turns
+the matmul into **pure adds/subtracts of activations** — no multipliers, no DSPs.
+
+Scope of this pass:
+
+- On-chip weight cache (BRAM), one layer-tile's worth.
+- Activation buffer + output buffer (BRAM).
+- 4-lane ternary dot-product datapath with int32 accumulators.
+- Integer scale/shift output stage (bit-exact vs. a Python reference).
+- A tiny host interface (register bus) so the whole thing is driven and verified without an SoC.
+- Sim verification: two randomized cases, bit-exact vs `tools/gen_golden.py`.
+
+Deliberately **not** in this pass (see §8 roadmap): external DRAM weight streaming, AXI, multi-
+layer sequencing, softmax, KV cache, systolic-array throughput, PCIe.
+
+## 2. Module hierarchy and wiring
+
+```
+                              hif (host bus: 16-bit word addr + 32-bit data)
+                                          │
+                    ┌─────────────────────▼──────────────────────┐
+                    │  hif_slave  — reg file + address decode    │
+                    │   CTRL STATUS CFG_K CFG_N SCALE            │
+                    └───┬───────────────┬───────────────┬────────┘
+                 start_pulse,cfg        │ port A (host) │ port A (host)
+                 scale_q15,shift        │ 32-bit wr/rd  │ 32-bit wr/rd
+                 busy/done/err  ┌───────▼───┐    ┌───────▼───┐
+                    ┌───────────▼─┐        │ wmem │    │ xbuf  │
+                    │  ctrl_fsm   │        │      │    │       │
+                    │  sequencer  │        └───┬───┘    └───┬───┘
+                    └─────┬───────┘            │ port B    │ port B
+                          │                    │ (gemv)    │ (gemv)
+        mac_en, clr_acc   │      w_in[7:0] ◄───┘  xb_rdata  x_addr
+        act_in[7:0] ◄─────┼─────────────┘        b_addr ────┘
+                          ▼
+                 ┌───────────────────┐
+                 │    gemv_core      │   4-lane ternary MAC tree,
+                 │  acc[127:0] (4×32)│   int32 accumulators
+                 └────────┬──────────┘
+                          │
+                 ┌────────▼──────────┐
+                 │    scale_unit     │   4× (acc·scale_q15 + rnd) >> shift
+                 │   ysat[63:0] (4×16)│   saturating to int16
+                 └────────┬──────────┘
+                          │
+                 ┌────────▼──────────┐
+                 │  ctrl_fsm drains  │   yw_addr/yw_data/yw_wen
+                 └────────┬──────────┘
+                          ▼
+                        ybuf (port B write; port A read by host)
+```
+
+Ports on the top (`t1llm_top`):
+
+| Port | Dir | Width | Meaning |
+|------|-----|-------|---------|
+| `clk` | in | 1 | system clock |
+| `rst_n` | in | 1 | async reset, active low |
+| `hif_wr_req` | in | 1 | host write strobe |
+| `hif_wr_addr` | in | 16 | word address |
+| `hif_wr_data` | in | 32 | write data |
+| `hif_rd_req` | in | 1 | host read strobe |
+| `hif_rd_addr` | in | 16 | word address |
+| `hif_rd_data` | out | 32 | read data (registered) |
+| `hif_rd_valid` | out | 1 | read data valid |
+| `hif_ready` | out | 1 | accepts transactions |
+
+## 3. Host interface and address map
+
+Synchronous, single-word transactions, always ready. Word-addressed (each address = one 32-bit word).
+
+| Window | Addr[15:12] | Contents |
+|--------|-------------|----------|
+| Control | `0x0` | registers, see below |
+| wmem | `0x1` | ternary weight memory, 4 entries per word (see §4 layout) |
+| xbuf | `0x2` | activation buffer, 4 int8 per word |
+| ybuf | `0x3` | output buffer, 2 int16 per word (read-only from host) |
+
+Registers (word offsets within the control window):
+
+| Addr | Name | Bits | Meaning |
+|------|------|------|---------|
+| 0x00 | CTRL | [0] start (self-clearing pulse) · [1] soft_reset · [2] clr_status | |
+| 0x01 | STATUS | [0] busy · [1] done · [2] err (read-only) | |
+| 0x02 | CFG_K | [15:0] | rows of the weight matrix (= activation length, ≥1) |
+| 0x03 | CFG_N | [15:0] | columns (= output length, multiple of 4) |
+| 0x04 | SCALE | [15:0] scale_q15 (signed) · [23:16] shift (0..15) | |
+
+## 4. Data formats and memory layout
+
+### 4.1 Ternary weight encoding — 2 bits per weight, 4 per byte
+
+```
+bits {sign, nz}:  nz = weight != 0,  sign = weight < 0
+  2'b00 →  0     2'b01 → +1     2'b10 → -1     2'b11 → -1
+```
+
+Decode in hardware: `value = nz ? (sign ? -1 : +1) : 0`, i.e. a MAC lane either adds, subtracts,
+or skips the activation. **No multiplier.**
+
+### 4.2 wmem layout — the GEMV read pattern
+
+`wmem` holds the weight matrix transposed for output-lane streaming. Group output columns into
+lanes of 4 (`g = n[15:2]`), with `K` rows each. Entry index `e = g·K + k` is one byte = the four
+ternary weights `w[k][4g+0..3]`:
+
+```
+byte e = g*K + k:
+  bits[1:0]   = w[k][4g+0]     lane 0
+  bits[3:2]   = w[k][4g+1]     lane 1
+  bits[5:4]   = w[k][4g+2]     lane 2
+  bits[7:6]   = w[k][4g+3]     lane 3
+```
+
+Total entries = `(N/4)·K`. Host writes 32-bit words = 4 consecutive entries, entry `4w+0` in the
+low byte. (First pass uses 8 of every 32 bits at the byte granularity the GEMV stream needs; the
+rest of the word is wasted — see §8, packing.)
+
+### 4.3 Activations and outputs
+
+- `xbuf`: `K` signed int8 entries (byte `k`), word = 4 consecutive bytes, byte `4w` in low byte.
+- `ybuf`: `N/2` words, each holding two signed int16 outputs, `{y[2g+1], y[2g]}` (hi/lo).
+
+## 5. Datapath and control
+
+### 5.1 GEMV math (exactly what `tools/gen_golden.py` mirrors)
+
+```
+acc[n] = Σ_k act[k] · w[k][n]          // ternary w: add/sub/skip, int32 acc
+y[n]   = sat16( (acc[n]·scale_q15 + rnd) >>> shift ),  rnd = shift ? (1<<(shift-1)) : 0
+```
+
+`>>>` is arithmetic shift; saturation to int16. Integer-only, deterministic, bit-exact.
+
+### 5.2 ctrl_fsm states
+
+```
+IDLE → CHECK → ADDR ⇄ MAC (×K) → DRAIN1 → DRAIN2 → (next g | DONE) → IDLE
+                └─ invalid config → ERR
+```
+
+- **CHECK** — validates `K ≥ 1`, `N % 4 == 0`, `(N/4)·K ≤ WMEM_DEPTH`; clears done/err; asserts busy.
+- **ADDR** — drives `wmem.b_addr = g·K + k`, `xbuf.b_addr = k`; asserts `clr_acc` on `k == 0`.
+- **MAC** — one cycle later the registered BRAM data is valid; asserts `mac_en` and samples
+  `w_in/xb_rdata`. Increments `k`; on `k == K-1` goes to drain.
+- **DRAIN1/DRAIN2** — writes `{ysat1,ysat0}` to `ybuf[2g]`, `{ysat3,ysat2}` to `ybuf[2g+1]`.
+  Increments `g`; done when `g == N/4`.
+- **DONE / ERR** — deasserts busy, latches status. `clr_status` clears it.
+
+Read latency pipeline: registered BRAM reads give `data(addr_t) = data_t+1`; the ADDR/MAC
+alternation consumes exactly that.
+
+### 5.3 Throughput (first pass)
+
+`≈ 2·K·N/4` cycles per GEMV (one ADDR + one MAC per (g,k)). Lane-parallelism is 4; the point of
+this pass is correctness and a clean wiring skeleton, not throughput. §8 lists the path to a
+systolic/tiled engine.
+
+## 6. Verification
+
+- `tools/gen_golden.py <case>` generates golden vectors (hex files) for two randomized cases:
+  - case 0: `K=8,  N=16`  (wmem 32 entries, ybuf 8 words; positive scale + rounding path)
+  - case 1: `K=16, N=8`   (wmem 32 entries, ybuf 4 words; negative scale + sign path)
+- `tb/tb_top.v` drives the design **through the host interface only** (write cfg → write wmem →
+  write xbuf → start → poll status → read ybuf), compares against the golden files, and also
+  exercises the FSM error path (invalid `N` → `STATUS.err` latched, then cleared via
+  `clr_status`). `make sim` must print `=== TB: ALL PASS ===`.
+- `make synth` runs yosys `synth_xilinx` as a synthesizability gate (no place-and-route in CI;
+  the full nextpnr/prjxray flow lives in `synth/xc7_flow.sh` and runs on the box with the
+  toolchain).
+
+## 7. File map
+
+```
+hw/1bit-llm/
+├── DESIGN.md
+├── Makefile
+├── rtl/
+│   ├── t1llm_top.v     top — wires everything
+│   ├── hif_slave.v     host interface, reg file, decode
+│   ├── ctrl_fsm.v      GEMV sequencer + status
+│   ├── wmem.v          weight BRAM (dual-port, port A host / port B gemv)
+│   ├── xbuf.v          activation BRAM (same dual-port shape)
+│   ├── ybuf.v          output BRAM (port A host read / port B gemv write)
+│   ├── gemv_core.v     4-lane ternary MAC + int32 accumulators
+│   └── scale_unit.v    4× saturating q15·acc >> shift
+├── tb/tb_top.v
+├── tools/gen_golden.py Python bit-exact reference + golden vectors
+├── synth/xc7_flow.sh   yosys → nextpnr-xilinx → prjxray → openFPGALoader (stub)
+└── sim/                build + generated vectors (gitignored)
+```
+
+## 8. Roadmap
+
+1. **Pack wmem to 32-bit words** (4 k-values per word) to remove the 4× waste; add AXI-lite
+   host path. *(this pass: plain bus, 8/32 bits used)*
+2. **Weight streaming from external DRAM** — the 1B model's weights don't fit on-chip; the
+   BRAM cache becomes a double-buffered tile cache.
+3. **Systolic/tiled datapath** — N_LANES up to 16-64, K pipelined, multi-bank BRAM; target the
+   50-150 tok/s envelope from the journey note.
+4. **Full decoder block** — RMSNorm, softmax, KV cache, layer loop; then multi-layer.
+5. **Board bring-up** — 7-series (open-source bitstream) first, then the U250 via Vivado using
+   this same RTL, plus LUT-LLM-style memory-compute ideas from `research/IDEAS.md` I-07.

--- a/hw/1bit-llm/Makefile
+++ b/hw/1bit-llm/Makefile
@@ -1,0 +1,44 @@
+# 1bit-LLM — build & verify (see DESIGN.md)
+#
+#   make gold   — generate golden vectors (python3 tools/gen_golden.py)
+#   make sim    — iverilog simulation, must print "=== TB: ALL PASS ==="
+#   make synth  — yosys synth_xilinx synthesizability gate (open-source 7-series)
+#   make clean
+
+IVERILOG ?= iverilog
+VVP      ?= vvp
+PYTHON   ?= python3
+YOSYS    ?= yosys
+
+RTL     := $(wildcard rtl/*.v)
+TB      := tb/tb_top.v
+SIM_DIR := sim
+
+.PHONY: all gold sim synth clean
+
+all: sim
+
+gold:
+	$(PYTHON) tools/gen_golden.py 0
+	$(PYTHON) tools/gen_golden.py 1
+
+sim: gold
+	@mkdir -p $(SIM_DIR)
+	$(IVERILOG) -g2005-sv -Wall -o $(SIM_DIR)/tb_top.vvp $(RTL) $(TB)
+	cd $(SIM_DIR) && $(VVP) tb_top.vvp
+
+# Synthesizability gate: elaboration + generic synth (no P&R here; the full
+# nextpnr-xilinx + prjxray flow lives in synth/xc7_flow.sh).
+synth: gold
+	@mkdir -p $(SIM_DIR)
+	$(YOSYS) -q -p "read_verilog $(RTL); \
+	    hierarchy -top t1llm_top; \
+	    proc; opt; \
+	    synth_xilinx -top t1llm_top; \
+	    stat; \
+	    write_verilog -noattr $(SIM_DIR)/t1llm_top_synth.v" \
+	    -l $(SIM_DIR)/synth.log
+	@echo "synth gate: OK (log in $(SIM_DIR)/synth.log)"
+
+clean:
+	rm -rf $(SIM_DIR)

--- a/hw/1bit-llm/rtl/ctrl_fsm.v
+++ b/hw/1bit-llm/rtl/ctrl_fsm.v
@@ -1,0 +1,187 @@
+`timescale 1ns/1ps
+// ctrl_fsm — GEMV sequencer + status.
+//
+// Runs one GEMV:  y[n] = sat16( ( Σ_k act[k]·w[k][n] ) · scale_q15 >> shift )
+// for n in 0..N-1, K activations, using the 4-lane gemv_core and scale_unit.
+//
+// State flow (see DESIGN.md §5.2):
+//   IDLE → CHECK → (ADDR ⇄ MAC)×K → DRAIN1 → DRAIN2 → (next g | DONE) → IDLE
+//
+// Timing: BRAM reads are registered, so ADDR issues the address and MAC (one
+// cycle later) consumes the data. clr_acc is asserted during ADDR when k==0 so
+// the accumulators reset one cycle before the first MAC.
+module ctrl_fsm #(
+    parameter WMEM_DEPTH = 8192,
+    parameter XBUF_DEPTH = 4096,
+    parameter YBUF_DEPTH = 4096,
+    parameter WMEM_AW    = 13,
+    parameter XBUF_AW    = 12,
+    parameter YBUF_AW    = 12
+)(
+    input  wire              clk,
+    input  wire              rst_n,
+    // control from hif
+    input  wire              start_pulse,
+    input  wire              soft_reset,
+    input  wire              clr_status,
+    input  wire [15:0]       cfg_k,
+    input  wire [15:0]       cfg_n,
+    input  wire [15:0]       scale_q15,
+    input  wire [7:0]        scale_shift,
+    // status to hif
+    output reg               busy,
+    output reg               done,
+    output reg               err,
+    // wmem port B
+    output reg  [WMEM_AW-1:0] wb_addr,
+    input  wire [7:0]        wb_rdata,
+    // xbuf port B
+    output reg  [XBUF_AW-1:0] xb_addr,
+    input  wire [7:0]        xb_rdata,
+    // gemv handshake
+    output wire              clr_acc,
+    output reg               mac_en,
+    output reg  [7:0]        act_in,
+    output reg  [7:0]        w_in,
+    // scaled results (from scale_unit, combinational on gemv acc)
+    input  wire [63:0]       ysat,
+    // ybuf write
+    output reg  [YBUF_AW-1:0] yw_addr,
+    output reg  [31:0]       yw_data,
+    output reg               yw_wen
+);
+    localparam S_IDLE   = 3'd0,
+               S_CHECK  = 3'd1,
+               S_ADDR   = 3'd2,
+               S_MAC    = 3'd3,
+               S_DRAIN1 = 3'd4,
+               S_DRAIN2 = 3'd5,
+               S_DONE   = 3'd6,
+               S_ERR    = 3'd7;
+
+    reg [2:0]  state;
+    reg [15:0] k, g;
+    reg [15:0] k_max, groups;
+
+    // ---------------------------------------------------------------- FSM
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            state <= S_IDLE;
+            busy  <= 1'b0;
+            done  <= 1'b0;
+            err   <= 1'b0;
+            k     <= 16'd0;
+            g     <= 16'd0;
+            k_max <= 16'd0;
+            groups<= 16'd0;
+        end else if (soft_reset) begin
+            state <= S_IDLE;
+            busy  <= 1'b0;
+            done  <= 1'b0;
+            err   <= 1'b0;
+        end else begin
+            case (state)
+                S_IDLE: begin
+                    if (start_pulse) begin
+                        k_max  <= cfg_k;
+                        groups <= cfg_n >> 2;
+                        k      <= 16'd0;
+                        g      <= 16'd0;
+                        busy   <= 1'b1;
+                        done   <= 1'b0;
+                        err    <= 1'b0;
+                        state  <= S_CHECK;
+                    end else if (clr_status) begin
+                        done <= 1'b0;
+                        err  <= 1'b0;
+                    end
+                end
+                S_CHECK: begin
+                    if (k_max == 16'd0                     || // K >= 1
+                        groups == 16'd0                    || // N >= 4
+                        cfg_n[1:0] != 2'b00                || // N % 4 == 0
+                        k_max > XBUF_DEPTH                 || // K fits xbuf
+                        (cfg_n >> 1) > YBUF_DEPTH          || // N/2 fits ybuf
+                        (k_max * groups) > WMEM_DEPTH) begin // entries fit wmem
+                        busy  <= 1'b0;
+                        err   <= 1'b1;
+                        state <= S_IDLE;
+                    end else begin
+                        state <= S_ADDR;
+                    end
+                end
+                S_ADDR: begin
+                    state <= S_MAC;
+                end
+                S_MAC: begin
+                    if (k == k_max - 16'd1)
+                        state <= S_DRAIN1;
+                    else begin
+                        k     <= k + 16'd1;
+                        state <= S_ADDR;
+                    end
+                end
+                S_DRAIN1: begin
+                    state <= S_DRAIN2;
+                end
+                S_DRAIN2: begin
+                    if (g + 16'd1 == groups) begin
+                        state <= S_DONE;
+                    end else begin
+                        g     <= g + 16'd1;
+                        k     <= 16'd0;
+                        state <= S_ADDR;
+                    end
+                end
+                S_DONE: begin
+                    busy  <= 1'b0;
+                    done  <= 1'b1;
+                    state <= S_IDLE;
+                end
+                S_ERR: begin
+                    busy  <= 1'b0;
+                    err   <= 1'b1;
+                    state <= S_IDLE;
+                end
+                default: state <= S_IDLE;
+            endcase
+        end
+    end
+
+    // --------------------------------------------------- combinational out
+    assign clr_acc = (state == S_ADDR) && (k == 16'd0);
+
+    always @(*) begin
+        // defaults
+        wb_addr = {WMEM_AW{1'b0}};
+        xb_addr = {XBUF_AW{1'b0}};
+        mac_en  = 1'b0;
+        act_in  = xb_rdata;
+        w_in    = wb_rdata;
+        yw_wen  = 1'b0;
+        yw_addr = {YBUF_AW{1'b0}};
+        yw_data = 32'd0;
+        case (state)
+            S_ADDR: begin
+                wb_addr = (g * k_max) + k;   // entry e = g*K + k  (validated ≤ WMEM_DEPTH-1)
+                xb_addr = k;
+            end
+            S_MAC: begin
+                mac_en  = 1'b1;
+                act_in  = xb_rdata;          // data for the addr issued in ADDR (1-cycle BRAM read)
+                w_in    = wb_rdata;
+            end
+            S_DRAIN1: begin
+                yw_wen  = 1'b1;
+                yw_addr = g[10:0] << 1;                      // ybuf[2g]
+                yw_data = {ysat[31:16], ysat[15:0]};         // {y1, y0}
+            end
+            S_DRAIN2: begin
+                yw_wen  = 1'b1;
+                yw_addr = (g[10:0] << 1) + 1'b1;             // ybuf[2g+1]
+                yw_data = {ysat[63:48], ysat[47:32]};        // {y3, y2}
+            end
+            default: ;
+        endcase
+    end
+endmodule

--- a/hw/1bit-llm/rtl/gemv_core.v
+++ b/hw/1bit-llm/rtl/gemv_core.v
@@ -1,0 +1,55 @@
+`timescale 1ns/1ps
+// gemv_core — 4-lane ternary MAC datapath with int32 accumulators.
+//
+// Per cycle (mac_en): for each lane l, acc[l] += act * w[l], where
+// w[l] decodes from 2 bits {sign,nz} to {-1,0,+1} — so the "multiply" is
+// an add, a subtract, or a skip of the activation. No multipliers.
+//
+//   clr_acc: pulse that resets all accumulators (group start).
+//   mac_en : act_in/w_in are valid; accumulate.
+//   acc    : {acc3,acc2,acc1,acc0} — lane l at [32l+31:32l].
+module gemv_core (
+    input  wire         clk,
+    input  wire         rst_n,
+    input  wire         clr_acc,
+    input  wire         mac_en,
+    input  wire [7:0]   act_in,   // signed int8 activation
+    input  wire [7:0]   w_in,     // 4 packed ternary weights, lane l at [2l+1:2l]
+    output wire [127:0] acc       // 4 × int32
+);
+    reg signed [31:0] acc0, acc1, acc2, acc3;
+
+    wire [1:0] wv0 = w_in[1:0];
+    wire [1:0] wv1 = w_in[3:2];
+    wire [1:0] wv2 = w_in[5:4];
+    wire [1:0] wv3 = w_in[7:6];
+
+    wire signed [8:0] act9 = $signed(act_in);
+
+    // contribution: nz ? (sign ? -act : act) : 0
+    wire signed [8:0] c0 = wv0[0] ? (wv0[1] ? -act9 : act9) : 9'sd0;
+    wire signed [8:0] c1 = wv1[0] ? (wv1[1] ? -act9 : act9) : 9'sd0;
+    wire signed [8:0] c2 = wv2[0] ? (wv2[1] ? -act9 : act9) : 9'sd0;
+    wire signed [8:0] c3 = wv3[0] ? (wv3[1] ? -act9 : act9) : 9'sd0;
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            acc0 <= 32'sd0;
+            acc1 <= 32'sd0;
+            acc2 <= 32'sd0;
+            acc3 <= 32'sd0;
+        end else if (clr_acc) begin
+            acc0 <= 32'sd0;
+            acc1 <= 32'sd0;
+            acc2 <= 32'sd0;
+            acc3 <= 32'sd0;
+        end else if (mac_en) begin
+            acc0 <= acc0 + {{23{c0[8]}}, c0};
+            acc1 <= acc1 + {{23{c1[8]}}, c1};
+            acc2 <= acc2 + {{23{c2[8]}}, c2};
+            acc3 <= acc3 + {{23{c3[8]}}, c3};
+        end
+    end
+
+    assign acc = {acc3, acc2, acc1, acc0};
+endmodule

--- a/hw/1bit-llm/rtl/hif_slave.v
+++ b/hw/1bit-llm/rtl/hif_slave.v
@@ -1,0 +1,167 @@
+`timescale 1ns/1ps
+// hif_slave — host interface: register file, address decode, memory port A.
+//
+// Single-word synchronous bus, always ready (hif_ready = 1).
+// Reads are 3 cycles: rd_req → (address applied) → rd_valid + rd_data.
+// Writes are 1 cycle.
+//
+// Address map (word addresses, see DESIGN.md §3):
+//   0x0000 CTRL   [0] start · [1] soft_reset · [2] clr_status   (write strobes)
+//   0x0001 STATUS [0] busy · [1] done · [2] err                  (read-only)
+//   0x0002 CFG_K  [15:0] rows (activation length)
+//   0x0003 CFG_N  [15:0] columns (output length, multiple of 4)
+//   0x0004 SCALE  [15:0] scale_q15 (signed) · [23:16] shift
+//   0x1xxx wmem   word = 4 entries (entry 4a in low byte)
+//   0x2xxx xbuf   word = 4 int8 activations
+//   0x3xxx ybuf   word = 2 int16 outputs (read-only)
+module hif_slave #(
+    parameter WMEM_AW = 13,
+    parameter XBUF_AW = 12,
+    parameter YBUF_AW = 12
+)(
+    input  wire               clk,
+    input  wire               rst_n,
+    // host bus
+    input  wire               hif_wr_req,
+    input  wire [15:0]        hif_wr_addr,
+    input  wire [31:0]        hif_wr_data,
+    input  wire               hif_rd_req,
+    input  wire [15:0]        hif_rd_addr,
+    output reg  [31:0]        hif_rd_data,
+    output reg                hif_rd_valid,
+    output wire               hif_ready,
+    // control to ctrl_fsm
+    output reg                start_pulse,
+    output reg                soft_reset,
+    output reg                clr_status,
+    output reg  [15:0]        cfg_k,
+    output reg  [15:0]        cfg_n,
+    output reg  [15:0]        scale_q15,
+    output reg  [7:0]         scale_shift,
+    // status from ctrl_fsm
+    input  wire               ctrl_busy,
+    input  wire               ctrl_done,
+    input  wire               ctrl_err,
+    // wmem port A
+    output reg  [WMEM_AW-3:0] wmem_a_addr,
+    output reg                wmem_a_wen,
+    output reg  [31:0]        wmem_a_wdata,
+    input  wire [31:0]        wmem_a_rdata,
+    // xbuf port A
+    output reg  [XBUF_AW-3:0] xbuf_a_addr,
+    output reg                xbuf_a_wen,
+    output reg  [31:0]        xbuf_a_wdata,
+    input  wire [31:0]        xbuf_a_rdata,
+    // ybuf port A (read)
+    output reg  [YBUF_AW-1:0] ybuf_a_addr,
+    input  wire [31:0]        ybuf_a_rdata
+);
+    // read pipeline (3 cycles): req → addr applied → data sampled
+    reg        rd_pending1, rd_pending2;
+    reg [15:0] rd_addr_q1,  rd_addr_q2;
+
+    assign hif_ready = 1'b1;
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            start_pulse  <= 1'b0;
+            soft_reset   <= 1'b0;
+            clr_status   <= 1'b0;
+            cfg_k        <= 16'd0;
+            cfg_n        <= 16'd0;
+            scale_q15    <= 16'd0;
+            scale_shift  <= 8'd0;
+            hif_rd_data  <= 32'd0;
+            hif_rd_valid <= 1'b0;
+            rd_pending1  <= 1'b0;
+            rd_pending2  <= 1'b0;
+            rd_addr_q1   <= 16'd0;
+            rd_addr_q2   <= 16'd0;
+            wmem_a_addr  <= {WMEM_AW-2{1'b0}};
+            wmem_a_wen   <= 1'b0;
+            wmem_a_wdata <= 32'd0;
+            xbuf_a_addr  <= {XBUF_AW-2{1'b0}};
+            xbuf_a_wen   <= 1'b0;
+            xbuf_a_wdata <= 32'd0;
+            ybuf_a_addr  <= {YBUF_AW{1'b0}};
+        end else begin
+            // one-cycle strobes default to 0
+            start_pulse <= 1'b0;
+            soft_reset  <= 1'b0;
+            clr_status  <= 1'b0;
+            wmem_a_wen  <= 1'b0;
+            xbuf_a_wen  <= 1'b0;
+
+            // ------------------------------------------------- writes
+            if (hif_wr_req) begin
+                case (hif_wr_addr[15:12])
+                    4'h0: begin
+                        if (hif_wr_addr[3:0] == 4'h0) begin
+                            start_pulse <= hif_wr_data[0];
+                            soft_reset  <= hif_wr_data[1];
+                            clr_status  <= hif_wr_data[2];
+                        end
+                        if (hif_wr_addr[3:0] == 4'h2) cfg_k       <= hif_wr_data[15:0];
+                        if (hif_wr_addr[3:0] == 4'h3) cfg_n       <= hif_wr_data[15:0];
+                        if (hif_wr_addr[3:0] == 4'h4) begin
+                            scale_q15   <= hif_wr_data[15:0];
+                            scale_shift <= hif_wr_data[23:16];
+                        end
+                    end
+                    4'h1: begin
+                        wmem_a_wen   <= 1'b1;
+                        wmem_a_addr  <= hif_wr_addr[10:0];
+                        wmem_a_wdata <= hif_wr_data;
+                    end
+                    4'h2: begin
+                        xbuf_a_wen   <= 1'b1;
+                        xbuf_a_addr  <= hif_wr_addr[9:0];
+                        xbuf_a_wdata <= hif_wr_data;
+                    end
+                    default: ;
+                endcase
+            end
+
+            // -------------------------------------------------- reads
+            if (hif_rd_req) begin
+                rd_pending1 <= 1'b1;
+                rd_addr_q1  <= hif_rd_addr;
+                case (hif_rd_addr[15:12])
+                    4'h1: wmem_a_addr <= hif_rd_addr[10:0];
+                    4'h2: xbuf_a_addr <= hif_rd_addr[9:0];
+                    4'h3: ybuf_a_addr <= hif_rd_addr[11:0];
+                    default: ;
+                endcase
+            end
+
+            if (rd_pending1) begin
+                rd_pending1 <= 1'b0;
+                rd_pending2 <= 1'b1;
+                rd_addr_q2  <= rd_addr_q1;
+            end
+
+            if (rd_pending2) begin
+                rd_pending2 <= 1'b0;
+                hif_rd_valid <= 1'b1;
+                case (rd_addr_q2[15:12])
+                    4'h0: begin
+                        case (rd_addr_q2[3:0])
+                            4'h0: hif_rd_data <= {31'd0, soft_reset};
+                            4'h1: hif_rd_data <= {29'd0, ctrl_err, ctrl_done, ctrl_busy};
+                            4'h2: hif_rd_data <= {16'd0, cfg_k};
+                            4'h3: hif_rd_data <= {16'd0, cfg_n};
+                            4'h4: hif_rd_data <= {8'd0, scale_shift, scale_q15};
+                            default: hif_rd_data <= 32'd0;
+                        endcase
+                    end
+                    4'h1: hif_rd_data <= wmem_a_rdata;
+                    4'h2: hif_rd_data <= xbuf_a_rdata;
+                    4'h3: hif_rd_data <= ybuf_a_rdata;
+                    default: hif_rd_data <= 32'd0;
+                endcase
+            end else begin
+                hif_rd_valid <= 1'b0;
+            end
+        end
+    end
+endmodule

--- a/hw/1bit-llm/rtl/scale_unit.v
+++ b/hw/1bit-llm/rtl/scale_unit.v
@@ -1,0 +1,38 @@
+`timescale 1ns/1ps
+// scale_unit — 4× saturating integer scale stage.
+//
+// y[l] = sat16( (acc[l] * scale_q15 + rnd) >>> shift ),  rnd = shift ? 1<<(shift-1) : 0
+//
+// Purely combinational; mirrors tools/gen_golden.py bit-for-bit.
+module scale_unit (
+    input  wire [15:0]  scale_q15,   // signed
+    input  wire [7:0]   scale_shift, // 0..15
+    input  wire [127:0] acc_in,      // 4 × int32, lane l at [32l+31:32l]
+    output wire [63:0]  y_out        // 4 × int16, lane l at [16l+15:16l]
+);
+    function automatic [15:0] scale_one;
+        input [31:0] a;
+        input [15:0] q15;
+        input [7:0]  sh;
+        reg signed [47:0] prod;
+        reg signed [47:0] y;
+        begin
+            prod = $signed(a) * $signed(q15);
+            y = prod;
+            if (sh != 8'd0)
+                y = prod + (48'sd1 << (sh - 1));
+            y = y >>> sh;
+            if (y > 48'sd32767)
+                scale_one = 16'sd32767;
+            else if (y < -48'sd32768)
+                scale_one = -16'sd32768;
+            else
+                scale_one = y[15:0];
+        end
+    endfunction
+
+    assign y_out[15:0]   = scale_one(acc_in[31:0],   scale_q15, scale_shift);
+    assign y_out[31:16]  = scale_one(acc_in[63:32],  scale_q15, scale_shift);
+    assign y_out[47:32]  = scale_one(acc_in[95:64],  scale_q15, scale_shift);
+    assign y_out[63:48]  = scale_one(acc_in[127:96], scale_q15, scale_shift);
+endmodule

--- a/hw/1bit-llm/rtl/t1llm_top.v
+++ b/hw/1bit-llm/rtl/t1llm_top.v
@@ -1,0 +1,190 @@
+`timescale 1ns/1ps
+// t1llm_top — top-level integration for the 1bit-LLM ternary GEMV engine.
+//
+// Wires: hif_slave (host bus + regs)  →  ctrl_fsm (sequencer)
+//        →  gemv_core (4-lane ternary MAC) → scale_unit → ybuf,
+// with wmem/xbuf dual-ported between host (port A) and datapath (port B).
+// See DESIGN.md §2 for the wiring diagram.
+module t1llm_top #(
+    parameter WMEM_DEPTH = 8192,
+    parameter XBUF_DEPTH = 4096,
+    parameter YBUF_DEPTH = 4096
+)(
+    input  wire        clk,
+    input  wire        rst_n,
+    input  wire        hif_wr_req,
+    input  wire [15:0] hif_wr_addr,
+    input  wire [31:0] hif_wr_data,
+    input  wire        hif_rd_req,
+    input  wire [15:0] hif_rd_addr,
+    output wire [31:0] hif_rd_data,
+    output wire        hif_rd_valid,
+    output wire        hif_ready
+);
+    localparam WMEM_AW = $clog2(WMEM_DEPTH);
+    localparam XBUF_AW = $clog2(XBUF_DEPTH);
+    localparam YBUF_AW = $clog2(YBUF_DEPTH);
+
+    // ---- hif_slave ↔ ctrl_fsm
+    wire        start_pulse, soft_reset, clr_status;
+    wire        ctrl_busy, ctrl_done, ctrl_err;
+    wire [15:0] cfg_k, cfg_n, scale_q15;
+    wire [7:0]  scale_shift;
+
+    // ---- wmem port A (host) / port B (ctrl)
+    wire [WMEM_AW-3:0] wmem_a_addr;
+    wire               wmem_a_wen;
+    wire [31:0]        wmem_a_wdata, wmem_a_rdata;
+    wire [WMEM_AW-1:0] wb_addr;
+    wire [7:0]         wb_rdata;
+
+    // ---- xbuf port A (host) / port B (ctrl)
+    wire [XBUF_AW-3:0] xbuf_a_addr;
+    wire               xbuf_a_wen;
+    wire [31:0]        xbuf_a_wdata, xbuf_a_rdata;
+    wire [XBUF_AW-1:0] xb_addr;
+    wire [7:0]         xb_rdata;
+
+    // ---- ybuf port A (host read) / port B (ctrl write)
+    wire [YBUF_AW-1:0] ybuf_a_addr;
+    wire [31:0]        ybuf_a_rdata;
+    wire [YBUF_AW-1:0] yw_addr;
+    wire [31:0]        yw_data;
+    wire               yw_wen;
+
+    // ---- ctrl ↔ gemv ↔ scale
+    wire        clr_acc, mac_en;
+    wire [7:0]  act_in, w_in;
+    wire [127:0] gemv_acc;
+    wire [63:0] ysat;
+
+    // ============================================================== host
+    hif_slave #(
+        .WMEM_AW (WMEM_AW),
+        .XBUF_AW (XBUF_AW),
+        .YBUF_AW (YBUF_AW)
+    ) u_hif (
+        .clk          (clk),
+        .rst_n        (rst_n),
+        .hif_wr_req   (hif_wr_req),
+        .hif_wr_addr  (hif_wr_addr),
+        .hif_wr_data  (hif_wr_data),
+        .hif_rd_req   (hif_rd_req),
+        .hif_rd_addr  (hif_rd_addr),
+        .hif_rd_data  (hif_rd_data),
+        .hif_rd_valid (hif_rd_valid),
+        .hif_ready    (hif_ready),
+        .start_pulse  (start_pulse),
+        .soft_reset   (soft_reset),
+        .clr_status   (clr_status),
+        .cfg_k        (cfg_k),
+        .cfg_n        (cfg_n),
+        .scale_q15    (scale_q15),
+        .scale_shift  (scale_shift),
+        .ctrl_busy    (ctrl_busy),
+        .ctrl_done    (ctrl_done),
+        .ctrl_err     (ctrl_err),
+        .wmem_a_addr  (wmem_a_addr),
+        .wmem_a_wen   (wmem_a_wen),
+        .wmem_a_wdata (wmem_a_wdata),
+        .wmem_a_rdata (wmem_a_rdata),
+        .xbuf_a_addr  (xbuf_a_addr),
+        .xbuf_a_wen   (xbuf_a_wen),
+        .xbuf_a_wdata (xbuf_a_wdata),
+        .xbuf_a_rdata (xbuf_a_rdata),
+        .ybuf_a_addr  (ybuf_a_addr),
+        .ybuf_a_rdata (ybuf_a_rdata)
+    );
+
+    // ============================================================ control
+    ctrl_fsm #(
+        .WMEM_DEPTH (WMEM_DEPTH),
+        .XBUF_DEPTH (XBUF_DEPTH),
+        .YBUF_DEPTH (YBUF_DEPTH),
+        .WMEM_AW    (WMEM_AW),
+        .XBUF_AW    (XBUF_AW),
+        .YBUF_AW    (YBUF_AW)
+    ) u_ctrl (
+        .clk          (clk),
+        .rst_n        (rst_n),
+        .start_pulse  (start_pulse),
+        .soft_reset   (soft_reset),
+        .clr_status   (clr_status),
+        .cfg_k        (cfg_k),
+        .cfg_n        (cfg_n),
+        .scale_q15    (scale_q15),
+        .scale_shift  (scale_shift),
+        .busy         (ctrl_busy),
+        .done         (ctrl_done),
+        .err          (ctrl_err),
+        .wb_addr      (wb_addr),
+        .wb_rdata     (wb_rdata),
+        .xb_addr      (xb_addr),
+        .xb_rdata     (xb_rdata),
+        .clr_acc      (clr_acc),
+        .mac_en       (mac_en),
+        .act_in       (act_in),
+        .w_in         (w_in),
+        .ysat         (ysat),
+        .yw_addr      (yw_addr),
+        .yw_data      (yw_data),
+        .yw_wen       (yw_wen)
+    );
+
+    // =========================================================== datapath
+    gemv_core u_gemv (
+        .clk     (clk),
+        .rst_n   (rst_n),
+        .clr_acc (clr_acc),
+        .mac_en  (mac_en),
+        .act_in  (act_in),
+        .w_in    (w_in),
+        .acc     (gemv_acc)
+    );
+
+    scale_unit u_scale (
+        .scale_q15   (scale_q15),
+        .scale_shift (scale_shift),
+        .acc_in      (gemv_acc),
+        .y_out       (ysat)
+    );
+
+    // ============================================================ memories
+    wmem #(
+        .DEPTH (WMEM_DEPTH),
+        .AW    (WMEM_AW)
+    ) u_wmem (
+        .clk     (clk),
+        .a_addr  (wmem_a_addr),
+        .a_wen   (wmem_a_wen),
+        .a_wdata (wmem_a_wdata),
+        .a_rdata (wmem_a_rdata),
+        .b_addr  (wb_addr),
+        .b_rdata (wb_rdata)
+    );
+
+    xbuf #(
+        .DEPTH (XBUF_DEPTH),
+        .AW    (XBUF_AW)
+    ) u_xbuf (
+        .clk     (clk),
+        .a_addr  (xbuf_a_addr),
+        .a_wen   (xbuf_a_wen),
+        .a_wdata (xbuf_a_wdata),
+        .a_rdata (xbuf_a_rdata),
+        .b_addr  (xb_addr),
+        .b_rdata (xb_rdata)
+    );
+
+    ybuf #(
+        .DEPTH (YBUF_DEPTH),
+        .AW    (YBUF_AW)
+    ) u_ybuf (
+        .clk     (clk),
+        .a_addr  (ybuf_a_addr),
+        .a_rdata (ybuf_a_rdata),
+        .b_addr  (yw_addr),
+        .b_wen   (yw_wen),
+        .b_wdata (yw_data)
+    );
+endmodule

--- a/hw/1bit-llm/rtl/wmem.v
+++ b/hw/1bit-llm/rtl/wmem.v
@@ -1,0 +1,35 @@
+`timescale 1ns/1ps
+// wmem — ternary weight memory.
+// One entry = one byte = four 2-bit ternary weights {lane3,lane2,lane1,lane0}
+// (see DESIGN.md §4). Dual port:
+//   port A: host, 32-bit word = 4 consecutive entries (entry 4a in low byte)
+//   port B: gemv, byte/entry index (the GEMV read pattern e = g*K + k)
+// Both reads are registered (BRAM-friendly).
+module wmem #(
+    parameter DEPTH = 8192,   // entries (bytes)
+    parameter AW    = 13      // $clog2(DEPTH)
+)(
+    input  wire             clk,
+    // port A — host
+    input  wire [AW-3:0]    a_addr,   // word index (4 entries per word)
+    input  wire             a_wen,
+    input  wire [31:0]      a_wdata,
+    output reg  [31:0]      a_rdata,
+    // port B — gemv
+    input  wire [AW-1:0]    b_addr,   // entry index
+    output reg  [7:0]       b_rdata
+);
+    reg [7:0] mem [0:DEPTH-1];
+
+    always @(posedge clk) begin
+        if (a_wen) begin
+            mem[{a_addr,2'b00}] <= a_wdata[7:0];
+            mem[{a_addr,2'b01}] <= a_wdata[15:8];
+            mem[{a_addr,2'b10}] <= a_wdata[23:16];
+            mem[{a_addr,2'b11}] <= a_wdata[31:24];
+        end
+        a_rdata <= {mem[{a_addr,2'b11}], mem[{a_addr,2'b10}],
+                    mem[{a_addr,2'b01}], mem[{a_addr,2'b00}]};
+        b_rdata <= mem[b_addr];
+    end
+endmodule

--- a/hw/1bit-llm/rtl/xbuf.v
+++ b/hw/1bit-llm/rtl/xbuf.v
@@ -1,0 +1,31 @@
+`timescale 1ns/1ps
+// xbuf — activation buffer (signed int8 per entry).
+// Same dual-port shape as wmem: host writes 32-bit words (4 acts), gemv reads bytes.
+module xbuf #(
+    parameter DEPTH = 4096,   // entries (bytes)
+    parameter AW    = 12      // $clog2(DEPTH)
+)(
+    input  wire             clk,
+    // port A — host
+    input  wire [AW-3:0]    a_addr,   // word index
+    input  wire             a_wen,
+    input  wire [31:0]      a_wdata,
+    output reg  [31:0]      a_rdata,
+    // port B — gemv
+    input  wire [AW-1:0]    b_addr,   // entry index (== k)
+    output reg  [7:0]       b_rdata
+);
+    reg [7:0] mem [0:DEPTH-1];
+
+    always @(posedge clk) begin
+        if (a_wen) begin
+            mem[{a_addr,2'b00}] <= a_wdata[7:0];
+            mem[{a_addr,2'b01}] <= a_wdata[15:8];
+            mem[{a_addr,2'b10}] <= a_wdata[23:16];
+            mem[{a_addr,2'b11}] <= a_wdata[31:24];
+        end
+        a_rdata <= {mem[{a_addr,2'b11}], mem[{a_addr,2'b10}],
+                    mem[{a_addr,2'b01}], mem[{a_addr,2'b00}]};
+        b_rdata <= mem[b_addr];
+    end
+endmodule

--- a/hw/1bit-llm/rtl/ybuf.v
+++ b/hw/1bit-llm/rtl/ybuf.v
@@ -1,0 +1,25 @@
+`timescale 1ns/1ps
+// ybuf — output buffer, one 32-bit word = two signed int16 outputs {y[2g+1], y[2g]}.
+//   port A: host read
+//   port B: gemv/ctrl write
+module ybuf #(
+    parameter DEPTH = 4096,   // words
+    parameter AW    = 12      // $clog2(DEPTH)
+)(
+    input  wire          clk,
+    // port A — host read
+    input  wire [AW-1:0] a_addr,
+    output reg  [31:0]   a_rdata,
+    // port B — datapath write
+    input  wire [AW-1:0] b_addr,
+    input  wire          b_wen,
+    input  wire [31:0]   b_wdata
+);
+    reg [31:0] mem [0:DEPTH-1];
+
+    always @(posedge clk) begin
+        if (b_wen)
+            mem[b_addr] <= b_wdata;
+        a_rdata <= mem[a_addr];
+    end
+endmodule

--- a/hw/1bit-llm/synth/vivado_u250_flow.tcl
+++ b/hw/1bit-llm/synth/vivado_u250_flow.tcl
@@ -1,0 +1,28 @@
+# vivado_u250_flow.tcl — Vivado implementation flow for the 1bit-LLM RTL on the
+# Alveo U250 (xcu250-figd2104-2L-e). Proves the portable RTL drops into a
+# Vivado project and closes place & route on the eventual box (journey UPDATE 32).
+#
+# Usage (on the box with Vivado 2026.1 + Alveo license):
+#   source /home/bcloud/Xilinx/2026.1/Vivado/settings64.sh
+#   # legacy libc (Ubuntu 24): Vivado needs libncurses.so.5/libtinfo.so.5
+#   export LD_LIBRARY_PATH=/home/bcloud/FPGAs_AdaptiveSoCs_Unified_SDI_2026.1_0616_1700/lib/lnx64.o/Ubuntu/24
+#   vivado -mode batch -nolog -nojournal -source vivado_u250_flow.tcl \
+#       -tclargs xcu250-figd2104-2L-e
+#
+# Result (2026-08-26, Vivado v2026.1): synth -> opt -> place -> route all
+# succeeded ("DONE_OK"), 0 errors. Utilization (routed):
+#   LUTs 98123 | FFs 99666 | URAM 1 | DSP 10 | BRAM 0
+#   (wmem/xbuf inferred as FF arrays; ybuf as URAM; scale_unit uses 8 DSPs)
+# No clock constraint was supplied, so timing reports NA (flow is a P&R-closure
+# gate, not a frequency target).
+
+set part [lindex $argv 0]
+puts "== 1bit-LLM Vivado flow: part=$part =="
+read_verilog [glob [file dirname [info script]]/../rtl/*.v]
+synth_design -top t1llm_top -part $part
+opt_design
+place_design
+route_design
+report_utilization -file /tmp/1bitllm_util.rpt -hierarchical
+report_timing_summary -file /tmp/1bitllm_timing.rpt
+puts "DONE_OK part=$part"

--- a/hw/1bit-llm/synth/xc7_flow.sh
+++ b/hw/1bit-llm/synth/xc7_flow.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# xc7_flow.sh — open-source 7-series bitstream flow for the 1bit-LLM design.
+#
+# Chain: iverilog (sim, in Makefile) → yosys synth_xilinx → nextpnr-xilinx
+#         → prjxray (fasm2frames → bitread check) → openFPGALoader.
+#
+# The toolchain lives on the Strix box (per docs/journey.md UPDATE 32):
+#   /home/bcloud/fpga-toolchain/   (nextpnr-xilinx + prjxray + openFPGALoader)
+# The RTL itself is tool-agnostic Verilog-2001; nothing here is required for
+# `make sim`. This script is the honest end-to-end path once a board is wired.
+#
+# TODO(board): pick the concrete 7-series board + part, e.g.
+#   - Arty A7-100T  (xc7a100tcsg324-1, 135k LUT / 4.86 Mb BRAM)
+#   - Nexys Video  (xc7a200tfbg484-1, 215k LUT / 13 Mb BRAM)
+#   A 1B ternary model needs external DRAM streaming (roadmap §8); this first
+#   pass exercises the on-chip weight cache path only.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+SIM="$HERE/sim"
+PART="${PART:-xc7a100tcsg324-1}"          # TODO(board): set your part
+FPGA_TOOLCHAIN="${FPGA_TOOLCHAIN:-/home/bcloud/fpga-toolchain}"
+RTL_FILES=("$HERE"/rtl/*.v)
+
+echo "== 1bit-LLM xc7 flow (part=$PART) =="
+
+# ---- 1. synthesize (gate: proves the RTL is synthesizable, not just simulatable)
+mkdir -p "$SIM"
+yosys -q -p "read_verilog ${RTL_FILES[*]}; \
+    hierarchy -top t1llm_top; proc; opt; \
+    synth_xilinx -top t1llm_top -arch xc7; \
+    write_verilog -noattr $SIM/t1llm_top_synth.v" \
+    -l "$SIM/synth.log"
+echo "   synth: OK"
+
+if ! command -v nextpnr-xilinx >/dev/null 2>&1; then
+    echo "   nextpnr-xilinx not on PATH — try:"
+    echo "     export PATH=\$PATH:$FPGA_TOOLCHAIN/nextpnr-xilinx/nextpnr-xilinx/bin"
+    echo "   P&R skipped (flow documented; run on the Strix box)."
+    exit 0
+fi
+
+# ---- 2. place & route (needs a .xdc — TODO(board))
+if [ -f "$HERE/synth/board.xdc" ]; then
+    nextpnr-xilinx --chipdb "$FPGA_TOOLCHAIN"/prjxray-db/*-*.chipdb \
+        --xdc "$HERE/synth/board.xdc" \
+        --json "$SIM/t1llm_top.json" \
+        --write "$SIM/t1llm_top.routed.json" \
+        --fasm "$SIM/t1llm_top.fasm"
+    echo "   P&R: OK"
+
+    # ---- 3. fasm → bitstream
+    "$FPGA_TOOLCHAIN"/prjxray/utils/fasm2frames.py \
+        --db-root "$FPGA_TOOLCHAIN"/prjxray-db \
+        --sparse "$SIM/t1llm_top.fasm" > "$SIM/t1llm_top.frames"
+    "$FPGA_TOOLCHAIN"/prjxray/utils/frames2bit.py \
+        --db-root "$FPGA_TOOLCHAIN"/prjxray-db \
+        --part "$PART" --frm_file "$SIM/t1llm_top.frames" \
+        > "$SIM/t1llm_top.bit"
+    echo "   bitstream: $SIM/t1llm_top.bit"
+
+    # ---- 4. load (TODO(board): cable present?)
+    openFPGALoader -b "$BOARD" "$SIM/t1llm_top.bit" 2>/dev/null \
+        || echo "   openFPGALoader skipped (no cable / board '$BOARD')"
+else
+    echo "   synth/board.xdc missing — P&R skipped (see TODO(board) at top)."
+fi

--- a/hw/1bit-llm/tb/tb_top.v
+++ b/hw/1bit-llm/tb/tb_top.v
@@ -1,0 +1,249 @@
+// tb_top — host-interface-driven testbench for t1llm_top.
+//
+// Runs two randomized cases (golden vectors from tools/gen_golden.py):
+//   case0: K=8,  N=16   · case1: K=16, N=8
+// Every interaction with the DUT goes through the host bus: program CFG,
+// write wmem/xbuf, start, poll STATUS, read ybuf — then compare bit-exact
+// against the golden files. Run from hw/1bit-llm/sim (see Makefile).
+`timescale 1ns/1ps
+
+module tb_top;
+    parameter CLK_PERIOD = 10;
+
+    reg clk = 0;
+    always #(CLK_PERIOD/2) clk = ~clk;
+
+    // ---- DUT
+    reg         rst_n;
+    reg         hif_wr_req, hif_rd_req;
+    reg  [15:0] hif_wr_addr, hif_rd_addr;
+    reg  [31:0] hif_wr_data;
+    wire [31:0] hif_rd_data;
+    wire        hif_rd_valid, hif_ready;
+
+    t1llm_top dut (
+        .clk         (clk),
+        .rst_n       (rst_n),
+        .hif_wr_req  (hif_wr_req),
+        .hif_wr_addr (hif_wr_addr),
+        .hif_wr_data (hif_wr_data),
+        .hif_rd_req  (hif_rd_req),
+        .hif_rd_addr (hif_rd_addr),
+        .hif_rd_data (hif_rd_data),
+        .hif_rd_valid(hif_rd_valid),
+        .hif_ready   (hif_ready)
+    );
+
+    // ---- golden memories (loaded per case)
+    reg [7:0]  tb_wmem  [0:8191];
+    reg [7:0]  tb_act   [0:4095];
+    reg [31:0] tb_ygold [0:4095];
+
+    reg global_fail = 0;
+
+    // ============================================================ bus tasks
+    task hif_write;
+        input [15:0] addr;
+        input [31:0] data;
+        begin
+            @(posedge clk);
+            hif_wr_req  = 1;
+            hif_wr_addr = addr;
+            hif_wr_data = data;
+            @(posedge clk);
+            hif_wr_req  = 0;
+        end
+    endtask
+
+    task hif_read;
+        input  [15:0] addr;
+        output [31:0] data;
+        integer t;
+        begin
+            @(posedge clk);
+            hif_rd_req  = 1;
+            hif_rd_addr = addr;
+            @(posedge clk);
+            hif_rd_req  = 0;
+            t = 0;
+            while (!hif_rd_valid && t <= 16) begin
+                @(posedge clk);
+                t = t + 1;
+            end
+            if (t > 16) begin
+                $display("FATAL: hif read timeout at addr %04h", addr);
+                $finish;
+            end
+            data = hif_rd_data;
+            @(posedge clk);
+        end
+    endtask
+
+    // ============================================================ run a case
+    task run_case;
+        input integer cid;
+        reg [15:0] K, N, q15;
+        reg [7:0]  sh;
+        integer fd, i, w_entries, mismatches, timeout, nread;
+        reg [31:0] rdata;
+        begin
+            mismatches = 0;
+
+            // fresh reset
+            rst_n = 0;
+            repeat (2) @(posedge clk);
+            rst_n = 1;
+            repeat (2) @(posedge clk);
+
+            // ---- load golden data for this case
+            if (cid == 0) begin
+                $readmemh("case0_wmem.hex", tb_wmem);
+                $readmemh("case0_act.hex",  tb_act);
+                $readmemh("case0_ygold.hex",tb_ygold);
+                fd = $fopen("case0_cfg.txt", "r");
+            end else begin
+                $readmemh("case1_wmem.hex", tb_wmem);
+                $readmemh("case1_act.hex",  tb_act);
+                $readmemh("case1_ygold.hex",tb_ygold);
+                fd = $fopen("case1_cfg.txt", "r");
+            end
+            if (fd == 0) begin
+                $display("FATAL: cannot open cfg file for case %0d", cid);
+                global_fail = 1;
+                $finish;
+            end
+            nread = $fscanf(fd, "%d %d %d %d", K, N, q15, sh);
+            if (nread != 4) begin
+                $display("FATAL: malformed cfg file for case %0d", cid);
+                global_fail = 1;
+                $finish;
+            end
+            $fclose(fd);
+
+            // ---- program config
+            hif_write(16'h0002, {16'd0, K});
+            hif_write(16'h0003, {16'd0, N});
+            hif_write(16'h0004, {8'd0, sh, q15});
+
+            // ---- load wmem: w_entries = (N/4)*K bytes, 4 per word
+            w_entries = (N / 4) * K;
+            for (i = 0; i < w_entries; i = i + 4)
+                hif_write(16'h1000 + i[15:2],
+                          {tb_wmem[i+3], tb_wmem[i+2], tb_wmem[i+1], tb_wmem[i]});
+
+            // ---- load activations: K bytes, 4 per word
+            for (i = 0; i < K; i = i + 4)
+                hif_write(16'h2000 + i[15:2],
+                          {tb_act[i+3], tb_act[i+2], tb_act[i+1], tb_act[i]});
+
+            // ---- go
+            hif_write(16'h0000, 32'd1);            // CTRL.start
+
+            // ---- wait for completion
+            timeout = 0;
+            rdata = 0;
+            while (!rdata[1] && !rdata[2] && timeout <= 1000000) begin
+                hif_read(16'h0001, rdata);          // STATUS
+                timeout = timeout + 1;
+            end
+            if (rdata[2]) begin
+                $display("case%0d: ERR status (K=%0d N=%0d)", cid, K, N);
+                mismatches = 1;
+            end
+            if (timeout > 1000000) begin
+                $display("case%0d: TIMEOUT waiting for done (K=%0d N=%0d)",
+                         cid, K, N);
+                mismatches = 1;
+            end
+
+            // ---- read back and compare
+            if (!rdata[2] && mismatches == 0) begin
+                for (i = 0; i < N / 2; i = i + 1) begin
+                    hif_read(16'h3000 + i[11:0], rdata);
+                    if (rdata !== tb_ygold[i]) begin
+                        mismatches = mismatches + 1;
+                        if (mismatches <= 8)
+                            $display("case%0d: ybuf[%0d] got %08h exp %08h",
+                                     cid, i, rdata, tb_ygold[i]);
+                    end
+                end
+            end
+
+            if (mismatches == 0)
+                $display("case%0d: PASS  (K=%0d N=%0d scale_q15=%0d shift=%0d)",
+                         cid, K, N, q15, sh);
+            else begin
+                $display("case%0d: FAIL  (%0d mismatches)", cid, mismatches);
+                global_fail = 1;
+            end
+        end
+    endtask
+
+    // ======================================================= error path test
+    // Invalid config (N not a multiple of 4) must be rejected with STATUS.err;
+    // clr_status must then clear the error latch.
+    task run_err_case;
+        reg [31:0] rdata;
+        integer timeout;
+        begin
+            rst_n = 0;
+            repeat (2) @(posedge clk);
+            rst_n = 1;
+            repeat (2) @(posedge clk);
+
+            hif_write(16'h0002, 32'd8);              // K = 8
+            hif_write(16'h0003, 32'd6);              // N = 6  → invalid
+            hif_write(16'h0004, 32'h00009000);       // scale_q15 = 0x9000
+            hif_write(16'h0000, 32'd1);              // start
+
+            timeout = 0;
+            rdata = 0;
+            while (!rdata[1] && !rdata[2] && timeout <= 10000) begin
+                hif_read(16'h0001, rdata);           // STATUS
+                timeout = timeout + 1;
+            end
+            if (rdata[2])
+                $display("err-case: PASS (N=6 rejected, ERR latched)");
+            else begin
+                $display("err-case: FAIL (expected ERR; got busy=%0d done=%0d)",
+                         rdata[0], rdata[1]);
+                global_fail = 1;
+            end
+
+            hif_write(16'h0000, 32'h4);              // CTRL.clr_status
+            hif_read(16'h0001, rdata);
+            if (!rdata[2])
+                $display("clr-status: PASS (ERR cleared)");
+            else begin
+                $display("clr-status: FAIL (ERR still set)");
+                global_fail = 1;
+            end
+        end
+    endtask
+
+    // ================================================================ main
+    initial begin
+        $dumpfile("tb_top.vcd");
+        $dumpvars(0, tb_top);
+
+        rst_n       = 0;
+        hif_wr_req  = 0;
+        hif_rd_req  = 0;
+        hif_wr_addr = 16'd0;
+        hif_rd_addr = 16'd0;
+        hif_wr_data = 32'd0;
+
+        repeat (4) @(posedge clk);
+        rst_n = 1;
+
+        run_case(0);
+        run_case(1);
+        run_err_case();
+
+        if (global_fail)
+            $display("=== TB: FAIL ===");
+        else
+            $display("=== TB: ALL PASS ===");
+        $finish;
+    end
+endmodule

--- a/hw/1bit-llm/tools/gen_golden.py
+++ b/hw/1bit-llm/tools/gen_golden.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Golden vector generator for the 1bit-LLM ternary GEMV (hw/1bit-llm).
+
+Mirrors the RTL exactly (see DESIGN.md §4-§5):
+  - ternary weight, 2 bits {sign, nz}: nz = (v != 0), sign = (v < 0)
+  - wmem entry e = g*K + k is one byte = 4 lane weights, lane l at bits [2l+1:2l]
+  - y[n] = sat16((acc[n] * scale_q15 + rnd) >> shift), rnd = shift ? 1 << (shift-1) : 0
+    (Python >> is arithmetic for negatives, matching Verilog >>>)
+
+Usage:  python3 tools/gen_golden.py <case_id>     # 0 or 1
+Writes: sim/case<id>_{cfg.txt,wmem.hex,act.hex,ygold.hex}
+"""
+
+import os
+import random
+import sys
+
+CASES = {
+    0: dict(K=8,  N=16, scale_q15=9000,  shift=12),  # scaling/rounding path
+    1: dict(K=16, N=8,  scale_q15=-4096, shift=9),   # negative-scale + sign path
+}
+
+
+def pack_lane(v):
+    """v in {-1,0,1} -> 2-bit {sign, nz}."""
+    sign = 1 if v < 0 else 0
+    nz = 1 if v != 0 else 0
+    return (sign << 1) | nz
+
+
+def scale(acc, q15, shift):
+    """Bit-exact mirror of scale_unit.scale_one."""
+    prod = acc * q15
+    rnd = (1 << (shift - 1)) if shift else 0
+    y = (prod + rnd) >> shift
+    return max(-32768, min(32767, y))
+
+
+def main():
+    cid = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+    if cid not in CASES:
+        sys.exit(f"unknown case {cid}; choose from {sorted(CASES)}")
+    cfg = CASES[cid]
+    K, N = cfg["K"], cfg["N"]
+    q15, sh = cfg["scale_q15"], cfg["shift"]
+
+    rng = random.Random(0x1B17 + cid)
+
+    acts = [rng.randint(-4, 4) for _ in range(K)]
+    # weights[k][n] in {-1, 0, +1}, ~25% zeros so lanes exercise add/sub/skip
+    weights = [[rng.choice([-1, 0, 1]) for _ in range(N)] for _ in range(K)]
+
+    # ---- reference GEMV
+    acc = [0] * N
+    for n in range(N):
+        for k in range(K):
+            acc[n] += acts[k] * weights[k][n]
+    y = [scale(a, q15, sh) for a in acc]
+
+    # ---- wmem bytes: entry e = g*K + k  ->  byte of 4 lane weights (n = 4g..4g+3)
+    wmem = []
+    for g in range(N // 4):
+        for k in range(K):
+            b = 0
+            for lane in range(4):
+                b |= pack_lane(weights[k][4 * g + lane]) << (2 * lane)
+            wmem.append(b)
+    assert len(wmem) == (N // 4) * K
+
+    # ---- write files (relative to repo root, into hw/1bit-llm/sim)
+    out = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "sim"))
+    os.makedirs(out, exist_ok=True)
+    base = f"case{cid}"
+    with open(f"{out}/{base}_cfg.txt", "w") as f:
+        f.write(f"{K} {N} {q15} {sh}\n")
+    with open(f"{out}/{base}_wmem.hex", "w") as f:
+        for b in wmem:
+            f.write(f"{b:02x}\n")
+    with open(f"{out}/{base}_act.hex", "w") as f:
+        for a in acts:
+            f.write(f"{(a & 0xFF):02x}\n")
+    with open(f"{out}/{base}_ygold.hex", "w") as f:
+        for g in range(N // 2):
+            word = ((y[2 * g + 1] & 0xFFFF) << 16) | (y[2 * g] & 0xFFFF)
+            f.write(f"{word:08x}\n")
+
+    print(f"case{cid}: K={K} N={N} scale_q15={q15} shift={sh} "
+          f"wmem_entries={len(wmem)} ybuf_words={N // 2}")
+    print(f"  acts      = {acts}")
+    print(f"  y[0..{min(3, N - 1)}] = {y[:4]}   (acc[0] = {acc[0]})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

The 1bit-LLM ternary GEMV accelerator RTL was never landed on main: main had **42k lines of generated sim outputs** committed (hex vectors, 33k-line yosys synth netlist, VCD, vvp binary — commit a0b322df) but **no RTL source**. The actual project lived only on the stale, never-merged `feat/hw-1bit-llm-fpga` branch.

## Changes

- **Add the real RTL source**: `rtl/` (t1llm_top, hif_slave, ctrl_fsm, gemv_core, scale_unit, wmem/xbuf/ybuf), `tb/tb_top.v`, `tools/gen_golden.py`, `Makefile`, `DESIGN.md`
- **Add `synth/vivado_u250_flow.tcl`**: Vivado 2026.1 U250 implementation flow — **verified DONE_OK** on `xcu250-figd2104-2L-e` (synth→opt→place→route all pass, 0 errors)
  - Routed utilization: **LUTs 98123 | FFs 99666 | URAM 1 | DSP 10 | BRAM 0** (wmem/xbuf infer as FF arrays, ybuf as URAM, scale_unit→8 DSPs)
  - No clock constraint supplied → timing NA; flow is a P&R-closure gate
- **Delete `hw/1bit-llm/sim/` generated artifacts** (regenerated by `make sim`; DESIGN.md §6 already documented them as gitignored)
- **.gitignore**: add `hw/1bit-llm/sim/`

## Verified

```
$ cd hw/1bit-llm && make sim
case0: PASS (K=8 N=16 ...)
case1: PASS (K=16 N=8 ...)
err-case: PASS / clr-status: PASS
=== TB: ALL PASS ===
```

Fixes the hw/ tracking state; supersedes the un-merged feat/hw-1bit-llm-fpga branch.