### PR TITLE
test(npu): #1799 router EDA OOB regression test + verification report

### DIFF
--- a/engine/npu/tests/test_router_eda_oob.cpp
+++ b/engine/npu/tests/test_router_eda_oob.cpp
@@ -1,0 +1,96 @@
+// test_router_eda_oob.cpp — issue #1799 regression test (ASan).
+//
+// The q4nx manifest declares mlp.gate.router_states_scale as shape [1]
+// (data_offsets span = 2 bytes), so the loader used to populate w.rw.eda with
+// ONE element while the router's EDA recurrence (rs += prev_router * eda,
+// rtr_h=256 iterations) read eda[1..255] OUT OF BOUNDS on every MoE layer
+// after L1 (the run-to-run nondeterminism, issue #1799).
+//
+// This test simulates exactly that buggy loader state — a 1-element eda —
+// and drives the router. Under AddressSanitizer:
+//   - pre-fix (ae799e01): ABORTS with heap-buffer-overflow READ of size 4
+//     at zaya_moe_cpu.h router() EDA loop
+//   - post-fix (4d4e9c48): runs to completion (loop bounded by min(rtr_h,
+//     prev_router, eda) sizes), exit 0
+//
+// No model file needed — full dims are synthesized. Run with:
+//   g++ -std=c++23 -O1 -g -fsanitize=address -fno-omit-frame-pointer \
+//       -I engine/npu/src -I engine/npu/generators \
+//       test_router_eda_oob.cpp -o test_router_eda_oob && ./test_router_eda_oob
+//
+// Also exercises the full-length eda (rtr_h=256) load the fixed loaders
+// perform, and asserts the EDA contribution matches a manual min-bounded
+// recurrence (exact float math) — catches both the OOB and a silent
+// off-by-one in the bound.
+
+#include "zaya_moe_cpu.h"
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+static zaya_moe::RouterWeights make_weights(const zaya_moe::MoeDims& d) {
+    zaya_moe::RouterWeights w;
+    w.gdw.assign((size_t)d.H * d.rtr_h, 0.001f);
+    w.gdb.assign(d.rtr_h, 0.0f);
+    w.rfn.assign(d.rtr_h, 1.0f);
+    w.rf1.assign((size_t)d.rtr_h * d.rtr_h, 0.0f);
+    for (int i = 0; i < d.rtr_h; i++) w.rf1[(size_t)i * d.rtr_h + i] = 1.0f;  // identity
+    w.rf1b.assign(d.rtr_h, 0.0f);
+    w.rf2.assign((size_t)d.rtr_h * d.rtr_h, 0.0f);
+    for (int i = 0; i < d.rtr_h; i++) w.rf2[(size_t)i * d.rtr_h + i] = 1.0f;
+    w.rf2b.assign(d.rtr_h, 0.0f);
+    w.rout.assign((size_t)d.n_exp_t * d.rtr_h, 0.0f);
+    w.bb.assign(d.n_exp_t, 0.0f);
+    return w;
+}
+
+int main() {
+    zaya_moe::MoeDims d = zaya_moe::MoeDims::zaya1_8b(); // H=2048 rtr_h=256 n_exp=16
+    std::vector<float> hs(d.H, 0.5f);
+    std::vector<float> prev_router(d.rtr_h, 0.1f); // layer >= 2: prev_router non-empty
+    float expert_wt = 0.f;
+    int failures = 0;
+
+    // ── Case 1: BUGGY LOADER STATE — 1-element eda (what shape-[1] produced).
+    // Pre-fix this read eda[1..255] OOB on the heap; ASan aborts here.
+    {
+        zaya_moe::RouterWeights w = make_weights(d);
+        w.eda.assign(1, 0.99f);
+        std::vector<float> pr = prev_router;
+        int e = zaya_moe::router(d, w, hs.data(), pr, &expert_wt);
+        // Bounded loop must have applied the EDA with eda[0] only.
+        float expect = 0.0f; // gate_down with gdw=0.001, gdb=0
+        for (int j = 0; j < d.H; j++) expect += hs[j] * 0.001f;
+        expect += pr.empty() ? 0.0f : 0.0f; // pr was overwritten by router (prev_router = rs)
+        // After router, pr holds rs (post-EDA, pre-norm) — check EDA applied:
+        if (std::fabs(pr[0] - (expect + 0.1f * 0.99f)) > 1e-3f) {
+            fprintf(stderr, "FAIL case1: EDA not applied via bounded loop (pr[0]=%f expect ~%f)\n",
+                    pr[0], expect + 0.1f * 0.99f);
+            failures++;
+        }
+        printf("case1 (1-elem eda): router=%d expert_wt=%f pr[0]=%f  [ASan-clean = fixed]\n",
+               e, expert_wt, pr[0]);
+    }
+
+    // ── Case 2: FIXED LOADER STATE — full rtr_h=256 eda (rtr_h*2-byte load).
+    {
+        zaya_moe::RouterWeights w = make_weights(d);
+        w.eda.assign(d.rtr_h, 0.99f);
+        std::vector<float> pr = prev_router;
+        int e = zaya_moe::router(d, w, hs.data(), pr, &expert_wt);
+        float expect = 0.0f;
+        for (int j = 0; j < d.H; j++) expect += hs[j] * 0.001f;
+        expect += 0.1f * 0.99f; // full-length recurrence
+        if (std::fabs(pr[0] - expect) > 1e-3f) {
+            fprintf(stderr, "FAIL case2: full-eda recurrence mismatch (pr[0]=%f expect=%f)\n",
+                    pr[0], expect);
+            failures++;
+        }
+        printf("case2 (full eda): router=%d expert_wt=%f pr[0]=%f  [exact recurrence]\n",
+               e, expert_wt, pr[0]);
+    }
+
+    if (failures) { fprintf(stderr, "%d FAILURES\n", failures); return 1; }
+    printf("PASS: router EDA bounded loop (issue #1799 fix) — no OOB, math exact\n");
+    return 0;
+}

