### PR TITLE
security: fix new CodeQL alerts — 404.html XSS/open-redirect + census PR-url check

### DIFF
--- a/Testing/census_autopr.py
+++ b/Testing/census_autopr.py
@@ -24,6 +24,7 @@ Environment:
   CENSUS_SKIP_PR=1 — never open PRs (alert only).
 """
 import json, os, re, subprocess, sys, difflib
+from urllib.parse import urlparse
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ENGINE = os.path.join(ROOT, "include", "rocm_cpp", "bitnet_model.h")
@@ -142,8 +143,15 @@ def _open_draft_pr(arch, target, models):
                 continue
             print(f"[autopr] cmd failed: {' '.join(cmd)}\n{r.stderr[:300]}", file=sys.stderr)
             return None
-    # return the PR url from the last command
-    return r.stdout.strip() if "github.com" in r.stdout else None
+    # return the PR url from the last command — only accept a real github.com https URL
+    out = r.stdout.strip()
+    if not out:
+        return None
+    try:
+        parsed = urlparse(out)
+    except ValueError:
+        return None
+    return out if parsed.scheme == "https" and parsed.netloc == "github.com" else None
 
 
 def maybe_file_draft_pr(uncovered, models=None, dry_run=None):

--- a/site/404.html
+++ b/site/404.html
@@ -36,7 +36,19 @@
         params.set("utm_medium", decodeURIComponent(seg[3]));
         params.set("share", decodeURIComponent(seg[1]));
         params.set("team", decodeURIComponent(seg[2]));
-        var target = new URLSearchParams(location.search).get("next") || "https://1bit.monster/";
+        // Only ever redirect to a real http(s) URL: rejects javascript:/data:/vbscript:
+        // and other scheme tricks coming from the untrusted ?next= query param.
+        var raw = new URLSearchParams(location.search).get("next") || "https://1bit.monster/";
+        var target;
+        try {
+          var u = new URL(raw, location.href);
+          if (u.protocol !== "https:" && u.protocol !== "http:") {
+            u = new URL("https://1bit.monster/");
+          }
+          target = u.href;
+        } catch (e) {
+          target = "https://1bit.monster/";
+        }
         document.getElementById("msg").textContent = "Redirecting to: " + target;
         // Give the beacon a moment to report this page load, then redirect.
         setTimeout(function () {


### PR DESCRIPTION
### **User description**
Fixes 2 of the 5 open CodeQL alerts; the other 3 (vendored third-party test, deliberate float SIMD test arithmetic, and the 404.html open-redirect companion) are dismissed with justification below.

- **2875 (error, js/xss)** — `site/404.html`: the untrusted `?next=` query param was passed straight into `location.replace()`, so `?next=javascript:…` was stored XSS. The redirect target is now validated: only `http:`/`https:` URLs are accepted, everything else (javascript:, data:, vbscript:, malformed) falls back to `https://1bit.monster/`.
- **2872 (warning, py/incomplete-url-substring-sanitization)** — `Testing/census_autopr.py`: replaced the `"github.com" in r.stdout` substring check with a strict `urlparse` validation (scheme == https, netloc == github.com).
- **2874 (warning, js/client-side-unvalidated-url-redirection)** — same `?next=` code path; scheme-validated in the same change. The /s/ share feature is *by design* an attribution redirect to an arbitrary user-chosen page, so an https open-redirect is intended behavior; XSS via scheme tricks is what's prevented here. If CodeQL still flags it after this lands, dismiss with this justification.
- **2871 (warning, py/insecure-protocol)** — `third_party/lemonade/test/test_tray_https.py`: vendored third-party test that stands up a mock TLS server on loopback; not reachable from product code. Dismissing as vendored.
- **2873 (warning, cpp/integer-multiplication-cast-to-long)** — `engine/npu/tests/test_i4_silu_q22.cpp`: deliberate float SIMD/test arithmetic (RMS-normalized values); matches the 47 alerts dismissed in triage #1825. Dismissing.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix stored XSS via `?next=` scheme validation

- Strict `urlparse` check for GitHub PR URLs

- Non-http(s) targets fall back to 1bit.monster


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["?next= query param"] --> B["URL scheme check http/https"]
  B -- "valid" --> C["redirect to target"]
  B -- "invalid" --> D["fallback to 1bit.monster"]
  E["PR URL from gh"] --> F["urlparse https + github.com"]
  F -- "valid" --> G["return PR URL"]
  F -- "invalid" --> H["return None"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>census_autopr.py</strong><dd><code>Strict GitHub PR URL validation in autopr</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Testing/census_autopr.py

<ul><li>Added <code>urlparse</code> import from <code>urllib.parse</code><br> <li> Replaced substring check with strict URL parsing<br> <li> Accepts only https URLs on github.com netloc<br> <li> Returns None for empty or invalid output</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1895/files#diff-0182339e60b9405c8d692fafdda5a68de66470ea1fa3de02be53bc1bd5868e14">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>404.html</strong><dd><code>Validate redirect target to prevent XSS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/404.html

<ul><li>Validates <code>?next=</code> redirect target with URL constructor<br> <li> Allows only https and http protocols<br> <li> Rejects javascript, data, vbscript schemes<br> <li> Falls back to https://1bit.monster/ when invalid</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1895/files#diff-8cbce8d617d964ddab39632760ab6337f1b8e3c5584de59ef68c68f07ba8624d">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

