### PR TITLE
ci(analytics): add visitors-by-country breakdown to traffic report

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -151,6 +151,15 @@ jobs:
                          { date: .dimensions.date, requests: .sum.requests, pageViews: .sum.pageViews }]
                         | .[] | "\(.date)\t\(.requests) req\t\(.pageViews) pv")
                      else "zone analytics query failed: \(.errors[0].message // "unknown")" end'
+
+            echo ""
+            echo "=== Visitors by country (top 10, 7d) ==="
+            gql "{ viewer { zones(filter: {zoneTag: \"$ZONE_ID\"}) { httpRequestsAdaptiveGroups(limit: 10, filter: {date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [count_DESC]) { dimensions { clientCountryName } count } } } }" | \
+              jq -r 'if .data then
+                       ([.data.viewer.zones[0].httpRequestsAdaptiveGroups[] |
+                         { country: (.dimensions.clientCountryName // "Unknown"), requests: .count }]
+                        | .[] | "\(.country)\t\(.requests) req")
+                     else "country query failed: \(.errors[0].message // "unknown")" end'
           else
             echo "Zone 1bit.monster not visible to the analytics token (need Zone: Read on the WA token)."
           fi


### PR DESCRIPTION
### **User description**
## What

The daily traffic report now shows **who is visiting, by country**.

- **`.github/workflows/analytics.yml`**: the Cloudflare zone section gains a
  second GraphQL query — `httpRequestsAdaptiveGroups` grouped by the
  `clientCountryName` dimension (top 10, 7d) — emitting `Country\tN req`
  lines after the date summary.
- **`~/.local/bin/discord-traffic-digest.py`** (machine-side, mirrored in
  `integrations/discord-support-bot/`): parses those lines and shows top 5
  countries with flag emojis under a new `🌍 Visitors:` line in the daily
  single-message report.

## Verification
- workflow YAML valid; digest compiles
- Zone query confirmed working live (zone id resolves, date rows returned) —
  the country-dimension query is the same endpoint/pattern, re-verified on
  the next run after this lands


___

### **PR Type**
Enhancement


___

### **Description**
- Add visitors-by-country breakdown to Cloudflare traffic report

- Query httpRequestsAdaptiveGroups grouped by clientCountryName (top 10, 7d)

- Emit `Country\tN req` lines after the existing date summary

- Include fallback error message for failed country query


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["analytics workflow"] --> B["Zone GraphQL query"]
  B --> C["Date summary (requests/pv)"]
  B --> D["Country breakdown (clientCountryName)"]
  D --> E["Top 10 countries by requests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.yml</strong><dd><code>Add country-level visitor breakdown to analytics workflow</code></dd></summary>
<hr>

.github/workflows/analytics.yml

<ul><li>Add a second GraphQL query using <code>httpRequestsAdaptiveGroups</code> for <br>country-level visitor stats<br> <li> Group results by <code>clientCountryName</code>, limit to top 10, 7-day window, <br>ordered by request count<br> <li> Parse with <code>jq</code> and output <code>Country\tN req</code> lines after the date summary<br> <li> Include error handling for the new country query</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1972/files#diff-607f949b9aca36160cbe6db71570383124fdf743994796f8091bb52cf1cc52a4">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