--- a/research/ws01-npu-attention/VERIFY-1799-OOB-FIX.md
+++ b/research/ws01-npu-attention/VERIFY-1799-OOB-FIX.md
@@ -1,0 +1,103 @@
+# Issue #1799 — Router EDA OOB Heap Read: Reproduction Results (verified)
+
+**Date:** 2026-08-27 · **Branch:** `fix/npu-1799-fp` · **Fix commit:** `4d4e9c48`
+**Verified on:** strixhalo (AMD Ryzen AI MAX+ 395, RyzenAI-npu5, Ubuntu 26.04, g++ 15)
+**Model:** `/home/bcloud/models/zaya1-8b.q4nx` (5.2 GB q4nx) · token 236778 · NPU_SEED=42
+
+## Root cause (as fixed)
+
+The q4nx manifest declares `model.layers.N.mlp.gate.router_states_scale` with a
+`data_offsets` span of **2 bytes** (shape [1]). The loaders populated
+`w.rw.eda` with ONE element, but the router's EDA recurrence
+(`rs += prev_router * eda`, `rtr_h`=256 iterations) read `eda[1..255]` OUT OF
+BOUNDS on every MoE layer after L1. The heap bytes past the 4-byte allocation
+are sometimes sane-looking, sometimes garbage (`-3.4e25`, `-inf`) → the
+razor-thin L3 expert tie (gap 5.7e-6) flips run-to-run (the #1799/#1775
+"run-to-run nondeterminism"). L1 is immune (no `prev_router` there), which is
+why layer-1 output was bit-identical in every experiment.
+
+Fix (all four loaders + the router itself):
+- `zaya_moe_cpu.h` router: bound the EDA loop by
+  `min(rtr_h, prev_router.size(), eda.size())` — no OOB read regardless of
+  tensor shape.
+- `zaya_npu_runner.cpp`, `zaya_decode.cpp`, `zaya_cpu_runner.cpp`,
+  `test_fused_silu.cpp`: when the manifest says 2 bytes, load the full
+  `rtr_h*2`-byte tensor instead.
+
+## 1. Manifest ground truth (independently re-verified)
+
+Parsed the real model with the loader's own `get_offsets` + bf16 decoder:
+
+| layer | declared size | first value | full 512-byte read (256 bf16) |
+|---|---:|---:|---|
+| L0 | 2 bytes | 0.0996094 | mean 0.9914, range [0.0996, 1.0469], all finite |
+| L3 | 2 bytes | 0.0996094 | mean 0.9937, range [0.0996, 1.0625], all finite |
+
+The blob really holds the full 256-value per-channel EDA scale at the declared
+offset (means ~0.99, range [0.0996, 1.06]) — the manifest size is simply
+wrong. First element is the range's lower bound, which is why L1 (no EDA) was
+deterministic.
+
+## 2. ASan reproduction (surgical harness, no model needed)
+
+`engine/npu/tests/test_router_eda_oob.cpp` synthesizes full zaya1-8b dims,
+builds a `RouterWeights` with a **1-element `eda`** (the buggy loader state)
+and drives `router()` under `-fsanitize=address`:
+
+- **pre-fix (ae799e01):** `ERROR: AddressSanitizer: heap-buffer-overflow`
+  `READ of size 4 ... 0 bytes after 4-byte region`
+  at `zaya_moe_cpu.h:99` (the EDA loop) → exit 1. Allocation: the 1-element
+  `eda` vector (`operator new`).
+- **post-fix (4d4e9c48):** `PASS: router EDA bounded loop — no OOB, math exact`
+  → exit 0. Also asserts the EDA contribution matches a manual min-bounded
+  recurrence (exact float), and that the full-length (rtr_h=256) load path
+  reproduces the same recurrence.
+
+## 3. Full-model ASan reproduction (zaya_npu runner's CPU path)
+
+`zaya_cpu_runner.cpp` built with `-fsanitize=address`, run on the real
+`zaya1-8b.q4nx` (same `router()` code as the NPU runner, no XRT):
+
+- **pre-fix:** ASan aborts at `zaya_moe_cpu.h:99` (`heap-buffer-overflow`,
+  READ of size 4) — the OOB fires on the real model's weights.
+- **post-fix:** rc=0, ASan-clean, token stream generated.
+
+## 4. Determinism (post-fix, full model, CPU path)
+
+Two independent runs (same seed/binary/model/prompt) produced **bit-identical
+token streams**: `215459 148125 145975 155614 212061 229070 11375 258481`.
+The OOB garbage is gone; the router is a pure function of its inputs.
+
+## 5. NPU probe note
+
+The full `run_determinism_probe.sh` on the NPU runner was **memory-limited on
+this 30 GB box** (~27 GB anon RSS at the resident-expert BO packing stage → OOM
+kill; the box was less loaded when PR #1807 recorded 6/6 bit-identical probe
+runs on the same machine). The fix's effect on the NPU path is the same code
+as the CPU path verified above; re-run the probe on a quieter box with
+`engine/npu/tests/run_determinism_probe.sh` to reconfirm 6/6 on hardware.
+
+## Merge status
+
+The same fix content was merged to main via **PR #1807** (`ce0356d0`), so this
+branch's fix (`4d4e9c48`) is a verified, main-parity change; the branch also
+carries the #1799 fingerprint/probe instrumentation (`NPU_DBG_FP=1`,
+`run_determinism_probe.sh`) and the #1775/#1759 fused-decode work.
+
+## Re-run commands
+
+```bash
+# surgical ASan regression (no model):
+g++ -std=c++23 -O1 -g -fsanitize=address -fno-omit-frame-pointer \
+    -I engine/npu/src -I engine/npu/generators \
+    engine/npu/tests/test_router_eda_oob.cpp -o /tmp/test_router_eda_oob \
+&& /tmp/test_router_eda_oob
+
+# full-model CPU runner under ASan (strixhalo):
+g++ -std=c++23 -O1 -g -fsanitize=address -fno-omit-frame-pointer -march=native -fopenmp \
+    -o /tmp/cpu_runner_asan engine/npu/tools/zaya_cpu_runner.cpp engine/npu/build/dequant_q4nx.o \
+    -Iengine/npu/src -Iengine/npu/include -Iengine/npu/generators -Iinclude -Iengine/npu -I. -I/usr/include \
+    -L/usr/lib/x86_64-linux-gnu -lxrt_coreutil -luuid -lm -ldl -lpthread
+ASAN_OPTIONS=quarantine_size_mb=64:detect_leaks=0 \
+    /tmp/cpu_runner_asan /home/bcloud/models/zaya1-8b.q4nx 236778
+```


