### PR TITLE
context7: schema-known fields only (suppress non-docs)

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,8 @@
 {
   "url": "https://context7.com/1bit-monster/1bit-monster",
-  "public_key": "pk_0KNup27JMOiyXo5acwmQ8"
+  "public_key": "pk_0KNup27JMOiyXo5acwmQ8",
+  "folders": ["docs"],
+  "excludeFolders": ["third_party", ".superpowers", "docs/superpowers", "docs/archive", "docs/plans", "docs/goals", "docs/bugs", "docs/bug-reports", "docs/research", "benchmarks", "Testing", "tools", "site"],
+  "excludeFiles": ["AGENTS.md", "AGENTS-WORKTREES.md", "CLAUDE.md", "TODO_TRACKING.md", "AUDIT_ISSUES.md", "CHANGELOG.md", "ROADMAP.md", "AGENT-COORDINATION.md", "TRIAGE-ISSUES-2026-08.md", "agent-role-prompts.md", "audit-trail.md", "journey.md", "validation-gaps.md", "reddit-zaya-dflash-draft.md", "search-console-setup.md", "seo-gap-analysis.md", "e2e-token-verify-1699.md", "zyphra-handoff-2026-08-05.md"],
+  "rules": ["1bit.MONSTER is a pure C++23 engine: no Python at runtime; Python files under tools/ are offline conversion/debug helpers only", "The canonical model format is .1bp; GGUF is also supported through a GGUF-native 1-bit pipeline", "The engine runs on NPU (Ryzen AI), GPU (ROCm/Vulkan/CUDA), and CPU", "Build with: cmake -B build && cmake --build build; the engine binary is ./build/1bit", "The Lemonade SDK under third_party/lemonade is vendored for compatibility only and is not part of the engine"]
 }


### PR DESCRIPTION
### **User description**
Use only url, public_key, folders, excludeFolders, excludeFiles, rules — exactly the published-schema fields.


___

### **PR Type**
Enhancement


___

### **Description**
- Add schema-known fields to context7.json

- Restrict context to docs; exclude non-docs

- Add root file and folder exclusion lists

- Add engine rule descriptions to config


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["context7.json filters"] --> B["folders: docs"]
  A --> C["excludeFolders: non-docs"]
  A --> D["excludeFiles: root files"]
  A --> E["rules: engine notes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>context7.json</strong><dd><code>Add context7 schema filters for docs-only content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

context7.json

<ul><li>Added <code>folders</code> to restrict context to <code>docs</code><br> <li> Added <code>excludeFolders</code> for third_party, tools, docs subfolders, <br>benchmarks<br> <li> Added <code>excludeFiles</code> for root markdown and coordination files<br> <li> Added <code>rules</code> describing engine constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1929/files#diff-3c87468eba6b0cc4c9718f1038f73074e16c6c2d9c59e00482c43ab0b1354b42">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

