### PR TITLE
ci: run PR Agent natively (pip CLI) + TheRock HIP include fix — complete loop on strixhalo

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   pr_agent:
     runs-on: [self-hosted, pr-agent]
-    timeout-minutes: 20
+    timeout-minutes: 30
     # Only run for same-repo PRs and trusted commenters (not external forks)
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
@@ -27,7 +27,7 @@ jobs:
 
       # GitNexus: build/refresh the local knowledge-graph index (incremental),
       # then map the PR diff to indexed symbols + affected execution flows.
-      # The report is injected into the review via artifact_path below.
+      # The report is injected into the review via the artifacts override below.
       # Only on pull_request events: comment-triggered runs have no
       # pull_request.base.sha for the cache key (PR agent still runs).
       # NOTE: self-hosted runner — the GitNexus index persists in the work
@@ -36,6 +36,12 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           set +e  # GitNexus is context-only; infra hiccups must not block the review
+          # The self-hosted runners install node/npm/gitnexus via nvm (crontab
+          # @reboot env has no nvm on PATH). Bootstrap PATH; no-op elsewhere.
+          export NVM_DIR="$HOME/.nvm"
+          if [ -s "$NVM_DIR/nvm.sh" ]; then . "$NVM_DIR/nvm.sh" >/dev/null 2>&1; fi
+          _node_bin="$(ls "$HOME/.nvm/versions/node" 2>/dev/null | sort -V | tail -1)"
+          if [ -n "$_node_bin" ]; then export PATH="$HOME/.nvm/versions/node/$_node_bin/bin:$PATH"; fi
           npm install -g gitnexus@1.6.10-rc.204 2>/dev/null || true  # pre-installed on the self-hosted runner; no-op here
           # Register a restored cache index (no-op if absent), then refresh
           # incrementally. rc.204 pins the #2432 native-worker abort fix
@@ -47,25 +53,54 @@ jobs:
           echo "--- gitnexus report (first 30 lines) ---"
           head -30 gitnexus-context.md
 
-      - name: PR Agent
-        uses: The-PR-Agent/pr-agent@4ebd5c5333c6ef21509e7304d27969eb825e6f22  # v0.43.0
-        with:
-          artifact_path: gitnexus-context.md
-          artifact_instructions: >
-            This is a GitNexus knowledge-graph analysis of the PR's changed
-            symbols: blast radius (upstream dependants), affected execution
-            flows, and risk level. Use it to prioritize review effort on
-            high-risk changes and to verify the PR's impact claims against
-            the repo's actual call graph.
+      # PR Agent — native pip CLI (no docker), so the loop runs on any
+      # self-hosted runner (strixhalo has no docker; the docker action cannot
+      # run there). The CLI auto-loads the repo-local .pr_agent.toml (DeepSeek
+      # v4-flash via litellm); the git provider token is passed via the
+      # GITHUB__USER_TOKEN env var (dynaconf, envvar_prefix=false).
+      - name: PR Agent (CLI)
         env:
-          # PR-Agent talks to DeepSeek via litellm's deepseek provider
-          # (model deepseek/deepseek-v4-flash in .pr_agent.toml). The
-          # provider default base (https://api.deepseek.com) is used, so no
-          # OPENAI_API_BASE override is needed here.
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-          # SECURITY: GITHUB_TOKEN with contents:write scope is passed to the
-          # third-party action The-PR-Agent/pr-agent. Mitigation: the job-level
-          # `if` guard above restricts execution to same-repo PRs only;
-          # external forks are never processed. Action pinned to v0.41.0 SHA.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONFIG_FILE: .pr_agent.toml
+          # Passed via env (not inlined into the script) so multiline/quoting
+          # comment bodies cannot break the dispatch shell.
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -e
+          # Pre-installed at ~/pr-agent-venv on the self-hosted runners;
+          # bootstrap on first use (or on runners without a pre-install).
+          export PATH="$HOME/pr-agent-venv/bin:$PATH"
+          if ! command -v pr-agent >/dev/null 2>&1; then
+            python3 -m venv "$HOME/pr-agent-venv"
+            "$HOME/pr-agent-venv/bin/pip" install -q "pr-agent==0.43.0"
+            export PATH="$HOME/pr-agent-venv/bin:$PATH"
+          fi
+          # PR-Agent reads the git token from settings[github].user_token;
+          # with envvar_prefix=false the env var is the dotted path in caps.
+          export GITHUB__USER_TOKEN="$GITHUB_TOKEN"
+
+          PR_URL="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}"
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Automated loop on PR events: review (+ GitNexus context), then describe.
+            # GitNexus context is best-effort; fall back to a plain review if absent.
+            if [ -f gitnexus-context.md ]; then
+              pr-agent --pr_url "$PR_URL" review \
+                --artifacts.enable=true \
+                --artifacts.artifact_path=gitnexus-context.md \
+                --artifacts.artifact_instructions="This is a GitNexus knowledge-graph analysis of the PR's changed symbols: blast radius (upstream dependants), affected execution flows, and risk level. Use it to prioritize review effort on high-risk changes and to verify the PR's impact claims against the repo's actual call graph."
+            else
+              pr-agent --pr_url "$PR_URL" review
+            fi
+            pr-agent --pr_url "$PR_URL" describe
+          else
+            # Comment-triggered: dispatch the PR-Agent command from the comment.
+            BODY="$COMMENT_BODY"
+            CMD=$(printf '%s' "$BODY" | sed -E 's/@[A-Za-z0-9_-]+//g; s/^[[:space:]]*\/{0,1}//; s/[[:space:]].*//' | tr '[:upper:]' '[:lower:]')
+            case "$CMD" in
+              describe) pr-agent --pr_url "$PR_URL" describe ;;
+              improve)  pr-agent --pr_url "$PR_URL" improve ;;
+              ask)      pr-agent --pr_url "$PR_URL" ask "$BODY" ;;
+              *)        pr-agent --pr_url "$PR_URL" review ;;
+            esac
+          fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,50 @@ _find_therock_sdk_base(THEROCK_SDK_BASE)
 set(ROCM_ROOT "${_RC_ROCM_DEFAULT}" CACHE PATH "ROCm install root")
 list(PREPEND CMAKE_PREFIX_PATH "${ROCM_ROOT}" "${ROCM_ROOT}/lib/cmake")
 
