### PR TITLE
site: rename footer 'Community support' link to 'Fluxer support'

### DIFF
--- a/site/1bit-benchmarks.html
+++ b/site/1bit-benchmarks.html
@@ -379,7 +379,7 @@
     <div class="container row-between">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-blog.html
+++ b/site/1bit-blog.html
@@ -459,7 +459,7 @@
         <span>© 2026 1bit.MONSTER · MIT License</span>
         <a class="meta" href="blog.xml">RSS feed</a>
         <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
       </div>
       <p class="place" data-od-id="footer-place">Metepenagiag Mi'kmaq Nation, New Brunswick, Canada</p>

--- a/site/1bit-docs.html
+++ b/site/1bit-docs.html
@@ -234,7 +234,7 @@
   <footer class="pagefoot" data-od-id="footer">
     <div class="container row-between">
       <span>© 2026 1bit.MONSTER · MIT License</span>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support ↗</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support ↗</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-jarvis.html
+++ b/site/1bit-jarvis.html
@@ -373,7 +373,7 @@ $ ./build/1bit jarvis --model "Qwen3-0.6B" \
     <div class="container row-between">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-models.html
+++ b/site/1bit-models.html
@@ -387,7 +387,7 @@
     <div class="container row-between">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-monster-v2.html
+++ b/site/1bit-monster-v2.html
@@ -400,7 +400,7 @@ $<span class="caret"></span></code></pre>
     <div class="container row-between">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-1775-models.html
+++ b/site/1bit-post-1775-models.html
@@ -182,7 +182,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-1bit-explained.html
+++ b/site/1bit-post-1bit-explained.html
@@ -178,7 +178,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-50t.html
+++ b/site/1bit-post-50t.html
@@ -192,7 +192,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-binary-formats.html
+++ b/site/1bit-post-binary-formats.html
@@ -197,7 +197,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-coding-agent.html
+++ b/site/1bit-post-coding-agent.html
@@ -196,7 +196,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-dspark.html
+++ b/site/1bit-post-dspark.html
@@ -199,7 +199,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-fleet.html
+++ b/site/1bit-post-fleet.html
@@ -196,7 +196,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-flm-zoo.html
+++ b/site/1bit-post-flm-zoo.html
@@ -194,7 +194,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-fused.html
+++ b/site/1bit-post-fused.html
@@ -193,7 +193,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-halo-reviews.html
+++ b/site/1bit-post-halo-reviews.html
@@ -199,7 +199,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-historical.html
+++ b/site/1bit-post-historical.html
@@ -187,7 +187,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-lemonade-v1170.html
+++ b/site/1bit-post-lemonade-v1170.html
@@ -210,7 +210,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <p class="place" data-od-id="footer-place">Metepenagiag Mi'kmaq Nation, New Brunswick, Canada</p>

--- a/site/1bit-post-lemonade-v1180.html
+++ b/site/1bit-post-lemonade-v1180.html
@@ -176,7 +176,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-local-rag.html
+++ b/site/1bit-post-local-rag.html
@@ -182,7 +182,7 @@ curl http://127.0.0.1:8088/v1/embeddings \
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-npu-reversal.html
+++ b/site/1bit-post-npu-reversal.html
@@ -208,7 +208,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-npu-v12.html
+++ b/site/1bit-post-npu-v12.html
@@ -191,7 +191,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-one-engine.html
+++ b/site/1bit-post-one-engine.html
@@ -189,7 +189,7 @@ CUDA    Metal   CPU</pre>
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-qwen36.html
+++ b/site/1bit-post-qwen36.html
@@ -195,7 +195,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-rocm-vs-cuda.html
+++ b/site/1bit-post-rocm-vs-cuda.html
@@ -178,7 +178,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-sprint.html
+++ b/site/1bit-post-sprint.html
@@ -201,7 +201,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-three-bugs.html
+++ b/site/1bit-post-three-bugs.html
@@ -201,7 +201,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-tokenrouter.html
+++ b/site/1bit-post-tokenrouter.html
@@ -187,7 +187,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-unsloth.html
+++ b/site/1bit-post-unsloth.html
@@ -196,7 +196,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-post-zyphra.html
+++ b/site/1bit-post-zyphra.html
@@ -195,7 +195,7 @@
     <div class="container row-between" style="max-width: 1000px;">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/1bit-store.html
+++ b/site/1bit-store.html
@@ -2546,7 +2546,7 @@
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="mailto:sales@1bit.monster">sales@1bit.monster</a>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/docs-building.html
+++ b/site/docs-building.html
@@ -241,7 +241,7 @@ $ cmake --build build --target zaya_gpu_decode    <span class="c"># -> build/lib
     <div class="container row-between">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/docs-getting-started.html
+++ b/site/docs-getting-started.html
@@ -222,7 +222,7 @@ $ curl -X POST http://localhost:8088/completion -H 'Content-Type: application/js
     <div class="container row-between">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/docs-jarvis.html
+++ b/site/docs-jarvis.html
@@ -218,7 +218,7 @@ $ ./build/1bit jarvis --model "Qwen3-0.6B" \
     <div class="container row-between">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/docs-models.html
+++ b/site/docs-models.html
@@ -208,7 +208,7 @@
     <div class="container row-between">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/docs-running.html
+++ b/site/docs-running.html
@@ -225,7 +225,7 @@ $ curl -X POST http://localhost:8088/completion -H 'Content-Type: application/js
     <div class="container row-between">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">

--- a/site/index.html
+++ b/site/index.html
@@ -288,7 +288,7 @@
     <div class="container row-between">
       <span>© 2026 1bit.MONSTER · MIT License</span>
       <a class="meta" href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Join Discord &#8599;</a>
-      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Community support &#8599;</a>
+      <a class="meta" href="https://fluxer.gg/7wqCREKi" target="_blank" rel="noopener">Fluxer support &#8599;</a>
       <a class="meta" href="https://github.com/1bit-MONSTER/1bit-MONSTER">github.com/1bit-MONSTER</a>
     </div>
     <div class="container">


### PR DESCRIPTION
Renames the footer support link on all 37 site pages from **Community support** to **Fluxer support**. Target unchanged (Fluxer support channel invite `https://fluxer.gg/7wqCREKi`).