### PR TITLE
feat(discord): reproducible /docs bot service + smoke test

### DIFF
--- a/integrations/discord-support-bot/README.md
+++ b/integrations/discord-support-bot/README.md
@@ -61,6 +61,29 @@ That starts a gateway connection and registers **`/docs`** with your bot.
 `DISCORD_GUILD_ID` (or auto-discovery) scopes the command to your server so it
 appears immediately instead of waiting up to an hour.
 
+### Run it as a service (recommended for always-on)
+The bot must stay connected to the Discord gateway, so run it as a systemd
+**user** service rather than a one-off process:
+
+```bash
+./install-docsbot-service.sh
+```
+
+This creates `~/.config/systemd/user/docsbot.service` from the committed
+`docsbot.service` template, installs the venv, enables linger (start at boot),
+and starts it. Manage it with `systemctl --user status/restart docsbot` and
+watch logs with `journalctl --user -u docsbot -f`.
+
+### Smoke test
+Validate the pipeline (does **not** need the DeepSeek key):
+
+```bash
+python3 smoke.py
+```
+
+It checks Context7 is retrieval-ready for `/1bit-monster/1bit-monster`, and, if
+`DEEPSEEK_API_KEY` is set, that a grounded answer is produced.
+
 ## Usage
 - **`/docs <question>`** — in any channel, e.g. `/docs how do I build the engine?`
 - The bot answers with a grounded reply plus the doc source links it used.

--- a/integrations/discord-support-bot/docsbot.service
+++ b/integrations/discord-support-bot/docsbot.service
@@ -1,0 +1,25 @@
+# 1bit.MONSTER Context7 `/docs` Discord bot — systemd user unit (template).
+#
+# The username is set at install time by `install-docsbot-service.sh` (it
+# replaces @USER@ and @BOT_DIR@). This is a template committed to the repo so
+# the bot can be deployed reproducibly on any host without a build step.
+#
+# Install/start:
+#   integrations/discord-support-bot/install-docsbot-service.sh
+
+[Unit]
+Description=1bit.MONSTER Context7 /docs Discord bot (gateway)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=@BOT_DIR@
+EnvironmentFile=@BOT_DIR@/.env
+ExecStart=@BOT_DIR@/.venv/bin/python @BOT_DIR@/docs_slash.py
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+
+[Install]
+WantedBy=default.target

--- a/integrations/discord-support-bot/install-docsbot-service.sh
+++ b/integrations/discord-support-bot/install-docsbot-service.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# install-docsbot-service.sh — install & start the /docs bot as a systemd user
+# service on this host. Idempotent (safe to re-run after updating the bot).
+#
+# Usage:   ./install-docsbot-service.sh
+# Notes:   creates ~/.config/systemd/user/docsbot.service from the template,
+#          requires linger so it starts at boot (loginctl enable-linger $USER).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+USER_DIR="$HOME/.config/systemd/user"
+SERVICE_NAME="docsbot.service"
+
+echo "==> bot dir: $HERE"
+echo "==> ensuring venv + .env exist (secrets live in .env, kept out of git)"
+[ -d "$HERE/.venv" ] || python3 -m venv "$HERE/.venv"
+"$HERE/.venv/bin/pip" install -q --disable-pip-version-check -r "$HERE/requirements.txt"
+[ -f "$HERE/.env" ] || { echo "ERROR: no $HERE/.env — copy .env.example and fill it in"; exit 1; }
+
+echo "==> writing $SERVICE_NAME from template"
+mkdir -p "$USER_DIR"
+sed -e "s|@BOT_DIR@|$HERE|g" "$HERE/docsbot.service" > "$USER_DIR/$SERVICE_NAME"
+chmod 644 "$USER_DIR/$SERVICE_NAME"
+
+echo "==> daemon-reload + enable/start"
+systemctl --user daemon-reload
+systemctl --user enable --now "$SERVICE_NAME" >/dev/null 2>&1 || true
+
+echo "==> enabling linger so the bot starts at boot (no login required)"
+loginctl enable-linger "$USER" 2>/dev/null || echo "   (could not enable linger; may need root)"
+
+echo "==> status"
+systemctl --user --no-pager status "$SERVICE_NAME" | sed 's/^/   /' | head -12
+
+echo ""
+echo "The /docs command is now live in Discord."
+echo "   Follow logs:  journalctl --user -u $SERVICE_NAME -f"
+echo "   Ask the bot:  /docs <question>"

