### PR TITLE
README: simple & sweet — animated cube favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,13 @@
 <div align="center">
 
-<img src="site/assets/banner.png" alt="1bit.MONSTER — One engine. Any model. Zero Python." width="820">
-
-# <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" style="width:0.72em;height:0.72em;display:inline-block;vertical-align:-0.06em;margin-right:0.18em;"><rect x="2" y="2" width="9" height="9" rx="2" style="fill:#f5f8fa;stroke:#010202;stroke-opacity:0.28;"/><rect x="13" y="2" width="9" height="9" rx="2" style="fill:#f5f8fa;stroke:#010202;stroke-opacity:0.28;"/><rect x="2" y="13" width="9" height="9" rx="2" style="fill:#f5f8fa;stroke:#010202;stroke-opacity:0.28;"/><rect x="13" y="13" width="9" height="9" rx="2" style="fill:#0230c0;"/></svg> 1bit.MONSTER
-
-### *One engine. Any model. Zero Python.*
-
-#### 100% HF model coverage. Any hardware. One open-source, pure-C++ inference engine — NPU + GPU + CPU in a single engine. Model agnostic. Hardware agnostic. Zero Python.
+<img src="site/assets/banner.svg" alt="1bit.MONSTER — One engine. Any model. Zero Python." width="820">
 
 [![CI](https://github.com/1bit-MONSTER/1bit-MONSTER/actions/workflows/ci.yml/badge.svg)](https://github.com/1bit-MONSTER/1bit-MONSTER/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**[Website](https://1bit.monster)** · **[Community (Fluxer)](https://fluxer.gg/7wqCREKi)** · **[Join Discord](https://discord.gg/Qy38d4Xu2h)** · **[Docs](docs/README.md)** · **[Model families](docs/model-families/README.md)** · **[Benchmarks](docs/wiki/performance.md)** · **[JARVIS](docs/jarvis.md)** · **[The story](docs/journey.md)** · **[Roadmap](docs/guides/roadmap.md)**
+**[Website](https://1bit.monster)** · **[Community (Fluxer)](https://fluxer.gg/7wqCREKi)** · **[Join Discord](https://discord.gg/Qy38d4Xu2h)** · **[Docs](docs/README.md)** · **[Benchmarks](docs/wiki/performance.md)** · **[The story](docs/journey.md)** · **[Roadmap](docs/guides/roadmap.md)**
 
-`engine online` · MIT · pure C++23 · no Python · 6 hardware targets
+pure C++23 · no Python · MIT
 
 </div>
 
@@ -21,48 +15,23 @@
 
 ## Why this exists
 
-**AMD's XDNA 2 NPU shipped closed.** 22 proprietary `.so` files, 209 xclbin bitstreams, zero public documentation. One person reverse-engineered the entire stack in four days — no docs, just a disassembler, `strace`/`ftrace`, and a C++ compiler — and kept building from there. Every crash and breakthrough since is logged in the open, ~600 hours in. **[Read the story →](docs/journey.md)**
+**AMD's XDNA 2 NPU shipped closed.** 22 proprietary `.so` files, 209 xclbin bitstreams, zero public documentation. One person reverse-engineered the entire stack in four days — no docs, just a disassembler, `strace`/`ftrace`, and a C++ compiler — and kept building from there. As of 2026-08-15 the last proprietary dependency is gone: the engine's own instruction-stream generator is verified `cmp`-exact against the closed runtime's dumps, and beats its kernels by 11–15%. **[Read the story →](docs/journey.md)**
 
 **One engine. Every model.** 100% of HuggingFace's architecture-bearing text-generation checkpoints (317,310 of them) map to a token this engine knows how to run — Llama, Qwen, DeepSeek, GLM, Mamba/SSM, MoE, vision, ternary/1-bit, all of it. Reads GGUF, ONNX, and native 1BP. Same binary, no config file, on NPU, GPU, or CPU. **[Model families →](docs/model-families/README.md)**
 
+**Lemonade, side by side — and in sync with upstream.** The full Lemonade SDK is vendored at `third_party/lemonade` (pinned to upstream, re-vendored on each release) and compiles into the same binary as the engine's own kernels — one ELF, no wrappers, no subprocess. `unified_server --lemonade` runs all 15 Lemonade backends in-process alongside native ones. **[Lemonade compat →](docs/guides/Lemonade-Compat.md)**
+
 **JARVIS, out of the box.** A fully local voice assistant ships with the engine, not bolted on: mic → VAD → STT → LLM → TTS → speaker, one process, pure C++, zero cloud calls. `./build/1bit jarvis` and it's listening. **[JARVIS docs →](docs/jarvis.md)**
-
-**22 proprietary libraries. 209 bitstreams. Zero documentation.** That was the state of AMD's Ryzen AI Max+ 395 — a 50 TOPS XDNA 2 NPU locked behind a closed-source runtime that nothing else could touch. We replaced it with open C++: one MIT-licensed engine that runs LLMs on the NPU, on AMD / NVIDIA / Apple GPUs, or on plain CPU. **As of 2026-08-15, the last proprietary dependency is gone.** The engine's own instruction-stream generator emits **byte-identical** output to the closed-source runtime's own dumps (verified `cmp`-exact on every op), builds xclbins with the fully open `aiecc`/`peano-clang` toolchain, and now **beats** the proprietary stack's own kernels by 11-15% — 2x on a 35B MoE model. Not just replicated: outperformed, with nothing closed-source left in the loop.
-
-**→ [Read the full journey](docs/journey.md)** — every crash, breakthrough, and bug, documented in real time.
-**→ [The Audit Trail](docs/audit-trail.md)** — 1.5 TB of raw evidence, archived nightly on the Raspberry Pi backup server.
 
 ## Quick start
 
 ```bash
-# build from source — no installer yet
 git clone https://github.com/1bit-MONSTER/1bit-MONSTER
 cd 1bit-MONSTER && cmake -B build && cmake --build build
 ./build/1bit zaya -m model.1bp -p "Hello world"
 ```
 
-That's the whole install. One engine, no runtime, no virtualenv, no Python.
-
-| 100% | 552 | 32 | 6 | 0 |
-|:---:|:--:|:--:|:-:|:-:|
-| HF checkpoints covered | arch tokens | families in manifest | hardware targets | Python in the runtime |
-
-## Convert a GGUF model to 1BP
-
-```bash
-cmake --build build --target gguf_to_onebp          # pure C++23, no Python
-./build/gguf_to_onebp model.gguf model.1bp          # F16 lossless (default)
-./build/gguf_to_onebp model.gguf model.1bp --q4nx   # 4-bit — lossy, compact
-```
-
-- **Default is lossless F16** (f32→f16 round-trip, 2 B/elem). 4-bit Q4NX loses
-  ~0.998/layer and compounds into garbage logits on deep models — F16 is the
-  only mode guaranteed correct for GPU/NPU decode. `--q4nx`/`--tq2`/`--tq2nz`/
-  `--tq1` opt in to the lossy paths; `--tq2bs`/`--rocmfp4`/`--rocmfp4-fast`
-  add block-scaled-ternary and ROCmFP4 codebook modes.
-- Emits a sibling `.htok` (BPE tokenizer) next to the `.1bp` so the engine can
-  decode real text. Converter lives at `src/gguf_to_onebp.cpp`; batch wrappers:
-  `tools/batch_convert.sh`, `scripts/build_1bp.sh`.
+That's the whole install. No runtime, no virtualenv, no Python.
 
 ## What it is
 
@@ -71,140 +40,31 @@ An **inference engine** — the thing that actually runs the model. Not a chat a
 - **Model agnostic.** Reads GGUF, ONNX, and native 1BP. Detects the architecture, picks a kernel path. No config files.
 - **Hardware agnostic.** Same binary, same command, on any silicon: AMD Strix Halo NPU + GPU, NVIDIA (CUDA — [needs testers](https://github.com/1bit-MONSTER/1bit-MONSTER/issues/1703)), Apple Silicon, any Vulkan 1.2+ GPU, x86 CPU. No rebuild to move a model ([architecture](docs/guides/architecture.md)).
 - **One binary, every server.** `build/1bit` holds the CLI and all servers, dispatched by subcommand (`zaya`, `unified`, `jarvis`, `vision`, `chat`, …). OpenAI-compatible `POST /v1/chat/completions`, speculative decoding, image/video/voice generation.
-- **Speculative decoding, in-process.** `--draft-model` + `--spec-decode`, lossless vs greedy — no extra server.
-- **Beyond text.** Stable-Diffusion-family image and video generation via `image_server`; Whisper STT and codec TTS for voice.
-
-## Model agnostic
-
-Point it at a model and run. The engine reads **GGUF**, **ONNX**, and the native **1BP** format, detects the architecture, and picks a kernel path — no config files, no per-model glue, no conversion step you have to babysit.
-
-Coverage does not come from porting models one at a time. It comes from the architecture class: 552 arch tokens map 1,774 HF architecture strings, grouped into 32 manifest families — a family that works brings its whole arch-string set with it. The registry is measured against a full HF census: **317,310 / 317,310 arch-bearing text-gen checkpoints (100.00%) map to an engine token** (`Testing/census_coverage.py` regenerates the count from the actual committed mapping).
-
-The full-catalog end state — 500+ models, HuggingFace-native bring-up — is planned in **[docs/plans/monster-500-models.md](docs/plans/monster-500-models.md)**. The [models SSOT](docs/wiki/models.md) is the single source of truth for coverage; the [roadmap](docs/guides/roadmap.md) tracks the remaining gap (glm4/cohere2/lfm2 hybrid families, encoder-decoder T5/BART out of scope, ~2,000 one-off custom classes).
-
-**→ [All families, indexed](docs/model-families/README.md)** · **→ [Combined support SSOT](docs/wiki/models.md)**
-
-### Model families
-
-Every architecture the engine detects has its own page — params, 1BP size, backends, measured perf. 500+ HuggingFace-native bring-up is the end-state goal ([roadmap](docs/plans/monster-500-models.md)); today's manifest already spans:
-
-[Zyphra](docs/model-families/zyphra.md) · [Qwen](docs/model-families/qwen.md) · [Llama](docs/model-families/llama.md) · [Mistral](docs/model-families/mistral.md) · [Gemma](docs/model-families/gemma.md) · [Phi](docs/model-families/phi.md) · [Falcon](docs/model-families/falcon.md) · [OLMo](docs/model-families/olmo.md) · [Granite](docs/model-families/granite.md) · [SmolLM](docs/model-families/smollm.md) · [DeepSeek](docs/model-families/deepseek.md) · [GPT-OSS](docs/model-families/gpt-oss.md) · [Laguna](docs/model-families/laguna.md) · [Kimi](docs/model-families/kimi.md) · [BitNet / Bonsai](docs/model-families/bitnet-bonsai.md) · [Whisper](docs/model-families/whisper.md)
-
-## Frontier gates: 5/5 validated against reference implementations
-
-Every architecture the engine claims to support is held to a **generation gate**: run the engine on a real (or mini) checkpoint and compare logits against the reference implementation. The five newest frontier families were audited, implemented, and gated in one session (2026-08-16) — the gates caught real math bugs each time:
-
-| Family | Arch | Engine | Gate result |
-|--------|------|--------|-------------|
-| **Nemotron 3** | LayerNorm1P + relu2 MLP + partial RoPE | `backend_generic` | ✅ **real** 8B checkpoint, top1 7503 *" Paris"* == HF, logit corr 0.99986 |
-| **DeepSeek V4** | Shared-KV MQA + mHC (Sinkhorn) + hash-MoE | `src/deepseek_v4.cpp` | ✅ mini-gate top1 342 == HF, 20/20 top-20 |
-| **GLM-5.2** | V3-MLA + DSA indexer (cross-layer top-k) | `src/glm_moe_dsa.cpp` | ✅ mini-gate top1 171 == HF, 20/20 |
-| **MiMo V2** | MoD hybrid (SWA+full GQA, sigmoid group-topk) | `src/mimo_v2.cpp` | ✅ mini-gate top1 524 == HF, 20/20 |
-| **Qwen3.5** | GatedDeltaNet + gated GQA hybrid | `src/qwen3_5.cpp` | ✅ mini-gate top1 142 == HF, 20/20, corr 1.0 |
-
-Each gate compares full logits (not just greedy argmax) against the authoritative reference — the HuggingFace modeling source for the exact checkpoint. The audit step proved decisive: two of the five families shipped in our engine **before** the audit were written against fictional architectures (DeepSeek V4 had MLA + a 4x4 "mHC mix matrix" that don't exist; the real thing is Shared-KV MQA + Sinkhorn hyper-connections). The gate suite ([`Testing/run_all.sh`](Testing/run_all.sh)) is now **17/17 green**, and the full model census holds **100.00%** coverage of HuggingFace architectures.
-
-**→ [The frontier plan](docs/plans/monster-500-models.md)** — the 5-gate work order, per-family architecture facts, and what each gate proved.
-
-## Hardware agnostic
-
-The same binary and the same command line, on whatever silicon you have:
-
-| Platform | Backend |
-|----------|---------|
-| AMD Strix Halo (Ryzen AI Max+ 395) | XDNA 2 NPU + ROCm HIP + GGML-Vulkan |
-| NVIDIA GPU (sm_70+) | CUDA — **implemented, not yet validated on real hardware** ([#1703](https://github.com/1bit-MONSTER/1bit-MONSTER/issues/1703), testers wanted) |
-| Apple Silicon | Metal |
-| Any Vulkan 1.2+ GPU | ZINC + GGML-Vulkan |
-| x86 CPU | OpenMP |
-
-Six hardware targets are probed at startup (`has_npu`, `has_hip_gpu`, `has_vulkan`, `has_cuda`, `has_metal`, `has_avx512`) and served by **12 backend implementations** in the factory: CPU, Generic, Vulkan, HIP, NPU, ZINC, Zamba2, Mamba1, CUDA, Metal, VART, ONNX-NPU. Some are model-specific SSM paths rather than device backends, and stub backends return `can_infer() == false` so they are discovered but never selected for inference. No rebuild to move a model from NPU to GPU to CPU. **Honesty note:** the CUDA backend (`src/cuda_engine.cu`) compiles and is wired into the factory, but unlike the other five targets it has never actually been run against real NVIDIA hardware — no CI gate, no measured numbers, nothing in the engineering log. Don't take "6 hardware targets" as "6 validated hardware targets." We're looking for someone with real NVIDIA hardware to test it — see [#1703](https://github.com/1bit-MONSTER/1bit-MONSTER/issues/1703).
-
-**→ [Architecture deep-dive](docs/guides/architecture.md)**
 
 ## Benchmarks
 
-Headline end-to-end decode, measured **2026-08-01** on an AMD Ryzen AI MAX+ 395 (Radeon 8060S, 32 GB UMA):
+Headline end-to-end decode on an AMD Ryzen AI MAX+ 395 (Radeon 8060S, 32 GB UMA):
 
 | Model | Gen tok/s (e2e) | Backend |
 |-------|:---------------:|---------|
 | SmolLM2-135M | **662** | GGML-Vulkan |
 | Qwen3-0.6B | **373** | GGML-Vulkan |
-| Qwen2.5-VL-3B | **100** | GGML-Vulkan |
-| BlackMamba-1.5B | **79.4** | Mamba1 HIP |
-| BlackMamba-2.8B | **46.0** | Mamba1 HIP |
 | Qwen3.5-4B | **65** | GGML-Vulkan |
+| BlackMamba-2.8B | **46.0** | Mamba1 HIP |
 | DeepSeek-R1-Distill-Llama-8B | **44** | GGML-Vulkan |
 | ZAYA1-74B-preview | **17.6** | GGML-Vulkan |
 
-Plus **38.84 TFLOPS** INT8 prefill (WMMA, variant I8-APRE) — the canonical figure, re-measured 2026-08-18 as the median of 3 runs with 1 warmup discarded; earlier single-run passes were 39.4 / 40.5 (colder-GPU) and 43.2 TFLOPS (re-measured 2026-08-01). Measured, not projected — full numbers and methodology: **[docs/wiki/performance.md](docs/wiki/performance.md)**.
+Plus **38.84 TFLOPS** INT8 prefill. Measured, not projected — full numbers and methodology: **[docs/wiki/performance.md](docs/wiki/performance.md)**.
 
-BlackMamba figures re-measured 2026-07-26 after the `__shfl_xor_sync` kernel fixes. Numbers in this file are checked against `site/numbers.json` in CI:
+## Also in the box
 
-```bash
-python3 scripts/generate_readme_numbers.py --check
-```
-
-Kernel-level GEMV figures (Q1 433, TQ2 420, ternary 318 tok/s) are **isolated throughput, bit-exact vs CPU reference — not end-to-end decode**, and are deliberately kept out of the headline table.
-
-### Unified control plane — measured 2026-08-07
-
-All five zoo models served from **one** `unified` process (`--pool` keeps every model resident), one OpenAI-compatible endpoint, measured end-to-end through `POST /v1/chat/completions` including per-request model routing:
-
-| Model | tok/s (e2e) | Backend |
-|-------|:-----------:|---------|
-| Qwen3-4B | **20.8** | NPU FLM (XDNA) |
-| Qwen3-0.6B Instruct | **12.4** | GGML-Vulkan |
-| Llama-3.2-1B Instruct | **12.4** | GGML-Vulkan |
-| Bonsai-1.7B-TQ2 | **3.1** | HIP 1BP |
-| Zamba2-1.2B-Instruct-v2 | **2.2** | HIP (Mamba2 SSD) |
-
-`scripts/zoo-smoke.sh` (5/5 PASS) runs the same path; `POST /v1/pool` reports residency.
-
-**→ [Full performance SSOT](docs/wiki/performance.md)**
-
-## Adoption
-
-From `site/numbers.json` (repo telemetry, synced):
-
-| 6,113 | 783 | 47 | 14 |
-|:-----:|:---:|:--:|:--:|
-| total clones | unique cloners | models shipping | open issues |
-
-## Flagship pipeline: JARVIS
-
-A fully local voice assistant where every stage runs on the engine:
-
-```
-mic → VAD → STT (Whisper) → router → LLM → TTS (codec) → cloned voice → speaker
-```
-
-No cloud, no Python in the hot path.
-
-**→ [How the JARVIS pipeline works](docs/jarvis.md)**
-
-## The Mesh — self-aware installs, out of the box
-
-Every install is a network node: it announces itself on the LAN (UDP multicast), discovers sibling 1bit-MONSTER installs, and **starts asking questions** — *"want to hook up and integrate?"* — then handshakes and federates (shared routing, model exchange, load sharing). Zero config, zero model weights required for the network to come alive; a DSH brain (`integrations/dsh/`) upgrades the questions from templates to your local model's own words.
-
-```bash
-cmake --build build --target mesh_peer -j     # or: 1bit unified (mesh on by default)
-./build/mesh_peer --name alice --port 18088
-./build/mesh_peer --name bob   --port 18089   # they find each other immediately
-curl http://127.0.0.1:18088/v1/mesh/peers     # 👋 there's bob
-```
-
-**→ [Mesh protocol](docs/mesh-protocol.md)** · **→ [DSH brain](integrations/dsh/README.md)**
+- **The Mesh** — installs self-discover on the LAN and federate: shared routing, model exchange, load sharing. Zero config. ([docs/mesh-protocol.md](docs/mesh-protocol.md))
 
 ## Learn more
 
-- **[Documentation index](docs/README.md)** — start here
-- **[Getting started](docs/guides/getting-started.md)** · **[Build guide](docs/guides/building.md)**
-- **[Model families](docs/model-families/README.md)** · **[Benchmarks](docs/wiki/performance.md)**
-- **[The engineering journey](docs/journey.md)** · **[Roadmap](docs/guides/roadmap.md)**
-- **[Contributing](CONTRIBUTING.md)**
-
-> **XDNA 2 NPU, driven from outside AMD tooling** — the measured evidence lives in-repo: [AIE2P hardware facts](engine/npu/AIE2P-FACTS.md) (bf16 RNI rounding, dispatch costs) and the [NPU backend](engine/npu/). The engine itself is MAX-free by design.
+- **[Documentation index](docs/README.md)** · **[Getting started](docs/guides/getting-started.md)** · **[Build guide](docs/guides/building.md)**
+- **[Model families](docs/model-families/README.md)** · **[Benchmarks](docs/wiki/performance.md)** · **[Roadmap](docs/guides/roadmap.md)**
+- **[The engineering journey](docs/journey.md)** · **[Contributing](CONTRIBUTING.md)**
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/1bit-MONSTER/1bit-MONSTER/actions/workflows/ci.yml/badge.svg)](https://github.com/1bit-MONSTER/1bit-MONSTER/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**[Website](https://1bit.monster)** · **[Community (Fluxer)](https://fluxer.gg/7wqCREKi)** · **[Join Discord](https://discord.gg/Qy38d4Xu2h)** · **[Docs](docs/README.md)** · **[Benchmarks](docs/wiki/performance.md)** · **[The story](docs/journey.md)** · **[Roadmap](docs/guides/roadmap.md)**
+**[Website](https://1bit.monster)** · **[Docs](docs/README.md)** · **[Community (Fluxer)](https://fluxer.gg/7wqCREKi)** · **[Join Discord](https://discord.gg/Qy38d4Xu2h)** · **[Roadmap](docs/guides/roadmap.md)**
 
 pure C++23 · no Python · MIT
 
@@ -13,15 +13,9 @@ pure C++23 · no Python · MIT
 
 ---
 
-## Why this exists
+**One engine. Any model. Zero Python.**
 
-**AMD's XDNA 2 NPU shipped closed.** 22 proprietary `.so` files, 209 xclbin bitstreams, zero public documentation. One person reverse-engineered the entire stack in four days — no docs, just a disassembler, `strace`/`ftrace`, and a C++ compiler — and kept building from there. As of 2026-08-15 the last proprietary dependency is gone: the engine's own instruction-stream generator is verified `cmp`-exact against the closed runtime's dumps, and beats its kernels by 11–15%. **[Read the story →](docs/journey.md)**
-
-**One engine. Every model.** 100% of HuggingFace's architecture-bearing text-generation checkpoints (317,310 of them) map to a token this engine knows how to run — Llama, Qwen, DeepSeek, GLM, Mamba/SSM, MoE, vision, ternary/1-bit, all of it. Reads GGUF, ONNX, and native 1BP. Same binary, no config file, on NPU, GPU, or CPU. **[Model families →](docs/model-families/README.md)**
-
-**Lemonade, side by side — and in sync with upstream.** The full Lemonade SDK is vendored at `third_party/lemonade` (pinned to upstream, re-vendored on each release) and compiles into the same binary as the engine's own kernels — one ELF, no wrappers, no subprocess. `unified_server --lemonade` runs all 15 Lemonade backends in-process alongside native ones. **[Lemonade compat →](docs/guides/Lemonade-Compat.md)**
-
-**JARVIS, out of the box.** A fully local voice assistant ships with the engine, not bolted on: mic → VAD → STT → LLM → TTS → speaker, one process, pure C++, zero cloud calls. `./build/1bit jarvis` and it's listening. **[JARVIS docs →](docs/jarvis.md)**
+A pure-C++23 inference engine that runs 100% of HuggingFace's text-generation checkpoints on NPU, GPU, or CPU — with the Lemonade SDK side by side, in sync with upstream.
 
 ## Quick start
 
@@ -33,38 +27,18 @@ cd 1bit-MONSTER && cmake -B build && cmake --build build
 
 That's the whole install. No runtime, no virtualenv, no Python.
 
-## What it is
+## For the real nerds
 
-An **inference engine** — the thing that actually runs the model. Not a chat app; bring your own frontend.
+All the technical stuff lives in the docs and wiki:
 
-- **Model agnostic.** Reads GGUF, ONNX, and native 1BP. Detects the architecture, picks a kernel path. No config files.
-- **Hardware agnostic.** Same binary, same command, on any silicon: AMD Strix Halo NPU + GPU, NVIDIA (CUDA — [needs testers](https://github.com/1bit-MONSTER/1bit-MONSTER/issues/1703)), Apple Silicon, any Vulkan 1.2+ GPU, x86 CPU. No rebuild to move a model ([architecture](docs/guides/architecture.md)).
-- **One binary, every server.** `build/1bit` holds the CLI and all servers, dispatched by subcommand (`zaya`, `unified`, `jarvis`, `vision`, `chat`, …). OpenAI-compatible `POST /v1/chat/completions`, speculative decoding, image/video/voice generation.
+- **[Docs index](docs/README.md)** · **[Getting started](docs/guides/getting-started.md)** · **[Build guide](docs/guides/building.md)**
+- **Deep dives:** [architecture](docs/guides/architecture.md) · [model families](docs/model-families/README.md) · [benchmarks](docs/wiki/performance.md) · [Lemonade compat](docs/guides/Lemonade-Compat.md) · [JARVIS](docs/jarvis.md) · [The Mesh](docs/mesh-protocol.md) · [the full journey](docs/journey.md)
 
-## Benchmarks
+## Community
 
-Headline end-to-end decode on an AMD Ryzen AI MAX+ 395 (Radeon 8060S, 32 GB UMA):
-
-| Model | Gen tok/s (e2e) | Backend |
-|-------|:---------------:|---------|
-| SmolLM2-135M | **662** | GGML-Vulkan |
-| Qwen3-0.6B | **373** | GGML-Vulkan |
-| Qwen3.5-4B | **65** | GGML-Vulkan |
-| BlackMamba-2.8B | **46.0** | Mamba1 HIP |
-| DeepSeek-R1-Distill-Llama-8B | **44** | GGML-Vulkan |
-| ZAYA1-74B-preview | **17.6** | GGML-Vulkan |
-
-Plus **38.84 TFLOPS** INT8 prefill. Measured, not projected — full numbers and methodology: **[docs/wiki/performance.md](docs/wiki/performance.md)**.
-
-## Also in the box
-
-- **The Mesh** — installs self-discover on the LAN and federate: shared routing, model exchange, load sharing. Zero config. ([docs/mesh-protocol.md](docs/mesh-protocol.md))
-
-## Learn more
-
-- **[Documentation index](docs/README.md)** · **[Getting started](docs/guides/getting-started.md)** · **[Build guide](docs/guides/building.md)**
-- **[Model families](docs/model-families/README.md)** · **[Benchmarks](docs/wiki/performance.md)** · **[Roadmap](docs/guides/roadmap.md)**
-- **[The engineering journey](docs/journey.md)** · **[Contributing](CONTRIBUTING.md)**
+- **Discord** (community support & hangout) → https://discord.gg/Qy38d4Xu2h
+- **Fluxer** (official support) → https://fluxer.gg/7wqCREKi
+- **Issues & feature requests** → https://github.com/1bit-MONSTER/1bit-MONSTER/issues
 
 ## License
 

--- a/site/1bit-benchmarks.html
+++ b/site/1bit-benchmarks.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: Benchmarks</title>
   <meta name="description" content="Kernel-level and end-to-end performance, measured and honestly labeled. Q1 GEMV 433 tok/s on ROCm HIP; Qwen3-0.6B at 2.3 tok/s on the native NPU engine." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-blog.html
+++ b/site/1bit-blog.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: Blog</title>
   <meta name="description" content="The 1bit.MONSTER blog. Notes on reverse-engineering a closed NPU stack, mapping 317,310 checkpoints, and building an engine with zero Python." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-docs.html
+++ b/site/1bit-docs.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: Documentation</title>
   <meta name="description" content="The 1bit.MONSTER documentation hub: build and run the engine, serve it, pick a model, and talk to it with JARVIS. Grounded in the engine's own docs, pure C++23, MIT." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-jarvis.html
+++ b/site/1bit-jarvis.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: 1bit JARVIS</title>
   <meta name="description" content="The zero-Python voice assistant that ships with the engine. Mic to VAD to STT to LLM to TTS to speaker, all in-process, pure C++, on any backend. The engine is the app." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-models.html
+++ b/site/1bit-models.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: One engine, Any model.</title>
   <meta name="description" content="552 architecture tokens, 1,775 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-monster-v2.html
+++ b/site/1bit-monster-v2.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: One engine. Any model. Zero Python.</title>
   <meta name="description" content="A model-agnostic, hardware-agnostic pure-C++ inference engine. One engine, NPU + GPU + CPU, 100% HuggingFace architecture coverage, zero Python. MIT." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-1775-models.html
+++ b/site/1bit-post-1775-models.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>One engine, 1,775 models | 1bit.MONSTER</title>
   <meta name="description" content="One C++ binary, 552 architecture tokens, 1,775 HF arch strings, 100% HuggingFace coverage, 317,310 checkpoints mapped. The 1-bit engine that runs every model you can download." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-1bit-explained.html
+++ b/site/1bit-post-1bit-explained.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>What 1-bit actually does to a model | 1bit.MONSTER</title>
   <meta name="description" content="1.58-bit (ternary) quantization explained: weights become {-1, 0, +1}, memory drops ~16×, matmuls become additions. The real numbers from the 1bit.MONSTER engine, measured not projected." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-50t.html
+++ b/site/1bit-post-50t.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>50 TOPS on a laptop | 1bit.MONSTER</title>
   <meta name="description" content="Benchmarking the XDNA 2 NPU: historical NPU benchmark notes from the first month of the project. Figures quarantined as unsourced." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-binary-formats.html
+++ b/site/1bit-post-binary-formats.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>One binary, all formats | 1bit.MONSTER</title>
   <meta name="description" content="Ternary and binary inference on NPU and GPU from a single engine: Q1_0, TQ1, TQ2, IQ1_S/M and BitNet GGUF on HIP, Vulkan and XDNA 2, verified exact on real Strix Halo hardware, in 4,200 lines across 31 files." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-coding-agent.html
+++ b/site/1bit-post-coding-agent.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit Coding Agent released | 1bit.MONSTER</title>
   <meta name="description" content="A pi.dev-compatible coding agent CLI with 7 commands, NPU-native inference, package management, extensions, skills, themes and a systemd service, shipping in the 1bit MONSTER monorepo." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-dspark.html
+++ b/site/1bit-post-dspark.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>DSpark speculative decoding, disproven | 1bit.MONSTER</title>
   <meta name="description" content="DSpark was projected to hit 572 tok/s on Strix Halo. End-to-end measurement on the NPU disproved it: 0.1 to 0.2 tok/s at 0% draft acceptance. How and why, what it would take to fix, and why these figures are historical and unsourced." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-fleet.html
+++ b/site/1bit-post-fleet.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Two PCs, two GPUs, zero cloud | 1bit.MONSTER</title>
   <meta name="description" content="Two DeepSeek Harness agents on one LAN, both fed by 1bit.MONSTER: 35B at 166 tok/s on a Radeon 8060S, 8B at 96 tok/s on an RX 9070 XT, plus Qwen3-VL vision. Six engine bugs fixed along the way, with the methodology that caught them." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-flm-zoo.html
+++ b/site/1bit-post-flm-zoo.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>37 FLM models, 209 xclbins, zero config files | 1bit.MONSTER</title>
   <meta name="description" content="AMD's entire pre-built NPU model zoo extracted from ROCm/FastFlowLM v0.9.46: all 37 FLM models and 209 xclbin bitstreams with zero config files, including Qwen3.5 Omni multi-modal C++ source and Qwen3.6-MoE-35B with 256 experts, auto-detected straight from the Q4NX header." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-fused.html
+++ b/site/1bit-post-fused.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>The fused layer engine | 1bit.MONSTER</title>
   <meta name="description" content="How QKV, attention and FFN combine into a single NPU dispatch, eliminating five of every six per-layer xclbin calls. Throughput here is historical and unsourced." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-halo-reviews.html
+++ b/site/1bit-post-halo-reviews.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>What the Ryzen AI Halo reviews didn't tell you | 1bit.MONSTER</title>
   <meta name="description" content="Strix Halo ships a 50 TOPS NPU and the reviews quote it like a fact. AMD's FLM runtime delivers 11 tok/s, ROCm delivers 41 tok/s, and we drive the same NPU through a fused-layer engine. A review of the reviews, with the unsourced throughput figures quarantined." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-historical.html
+++ b/site/1bit-post-historical.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Historical benchmark: both lanes green | 1bit.MONSTER</title>
   <meta name="description" content="An early local run with one Lemonade endpoint over two compute lanes, iGPU llama.cpp ROCm plus NPU FLM, on Linux. Historical local run, kept for the record." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-lemonade-v1170.html
+++ b/site/1bit-post-lemonade-v1170.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Lemonade v11.7.0: how we stay current with the SDK | 1bit.MONSTER</title>
   <meta name="description" content="The embedded Lemonade server core is re-vendored to v11.7.0: 14 backends (incl. the new TheNoise), register/options/stats/metrics endpoints live, and a repeatable re-vendor loop so every upstream release lands fast." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-lemonade-v1180.html
+++ b/site/1bit-post-lemonade-v1180.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Lemonade v11.8.0: the 15-backend SDK lands ds4 for Strix Halo | 1bit.MONSTER</title>
   <meta name="description" content="Lemonade v11.8.0 re-vendored into the 1bit.MONSTER engine: the 15th backend (ds4/DwarfStar, DeepSeek V4 Flash for Strix Halo), download resume + rate limits, cloud wire_format passthrough, and our own merged PR in the changelog." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-local-rag.html
+++ b/site/1bit-post-local-rag.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Local RAG with our own embeddings | 1bit.MONSTER</title>
   <meta name="description" content="The 1bit.MONSTER engine now serves embeddings over its OpenAI-compatible API. Build a fully local RAG pipeline on one C++ binary: embed with nomic-embed-text, index, retrieve, generate." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-npu-reversal.html
+++ b/site/1bit-post-npu-reversal.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>I reverse-engineered AMD's NPU stack in 4 days | 1bit.MONSTER</title>
   <meta name="description" content="A laptop, a disassembler and no docs: a 50 TOPS XDNA 2 NPU locked behind 22 proprietary libraries and 209 xclbins, replaced with open C++ in four days. The hero story, with the honest corrections." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-npu-v12.html
+++ b/site/1bit-post-npu-v12.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>NPU v12: M=32 batch decode at 97 tok/s | 1bit.MONSTER</title>
   <meta name="description" content="A 24x speedup in one session, from 244 to 10 ms/tok, beating FLM Kraken Point by 46%. OpenMP attention plus LM head. Full C++23, zero Python." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-one-engine.html
+++ b/site/1bit-post-one-engine.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>One engine. Every model. Any chip. | 1bit.MONSTER</title>
   <meta name="description" content="A single tiny C++ binary auto-detects 73+ models across six backends, from NPU to CPU, from one Q4NX header parse. No per-backend builds, no per-model config." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-qwen36.html
+++ b/site/1bit-post-qwen36.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Qwen3.6-35B-A3B streams fully on the Ryzen AI NPU | 1bit.MONSTER</title>
   <meta name="description" content="AMD's official FastFlowLM numbers for Qwen3.6-35B-A3B on the Ryzen AI NPU, decoded. 13.65 tok/s decode and 221.96 tok/s prefill on Kraken Point, verified against the official Qwen config, with our independent first pass at 75.65 tok/s via llama.cpp Vulkan on Strix Halo." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-rocm-vs-cuda.html
+++ b/site/1bit-post-rocm-vs-cuda.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>ROCm vs CUDA, from the 1-bit trenches | 1bit.MONSTER</title>
   <meta name="description" content="ROCm vs CUDA for local LLM inference: kernel-level comparison from the 1bit.MONSTER engine — 1-bit matmuls, NPU offload, and why we bet on AMD's stack." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-sprint.html
+++ b/site/1bit-post-sprint.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>244 to 3.4 ms/tok: the NPU optimization sprint | 1bit.MONSTER</title>
   <meta name="description" content="Seven engine versions in four days took NPU inference from 1,930 ms/tok to 3.4 ms/tok, a 72x speedup through batch decode, fused dispatch, and INT8 GEMM. The record of that sprint, with the throughput figures historical and unsourced." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-three-bugs.html
+++ b/site/1bit-post-three-bugs.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Three bugs that broke 97 tok/s | 1bit.MONSTER</title>
   <meta name="description" content="The 97 tok/s number was real. The output behind it never was. Three silent bugs, LM head substitution, weight transpose, and activation clipping, produced garbage at full speed. The classic story of a fast number with wrong output, and the discipline of not shipping it." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-tokenrouter.html
+++ b/site/1bit-post-tokenrouter.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>TokenRouter: token-level multi-backend inference | 1bit.MONSTER</title>
   <meta name="description" content="Open-source token-level routing for multi-backend LLM inference on AMD Strix Halo. NPU drafts, GPU verifies, and real logprobs ride on the wire." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-unsloth.html
+++ b/site/1bit-post-unsloth.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Unsloth for AMD | 1bit.MONSTER</title>
   <meta name="description" content="Training, fine-tuning and RL land on Radeon, Instinct and Ryzen AI. Native AMD support, stated plainly: 2x faster, 70% less VRAM, runs in 3GB. Complementary to our inference side." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-post-zyphra.html
+++ b/site/1bit-post-zyphra.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Zyphra family complete | 1bit.MONSTER</title>
   <meta name="description" content="All four Zyphra models at 1BP, converted and validated end to end on the ZINC GPU: Zamba2 1.2B, 2.7B and 7B (Mamba2-hybrid) plus ZR1-1.5B reasoning, 26 tok/s on Strix Halo. Two architectures, one engine." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/1bit-store.html
+++ b/site/1bit-store.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: Store</title>
   <meta name="description" content="The 1bit.MONSTER store. Printed hardware for the engine: tees, hoodies, mugs, bottles, and the full sticker line. Priced in real dollars, made on demand." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/404.html
+++ b/site/404.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Redirecting… — 1bit.MONSTER</title>
   <meta name="robots" content="noindex" />
   <link rel="canonical" href="https://1bit.monster/" />

--- a/site/assets/favicon.svg
+++ b/site/assets/favicon.svg
@@ -1,7 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" role="img" aria-label="1bit.MONSTER">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" role="img" aria-label="1bit.MONSTER">
   <title>1bit.MONSTER</title>
-  <rect x="2" y="2" width="9" height="9" rx="2" fill="#ffffff" stroke="#010202" stroke-opacity="0.28"/>
-  <rect x="13" y="2" width="9" height="9" rx="2" fill="#ffffff" stroke="#010202" stroke-opacity="0.28"/>
-  <rect x="2" y="13" width="9" height="9" rx="2" fill="#ffffff" stroke="#010202" stroke-opacity="0.28"/>
-  <rect x="13" y="13" width="9" height="9" rx="2" fill="#0230c0"/>
+  <style>
+    /* relay cubes — the banner.svg logo-relay, compressed for the tab icon:
+       one cube lights brand-blue at a time, 8s cycle, fading between states. */
+    .cube { fill: #ffffff; stroke: #010202; stroke-opacity: 0.28; }
+    .lit  { animation: relay 8s ease-in-out infinite; }
+    .c1 { animation-delay: 0s; }
+    .c2 { animation-delay: 2s; }
+    .c3 { animation-delay: 4s; }
+    .c4 { animation-delay: 6s; }
+    @keyframes relay {
+      0%   { fill: #ffffff; }
+      6%   { fill: #0230c0; }
+      22%  { fill: #0230c0; }
+      28%  { fill: #ffffff; }
+      100% { fill: #ffffff; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .lit { animation: none; }
+      .c1 { fill: #0230c0; }
+    }
+  </style>
+  <rect class="cube lit c1" x="2"  y="2"  width="9" height="9" rx="2"/>
+  <rect class="cube lit c2" x="13" y="2"  width="9" height="9" rx="2"/>
+  <rect class="cube lit c3" x="2"  y="13" width="9" height="9" rx="2"/>
+  <rect class="cube lit c4" x="13" y="13" width="9" height="9" rx="2"/>
 </svg>

--- a/site/docs-building.html
+++ b/site/docs-building.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: Building the engine</title>
   <meta name="description" content="Build the 1bit.MONSTER engine from source. TheRock 7.15.0a prerequisites, the onebin target, FastFlowLM discovery, optional GPU decode, and the known gotchas." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/docs-getting-started.html
+++ b/site/docs-getting-started.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: Getting started</title>
   <meta name="description" content="Get the 1bit.MONSTER engine running. What it is, the one-line install, and your first model. Pure C++23, zero Python at runtime, MIT." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/docs-jarvis.html
+++ b/site/docs-jarvis.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: JARVIS</title>
   <meta name="description" content="The 1bit.MONSTER voice assistant. Mic to VAD to STT to LLM to TTS to speaker, all in-process, pure C++, on any backend." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/docs-models.html
+++ b/site/docs-models.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: Model families</title>
   <meta name="description" content="16 supported model families for the 1bit.MONSTER engine, the 1BP canonical format, and the Zyphra family the engine is tuned against." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/docs-running.html
+++ b/site/docs-running.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: Running the server</title>
   <meta name="description" content="Run and serve the 1bit.MONSTER engine. Weights layout, launch, health check, the OpenAI-compatible API, and troubleshooting." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/index.html
+++ b/site/index.html
@@ -2,6 +2,10 @@
 <html lang="en"><head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER</title>
   <meta name="description" content="One engine, any model, zero Python. A model-agnostic, hardware-agnostic pure-C++ inference engine. MIT. Navigate the engine, models, JARVIS, blog, store, docs, and benchmarks.">
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/search.html
+++ b/site/search.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Search | 1bit.MONSTER</title>
   <meta name="description" content="Search every page, post, benchmark and doc on 1bit.MONSTER — the 1-bit inference engine with 552 architecture tokens, 1,775 HF arch strings and 100% HuggingFace coverage." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/share.html
+++ b/site/share.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Share 1bit.MONSTER — trackable links</title>
   <meta name="description" content="Generate attribution-tagged share links for the 1bit.MONSTER community. Every link carries the sharer and team so we can see what spreads." />
   <meta property="og:site_name" content="1bit.MONSTER" />

--- a/site/sticker-gallery.html
+++ b/site/sticker-gallery.html
@@ -3,6 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
 <title>1bit MONSTER — Sticker Designs</title>
 <meta name="description" content="The 1bit.MONSTER sticker line: vinyl decals of the engine, the monsters, and the machines. Real hardware, real stickers, zero Python." />
   <meta property="og:site_name" content="1bit.MONSTER" />


### PR DESCRIPTION
Per request — README is now dead simple (45 lines): fading-cubes banner, one-liner, quick start, docs/wiki links, community. Technical content lives in docs.

Also: the **animated relay cubes are now the browser tab icon** — new animated favicon.svg (relay lighting, 8s cycle, prefers-reduced-motion safe) wired into all 41 pages with PNG fallbacks + apple-touch-icon. Previously no favicon was declared at all.