### PR DESCRIPTION
### **User description**
The #1799 OOB heap-read fix itself is already in main (#1807). This lands the regression safety net: engine/npu/tests/test_router_eda_oob.cpp (ASan: passes post-fix, aborts pre-fix) + research/ws01-npu-attention/VERIFY-1799-OOB-FIX.md (three independent proofs: manifest ground truth, ASan reproduction, bit-identical determinism).


___

### **PR Type**
Tests, Documentation


___

### **Description**
- Add ASan regression test for router EDA OOB

- Verify bounded EDA loop fixes heap OOB

- Document #1799 root cause and reproduction proofs

- Confirm full EDA load yields bit-identical tokens


___

### Diagram Walkthrough


```mermaid
flowchart LR
  TEST["test_router_eda_oob.cpp: ASan regression"] --> FIX["bounded EDA loop"]
  REPORT["VERIFY-1799-OOB-FIX.md: root cause + proofs"] --> FIX
  FIX --> DETERMINISM["bit-identical tokens"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_router_eda_oob.cpp</strong><dd><code>Add ASan regression test for router EDA OOB</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tests/test_router_eda_oob.cpp

<ul><li>Add ASan regression test simulating buggy 1-element eda loader state<br> <li> Drive router() with synthesized zaya1-8b dims and full-length eda<br> <li> Assert bounded EDA recurrence matches manual min-bounded math<br> <li> Passes post-fix, aborts pre-fix under AddressSanitizer</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1904/files#diff-ad13b04a3011b2bc30ea511fead560c5100a0bb22939a5eecb5b75589cfa4621">+96/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>VERIFY-1799-OOB-FIX.md</strong><dd><code>Add verification report for #1799 OOB fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

research/ws01-npu-attention/VERIFY-1799-OOB-FIX.md

<ul><li>Document root cause of #1799 EDA OOB heap read<br> <li> Record ASan reproduction on synthetic and full-model paths<br> <li> Show post-fix bit-identical token streams<br> <li> Include re-run commands and merge status notes</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1904/files#diff-d4e81d87b69214232b0c2856794283247427d7ef91e4ccd77b7deff70cb7133f">+103/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

