### PR TITLE
feat(discord): Context7-backed /docs support bot

### DIFF
--- a/integrations/discord-support-bot/.env.example
+++ b/integrations/discord-support-bot/.env.example
@@ -1,0 +1,38 @@
+# Copy this file to `.env` and fill in the real values. `.env` is git-ignored.
+# All are read via environment variables; if you export them instead, that works too.
+
+# ── Discord (required) ────────────────────────────────────────────────────
+# Bot token from https://discord.com/developers/applications → your bot → Bot.
+# If DISCORD_TOKEN is unset, docs_slash.py falls back to the token file
+# ( ~/.secrets/Discord Bot token.txt then ~/Documents/Discord Bot token.txt ).
+DISCORD_TOKEN=your-discord-bot-token
+
+# Slash-command scoping. Set a guild id to register /docs there instantly
+# (global registration can take up to an hour). Leave empty to auto-discover
+# from DISCORD_KNOWN_CHANNEL, or fully empty for a global command.
+DISCORD_GUILD_ID=
+# Channel used only to auto-discover the bot's guild (the channel the inbox
+# bot already watches). Needed only when DISCORD_GUILD_ID is empty.
+DISCORD_KNOWN_CHANNEL=1542589031055888386
+
+# ── DeepSeek (required) — powers the grounded, friendly answer ────────────
+DEEPSEEK_API_KEY=sk-...
+DEEPSEEK_BASE_URL=https://api.deepseek.com
+DEEPSEEK_MODEL=deepseek-chat
+MAX_TOKENS=1024
+
+# ── Context7 (required) — the documentation retrieval layer ──────────────
+# API key from https://context7.com/dashboard
+CONTEXT7_API_KEY=...
+CONTEXT7_LIBRARY_ID=/1bit-monster/1bit-monster
+CONTEXT7_BASE_URL=https://context7.com
+
+# ── Behaviour (optional) ──────────────────────────────────────────────────
+# Comma-separated channel IDs where ANY message is treated as a support
+# question. Leave empty to only answer the explicit `!docs` prefix command.
+SUPPORT_CHANNEL_IDS=
+# The prefix command (default !docs). Works in any channel.
+DOCS_COMMAND=!docs
+# Per-user cooldown between answers (seconds) and max concurrent answers.
+COOLDOWN_SECONDS=8
+MAX_WORKERS=3

--- a/integrations/discord-support-bot/.gitignore
+++ b/integrations/discord-support-bot/.gitignore
@@ -1,0 +1,8 @@
+# Secrets — never commit real credentials
+.env
+
+# Python
+__pycache__/
+*.pyc
+.venv/
+venv/

