### PR TITLE
fix(census): map 4 new model classes to known families (watcher first-run findings)

### DIFF
--- a/include/rocm_cpp/bitnet_model.h
+++ b/include/rocm_cpp/bitnet_model.h
@@ -2433,6 +2433,19 @@ static inline rcpp_arch_t rcpp_arch_from_string(const char* s) {
     if (strcmp(s, "zzjrabbit22") == 0) return RCPP_ARCH_ZZJRABBIT22;
     if (strcmp(s, "zzjrabbit3") == 0) return RCPP_ARCH_ZZJRABBIT3;
     if (strcmp(s, "zzjrabbitmodel") == 0) return RCPP_ARCH_ZZJRABBIT;
+    // ── 2026-08-27 census watcher first-run findings ──
+    // Testing/hf_new_models.py flagged these classes as UNCOVERED on its
+    // first CI run; each is a variant of an already-mapped family (class
+    // names verified against live HF configs 2026-08-27). baretorch is
+    // intentionally NOT mapped — cs_lrad chunked-state linear-recurrent is
+    // a genuinely new architecture (engine work, not an alias).
+    if (strcmp(s, "glm5next") == 0) return RCPP_ARCH_LLAMA;            // Glm5NextForConditionalGeneration (GLM-5.3-Flash)
+    if (strcmp(s, "glm5_next") == 0) return RCPP_ARCH_LLAMA;           // HF model_type
+    if (strcmp(s, "lfm2dsparkdraft") == 0) return RCPP_ARCH_LFM2;      // Lfm2DSparkDraftModel (LFM2.5 DSpark speculative draft)
+    if (strcmp(s, "museglimmerassistant") == 0) return RCPP_ARCH_MUSE; // MuseGlimmerAssistantModel (Muse-Glimmer assistant variant)
+    if (strcmp(s, "muse_glimmer_assistant") == 0) return RCPP_ARCH_MUSE;  // HF model_type
+    if (strcmp(s, "qwen4exp") == 0) return RCPP_ARCH_QWEN3NEXT;        // Qwen4ExpForConditionalGeneration (Qwen3.8-Flash-Next, GDN)
+    if (strcmp(s, "qwen4_exp") == 0) return RCPP_ARCH_QWEN3NEXT;       // HF model_type
     // Unmapped architecture — do NOT fall back to BITNET silently.
     return RCPP_ARCH_UNKNOWN;
 }


### PR DESCRIPTION
### **User description**
## Summary

The daily new-model watcher (`Testing/hf_new_models.py`, landed in #1900) ran on CI for the first time (2026-08-27) and flagged **5** HF architecture classes as UNCOVERED by the engine registry (`rcpp_arch_from_string` in `include/rocm_cpp/bitnet_model.h`).

4 of the 5 are variants of already-mapped families → this PR adds the aliases (following the `kimik3 -> KIMI_K3` pattern from #1848). **baretorch is intentionally NOT mapped** — it is a genuinely new architecture that needs real engine work (tracked in #1907).

## Aliases added (exact lines)

| Key(s) | Family | HF class (verified 2026-08-27) | model_type |
|---|---|---|---|
| `glm5next` (+ `glm5_next`) | `RCPP_ARCH_LLAMA` | `Glm5NextForConditionalGeneration` | `glm5_next` |
| `lfm2dsparkdraft` | `RCPP_ARCH_LFM2` | `Lfm2DSparkDraftModel` | `qwen3` |
| `museglimmerassistant` (+ `muse_glimmer_assistant`) | `RCPP_ARCH_MUSE` | `MuseGlimmerAssistantModel` | `muse_glimmer_assistant` |
| `qwen4exp` (+ `qwen4_exp`) | `RCPP_ARCH_QWEN3NEXT` | `Qwen4ExpForConditionalGeneration` | `qwen4_exp` |

## HF evidence

- `glm5next`: `zai-org/GLM-5.3-Flash`, `Harech/GLM-5.3-Flash` → config `architectures: ["Glm5NextForConditionalGeneration"]`, `model_type: glm5_next`
- `lfm2dsparkdraft`: `LiquidAI/LFM2.5-1.2B-Instruct-DSpark`, `sonic-coder/LFM2.5-1.2B-Instruct-DSpark` → `architectures: ["Lfm2DSparkDraftModel"]` (LFM2.5 DSpark speculative-draft)
- `museglimmerassistant`: `meta-models/Muse-Glimmer-30B-assistant`, `SwinliQ-AI-2/Muse-Glimmer-30B-assistant` → `architectures: ["MuseGlimmerAssistantModel"]`, `model_type: muse_glimmer_assistant`
- `qwen4exp`: `mbehr90/Qwen3.8-Flash-Next-fp8` → `architectures: ["Qwen4ExpForConditionalGeneration"]`, `model_type: qwen4_exp` (Qwen3.8-Flash-Next = Qwen4 experimental; GatedDeltaNet text decoder)
- `baretorch` (NOT mapped): `model-rampage/BareTorch-500M-Base|SFT` → `architectures: ["BareTorchForCausalLM"]`, `model_type: baretorch` — cs_lrad chunked-state linear-recurrent

## Verification

- Header compiles standalone (g++ `-std=c++17` TU, same as the watcher's probe)
- Watcher probe path (`census_coverage.build_mapper` + `probe`): all 4 classes now resolve; `baretorch` still UNKNOWN (intended)
- `python3 -m py_compile` on `Testing/hf_new_models.py` + `census_coverage.py` ✓
- `python3 Testing/census_coverage.py`: 317,310/317,310 (100.00%) still covered ✓


___

### **PR Type**
Bug fix


___

### **Description**
- Map 4 watcher-flagged HF classes to known architecture families

- Add `glm5next`/`glm5_next` -> `RCPP_ARCH_LLAMA` in `rcpp_arch_from_string`

- Add `lfm2dsparkdraft` -> `RCPP_ARCH_LFM2` and `museglimmerassistant`/`muse_glimmer_assistant` -> `RCPP_ARCH_MUSE`

- Add `qwen4exp`/`qwen4_exp` -> `RCPP_ARCH_QWEN3NEXT`; leave `baretorch` unmapped


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["rcpp_arch_from_string"] --> B["glm5next -> LLAMA"]
  A --> C["lfm2dsparkdraft -> LFM2"]
  A --> D["museglimmerassistant -> MUSE"]
  A --> E["qwen4exp -> QWEN3NEXT"]
  B --> F["Census coverage restored"]
  C --> F
  D --> F
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitnet_model.h</strong><dd><code>Add census watcher alias mappings to arch registry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/rocm_cpp/bitnet_model.h

<ul><li>Add aliases for <code>glm5next</code>/<code>glm5_next</code>, <code>lfm2dsparkdraft</code>, <br><code>museglimmerassistant</code>/<code>muse_glimmer_assistant</code>, and <code>qwen4exp</code>/<code>qwen4_exp</code><br> <li> Map new classes to existing <code>RCPP_ARCH_LLAMA</code>, <code>RCPP_ARCH_LFM2</code>, <br><code>RCPP_ARCH_MUSE</code>, and <code>RCPP_ARCH_QWEN3NEXT</code><br> <li> Document 2026-08-27 census watcher first-run findings in comments<br> <li> Keep <code>baretorch</code> intentionally unmapped pending dedicated engine work</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1906/files#diff-12d8fec0ba47f1c901fbf55f16f798edaba0a693e7c892bfd9302e0b1a87318a">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

