### PR TITLE
ci(docs): provision docs.1bit.monster domain

### DIFF
--- a/.github/workflows/provision-docs-domain.yml
+++ b/.github/workflows/provision-docs-domain.yml
@@ -1,0 +1,71 @@
+name: Provision docs.1bit.monster domain
+
+# Attaches the docs.1bit.monster custom domain to the 1bit-monster-docs
+# Cloudflare Pages project and ensures the `docs` CNAME in the 1bit.monster
+# zone. Uses the repo's existing CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID
+# secrets (the same ones the main-site deploy uses).
+#
+# The Pages custom-domain API auto-creates the DNS record when the zone is in
+# the same Cloudflare account; this also sets the record explicitly so it works
+# even if that automation is off.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/provision-docs-domain.yml'
+
+concurrency:
+  group: provision-docs-domain
+  cancel-in-progress: false
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Attach docs.1bit.monster custom domain + DNS
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -u
+          API="https://api.cloudflare.com/client/v4"
+          PROJECT="1bit-monster-docs"
+          HOSTNAME="docs.1bit.monster"
+          ZONE="1bit.monster"
+
+          auth=(-H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json")
+
+          echo "== 1) find zone id for $ZONE =="
+          zone_json=$(curl -s "${auth[@]}" "$API/zones?name=$ZONE&per_page=1")
+          echo "$zone_json" | python3 -c "import sys,json;d=json.load(sys.stdin);z=d.get('result',[]);print('zone found:',bool(z));print('zone_id:',z[0]['id'] if z else 'NONE')" || true
+          zone_id=$(echo "$zone_json" | python3 -c "import sys,json;d=json.load(sys.stdin);z=d.get('result',[]);print(z[0]['id'] if z else '')" 2>/dev/null)
+
+          echo "== 2) attach custom domain to Pages project =="
+          dom_json=$(curl -s -X POST "${auth[@]}" \
+            "$API/accounts/$CF_ACCOUNT/pages/projects/$PROJECT/domains" \
+            --data "{\"name\":\"$HOSTNAME\"}")
+          echo "$dom_json" | python3 -c "import sys,json;d=json.load(sys.stdin);print('attach success:',d.get('success'));print('status:',(d.get('result') or {}).get('status','?'));print('errors:',d.get('errors'))" || true
+
+          if [ -n "$zone_id" ]; then
+            echo "== 3) ensure docs CNAME -> $PROJECT.pages.dev =="
+            existing=$(curl -s "${auth[@]}" "$API/zones/$zone_id/dns_records?type=CNAME&name=$HOSTNAME" | \
+              python3 -c "import sys,json;d=json.load(sys.stdin);r=d.get('result',[]);print(r[0]['id'] if r else '')" 2>/dev/null)
+            if [ -z "$existing" ]; then
+              rec_json=$(curl -s -X POST "${auth[@]}" "$API/zones/$zone_id/dns_records" \
+                --data "{\"type\":\"CNAME\",\"name\":\"$HOSTNAME\",\"content\":\"$PROJECT.pages.dev\",\"proxied\":true}")
+              echo "$rec_json" | python3 -c "import sys,json;d=json.load(sys.stdin);print('dns create success:',d.get('success'));print('errors:',d.get('errors'))" || true
+            else
+              echo "dns record already exists (id=$existing)"
+            fi
+          else
+            echo "!! could not resolve zone $ZONE (token may lack Zone permissions)"
+          fi
+
+          echo "== done =="


### PR DESCRIPTION
### **User description**
Adds a workflow that uses the repo's Cloudflare secrets to attach the docs.1bit.monster custom domain to the 1bit-monster-docs Pages project and create the DNS CNAME.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds GitHub Actions workflow to provision Cloudflare Pages domain

- Attaches `docs.1bit.monster` to `1bit-monster-docs` project

- Creates `docs` CNAME DNS record when missing

- Runs on push to main and manual `workflow_dispatch`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions workflow"] --> B["Resolve zone ID"]
  B --> C["Attach custom domain to Pages project"]
  C --> D["Ensure docs CNAME record"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>provision-docs-domain.yml</strong><dd><code>Add workflow provisioning docs domain and DNS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/provision-docs-domain.yml

<ul><li>New workflow to provision <code>docs.1bit.monster</code> Cloudflare domain<br> <li> Resolves <code>1bit.monster</code> zone ID via Cloudflare API<br> <li> Attaches custom domain to <code>1bit-monster-docs</code> Pages project<br> <li> Creates <code>docs</code> CNAME to <code>*.pages.dev</code> if missing</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1939/files#diff-76954641ac70b7250f870143843eb1d44ffc82344cf1e6fd6f589459b1ee737f">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