--- a/integrations/discord-support-bot/README.md
+++ b/integrations/discord-support-bot/README.md
@@ -1,0 +1,84 @@
+# Context7 Discord Support Bot
+
+A `/docs` support command for the existing 1bit.MONSTER Discord bot that
+answers users' questions **grounded in the official documentation** — not from
+memory, and with source links.
+
+```
+user: /docs how do I build the engine?
+   └─► docs_slash.py ──► Context7 (/1bit-monster/1bit-monster)   retrieve relevant docs
+                     └──► DeepSeek (deepseek-chat)               write a grounded answer
+                        └──► replies in Discord (answer + doc links)
+```
+
+`Context7` supplies the **facts** (your indexed docs — guides, model families,
+wiki, reference). `DeepSeek` supplies the **wording**. No hallucinations.
+
+> Context7 itself does **not** ship a Discord bot. This is a small command you
+> attach to your existing bot, using Context7 as the retrieval backend.
+
+---
+
+## What's here
+
+| File | Purpose |
+|------|---------|
+| **`docs_slash.py`** | **Primary.** A `discord.py` component that adds a `/docs` slash command to the existing bot. |
+| `bot.py` | Alternative: a standalone bot that answers a `!docs` prefix command or any message in a support channel (no slash registration). |
+| `context7.py` | Retrieval client for Context7 `GET /v2/context` (framework-agnostic). |
+| `llm.py` | DeepSeek chat-completions client (framework-agnostic). |
+| `.env.example` | Copy to `.env` and fill in real credentials. |
+| `requirements.txt` | `discord.py`, `requests`. |
+
+The answer pipeline (`context7.py` + `llm.py`) is plain functions, so you can
+also drop it into any bot framework (discord.js, py-cord, etc.).
+
+## Setup
+
+### 1. Bot already authorized — just confirm the scope
+Your bot token is already on this machine
+(`~/.secrets/Discord Bot token.txt`, which `docs_slash.py` reads automatically).
+Make sure the bot was invited with the **`applications.commands`** OAuth2 scope
+so slash commands are reachable. If it was only invited with `bot`, re-invite:
+
+`https://discord.com/oauth2/authorize?client_id=<APP_ID>&scope=bot+applications.commands&permissions=<perms>`
+
+You can reuse the same invite from the Developer Portal → OAuth2 → URL Generator.
+
+### 2. Keys
+- **Context7:** https://context7.com/dashboard → `CONTEXT7_API_KEY`
+- **DeepSeek:** your deepseek API key → `DEEPSEEK_API_KEY`
+
+### 3. Configure + run
+```bash
+cd integrations/discord-support-bot
+python3 -m pip install -r requirements.txt
+cp .env.example .env      # set CONTEXT7_API_KEY + DEEPSEEK_API_KEY; DISCORD_TOKEN optional
+python3 docs_slash.py
+```
+
+That starts a gateway connection and registers **`/docs`** with your bot.
+`DISCORD_GUILD_ID` (or auto-discovery) scopes the command to your server so it
+appears immediately instead of waiting up to an hour.
+
+## Usage
+- **`/docs <question>`** — in any channel, e.g. `/docs how do I build the engine?`
+- The bot answers with a grounded reply plus the doc source links it used.
+
+The `/docs` command runs its own gateway connection. Your other 1bit bots
+(`discord-inbox.py`, traffic-digest, etc.) are REST pollers and load
+separately, so they don't conflict.
+
+## How answers stay accurate
+1. `context7.get_context(...)` calls
+   `GET /api/v2/context?libraryId=/1bit-monster/1bit-monster&query=<question>`
+   for the most relevant guide + code snippets.
+2. `llm.generate(...)` sends them to DeepSeek with a system prompt that says
+   *use ONLY this context*.
+3. If nothing relevant is returned, the bot says so rather than guessing.
+
+Because snippets come from your curated docs, you control what it can answer.
+
+---
+
+*MIT — part of 1bit.MONSTER.*