+# TheRock pip/venv SDKs keep headers under
+# lib/python*/site-packages/_rocm_sdk_devel/include and leave the
+# top-level ${ROCM_ROOT}/include empty. Falling through to the system
+# ROCm headers (e.g. Ubuntu /usr/include/hip, 7.1) breaks amdclang++
+# builds: amd_hip_bf16.h references __ocml_* builtins that TheRock's
+# clang does not declare (smoke-test failure, 2026-08-28). Resolve the
+# include root that actually contains hip/; guarded so classic ROCm
+# installs keep ${ROCM_ROOT}/include unchanged.
+set(ROCM_INCLUDE_DIR "${ROCM_ROOT}/include")
+if(THEROCK_SDK_BASE AND NOT EXISTS "${ROCM_INCLUDE_DIR}/hip")
+    set(ROCM_INCLUDE_DIR "${THEROCK_SDK_BASE}/include")
+    message(STATUS "rocm-cpp: ROCm include root = ${ROCM_INCLUDE_DIR} (TheRock SDK layout)")
+endif()
+
+# HIP-language objects (amdclang++ -x hip) do not inherit SYSTEM include
+# dirs from target_include_directories / hip::host usage requirements
+# (observed with CMake 4.2's HIP rules — .hip objects compile without any
+# -isystem, fall back to the system ROCm 7.1 headers under /usr/include and
+# fail on __ocml_* builtins). Apply the resolved ROCm include to every HIP
+# compile via CMAKE_HIP_FLAGS. Guarded so repeated evaluation in one
+# configure does not duplicate the flag; on classic ROCm installs
+# ROCM_INCLUDE_DIR == ${ROCM_ROOT}/include, i.e. the same include the
+# explicit SYSTEM include lines already provided.
+if(ROCM_INCLUDE_DIR AND NOT CMAKE_HIP_FLAGS MATCHES "isystem${ROCM_INCLUDE_DIR}")
+    # Plain (normal) variable: the HIP rules expand CMAKE_HIP_FLAGS at
+    # generate time from the project-scope variable, not from the cache
+    # (a CACHE FORCE set would be shadowed by the variable project()
+    # created when the HIP language was enabled).
+    set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -isystem${ROCM_INCLUDE_DIR}")
+    message(STATUS "rocm-cpp: HIP flags += -isystem${ROCM_INCLUDE_DIR}")
+endif()
+
+# TheRock pip/venv SDKs ship their own hip-config under
+# <sdk>/lib/cmake/hip; without pinning hip_DIR the CONFIG search below
+# resolves the SYSTEM hip package first (/usr/...), whose HIP_INCLUDE_DIRS
+# point at the Ubuntu ROCm 7.1 headers (/usr/include/hip) — those reference
+# __ocml_* builtins that TheRock's clang does not declare, breaking every
+# bf16/fp8 kernel (smoke-test failure, 2026-08-28). Pin to TheRock's config
+# when present; classic ROCm installs (no SDK config) keep default detection.
+if(THEROCK_SDK_BASE AND EXISTS "${THEROCK_SDK_BASE}/lib/cmake/hip/hip-config.cmake")
+    set(hip_DIR "${THEROCK_SDK_BASE}/lib/cmake/hip" CACHE PATH "HIP config (TheRock SDK)")
+    message(STATUS "rocm-cpp: pinning hip_DIR to TheRock SDK: ${hip_DIR}")
+endif()
+
 find_package(hip REQUIRED CONFIG
     PATHS "${ROCM_ROOT}"
     # System-wide HIP runtime (hip-runtime-amd package)
@@ -237,7 +281,9 @@ foreach(_rc_base "${_RC_PIP_PATH}" "${_RC_THEROCK_DIR}" "${_RC_THEROCK_LEGACY}" 
 endforeach()
 
 if(NOT ROCWMMA_FOUND)
-    file(GLOB_RECURSE _RC_ROCWMMA_HPP "$ENV{HOME}/.local/lib/python*/site-packages/_rocm_sdk_devel/include/rocwmma/rocwmma.hpp")
+    file(GLOB_RECURSE _RC_ROCWMMA_HPP
+        "$ENV{HOME}/.local/lib/python*/site-packages/_rocm_sdk_devel/include/rocwmma/rocwmma.hpp"
+        "${_RC_THEROCK_OPT}/lib/python*/site-packages/_rocm_sdk_devel/include/rocwmma/rocwmma.hpp")
     list(LENGTH _RC_ROCWMMA_HPP _RC_ROCWMMA_N)
     if(_RC_ROCWMMA_N GREATER 0)
         list(GET _RC_ROCWMMA_HPP 0 _RC_ROCWMMA_PATH)
@@ -654,7 +700,7 @@ target_include_directories(backend_manager PUBLIC
     $<INSTALL_INTERFACE:include>)
 target_include_directories(backend_manager PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
-target_include_directories(backend_manager PRIVATE "${ROCM_ROOT}/include")
+target_include_directories(backend_manager PRIVATE "${ROCM_INCLUDE_DIR}")
 target_compile_definitions(backend_manager PRIVATE __HIP_PLATFORM_AMD__=1)
 target_link_libraries(backend_manager PUBLIC dl rocm_cpp hip::host hip::device)
 if(RCPP_HAVE_CUDA)


### PR DESCRIPTION
### **User description**
## What & why

The PR-Agent loop currently runs on the docker-based `The-PR-Agent/pr-agent` action, so it can only execute on **ryzen** (strixhalo has no docker). This switches it to the **pip-installed `pr-agent` CLI (0.43.0 — same version as the action pin)**, which runs on any self-hosted runner, and registers strixhalo as a `pr-agent` runner.

### Changes

1. **`.github/workflows/pr-agent.yml`** — native CLI step:
   - Auto-loads the repo `.pr_agent.toml` (DeepSeek `deepseek-v4-flash` via litellm); git token via `GITHUB__USER_TOKEN`.
   - GitNexus context (from the existing impact-analysis step) injected into the review through the `artifacts` config.
   - Venv bootstraps on first use (`~/pr-agent-venv`, pre-installed on strixhalo).
   - Comment dispatch: `/describe`, `/improve`, `/ask`, default `/review` (body passed via env, not inlined).
   - GitNexus step made nvm-aware (crontab env has no nvm on PATH).

2. **`CMakeLists.txt`** — TheRock HIP include resolution (identical to the fix in #1917): `ROCM_INCLUDE_DIR` → `_rocm_sdk_devel/include`, `hip_DIR` pinned to the SDK config, `-isystem<SDK>` on every HIP compile. Required here because touching `.github/workflows/*` triggers the smoke-test, which currently fails on this box with `__ocml_*` undeclared (system `/usr/include/hip` 7.1 shadowing the SDK headers). Merges cleanly in either order with #1917 (identical content).

### Scope

`.github` and `CMakeLists.txt` are engine-scope per Scope Guard.

### Test plan

The PR's own checks exercise the new path end-to-end: the `pr_agent` job (now eligible for strixhalo) runs GitNexus analyze → CLI review/describe via DeepSeek, and the smoke-test validates the CMake include fix on the self-hosted runner.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Switch PR Agent to native pip CLI (no docker)

- Make GitNexus step nvm-aware on self-hosted runners

- Fix TheRock HIP headers overriding system ROCm includes

- Pin hip_DIR, HIP flags, and rocwmma to SDK paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pr-agent.yml CI workflow"] --> B["pip pr-agent CLI 0.43.0"]
  A --> C["GitNexus impact analysis nvm-aware"]
  B --> D["/review, /describe, /improve, /ask dispatch"]
  E["CMakeLists.txt build"] --> F["ROCM_INCLUDE_DIR TheRock SDK"]
  E --> G["CMAKE_HIP_FLAGS -isystem SDK"]
  E --> H["hip_DIR pinned + rocwmma glob"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Ci enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>Run PR Agent natively via pip CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>Replace docker-based PR-Agent action with pip-installed CLI<br> <li> Add comment-triggered dispatch for describe/improve/ask/review<br> <li> Make GitNexus step source nvm before running node tools<br> <li> Increase job timeout to 30 minutes</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1923/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+56/-21</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Build fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Fix TheRock HIP include resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CMakeLists.txt

<ul><li>Resolve ROCM_INCLUDE_DIR to TheRock SDK include layout<br> <li> Add -isystem SDK include to CMAKE_HIP_FLAGS<br> <li> Pin hip_DIR to TheRock SDK hip-config<br> <li> Extend rocwmma glob to opt SDK path</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1923/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+48/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

