### PR TITLE
wip(npu): 1769 C1-bypass experiment (CPU-silu fallback probe)

### DIFF
--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -3167,7 +3167,10 @@ struct Bf16Ctx {
     {
         auto ts_boot=std::chrono::steady_clock::now();
         memcpy(sb_data.data(),h_data.data(),H*4);rn_c(sb_data.data(),fin_v.data(),H);
+        if(npu_dbg()){fprintf(stderr,"BOOT h_data:");for(int i=0;i<8;i++)fprintf(stderr," %.6g",h_data[i]);fprintf(stderr,"\n");}
+        if(npu_dbg()){fprintf(stderr,"BOOT fin_v:");for(int i=0;i<8;i++)fprintf(stderr," %.6g",fin_v[i]);fprintf(stderr,"\n");}
         lm_topk_omp(sb_data.data(),lg_buf.data(),top_ids,BS,lm_nv,H,lm_emb);
+        if(npu_dbg()){fprintf(stderr,"BOOT lg:");for(int i=0;i<8;i++)fprintf(stderr," %.6g",lg_buf[i]);fprintf(stderr,"\n");}
         if (getenv("NPU_DEBUG_BOOT")) {
             fprintf(stderr, "  [boot-debug] top-5 ids:");
             for (int b = 0; b < 5 && b < BS; b++) fprintf(stderr, " %d", top_ids[b]);

--- a/engine/npu/src/zaya_decode.cpp
+++ b/engine/npu/src/zaya_decode.cpp
@@ -566,6 +566,118 @@ int zaya_decode_main(int argc, char** argv) {
                             num += (double)cpu_out[i]*moe_out[i]; d1 += (double)cpu_out[i]*cpu_out[i]; d2 += (double)moe_out[i]*moe_out[i];
                             maxd = std::max(maxd, std::fabs(cpu_out[i]-moe_out[i]));
                         }
+                        {
+                            // CPU-silu fallback probe: the P1 C1 readback
+                            // (chunk 0, row 0 = GU cols 0..7) vs the CPU
+                            // reference C1h from the int8 shadow.
+                            float ag2 = 0;
+                            for (int i = 0; i < d.H; i++) ag2 = std::max(ag2, std::fabs(residual[i]));
+                            ag2 = ag2 < 1e-12f ? 1.0f : ag2 / 127.0f;
+                            std::vector<int8_t> Ai(d.H);
+                            for (int i = 0; i < d.H; i++) {
+                                int x = (int)std::roundf(residual[i] / ag2);
+                                Ai[i] = (int8_t)(x > 127 ? 127 : x < -127 ? -127 : x);
+                            }
+                            const int N2 = 2 * m.n_ff;
+                            std::vector<int32_t> C1h(N2, 0);
+                            const std::vector<int8_t>& guBv2 = fgu_row[l][e];
+                            for (int j = 0; j < N2; j++)
+                                for (int i = 0; i < d.H; i++)
+                                    C1h[j] += (int32_t)Ai[i] * guBv2[(size_t)i * N2 + j];
+                            // v86 (ported): host unscaled C1 = Am . (q4*16) under 3
+                            // unpack-order interpretations (nt=0, full K): NAT, INT
+                            // (low nibbles first), TRN (kk/cc swapped)
+                            {
+                                const uint8_t* Bm5 = (const uint8_t*)fgu_bo[l][e]->map();
+                                const int nt0 = 0;
+                                fprintf(stderr, "\n[c1unscNAT] ");
+                                fprintf(stderr, "\n[c1unscINT] ");
+                                fprintf(stderr, "\n[c1unscTRN] ");
+                                for (int c = 0; c < 128; c += 2) {
+                                    long long aN = 0, aI = 0, aT = 0;
+                                    for (int ki = 0; ki < 32; ki++)
+                                        for (int k = 0; k < 64; k++) {
+                                            int gk = ki * 64 + k;
+                                            size_t off = (size_t)(ki * 32 + nt0) * GuI4Pack::TILE_TOTAL
+                                                + (size_t)((k % 64) / 8) * 512 + (size_t)(c / 8) * 32
+                                                + (size_t)(k % 8) * 4 + (size_t)((c % 8) / 2);
+                                            int b = (int)Bm5[off];
+                                            int lo = b & 0x0F, hi = (b >> 4) & 0x0F;
+                                            if (lo >= 8) lo -= 16;
+                                            if (hi >= 8) hi -= 16;
+                                            int cc = c % 8, kk = k % 8;
+                                            int qN = (cc % 2 == 0) ? lo : hi;
+                                            int e = kk * 8 + cc;
+                                            int qI = (e / 32 == 0) ? lo : hi;
+                                            size_t offT = (size_t)(ki * 32 + nt0) * GuI4Pack::TILE_TOTAL
+                                                + (size_t)((k % 64) / 8) * 512 + (size_t)(cc) * 32
+                                                + (size_t)((c / 8) % 8) * 4 + (size_t)((kk) / 2);
+                                            int bT = (int)Bm5[offT];
+                                            int loT = bT & 0x0F, hiT = (bT >> 4) & 0x0F;
+                                            if (loT >= 8) loT -= 16;
+                                            if (hiT >= 8) hiT -= 16;
+                                            int qT = (kk % 2 == 0) ? loT : hiT;
+                                            aN += (long long)fused_ctx.Am[gk] * (qN * 16);
+                                            aI += (long long)fused_ctx.Am[gk] * (qI * 16);
+                                            aT += (long long)fused_ctx.Am[gk] * (qT * 16);
+                                        }
+                                    fprintf(stderr, "%lld %lld %lld ", (long long)(aN / 32),
+                                            (long long)(aI / 32), (long long)(aT / 32));
+                                }
+                                fprintf(stderr, "\n");
+                            }
+                            const int32_t* c1m = fused_ctx.Cm;
+                            {   // DIAG: host h2 (row 0) vs reference h2
+                                std::vector<float> fold2(2 * m.n_ff);
+                                for (int p = 0; p < m.n_ff; p++) {
+                                    fold2[2 * p]     = ag * fgu_cs[l][e][2 * p];
+                                    fold2[2 * p + 1] = ag * qn_s * fgu_cs[l][e][2 * p + 1];
+                                }
+                                std::vector<int8_t> h2r(m.n_ff), h2n(m.n_ff);
+                                silu_quant_i8(C1h.data(), fold2.data(), h2r.data(), m.n_ff);
+                                const int8_t* h2m2 = (const int8_t*)h2_bo[l]->map();
+                                for (int p = 0; p < 16; p++) h2n[p] = h2m2[(p >> 3) * 8 + (p & 7)];
+                                fprintf(stderr, "[h2ref] ");
+                                for (int p = 0; p < 16; p++) fprintf(stderr, "%d ", h2r[p]);
+                                fprintf(stderr, "\n[h2npu] ");
+                                for (int p = 0; p < 16; p++) fprintf(stderr, "%d ", h2n[p]);
+                                fprintf(stderr, "\n");
+                                {   // D-chain host reference: C2h = h2r . D_int8(shadow)
+                                    std::vector<int32_t> C2h(d.H, 0);
+                                    for (int j = 0; j < d.H; j++) {
+                                        long long acc = 0;
+                                        for (int i = 0; i < m.n_ff; i++)
+                                            acc += (long long)h2r[i] * fd_row[l][e][(size_t)i * d.H + j];
+                                        C2h[j] = (int32_t)acc;
+                                    }
+                                    fprintf(stderr, "[Dhost] ");
+                                    for (int j = 0; j < 8; j++) fprintf(stderr, "%.4f ", (float)C2h[j] * fd_cs[l][e][j] / qn_s);
+                                    fprintf(stderr, "\n[Dnpu ] ");
+                                    for (int j = 0; j < 8; j++) fprintf(stderr, "%.4f ", moe_out[j]);
+                                    fprintf(stderr, "\n[Da   ] ");
+                                    for (int j = 0; j < 8; j++) fprintf(stderr, "%.4f ", cpu_out[j]);
+                                    fprintf(stderr, "\n");
+                                    fprintf(stderr, "[C2host] ");
+                                    for (int j = 0; j < 8; j++) fprintf(stderr, "%d ", C2h[j]);
+                                    fprintf(stderr, "\n[C2npu ] ");
+                                    for (int j = 0; j < 8; j++) fprintf(stderr, "%d ", fused_ctx_p2.Cm[j]);
+                                    fprintf(stderr, "\n");
+                                }
+                            }
+
+                            fprintf(stderr, "[c1cmp] cpu: ");
+                            if (getenv("NPU_C1_TEST"))
+                                for (int j = 0; j < 8; j++) fprintf(stderr, "%d ", 260096 * (j % 16));
+                            else
+                                for (int j = 0; j < 8; j++) fprintf(stderr, "%d ", C1h[j]);
+                            fprintf(stderr, "\n[c1cmp] npu: ");
+                            for (int j = 0; j < 8; j++) fprintf(stderr, "%d ", c1m[j]);
+                            fprintf(stderr, "\n");
+                            if (getenv("NPU_C1_TEST")) {
+                                FILE* f = fopen("/tmp/c1_layout.bin", "wb");
+                                fwrite(c1m, 4, 1024, f); fclose(f);
+                            }
+                        }
                         fprintf(stderr, "[MoE L1 fused dbg] corr=%.6f maxdiff=%.6f (cpu rms=%.4f npu rms=%.4f) qn_s=%.4f\n",
                             num/std::sqrt(d1*d2), maxd, std::sqrt(d1/d.H), std::sqrt(d2/d.H), qn_s);
                     }


### PR DESCRIPTION
### **User description**
Recovered WIP from the strixhalo session (previously only in the working tree / cpu-contract branch). Adds the C1 readback probe — GU cols 0..7 vs the int8-shadow C1h — plus the NPU host hook, env-gated. **Not yet validated end-to-end**; the C++ build gate confirms compilation, on-NPU validation follows on strixhalo.


___

### **PR Type**
Enhancement


___

### **Description**
- Add C1 readback probe vs int8-shadow C1h.

- Add CPU-silu fallback with NAT/INT/TRN unpack variants.

- Add DIAG h2/D/C2 host-vs-NPU comparison prints.

- WIP env-gated probing, not yet validated end-to-end.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["zaya_decode: CPU-silu fallback"] --> B["compute C1h int8 shadow"]
    C["NPU C1 readback GU cols 0..7"] --> D["compare c1cmp output"]
    B --> D
    D --> E["DIAG h2/D/C2 host-vs-NPU"]
    F["npu_engine BOOT debug prints"] --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Diagnostics</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>npu_engine_universal.cpp</strong><dd><code>Add BOOT debug prints for first-token inputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/npu_engine_universal.cpp

<ul><li>Adds <code>npu_dbg()</code>-gated BOOT prints for first 8 <code>h_data</code>, <code>fin_v</code>, and <code>lg_buf</code> <br>values.<br> <li> Supplements existing <code>NPU_DEBUG_BOOT</code> top-5 logging with input <br>diagnostics.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1893/files#diff-63677a636d5ff19712cf034cc1e2c15a96b194137caee54d8bd6883b0b76a10b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zaya_decode.cpp</strong><dd><code>Add C1 readback and CPU-silu fallback probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/zaya_decode.cpp

<ul><li>Adds C1 readback probe comparing NPU <code>Cm</code> GU cols 0..7 vs int8-shadow <br><code>C1h</code>.<br> <li> Implements host unscaled C1 under NAT/INT/TRN unpack-order <br>interpretations.<br> <li> Adds DIAG host-vs-NPU comparisons for h2, D-chain C2h, and C2 outputs.<br> <li> Enables <code>NPU_C1_TEST</code> dump of <code>/tmp/c1_layout.bin</code> and <code>[c1cmp]</code> prints.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1893/files#diff-03d765f3c907f9bbf3b9e72824d9f24105ec11666aacb7a9b57702d5254669ae">+112/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

