### PR TITLE
context7: remove $schema (unknown field) from context7.json

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,1 +1,51 @@
-{"$schema": "https://context7.com/schema/context7.json", "url": "https://context7.com/1bit-monster/1bit-monster", "public_key": "pk_0KNup27JMOiyXo5acwmQ8", "projectTitle": "1bit.MONSTER", "description": "A pure-C++23, hardware-agnostic 1-bit LLM inference engine that runs 100% of HuggingFace text-generation checkpoints on NPU (Ryzen AI), GPU (ROCm/Vulkan/CUDA), or CPU. Zero Python at runtime, GGUF-native 1-bit pipeline, MIT licensed.", "folders": ["docs"], "excludeFolders": ["third_party", ".superpowers", "docs/superpowers", "docs/archive", "docs/plans", "docs/goals", "docs/bugs", "docs/bug-reports", "docs/research", "benchmarks", "Testing", "tools", "site"], "excludeFiles": ["AGENTS.md", "AGENTS-WORKTREES.md", "CLAUDE.md", "TODO_TRACKING.md", "AUDIT_ISSUES.md", "CHANGELOG.md", "ROADMAP.md", "AGENT-COORDINATION.md", "TRIAGE-ISSUES-2026-08.md", "agent-role-prompts.md", "audit-trail.md", "journey.md", "validation-gaps.md", "reddit-zaya-dflash-draft.md", "search-console-setup.md", "seo-gap-analysis.md", "e2e-token-verify-1699.md", "zyphra-handoff-2026-08-05.md"], "rules": ["1bit.MONSTER is a pure C++23 engine: no Python at runtime; Python files under tools/ are offline conversion/debug helpers only", "The canonical model format is .1bp; GGUF is also supported through a GGUF-native 1-bit pipeline", "The engine runs on NPU (Ryzen AI), GPU (ROCm/Vulkan/CUDA), and CPU", "Build with: cmake -B build && cmake --build build; the engine binary is ./build/1bit", "The Lemonade SDK under third_party/lemonade is vendored for compatibility only and is not part of the engine"]}
+{
+  "url": "https://context7.com/1bit-monster/1bit-monster",
+  "public_key": "pk_0KNup27JMOiyXo5acwmQ8",
+  "projectTitle": "1bit.MONSTER",
+  "description": "A pure-C++23, hardware-agnostic 1-bit LLM inference engine that runs 100% of HuggingFace text-generation checkpoints on NPU (Ryzen AI), GPU (ROCm/Vulkan/CUDA), or CPU. Zero Python at runtime, GGUF-native 1-bit pipeline, MIT licensed.",
+  "folders": [
+    "docs"
+  ],
+  "excludeFolders": [
+    "third_party",
+    ".superpowers",
+    "docs/superpowers",
+    "docs/archive",
+    "docs/plans",
+    "docs/goals",
+    "docs/bugs",
+    "docs/bug-reports",
+    "docs/research",
+    "benchmarks",
+    "Testing",
+    "tools",
+    "site"
+  ],
+  "excludeFiles": [
+    "AGENTS.md",
+    "AGENTS-WORKTREES.md",
+    "CLAUDE.md",
+    "TODO_TRACKING.md",
+    "AUDIT_ISSUES.md",
+    "CHANGELOG.md",
+    "ROADMAP.md",
+    "AGENT-COORDINATION.md",
+    "TRIAGE-ISSUES-2026-08.md",
+    "agent-role-prompts.md",
+    "audit-trail.md",
+    "journey.md",
+    "validation-gaps.md",
+    "reddit-zaya-dflash-draft.md",
+    "search-console-setup.md",
+    "seo-gap-analysis.md",
+    "e2e-token-verify-1699.md",
+    "zyphra-handoff-2026-08-05.md"
+  ],
+  "rules": [
+    "1bit.MONSTER is a pure C++23 engine: no Python at runtime; Python files under tools/ are offline conversion/debug helpers only",
+    "The canonical model format is .1bp; GGUF is also supported through a GGUF-native 1-bit pipeline",
+    "The engine runs on NPU (Ryzen AI), GPU (ROCm/Vulkan/CUDA), and CPU",
+    "Build with: cmake -B build && cmake --build build; the engine binary is ./build/1bit",
+    "The Lemonade SDK under third_party/lemonade is vendored for compatibility only and is not part of the engine"
+  ]
+}


### PR DESCRIPTION
### **User description**
Keep only url, public_key, and known config fields so Context7's claim validator accepts the file.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove `$schema` field so Context7's claim validator accepts the config.

- Reformat `context7.json` to pretty-printed multi-line JSON.

- Preserve all existing configuration values (`url`, `public_key`, folders, rules, etc.).


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Single-line JSON with $schema"] -- "validator rejects" --> B["Drop $schema & pretty-print"] -- "validator accepts" --> C["Multi-line JSON without $schema"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>context7.json</strong><dd><code>Drop $schema and format JSON for Context7</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

context7.json

<ul><li>Removed the <code>$schema</code> field, which Context7 treats as an unknown field.<br> <li> Reformatted the file from a single line to indented multi-line JSON.<br> <li> Kept all configuration content (<code>url</code>, <code>public_key</code>, <code>projectTitle</code>, <br><code>description</code>, <code>folders</code>, <code>excludeFolders</code>, <code>excludeFiles</code>, <code>rules</code>) unchanged.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1927/files#diff-3c87468eba6b0cc4c9718f1038f73074e16c6c2d9c59e00482c43ab0b1354b42">+51/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

