### PR TITLE
ci(docs): fix setup-python pin (v7.0.0) in deploy-docs.yml

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@39cd14987082fddc554f5c9d559f31e2a45d2b8d  # v5.2.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
### **User description**
The auto-triggered docs deploy failed at 'Set up Python': the pinned setup-python SHA (39cd1498...) doesn't exist. Fix the pin to 5fda3b95... (v7.0.0), matching the other workflows in the repo.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix invalid setup-python SHA in deploy-docs.yml

- Update action to v7.0.0 commit

- Align with other workflows in repo

- Unblock failed docs deployment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Broken setup-python pin v5.2.0"] -- "fix SHA" --> B["Valid setup-python pin v7.0.0"] -- "enables" --> C["Docs deploy"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-docs.yml</strong><dd><code>Fix setup-python action SHA pin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-docs.yml

<ul><li>Updates <code>actions/setup-python</code> SHA pin from v5.2.0 to v7.0.0<br> <li> Resolves invalid commit reference causing CI failure<br> <li> Matches setup-python version used across other workflows</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1936/files#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