--- a/integrations/discord-support-bot/smoke.py
+++ b/integrations/discord-support-bot/smoke.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""smoke.py — validate the /docs answer pipeline without needing secrets.
+
+Checks:
+  1. CONTEXT7_LIBRARY_ID is configured (has a sane default).
+  2. Context7 retrieval returns snippets for a sample question (uses
+     CONTEXT7_API_KEY if set, otherwise anonymous).
+  3. If DEEPSEEK_API_KEY is set, generates a real grounded answer and reports
+     its length; otherwise it's skipped (marked SKIP, not a failure).
+
+Exit code 0 if all required checks pass, 1 otherwise.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import context7
+import llm
+
+PASS = "PASS"
+FAIL = "FAIL"
+SKIP = "SKIP"
+
+
+def load_dotenv(path: str = ".env") -> None:
+    if not os.path.exists(path):
+        return
+    for line in open(path, encoding="utf-8"):
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+
+def check(name: str, ok: bool, detail: str = "") -> bool:
+    status = PASS if ok else FAIL
+    print(f"[{status}] {name}" + (f" — {detail}" if detail else ""))
+    if not ok:
+        return False
+    return True
+
+
+def main() -> int:
+    load_dotenv()
+    ok = True
+
+    library_id = os.getenv("CONTEXT7_LIBRARY_ID", "/1bit-monster/1bit-monster")
+    ok &= check("CONTEXT7_LIBRARY_ID configured", bool(library_id), library_id)
+
+    # --- Context7 retrieval (no key needed) ---
+    try:
+        data = context7.get_context(library_id, "How do I build the engine?")
+        block = context7.format_context(data)
+        info = len(data.get("infoSnippets", []))
+        code = len(data.get("codeSnippets", []))
+        ok &= check(
+            "Context7 retrieval returns grounded docs",
+            len(block.strip()) > 0 and (info + code) > 0,
+            f"{info} info + {code} code snippets, {len(block)} chars",
+        )
+    except Exception as exc:  # noqa: BLE001
+        ok &= check("Context7 retrieval returns grounded docs", False, f"{type(exc).__name__}: {exc}")
+
+    # --- Optional DeepSeek answer (only if key present) ---
+    if os.getenv("DEEPSEEK_API_KEY"):
+        try:
+            ans = llm.generate("How do I build the engine?", block, os.getenv("DEEPSEEK_API_KEY"))
+            ok &= check("DeepSeek grounded answer", len(ans.strip()) > 0, f"{len(ans.strip())} chars")
+        except Exception as exc:  # noqa: BLE001
+            ok &= check("DeepSeek grounded answer", False, f"{type(exc).__name__}: {exc}")
+    else:
+        print(f"[{SKIP}] DeepSeek grounded answer — DEEPSEEK_API_KEY not set (skipped; retrieval already verified)")
+
+    print("\n" + ("SMOKE PASS" if ok else "SMOKE FAIL"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### **User description**
Adds an installable systemd user service and a smoke test for the /docs support bot, so it's reproducible on any host. Secrets remain in a gitignored .env.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add systemd user service for /docs bot deployment

- Add idempotent install script creating venv and unit

- Add smoke test validating Context7 retrieval and optional DeepSeek

- Update README with service and smoke test usage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Install["install-docsbot-service.sh"] --> Venv["create .venv + install deps"]
  Install --> Env["require .env with secrets"]
  Install --> Unit["write docsbot.service from template"]
  Unit --> Linger["enable linger at boot"]
  Unit --> Start["systemctl --user start docsbot"]
  Smoke["smoke.py"] --> Context["Context7 retrieval (no key needed)"]
  Context --> DeepSeek["optional DeepSeek grounded answer"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>smoke.py</strong><dd><code>Add smoke test for Context7 and DeepSeek pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/discord-support-bot/smoke.py

<ul><li>New CLI script validating the /docs answer pipeline without secrets<br> <li> Loads .env, checks CONTEXT7_LIBRARY_ID, and runs Context7 retrieval<br> <li> Optionally verifies DeepSeek grounded answer when key is set<br> <li> Prints PASS/FAIL/SKIP and exits non-zero on failures</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1940/files#diff-45ebd3345188ae3d68e218d52457ca51c45024fd504513157a703172ef69b1dd">+80/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install-docsbot-service.sh</strong><dd><code>Add script to install and start docsbot service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/discord-support-bot/install-docsbot-service.sh

<ul><li>New idempotent installer for the /docs bot systemd user service<br> <li> Creates .venv, installs requirements, and requires .env to exist<br> <li> Writes docsbot.service from template to ~/.config/systemd/user<br> <li> Enables linger, starts the service, and prints status/log instructions</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1940/files#diff-8aafb10411d9d3f249352dd4b505840714fab8d3e286a3f45143e61c1cc2b7d1">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docsbot.service</strong><dd><code>Add systemd unit template for /docs bot</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/discord-support-bot/docsbot.service

<ul><li>New systemd user unit template for the /docs Discord bot<br> <li> Substitutes @BOT_DIR@ at install time, uses .env for secrets<br> <li> Runs docs_slash.py with restart on failure and NoNewPrivileges</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1940/files#diff-244ff45e255647de7cf8fdb3292aa61a85497e5dbac852333c9715b51f7e515a">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document service deployment and smoke test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/discord-support-bot/README.md

<ul><li>Adds "Run it as a service" section using install-docsbot-service.sh<br> <li> Documents managing service with systemctl and journalctl<br> <li> Adds smoke test usage and what it validates</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1940/files#diff-78d529696b10b796c036d72603cb1cbba0f2172c543e946065525c54d4103b65">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