--- a/integrations/discord-support-bot/bot.py
+++ b/integrations/discord-support-bot/bot.py
@@ -1,0 +1,196 @@
+"""bot.py — Context7-backed Discord support bot for 1bit.MONSTER.
+
+Answers users' support questions in Discord, grounded in the official
+1bit.MONSTER documentation retrieved from Context7, and phrased by DeepSeek.
+
+Two ways to trigger it (configurable):
+  * an explicit prefix command, e.g. ``!docs how do I build?`` (any channel)
+  * any message in a configured support channel (no prefix needed)
+
+Run:
+    python3 -m pip install -r requirements.txt
+    python3 bot.py            # reads credentials from the .env file
+
+Requires DISCORD_TOKEN, DEEPSEEK_API_KEY, CONTEXT7_API_KEY (see .env.example).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+
+import discord
+
+import context7
+import llm
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+log = logging.getLogger("docsbot")
+
+# ── config ──────────────────────────────────────────────────────────────── #
+DISCORD_TOKEN = os.getenv("DISCORD_TOKEN", "")
+DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY", "")
+CONTEXT7_API_KEY = os.getenv("CONTEXT7_API_KEY", "")
+LIBRARY_ID = os.getenv("CONTEXT7_LIBRARY_ID", "/1bit-monster/1bit-monster")
+COMMAND = os.getenv("DOCS_COMMAND", "!docs").strip().lower()
+MAX_TOKENS = int(os.getenv("MAX_TOKENS", "1024"))
+
+
+def _channel_ids() -> set[int]:
+    raw = os.getenv("SUPPORT_CHANNEL_IDS", "")
+    return {int(x) for x in raw.split(",") if x.strip().isdigit()}
+
+
+SUPPORT_CHANNELS = _channel_ids()
+COOLDOWN_SECONDS = int(os.getenv("COOLDOWN_SECONDS", "8"))
+MAX_WORKERS = int(os.getenv("MAX_WORKERS", "3"))
+
+
+def split_msg(text: str, limit: int = 1993) -> list[str]:
+    """Split a message into Discord-safe chunks (2000-char limit)."""
+    if len(text) <= limit:
+        return [text]
+    chunks: list[str] = []
+    cur = ""
+    for para in text.split("\n"):
+        if len(cur) + len(para) + 1 > limit:
+            if cur:
+                chunks.append(cur)
+            cur = ""
+            while len(para) > limit:  # giant single line
+                chunks.append(para[:limit])
+                para = para[limit:]
+        cur = (cur + "\n" + para).strip() if cur else para.strip()
+    if cur:
+        chunks.append(cur)
+    return chunks
+
+
+class RateLimiter:
+    def __init__(self) -> None:
+        self._last: dict[int, float] = {}
+        self._lock = threading.Lock()
+
+    def allowed(self, user_id: int) -> bool:
+        now = time.time()
+        with self._lock:
+            prev = self._last.get(user_id, 0.0)
+            if now - prev < COOLDOWN_SECONDS:
+                return False
+            self._last[user_id] = now
+            return True
+
+
+class DocsBot(discord.Client):
+    def __init__(self) -> None:
+        intents = discord.Intents.default()
+        intents.message_content = True  # required in the dev portal too
+        super().__init__(intents=intents)
+        self._limiter = RateLimiter()
+        self._sem = threading.BoundedSemaphore(MAX_WORKERS)
+
+    async def on_ready(self) -> None:
+        log.info("Logged in as %s (id=%s)", self.user, self.user.id)
+        log.info(
+            "support channels=%s command='%s' library=%s",
+            sorted(SUPPORT_CHANNELS) or "ALL",
+            COMMAND,
+            LIBRARY_ID,
+        )
+
+    # ── message routing ── #
+    async def on_message(self, message: discord.Message) -> None:
+        if message.author.bot or not message.content:
+            return
+        if not message.guild:  # ignore DM-based spam; only support guild channels
+            return
+
+        content = message.content.strip()
+        lowered = content.lower()
+        is_command = lowered == COMMAND or lowered.startswith(COMMAND + " ")
+        is_support_channel = message.channel.id in SUPPORT_CHANNELS
+
+        if not (is_command or is_support_channel):
+            return
+
+        question = content
+        if is_command:
+            question = content[len(COMMAND):].strip()
+        if not question:
+            await message.channel.send(
+                f"Hi! Ask me anything about 1bit.MONSTER, e.g. `{COMMAND} how do I build the engine?`"
+            )
+            return
+
+        await self._answer(message, question)
+
+    async def _answer(self, message: discord.Message, question: str) -> None:
+        if not self._limiter.allowed(message.author.id):
+            await message.channel.send(
+                f"Please wait a moment before asking again ({COOLDOWN_SECONDS}s)."
+            )
+            return
+        if not DEEPSEEK_API_KEY or not CONTEXT7_API_KEY:
+            await message.channel.send(
+                "The support bot is not configured yet: missing DEEPSEEK_API_KEY / CONTEXT7_API_KEY."
+            )
+            return
+
+        await message.channel.send("🔎 Looking that up in the docs…")
+        try:
+            data = context7.get_context(LIBRARY_ID, question, CONTEXT7_API_KEY)
+            block = context7.format_context(data)
+            if not block.strip():
+                await message.channel.send(
+                    "I couldn't find relevant docs for that. Try rephrasing, or check the [docs hub](https://docs.1bit.monster)."
+                )
+                return
+            answer = llm.generate(
+                question, block, DEEPSEEK_API_KEY, max_tokens=MAX_TOKENS
+            )
+        except Exception as exc:  # noqa: BLE001 - surface to user, log details
+            log.exception("answer failed for question=%r", question)
+            await message.channel.send(
+                f"Sorry, I hit an error while answering: `{type(exc).__name__}`."
+            )
+            return
+
+        links = context7.source_links(data)
+        if links:
+            answer = answer.rstrip() + "\n\n**Sources:** " + " · ".join(links[:4])
+        for chunk in split_msg(answer):
+            await message.channel.send(chunk)
+
+
+def _load_dotenv(path: str = ".env") -> None:
+    """Minimal .env loader (no external dependency)."""
+    if not os.path.exists(path):
+        return
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, val = line.partition("=")
+            key = key.strip()
+            val = val.strip().strip('"').strip("'")
+            os.environ.setdefault(key, val)
+
+
+def main() -> None:
+    _load_dotenv()
+    token = os.getenv("DISCORD_TOKEN")
+    if not token:
+        log.error("DISCORD_TOKEN is not set (copy .env.example → .env and fill it).")
+        return
+    client = DocsBot()
+    client.run(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/discord-support-bot/context7.py
+++ b/integrations/discord-support-bot/context7.py
@@ -1,0 +1,100 @@
+"""context7.py — retrieve grounded documentation snippets from Context7.
+
+Thin client for Context7's REST API ``GET /v2/context`` which returns the
+most relevant code + info snippets for a library given a free-text question.
+See https://context7.com/docs/api-guide and the OpenAPI spec.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+
+CONTEXT7_BASE = os.getenv("CONTEXT7_BASE_URL", "https://context7.com")
+CONTEXT_PATH = "/api/v2/context"
+
+
+def get_context(
+    library_id: str,
+    query: str,
+    api_key: str | None = None,
+    fmt: str = "json",
+    fast: str = "false",
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """Return the Context7 context response for a library + question."""
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    params = {"libraryId": library_id, "query": query, "type": fmt, "fast": fast}
+    resp = requests.get(
+        CONTEXT7_BASE + CONTEXT_PATH,
+        headers=headers,
+        params=params,
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _snippet_lines(data: dict[str, Any], max_chars: int = 12000) -> list[str]:
+    parts: list[str] = []
+    seen: set[str] = set()
+
+    for snip in data.get("infoSnippets", []):
+        content = (snip.get("content") or "").strip()
+        if not content:
+            continue
+        breadcrumb = (snip.get("breadcrumb") or snip.get("pageId") or "doc").strip()
+        block = f"### {breadcrumb}\n{content}"
+        if block not in seen:
+            seen.add(block)
+            parts.append(block)
+
+    for snip in data.get("codeSnippets", []):
+        code_lines = snip.get("codeList") or []
+        code = "\n".join(
+            (item.get("code") if isinstance(item, dict) else str(item))
+            for item in code_lines
+        ).strip()
+        if not code:
+            code = (snip.get("codeDescription") or "").strip()
+        if not code:
+            continue
+        title = (snip.get("codeTitle") or snip.get("pageTitle") or snip.get("sourceFile") or "code").strip()
+        block = f"### Code: {title}\n```\n{code}\n```"
+        if block not in seen:
+            seen.add(block)
+            parts.append(block)
+
+    return parts
+
+
+def format_context(
+    data: dict[str, Any], max_chars: int = 12000
+) -> str:
+    """Flatten snippets + rules into a prompt-ready text block."""
+    parts = _snippet_lines(data, max_chars)
+
+    rules = data.get("rules") or {}
+    rule_lines: list[str] = []
+    for rule_group in ("global", "libraryOwn", "libraryTeam"):
+        for rule in rules.get(rule_group, []):
+            if rule.strip():
+                rule_lines.append(f"- {rule.strip()}")
+    if rule_lines:
+        parts.append("## Project rules\n" + "\n".join(rule_lines))
+
+    text = "\n\n".join(parts)
+    return text[:max_chars]
+
+
+def source_links(data: dict[str, Any]) -> list[str]:
+    """Collect dedup'd source page URLs from the snippets for citations."""
+    links: list[str] = []
+    seen: set[str] = set()
+    for snip in data.get("infoSnippets", []):
+        url = snip.get("pageId") or ""
+        if url.startswith("http") and url not in seen:
+            seen.add(url)
+            links.append(url)
+    return links

--- a/integrations/discord-support-bot/docs_slash.py
+++ b/integrations/discord-support-bot/docs_slash.py
@@ -1,0 +1,185 @@
+"""docs_slash.py — /docs slash command backed by Context7 + DeepSeek.
+
+A self-contained ``discord.py`` component that adds a ``/docs`` slash command
+to the existing authorized 1bit.MONSTER Discord bot. When a user runs
+``/docs <question>`` it:
+   1. fetches the most relevant docs from Context7 (/1bit-monster/1bit-monster)
+   2. has DeepSeek write a grounded answer
+   3. replies with the answer + source links
+
+This component runs its own gateway connection. The other 1bit bots
+(discord-inbox.py, traffic-digest, etc.) are REST pollers, so they load
+separately and do not conflict with this gateway connection. The bot must be
+invited with the ``applications.commands`` scope for the slash command to show.
+
+Run:
+    python3 docs_slash.py            # reads .env (see .env.example)
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+import urllib.request
+
+import discord
+from discord import app_commands
+
+import context7
+import llm
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+log = logging.getLogger("docsbot")
+
+API = "https://discord.com/api/v10"
+# Channel the existing inbox bot watches — used only to auto-discover the guild.
+KNOWN_CHANNEL = os.getenv("DISCORD_KNOWN_CHANNEL", "1542589031055888386")
+
+LIBRARY_ID = os.getenv("CONTEXT7_LIBRARY_ID", "/1bit-monster/1bit-monster")
+COMMAND_NAME = os.getenv("DOCS_COMMAND_NAME", "docs")
+COMMAND_DESC = os.getenv(
+    "DOCS_COMMAND_DESC",
+    "Ask the 1bit.MONSTER docs (grounded in the official documentation)",
+)
+MAX_TOKENS = int(os.getenv("MAX_TOKENS", "1024"))
+
+
+def token_from_env_or_files() -> str:
+    t = os.getenv("DISCORD_TOKEN")
+    if t:
+        return t.strip()
+    for path in (
+        os.path.expanduser("~/.secrets/Discord Bot token.txt"),
+        os.path.expanduser("~/Documents/Discord Bot token.txt"),
+    ):
+        try:
+            with open(path, encoding="utf-8") as fh:
+                val = fh.read().strip()
+            if val:
+                return val
+        except OSError:
+            continue
+    return ""
+
+
+def _discover_guild_id(token: str) -> int | None:
+    """Best-effort: find the guild id from a known channel, else /users/@me."""
+    try:
+        req = urllib.request.Request(
+            API + f"/channels/{KNOWN_CHANNEL}",
+            headers={"Authorization": "Bot " + token, "User-Agent": "1bit-docsbot (1.0)"},
+        )
+        with urllib.request.urlopen(req, timeout=15) as r:
+            data = __import__("json").load(r)
+        return data.get("guild_id")
+    except Exception as exc:  # noqa: BLE001
+        log.warning("could not discover guild id from channel %s: %s", KNOWN_CHANNEL, exc)
+        return None
+
+
+def _split(text: str, limit: int = 1993) -> list[str]:
+    if len(text) <= limit:
+        return [text]
+    out, cur = [], ""
+    for para in text.split("\n"):
+        if len(cur) + len(para) + 1 > limit:
+            if cur:
+                out.append(cur)
+            cur = ""
+            while len(para) > limit:
+                out.append(para[:limit])
+                para = para[limit:]
+        cur = (cur + "\n" + para).strip() if cur else para.strip()
+    if cur:
+        out.append(cur)
+    return out
+
+
+class DocsSlash(discord.Client):
+    def __init__(self, token: str, guild_id: int | None) -> None:
+        intents = discord.Intents.default()  # message_content not needed for slash
+        super().__init__(intents=intents)
+        self.token = token
+        self.guild_id = guild_id
+        self.tree = app_commands.CommandTree(self)
+
+    async def setup_hook(self) -> None:
+        # If we know the guild, scope the command there so it registers instantly
+        # (global registration can take up to an hour).
+        @self.tree.command(name=COMMAND_NAME, description=COMMAND_DESC)
+        async def docs(interaction: discord.Interaction, question: str) -> None:  # noqa: ANN202
+            await self._answer(interaction, question)
+
+        if self.guild_id:
+            guild = self.get_guild(self.guild_id) or await self.fetch_guild(self.guild_id)
+            self.tree.copy_global_to(guild=guild)
+            await self.tree.sync(guild=guild)
+            log.info("synced /%s to guild %s", COMMAND_NAME, guild.id)
+        else:
+            await self.tree.sync()
+            log.info("synced /%s globally", COMMAND_NAME)
+
+    async def on_ready(self) -> None:
+        log.info("Logged in as %s (id=%s)", self.user, self.user.id)
+
+    async def _answer(self, interaction: discord.Interaction, question: str) -> None:
+        question = (question or "").strip()
+        if not question:
+            await interaction.response.send_message(
+                "Ask me anything about 1bit.MONSTER, e.g. `/docs how do I build the engine?`"
+            )
+            return
+        # Defer so the user sees "thinking" while Context7 + DeepSeek run.
+        await interaction.response.defer(thinking=True)
+        try:
+            data = context7.get_context(LIBRARY_ID, question, os.getenv("CONTEXT7_API_KEY"))
+            block = context7.format_context(data)
+            if not block.strip():
+                await interaction.followup.send(
+                    "I couldn't find relevant docs for that. Try rephrasing, or check the [docs hub](https://docs.1bit.monster)."
+                )
+                return
+            answer = llm.generate(
+                question, block, os.getenv("DEEPSEEK_API_KEY"), max_tokens=MAX_TOKENS
+            )
+            links = context7.source_links(data)
+            if links:
+                answer = answer.rstrip() + "\n\n**Sources:** " + " · ".join(links[:4])
+        except Exception as exc:  # noqa: BLE001
+            log.exception("answer failed")
+            await interaction.followup.send(
+                f"Sorry, I hit an error while answering: `{type(exc).__name__}`."
+            )
+            return
+        for chunk in _split(answer):
+            await interaction.followup.send(chunk)
+
+
+def _load_dotenv(path: str = ".env") -> None:
+    if not os.path.exists(path):
+        return
+    for line in open(path, encoding="utf-8"):
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+
+def main() -> None:
+    _load_dotenv()
+    token = token_from_env_or_files()
+    if not token:
+        log.error("Could not find DISCORD_TOKEN (set it or place a token file).")
+        return
+    guild_id = os.getenv("DISCORD_GUILD_ID")
+    guild_id = int(guild_id) if guild_id and guild_id.strip().isdigit() else None
+    if guild_id is None:
+        guild_id = _discover_guild_id(token)
+    if not os.getenv("DEEPSEEK_API_KEY") or not os.getenv("CONTEXT7_API_KEY"):
+        log.warning("DEEPSEEK_API_KEY / CONTEXT7_API_KEY not set — /docs will error until set.")
+    bot = DocsSlash(token, guild_id)
+    bot.run(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/discord-support-bot/llm.py
+++ b/integrations/discord-support-bot/llm.py
@@ -1,0 +1,63 @@
+"""llm.py — DeepSeek chat-completions client (OpenAI wire-compatible).
+
+DeepSeek exposes an OpenAI-compatible ``/chat/completions`` endpoint, so we
+call it with ``requests`` and no extra SDK. The prompt is grounded in the
+Context7 snippets already retrieved.
+"""
+from __future__ import annotations
+
+import os
+
+import requests
+
+DEEPSEEK_BASE = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
+DEEPSEEK_MODEL = os.getenv("DEEPSEEK_MODEL", "deepseek-chat")
+
+
+def _system_prompt(context: str) -> str:
+    return (
+        "You are the 1bit.MONSTER support assistant. You answer questions about "
+        "the 1bit.MONSTER engine (a pure C++23, hardware-agnostic 1-bit LLM "
+        "inference engine that runs on NPU (Ryzen AI), GPU (ROCm/Vulkan/CUDA), "
+        "and CPU; zero Python at runtime; .1bp and GGUF formats; MIT licensed).\n\n"
+        "Answer ONLY from the documentation context below. If the context does "
+        "not contain the answer, say so plainly and suggest where the user can "
+        "find more info. Be concise, accurate, and friendly. Cite source links "
+        "from the context when relevant."
+        "\n\n---- DOCUMENTATION CONTEXT ----\n" + context
+    )
+
+
+def generate(
+    question: str,
+    context: str,
+    api_key: str,
+    model: str = DEEPSEEK_MODEL,
+    max_tokens: int = 1024,
+    temperature: float = 0.2,
+    timeout: int = 60,
+) -> str:
+    """Return a grounded answer for ``question`` using ``context``."""
+    if not api_key:
+        raise ValueError("DEEPSEEK_API_KEY is not set")
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": _system_prompt(context)},
+            {"role": "user", "content": question},
+        ],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+    resp = requests.post(
+        DEEPSEEK_BASE + "/chat/completions",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        json=body,
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return (data["choices"][0]["message"]["content"] or "").strip()

--- a/integrations/discord-support-bot/requirements.txt
+++ b/integrations/discord-support-bot/requirements.txt
@@ -1,0 +1,2 @@
+discord.py>=2.3.2
+requests>=2.31.0


### PR DESCRIPTION
### **User description**
Adds a `/docs` slash command to the existing 1bit.MONSTER Discord bot, answering support questions grounded in the official docs (via Context7) and phrased by DeepSeek. Secrets are not included (`.env` is gitignored).


___

### **PR Type**
Enhancement


___

### **Description**
- Adds Context7-backed /docs slash command Discord bot

- Grounds answers in official 1bit.MONSTER docs

- DeepSeek phrases grounded replies with source links

- Includes prefix/support-channel bot alternative


___

### Diagram Walkthrough


```mermaid
flowchart TD
  User["/docs question"] --> Slash["docs_slash.py /docs"]
  Slash --> C7["context7.py Context7 API"]
  C7 --> Docs["Official 1bit.MONSTER docs"]
  Slash --> DS["llm.py DeepSeek chat"]
  C7 --> DS
  DS --> Reply["Grounded answer + source links"]
  Reply --> Discord["Discord reply"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>bot.py</strong><dd><code>Standalone prefix/support-channel bot with rate limiting</code>&nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1938/files#diff-0c43fce66247bfa4dc8919f4c01d3d876f4e4ad040d83608aea45ccd1852e9b7">+196/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>context7.py</strong><dd><code>Context7 retrieval, formatting, and source link client</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1938/files#diff-5f484e98f3b224e60ba407a07adefb1e75284d9cd707647749026b21b5fa196f">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>docs_slash.py</strong><dd><code>/docs slash command with guild-scoped registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1938/files#diff-9ceb0d708c53b8d1c7d09a02cbcc40f2cb85f1fae85c83b7bbeb932a1c99b4f2">+185/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>llm.py</strong><dd><code>DeepSeek chat-completions client with grounded prompt</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1938/files#diff-2eed3a8de60c869202a3b15e0b7923e8803c9443ad51d9a7088691e91a65b8da">+63/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>.env.example</strong><dd><code>Example environment configuration for bot credentials</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1938/files#diff-15f5b540aec7c27d7401cbb72cece30eed5f97fe51d2815c2c5d4c2985b29b22">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Usage, setup, and architecture documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1938/files#diff-78d529696b10b796c036d72603cb1cbba0f2172c543e946065525c54d4103b65">+84/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>requirements.txt</strong><dd><code>Dependencies discord.py and requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1938/files#diff-7e39aa970c4fe0216c3308ba0139e10f780408803a6091778e610c94b11ea3b2">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

