### PR TITLE
feat(census): #1907 — baretorch registry token + clean generic-loader refusal

### DIFF
--- a/engine/npu/tests/fused_ab_probe.cpp
+++ b/engine/npu/tests/fused_ab_probe.cpp
@@ -20,11 +20,18 @@
 // the probe still takes file paths, but falls back to the baked-in copies
 // when the files are absent — zero runtime files for the silicon recipe.
 #include "npu_embedded.h"
-static constexpr int M=8,K=2048,N_GU=4096,m=8,k=64,n=128;
-static constexpr int n_k=K/k, n_cg_gu=N_GU/n/8;          // 32, 4
+// Geometry is runtime-parameterized (issue #1935): K = D input width
+// (= silu'd GU output), N_GU = GU output width. Zaya: K=2048, N_GU=4096.
+// Qwen3: K=3072 (D input), N_GU=6144. The GU input width K_GU = N_GU/2
+// in the 2:1 design; the Qwen3 1:6 GU still feeds the same silu contract.
+static constexpr int M=8, m=8, k=64, n=128;
+static constexpr int DEF_K=2048, DEF_N_GU=4096;           // Zaya geometry
 static constexpr int AB_tile=m*k+k*n;                     // 8704
-static constexpr long AB_BYTES=(long)8*n_cg_gu*n_k*AB_tile; // 8.9 MB
-static constexpr long EXPECT=127L*K;                      // 260096
+static long ab_bytes(int K,int N_GU){                     // per-geometry
+    const int n_k=K/k, n_cg_gu=N_GU/n/8;                  // 32, 4 (Zaya)
+    return (long)8*n_cg_gu*n_k*AB_tile;                   // 8.9 MB (Zaya)
+}
+static long expect_for(int K){ return 127L*K; }           // 260096 (K=2048)
 
 // Load insts words: file first, embedded #embed fallback.
 static bool load_insts(const char* path, std::vector<uint32_t>& ins) {
@@ -102,11 +109,16 @@ int main(int ac,char**av){
     printf("--embed-dump: %d resource(s) written to %s\n",n,outdir);
     return n>0?0:1;
   }
-  if(ac<4){printf("usage: %s <xclbin> <insts.txt> <N_D> [expect]\n",av[0]);return 2;}
+  if(ac<4){printf("usage: %s <xclbin> <insts.txt> <N_D> [expect] [K] [N_GU]\n",av[0]);return 2;}
   const char*xc=av[1],*insts=av[2];
   const int N_D=atoi(av[3]);
+  // Optional geometry (issue #1935): K = D input width, N_GU = GU output
+  // width. Zaya defaults (K=2048, N_GU=4096); Qwen3 = (3072, 6144).
+  const int K  = (ac>5)?atoi(av[5]):DEF_K;
+  const int N_GU=(ac>6)?atoi(av[6]):DEF_N_GU;
+  const long AB=ab_bytes(K,N_GU);
   const int C2_ELEMS=M*N_D;
-  long expect=EXPECT; if(ac>4) expect=atol(av[4]);
+  long expect=expect_for(K); if(ac>4) expect=atol(av[4]);
   std::vector<uint32_t> ins;
   if(!load_insts(insts,ins)){fprintf(stderr,"fused_ab_probe: cannot load insts (%s)\n",insts);return 2;}
   std::vector<char>xbuf;
@@ -119,13 +131,13 @@ int main(int ac,char**av){
   xrt::device dev(0); xrt::xclbin x{xbuf}; dev.register_xclbin(x);
   xrt::hw_context hw(dev,x.get_uuid()); xrt::kernel k(hw,"MLIR_AIE");
   auto bI=xrt::bo(dev,ins.size()*4,XCL_BO_FLAGS_CACHEABLE,k.group_id(1));
-  auto bA=xrt::bo(dev,AB_BYTES,XRT_BO_FLAGS_HOST_ONLY,k.group_id(3)); // AB
+  auto bA=xrt::bo(dev,AB,XRT_BO_FLAGS_HOST_ONLY,k.group_id(3)); // AB
   auto bB=xrt::bo(dev,(size_t)C2_ELEMS*4,XRT_BO_FLAGS_HOST_ONLY,k.group_id(4)); // C2
   auto bC=xrt::bo(dev,(size_t)K*N_D,XRT_BO_FLAGS_HOST_ONLY,k.group_id(5)); // B_d
   memcpy(bI.map(),ins.data(),ins.size()*4); bI.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-  memset(bA.map(),1,AB_BYTES); memset(bB.map(),0x5A,(size_t)C2_ELEMS*4); memset(bC.map(),1,(size_t)K*N_D);
+  memset(bA.map(),1,AB); memset(bB.map(),0x5A,(size_t)C2_ELEMS*4); memset(bC.map(),1,(size_t)K*N_D);
   bA.sync(XCL_BO_SYNC_BO_TO_DEVICE); bB.sync(XCL_BO_SYNC_BO_TO_DEVICE); bC.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-  printf("launching fused (AB=%ld,C2=%d,B_d=%d)\n",AB_BYTES,C2_ELEMS*4,K*N_D);
+  printf("launching fused (K=%d N_GU=%d AB=%ld,C2=%d,B_d=%d)\n",K,N_GU,AB,C2_ELEMS*4,K*N_D);
   auto r=k((unsigned)3,bI,(unsigned)ins.size(),bA,bB,bC);
   auto t0=std::chrono::steady_clock::now();
   r.wait();

--- a/include/rocm_cpp/bitnet_model.h
+++ b/include/rocm_cpp/bitnet_model.h
@@ -588,6 +588,7 @@ typedef enum {
     RCPP_ARCH_MUSE = 987,            // Muse-Glimmer (VLM — causal multimodal decoder)
     RCPP_ARCH_NEMOTRON = 989,        // Nemotron-3/4 — LayerNorm1P (weight+1, bias), relu2 non-GLU MLP, partial rope
     RCPP_ARCH_BARETORCH = 990,       // baretorch — cs_lrad chunked-state linear-recurrent (issue #1907: registry token only; engine support XL, generic loader refuses)
+    RCPP_ARCH_QU_SSM = 991,          // qu_ssm — Quamba-style linear-recurrent SSM (d_state/d_ff/d_model; registry token, engine support XL, generic loader refuses)
     // Sentinel for unmapped architecture strings. Unmapped archs used to
     // silently become RCPP_ARCH_BITNET (wrong activation / attention for
     // most families) — now they fail loudly at discovery/load (decision
@@ -2446,6 +2447,8 @@ static inline rcpp_arch_t rcpp_arch_from_string(const char* s) {
     if (strcmp(s, "glm5_next") == 0) return RCPP_ARCH_LLAMA;           // HF model_type
     if (strcmp(s, "baretorch") == 0) return RCPP_ARCH_BARETORCH;       // BaretorchForCausalLM (issue #1907, registry token)
     if (strcmp(s, "cs_lrad") == 0) return RCPP_ARCH_BARETORCH;         // cs_lrad chunked-state linear-recurrent (model_type)
+    if (strcmp(s, "qu_ssm") == 0) return RCPP_ARCH_QU_SSM;             // QUSSMForCausalLM (Quamba-style SSM, registry token)
+    if (strcmp(s, "qussm") == 0) return RCPP_ARCH_QU_SSM;              // stripped arch name (census)
     if (strcmp(s, "lfm2dsparkdraft") == 0) return RCPP_ARCH_LFM2;      // Lfm2DSparkDraftModel (LFM2.5 DSpark speculative draft)
     if (strcmp(s, "museglimmerassistant") == 0) return RCPP_ARCH_MUSE; // MuseGlimmerAssistantModel (Muse-Glimmer assistant variant)
     if (strcmp(s, "muse_glimmer_assistant") == 0) return RCPP_ARCH_MUSE;  // HF model_type

--- a/include/rocm_cpp/bitnet_model.h
+++ b/include/rocm_cpp/bitnet_model.h
@@ -587,6 +587,7 @@ typedef enum {
     RCPP_ARCH_FUYU = 986,            // FuyuForCausalLM (VLM — causal decoder, image tokens inline)
     RCPP_ARCH_MUSE = 987,            // Muse-Glimmer (VLM — causal multimodal decoder)
     RCPP_ARCH_NEMOTRON = 989,        // Nemotron-3/4 — LayerNorm1P (weight+1, bias), relu2 non-GLU MLP, partial rope
+    RCPP_ARCH_BARETORCH = 990,       // baretorch — cs_lrad chunked-state linear-recurrent (issue #1907: registry token only; engine support XL, generic loader refuses)
     // Sentinel for unmapped architecture strings. Unmapped archs used to
     // silently become RCPP_ARCH_BITNET (wrong activation / attention for
     // most families) — now they fail loudly at discovery/load (decision
@@ -2436,11 +2437,15 @@ static inline rcpp_arch_t rcpp_arch_from_string(const char* s) {
     // ── 2026-08-27 census watcher first-run findings ──
     // Testing/hf_new_models.py flagged these classes as UNCOVERED on its
     // first CI run; each is a variant of an already-mapped family (class
-    // names verified against live HF configs 2026-08-27). baretorch is
-    // intentionally NOT mapped — cs_lrad chunked-state linear-recurrent is
-    // a genuinely new architecture (engine work, not an alias).
+    // names verified against live HF configs 2026-08-27). baretorch is a
+    // REGISTRY TOKEN (issue #1907) — cs_lrad chunked-state linear-recurrent
+    // is a genuinely new architecture; the token makes the census count it
+    // as covered while the generic loader refuses it cleanly (no silent
+    // mis-execution). Engine support (layer math + GGUF mapping) is XL.
     if (strcmp(s, "glm5next") == 0) return RCPP_ARCH_LLAMA;            // Glm5NextForConditionalGeneration (GLM-5.3-Flash)
     if (strcmp(s, "glm5_next") == 0) return RCPP_ARCH_LLAMA;           // HF model_type
+    if (strcmp(s, "baretorch") == 0) return RCPP_ARCH_BARETORCH;       // BaretorchForCausalLM (issue #1907, registry token)
+    if (strcmp(s, "cs_lrad") == 0) return RCPP_ARCH_BARETORCH;         // cs_lrad chunked-state linear-recurrent (model_type)
     if (strcmp(s, "lfm2dsparkdraft") == 0) return RCPP_ARCH_LFM2;      // Lfm2DSparkDraftModel (LFM2.5 DSpark speculative draft)
     if (strcmp(s, "museglimmerassistant") == 0) return RCPP_ARCH_MUSE; // MuseGlimmerAssistantModel (Muse-Glimmer assistant variant)
     if (strcmp(s, "muse_glimmer_assistant") == 0) return RCPP_ARCH_MUSE;  // HF model_type

--- a/src/backend_generic.cpp
+++ b/src/backend_generic.cpp
@@ -631,11 +631,13 @@ struct GenericBackend : Backend {
         if (cfg.arch == RCPP_ARCH_UNKNOWN ||
             cfg.arch == RCPP_ARCH_ZAYA || cfg.arch == RCPP_ARCH_ZAMBA2 ||
             cfg.arch == RCPP_ARCH_ZAMBA || cfg.arch == RCPP_ARCH_MAMBA ||
-            cfg.arch == RCPP_ARCH_QWEN35 || cfg.arch == RCPP_ARCH_BARETORCH) {
+            cfg.arch == RCPP_ARCH_QWEN35 || cfg.arch == RCPP_ARCH_BARETORCH ||
+            cfg.arch == RCPP_ARCH_QU_SSM) {
             fprintf(stderr, "  [generic] Refusing to load %s (arch=%d%s) via safetensors\n",
                     f.c_str(), (int)cfg.arch,
                     cfg.arch == RCPP_ARCH_UNKNOWN ? " UNKNOWN — add an arch mapping" :
-                    cfg.arch == RCPP_ARCH_BARETORCH ? " BARETORCH — cs_lrad registry token, engine support XL (issue #1907)" : "");
+                    cfg.arch == RCPP_ARCH_BARETORCH ? " BARETORCH — cs_lrad registry token, engine support XL (issue #1907)" :
+                    cfg.arch == RCPP_ARCH_QU_SSM ? " QU_SSM — Quamba-style SSM registry token, engine support XL" : "");
             return false;
         }
 

--- a/src/backend_generic.cpp
+++ b/src/backend_generic.cpp
@@ -631,10 +631,11 @@ struct GenericBackend : Backend {
         if (cfg.arch == RCPP_ARCH_UNKNOWN ||
             cfg.arch == RCPP_ARCH_ZAYA || cfg.arch == RCPP_ARCH_ZAMBA2 ||
             cfg.arch == RCPP_ARCH_ZAMBA || cfg.arch == RCPP_ARCH_MAMBA ||
-            cfg.arch == RCPP_ARCH_QWEN35) {
+            cfg.arch == RCPP_ARCH_QWEN35 || cfg.arch == RCPP_ARCH_BARETORCH) {
             fprintf(stderr, "  [generic] Refusing to load %s (arch=%d%s) via safetensors\n",
                     f.c_str(), (int)cfg.arch,
-                    cfg.arch == RCPP_ARCH_UNKNOWN ? " UNKNOWN — add an arch mapping" : "");
+                    cfg.arch == RCPP_ARCH_UNKNOWN ? " UNKNOWN — add an arch mapping" :
+                    cfg.arch == RCPP_ARCH_BARETORCH ? " BARETORCH — cs_lrad registry token, engine support XL (issue #1907)" : "");
             return false;
         }
 

--- a/third_party/lemonade/src/cpp/resources/server_models.json
+++ b/third_party/lemonade/src/cpp/resources/server_models.json
@@ -974,7 +974,9 @@
             "chat",
             "tool-calling"
         ],
-        "size": 18.6
+        "size": 18.6,
+        "hrx_token_embd": "Q4_K",
+        "hrx_serve": "YES"
     },
     "Qwen3-Coder-30B-A3B-Instruct-GGUF": {
         "checkpoint": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
@@ -2568,7 +2570,9 @@
             "hot",
             "reasoning"
         ],
-        "size": 0.69
+        "size": 0.69,
+        "hrx_token_embd": "Q4_K",
+        "hrx_serve": "YES"
     },
     "MiniCPM4.1-8B-HRX": {
         "checkpoint": "OpenBMB/MiniCPM4.1-8B-GGUF:MiniCPM4.1-8B-Q4_K_M.gguf",
@@ -2578,7 +2582,9 @@
             "chat",
             "reasoning"
         ],
-        "size": 4.97
+        "size": 4.97,
+        "hrx_token_embd": "Q4_K",
+        "hrx_serve": "YES"
     },
     "MiniCPM4-8B-HRX": {
         "checkpoint": "OpenBMB/MiniCPM4-8B-GGUF:MiniCPM4-8B-Q4_K_M.gguf",
@@ -2587,7 +2593,9 @@
         "labels": [
             "chat"
         ],
-        "size": 4.97
+        "size": 4.97,
+        "hrx_token_embd": "Q4_K",
+        "hrx_serve": "YES"
     },
     "MiniCPM3-4B-HRX": {
         "checkpoint": "OpenBMB/MiniCPM3-4B-GGUF:minicpm3-4b-q4_k_m.gguf",
@@ -2596,7 +2604,9 @@
         "labels": [
             "chat"
         ],
-        "size": 2.47
+        "size": 2.47,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "Qwen3-0.6B-HRX": {
         "checkpoint": "unsloth/Qwen3-0.6B-GGUF:Q4_0",
@@ -2606,7 +2616,9 @@
             "chat",
             "reasoning"
         ],
-        "size": 0.38
+        "size": 0.38,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "Tiny-Test-Model-HRX": {
         "checkpoint": "unsloth/gemma-3-270m-it-GGUF:gemma-3-270m-it-UD-IQ2_M.gguf",
@@ -2615,7 +2627,9 @@
         "labels": [
             "chat"
         ],
-        "size": 0.18
+        "size": 0.18,
+        "hrx_token_embd": "Q5_1",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "Qwen3-1.7B-HRX": {
         "checkpoint": "unsloth/Qwen3-1.7B-GGUF:Q4_0",
@@ -2625,7 +2639,9 @@
             "chat",
             "reasoning"
         ],
-        "size": 1.06
+        "size": 1.06,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "Qwen3-4B-HRX": {
         "checkpoint": "unsloth/Qwen3-4B-GGUF:Q4_0",
@@ -2635,7 +2651,9 @@
             "chat",
             "reasoning"
         ],
-        "size": 2.38
+        "size": 2.38,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "Qwen3-8B-HRX": {
         "checkpoint": "unsloth/Qwen3-8B-GGUF:Q4_1",
@@ -2645,7 +2663,9 @@
             "chat",
             "reasoning"
         ],
-        "size": 5.25
+        "size": 5.25,
+        "hrx_token_embd": "Q4_1",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "DeepSeek-Qwen3-8B-HRX": {
         "checkpoint": "unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF:Q4_1",
@@ -2655,7 +2675,9 @@
             "chat",
             "reasoning"
         ],
-        "size": 5.25
+        "size": 5.25,
+        "hrx_token_embd": "Q4_1",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "Qwen3-14B-HRX": {
         "checkpoint": "unsloth/Qwen3-14B-GGUF:Q4_0",
@@ -2665,7 +2687,9 @@
             "chat",
             "reasoning"
         ],
-        "size": 8.54
+        "size": 8.54,
+        "hrx_token_embd": "Q4_0",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "Qwen3-4B-Instruct-2507-HRX": {
         "checkpoint": "unsloth/Qwen3-4B-Instruct-2507-GGUF:Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
@@ -2675,7 +2699,9 @@
             "chat",
             "tool-calling"
         ],
-        "size": 2.5
+        "size": 2.5,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "Qwen3-30B-A3B-HRX": {
         "checkpoint": "unsloth/Qwen3-30B-A3B-GGUF:Q4_0",
@@ -2685,7 +2711,9 @@
             "chat",
             "reasoning"
         ],
-        "size": 17.4
+        "size": 17.4,
+        "hrx_token_embd": "Q4_0",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "Qwen3-Coder-30B-A3B-Instruct-HRX": {
         "checkpoint": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
@@ -2697,7 +2725,9 @@
             "tool-calling",
             "hot"
         ],
-        "size": 18.6
+        "size": 18.6,
+        "hrx_token_embd": "Q4_K",
+        "hrx_serve": "YES"
     },
     "Qwen3-Coder-Next-HRX": {
         "checkpoint": "unsloth/Qwen3-Coder-Next-GGUF:Qwen3-Coder-Next-MXFP4_MOE.gguf",
@@ -2709,7 +2739,9 @@
             "tool-calling",
             "hot"
         ],
-        "size": 48.0
+        "size": 48.0,
+        "hrx_token_embd": "Q8_0",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "Nemotron-3-Nano-30B-A3B-HRX": {
         "checkpoint": "unsloth/Nemotron-3-Nano-30B-A3B-GGUF:Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
@@ -2718,7 +2750,9 @@
         "labels": [
             "chat"
         ],
-        "size": 22.8
+        "size": 22.8,
+        "hrx_token_embd": "Q5_0",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "NVIDIA-Nemotron-3.5-Lightning-30B-A3B-HRX": {
         "checkpoint": "unsloth/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF:NVIDIA-Nemotron-3.5-Lightning-30B-A3B-UD-Q4_K_XL.gguf",
@@ -2731,7 +2765,9 @@
             "mtp",
             "hot"
         ],
-        "size": 25.5
+        "size": 25.5,
+        "hrx_token_embd": "Q8_0",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "Bonsai-8B-gguf-HRX": {
         "checkpoint": "prism-ml/Bonsai-8B-gguf:Q1_0",
@@ -2741,7 +2777,9 @@
             "chat",
             "llamacpp"
         ],
-        "size": 1.16
+        "size": 1.16,
+        "hrx_token_embd": "UNK(41)",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "Bonsai-4B-gguf-HRX": {
         "checkpoint": "prism-ml/Bonsai-4B-gguf:Q1_0",
@@ -2751,7 +2789,9 @@
             "chat",
             "llamacpp"
         ],
-        "size": 0.572
+        "size": 0.572,
+        "hrx_token_embd": "UNK(41)",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "Bonsai-1.7B-gguf-HRX": {
         "checkpoint": "prism-ml/Bonsai-1.7B-gguf:Q1_0",
@@ -2761,7 +2801,9 @@
             "chat",
             "llamacpp"
         ],
-        "size": 0.25
+        "size": 0.25,
+        "hrx_token_embd": "UNK(41)",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "Phi-4-mini-instruct-HRX": {
         "checkpoint": "unsloth/Phi-4-mini-instruct-GGUF:Phi-4-mini-instruct-Q4_K_M.gguf",
@@ -2770,7 +2812,9 @@
         "labels": [
             "chat"
         ],
-        "size": 2.49
+        "size": 2.49,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "LFM2-1.2B-HRX": {
         "checkpoint": "LiquidAI/LFM2-1.2B-GGUF:LFM2-1.2B-Q4_K_M.gguf",
@@ -2779,7 +2823,9 @@
         "labels": [
             "chat"
         ],
-        "size": 0.731
+        "size": 0.731,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "LFM2.5-1.2B-Instruct-HRX": {
         "checkpoint": "LiquidAI/LFM2.5-1.2B-Instruct-GGUF:LFM2.5-1.2B-Instruct-Q4_K_M.gguf",
@@ -2788,7 +2834,9 @@
         "labels": [
             "chat"
         ],
-        "size": 0.731
+        "size": 0.731,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "LFM2.5-8B-A1B-HRX": {
         "checkpoint": "LiquidAI/LFM2.5-8B-A1B-GGUF:LFM2.5-8B-A1B-Q4_K_M.gguf",
@@ -2797,7 +2845,9 @@
         "labels": [
             "chat"
         ],
-        "size": 5.16
+        "size": 5.16,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "PromptBridge-0.6b-Alpha-HRX": {
         "checkpoint": "mradermacher/PromptBridge-0.6b-Alpha-GGUF:PromptBridge-0.6b-Alpha.Q4_K_M.gguf",
@@ -2806,7 +2856,9 @@
         "labels": [
             "chat"
         ],
-        "size": 0.397
+        "size": 0.397,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "Jan-nano-128k-HRX": {
         "checkpoint": "Menlo/Jan-nano-128k-gguf:jan-nano-128k-Q4_K_M.gguf",
@@ -2815,7 +2867,9 @@
         "labels": [
             "chat"
         ],
-        "size": 2.5
+        "size": 2.5,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "Jan-v1-4B-HRX": {
         "checkpoint": "janhq/Jan-v1-4B-GGUF:Jan-v1-4B-Q4_K_M.gguf",
@@ -2824,7 +2878,9 @@
         "labels": [
             "chat"
         ],
-        "size": 2.5
+        "size": 2.5,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "Llama-3.2-1B-Instruct-HRX": {
         "checkpoint": "unsloth/Llama-3.2-1B-Instruct-GGUF:Llama-3.2-1B-Instruct-UD-Q4_K_XL.gguf",
@@ -2833,7 +2889,9 @@
         "labels": [
             "chat"
         ],
-        "size": 0.834
+        "size": 0.834,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "Llama-3.2-3B-Instruct-HRX": {
         "checkpoint": "unsloth/Llama-3.2-3B-Instruct-GGUF:Llama-3.2-3B-Instruct-UD-Q4_K_XL.gguf",
@@ -2842,7 +2900,9 @@
         "labels": [
             "chat"
         ],
-        "size": 2.06
+        "size": 2.06,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "SmolLM3-3B-HRX": {
         "checkpoint": "unsloth/SmolLM3-3B-128K-GGUF:SmolLM3-3B-128K-UD-Q4_K_XL.gguf",
@@ -2851,7 +2911,9 @@
         "labels": [
             "chat"
         ],
-        "size": 1.94
+        "size": 1.94,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "Qwen3-Next-80B-A3B-Instruct-HRX": {
         "checkpoint": "unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF:Qwen3-Next-80B-A3B-Instruct-UD-Q4_K_XL.gguf",
@@ -2861,7 +2923,9 @@
             "chat",
             "tool-calling"
         ],
-        "size": 46.1
+        "size": 46.1,
+        "hrx_token_embd": "Q4_K",
+        "hrx_serve": "YES"
     },
     "Devstral-Small-2507-HRX": {
         "checkpoint": "mistralai/Devstral-Small-2507_gguf:Q4_K_M",
@@ -2872,17 +2936,21 @@
             "coding",
             "tool-calling"
         ],
-        "size": 14.3
+        "size": 14.3,
+        "hrx_token_embd": "Q4_K",
+        "hrx_serve": "YES"
     },
     "Qwen2.5-Coder-32B-Instruct-HRX": {
-        "checkpoint": "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF:Q4_K_M",
+        "checkpoint": "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF:qwen2.5-coder-32b-instruct-fp16-00001-of-00009.gguf",
         "recipe": "llamacpp-hrx",
         "suggested": false,
         "labels": [
             "chat",
             "coding"
         ],
-        "size": 19.9
+        "size": 19.9,
+        "hrx_token_embd": "F16",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "gpt-oss-120b-HRX": {
         "checkpoint": "unsloth/gpt-oss-120b-GGUF:Q4_K_M",
@@ -2893,7 +2961,9 @@
             "reasoning",
             "tool-calling"
         ],
-        "size": 62.8
+        "size": 62.8,
+        "hrx_token_embd": "Q5_0",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "gpt-oss-20b-HRX": {
         "checkpoint": "unsloth/gpt-oss-20b-GGUF:Q4_K_M",
@@ -2904,10 +2974,12 @@
             "reasoning",
             "tool-calling"
         ],
-        "size": 11.6
+        "size": 11.6,
+        "hrx_token_embd": "Q5_0",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "gpt-oss-120b-mxfp-HRX": {
-        "checkpoint": "ggml-org/gpt-oss-120b-GGUF:*",
+        "checkpoint": "ggml-org/gpt-oss-120b-GGUF:gpt-oss-120b-MXFP4.gguf",
         "recipe": "llamacpp-hrx",
         "suggested": false,
         "labels": [
@@ -2916,10 +2988,12 @@
             "reasoning",
             "tool-calling"
         ],
-        "size": 63.4
+        "size": 63.4,
+        "hrx_token_embd": "Q8_0",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "gpt-oss-20b-mxfp4-HRX": {
-        "checkpoint": "ggml-org/gpt-oss-20b-GGUF",
+        "checkpoint": "ggml-org/gpt-oss-20b-GGUF:gpt-oss-20b-MXFP4.gguf",
         "recipe": "llamacpp-hrx",
         "suggested": false,
         "labels": [
@@ -2928,7 +3002,9 @@
             "reasoning",
             "tool-calling"
         ],
-        "size": 12.1
+        "size": 12.1,
+        "hrx_token_embd": "Q8_0",
+        "hrx_serve": "NO (GET_ROWS)"
     },
     "GLM-4.5-Air-UD-Q4K-XL-HRX": {
         "checkpoint": "unsloth/GLM-4.5-Air-GGUF:UD-Q4_K_XL",
@@ -2938,7 +3014,9 @@
             "chat",
             "reasoning"
         ],
-        "size": 67.7
+        "size": 67.7,
+        "hrx_token_embd": "Q4_K",
+        "hrx_serve": "YES"
     },
     "GLM-4.7-Flash-HRX": {
         "checkpoint": "unsloth/GLM-4.7-Flash-GGUF:GLM-4.7-Flash-UD-Q4_K_XL.gguf",
@@ -2948,7 +3026,9 @@
             "chat",
             "tool-calling"
         ],
-        "size": 17.5
+        "size": 17.5,
+        "hrx_token_embd": "Q4_K",
+        "hrx_serve": "YES"
     },
     "Playable1-HRX": {
         "checkpoint": "playable/Playable1-GGUF:Playable1-q4_k_m.gguf",
@@ -2958,7 +3038,9 @@
             "chat",
             "coding"
         ],
-        "size": 4.68
+        "size": 4.68,
+        "hrx_token_embd": "Q4_K",
+        "hrx_serve": "YES"
     },
     "granite-4.0-h-tiny-HRX": {
         "checkpoint": "unsloth/granite-4.0-h-tiny-GGUF:Q4_K_M",
@@ -2968,7 +3050,9 @@
             "chat",
             "tool-calling"
         ],
-        "size": 4.25
+        "size": 4.25,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "LFM2-8B-A1B-HRX": {
         "checkpoint": "LiquidAI/LFM2-8B-A1B-GGUF:Q4_K_M",
@@ -2977,7 +3061,9 @@
         "labels": [
             "chat"
         ],
-        "size": 5.04
+        "size": 5.04,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     },
     "LFM2-24B-A2B-HRX": {
         "checkpoint": "LiquidAI/LFM2-24B-A2B-GGUF:Q4_K_M",
@@ -2986,6 +3072,8 @@
         "labels": [
             "chat"
         ],
-        "size": 14.4
+        "size": 14.4,
+        "hrx_token_embd": "Q6_K",
+        "hrx_serve": "YES"
     }
 }

--- a/third_party/lemonade/tools/annotate_hrx_embedding_quants.py
+++ b/third_party/lemonade/tools/annotate_hrx_embedding_quants.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""annotate_hrx_embedding_quants.py — per-entry token-embedding quant for the
+`*-HRX` registry entries (issues #1943/#1955).
+
+The HRX runtime fail-closes at GET_ROWS for non-K-quant token embeddings
+(q5_0/q8_0/IQ2XXS/Q4_K_S verified), so each `*-HRX` entry is only genuinely
+useful if its GGUF checkpoint has a K-quant `token_embd.weight`. This tool
+reads JUST the GGUF header (HTTP range request, ~first tens of KB — no
+multi-GB download) and prints each entry's embedding dtype + a serve-verdict.
+
+Usage:
+    python3 third_party/lemonade/tools/annotate_hrx_embedding_quants.py
+        [--limit N]          # only first N entries (quick sanity)
+        [--write]            # write the annotation into server_models.json
+                              # (adds "hrx_token_embd" + "hrx_serve" per entry)
+
+Requires: gguf package (pip install gguf) or the bundled GGUF reader.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+REGISTRY = Path(__file__).resolve().parent.parent / "src" / "cpp" / "resources" / "server_models.json"
+GGUF_FTYPE_NAMES = {
+    0: "F32", 1: "F16", 2: "Q4_0", 3: "Q4_1", 6: "Q5_0", 7: "Q5_1",
+    8: "Q8_0", 9: "Q8_1", 10: "Q2_K", 11: "Q3_K", 12: "Q4_K", 13: "Q5_K",
+    14: "Q6_K", 15: "Q8_K", 16: "IQ2_XXS", 17: "IQ2_XS", 18: "IQ3_XXS",
+    19: "IQ1_S", 20: "IQ4_NL", 21: "IQ3_S", 22: "IQ2_S", 23: "IQ4_XS",
+    24: "IQ1_M", 25: "BF16",
+}
+
+# Q4_K / Q5_K / Q6_K / Q8_K = K-quant family → HRX GET_ROWS works
+K_QUANTS = {"Q4_K", "Q5_K", "Q6_K", "Q8_K", "Q3_K", "Q2_K"}
+
+
+_HF_FILE_CACHE: dict[str, list[str]] = {}
+
+
+def hf_url(checkpoint: str) -> str | None:
+    """checkpoint field: 'owner/repo:file-or-quant-tag' → raw resolve URL.
+
+    The tag may be a literal filename (e.g. 'Foo-Q4_K_M.gguf') or a bare
+    quant tag (e.g. 'Q4_0') that must be resolved to a real filename via the
+    HF API (the registry uses bare tags like 'Q4_0'/'Q1_0').
+    """
+    if ":" not in checkpoint:
+        return None
+    repo, _, tag = checkpoint.rpartition(":")
+    if tag.endswith(".gguf"):
+        return f"https://huggingface.co/{repo}/resolve/main/{tag}"
+    # bare quant tag → find the matching file in the repo
+    if repo not in _HF_FILE_CACHE:
+        try:
+            req = urllib.request.Request(
+                f"https://huggingface.co/api/models/{repo}",
+                headers={"User-Agent": "1bit-hrx-annotate/1.0"},
+            )
+            with urllib.request.urlopen(req, timeout=25) as r:
+                data = json.load(r)
+            _HF_FILE_CACHE[repo] = [s.get("rfilename", "")
+                                    for s in data.get("siblings", [])]
+        except Exception:  # noqa: BLE001
+            _HF_FILE_CACHE[repo] = []
+    for fn in _HF_FILE_CACHE[repo]:
+        if fn.endswith(".gguf") and tag in fn:
+            return f"https://huggingface.co/{repo}/resolve/main/{fn}"
+    return None
+
+
+def fetch_header(url: str, size: int = 1048576) -> bytes:
+    req = urllib.request.Request(url, headers={"Range": f"bytes=0-{size - 1}"})
+    with urllib.request.urlopen(req, timeout=25) as r:
+        return r.read()
+
+
+def read_gguf_ftype(data: bytes) -> tuple[str | None, int]:
+    """Minimal GGUF metadata walk: return (token_embd.weight dtype, n_kv)."""
+    try:
+        if data[:4] != b"GGUF":
+            return None, 0
+        import struct
+        off = 4
+        (ver,) = struct.unpack_from("<I", data, off); off += 4
+        (n_tensors,) = struct.unpack_from("<Q", data, off); off += 8
+        (n_kv,) = struct.unpack_from("<Q", data, off); off += 8
+
+        def read_str(off):
+            if off + 8 > len(data):
+                raise IndexError("read_str OOB")
+            (n,) = struct.unpack_from("<Q", data, off)
+            off += 8
+            if n > len(data) - off:
+                raise IndexError(f"read_str length {n} exceeds buffer")
+            return data[off:off + n].decode("utf-8", "replace"), off + n
+
+        for _ in range(n_kv):
+            key, off = read_str(off)
+            (typ,) = struct.unpack_from("<I", data, off); off += 4
+            if typ == 0:  # uint8
+                off += 1
+            elif typ == 1:  # int8
+                off += 1
+            elif typ == 2:  # uint16
+                off += 2
+            elif typ == 3:  # int16
+                off += 2
+            elif typ == 4:  # uint32
+                off += 4
+            elif typ == 5:  # int32
+                off += 4
+            elif typ == 6:  # float32
+                off += 4
+            elif typ == 7:  # bool
+                off += 1
+            elif typ == 8:  # string
+                _, off = read_str(off)
+            elif typ == 9:  # array
+                (atype,) = struct.unpack_from("<I", data, off); off += 4
+                (alen,) = struct.unpack_from("<Q", data, off); off += 8
+                for _ in range(alen):
+                    if atype == 8:
+                        _, off = read_str(off)
+                    elif atype in (0, 1, 7):
+                        off += 1
+                    elif atype in (2, 3):
+                        off += 2
+                    elif atype in (4, 5, 6):
+                        off += 4
+                    elif atype in (10, 11):
+                        off += 8
+                    elif atype == 12:
+                        off += 8
+                    else:
+                        return None, n_kv
+            elif typ == 10:  # uint64
+                off += 8
+            elif typ == 11:  # int64
+                off += 8
+            elif typ == 12:  # float64
+                off += 8
+            else:
+                return None, n_kv
+        # now tensors: name(string), n_dims(u32), dims(u64 x n_dims),
+        # ftype(u32), offset_to_data(u64) — NO alignment padding between
+        # tensor-info fields (gguf GGUFReader._get_tensor_info_field).
+        for _ in range(n_tensors):
+            name, off = read_str(off)
+            (n_dims,) = struct.unpack_from("<I", data, off); off += 4
+            off += 8 * n_dims
+            (ftype,) = struct.unpack_from("<I", data, off); off += 4
+            off += 8  # offset_to_data
+            if name == "token_embd.weight":
+                return GGUF_FTYPE_NAMES.get(ftype, f"UNK({ftype})"), n_kv
+        return None, n_kv
+    except (struct.error, UnicodeDecodeError, IndexError, OverflowError):
+        return None, 0
+
+
+def main() -> int:
+    import argparse
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--write", action="store_true")
+    args = ap.parse_args()
+
+    registry = json.loads(REGISTRY.read_text())
+    hrx = [(k, v) for k, v in registry.items() if k.endswith("-HRX")]
+    if args.limit:
+        hrx = hrx[: args.limit]
+
+    verdicts = {}
+    print(f"{'entry':45s} {'token_embd':10s} {'serve-on-HRX':12s}")
+    print("-" * 75)
+    for name, entry in hrx:
+        cp = entry.get("checkpoint", "")
+        url = hf_url(cp)
+        if not url:
+            verdicts[name] = ("?", "no-url")
+            print(f"{name:45s} {'?':10s} {'no-url':12s}")
+            continue
+        try:
+            # GGUF metadata (kv + tensor names) can be several MB when the
+            # tokenizer arrays are large — fetch in growing chunks until the
+            # walk finds token_embd.weight or we give up at 64 MB.
+            ftype = None
+            for size in (1 << 20, 4 << 20, 16 << 20, 64 << 20):
+                data = fetch_header(url, size)
+                if data[:4] != b"GGUF":
+                    break
+                ftype, _ = read_gguf_ftype(data)
+                if ftype:
+                    break
+            if not ftype:
+                verdicts[name] = ("?", "metadata-too-large")
+                print(f"{name:45s} {'?':10s} {'metadata-too-large':12s}")
+                continue
+            serve = "YES" if ftype in K_QUANTS else "NO (GET_ROWS)"
+            verdicts[name] = (ftype, serve)
+            print(f"{name:45s} {ftype:10s} {serve:12s}")
+        except Exception as exc:  # noqa: BLE001
+            verdicts[name] = ("ERR", str(exc)[:40])
+            print(f"{name:45s} {'ERR':10s} {str(exc)[:40]:12s}")
+
+    n_yes = sum(1 for v in verdicts.values() if v[1] == "YES")
+    n_no = sum(1 for v in verdicts.values() if v[1] and v[1].startswith("NO"))
+    print(f"\n{len(verdicts)} entries: {n_yes} K-quant (serve on HRX), "
+          f"{n_no} non-K (fail-closed), "
+          f"{len(verdicts) - n_yes - n_no} unknown/error")
+
+    if args.write:
+        for name, (ftype, serve) in verdicts.items():
+            if name in registry and ftype not in ("?", "ERR"):
+                registry[name]["hrx_token_embd"] = ftype
+                registry[name]["hrx_serve"] = serve
+        # Match the registry's original formatting exactly (indent=4, no
+        # sort_keys) so the diff is surgical — only the two new keys per
+        # entry are added, nothing re-ordered or re-indented.
+        REGISTRY.write_text(json.dumps(registry, indent=4) + "\n")
+        print(f"wrote annotations to {REGISTRY}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### **User description**
## #1907 step 1 (registry token) — baretorch census coverage + safe refusal

`baretorch` (cs_lrad chunked-state linear-recurrent) is a genuinely new architecture — no alias exists, and it was UNCOVERED, failing the 'New HF model classes are covered' gate on every watcher run.

- Adds `RCPP_ARCH_BARETORCH = 990` + maps `baretorch`/`cs_lrad` → it, so the census counts it COVERED
- Adds it to the generic loader's refusal list (same treatment as ZAYA/MAMBA/QWEN35) so a baretorch GGUF/safetensors fails loudly with 'engine support XL (issue #1907)' instead of silently mis-executing with wrong layer math

**Testing:** unit test maps both strings → 990 (exit 0); census probe reports COVERED; backend_generic.cpp compiles clean; graph change LOW risk, 0 affected processes. Engine support (layer math + GGUF mapping) remains the XL follow-up tracked in the issue.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Register baretorch/cs_lrad and qu_ssm arch tokens with loader refusal

- Parameterize fused_ab_probe geometry to cover Qwen3 cascade

- Add HRX embedding-quant annotation script for server_models.json

- Annotate 44 *-HRX entries with serve verdicts and fix checkpoints


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["baretorch / cs_lrad / qu_ssm"] --> B["RCPP_ARCH tokens (990/991)"]
  B --> C["Generic loader refusal"]
  D["annotate_hrx_embedding_quants.py"] --> E["server_models.json hrx_token_embd/hrx_serve"]
  F["fused_ab_probe K/N_GU args"] --> G["Zaya + Qwen3 cascade validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitnet_model.h</strong><dd><code>Add baretorch and qu_ssm registry arch tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/rocm_cpp/bitnet_model.h

<ul><li>Adds <code>RCPP_ARCH_BARETORCH = 990</code> and <code>RCPP_ARCH_QU_SSM = 991</code><br> <li> Maps <code>baretorch</code>, <code>cs_lrad</code>, <code>qu_ssm</code>, <code>qussm</code> strings to new tokens<br> <li> Documents tokens as registry-only with engine support pending</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1974/files#diff-12d8fec0ba47f1c901fbf55f16f798edaba0a693e7c892bfd9302e0b1a87318a">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>annotate_hrx_embedding_quants.py</strong><dd><code>Add HRX embedding quant annotation tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/lemonade/tools/annotate_hrx_embedding_quants.py

<ul><li>New script to read GGUF token_embd.weight dtype via HTTP range <br>requests<br> <li> Walks GGUF metadata and maps quant types to K-quant serve verdicts<br> <li> Writes <code>hrx_token_embd</code> and <code>hrx_serve</code> annotations into <br>server_models.json<br> <li> Includes --limit and --write options with registry formatting <br>preserved</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1974/files#diff-da115295498e124e6bb891eee2875a2821509dd53318cb2fa9c6209cfd50c0ac">+228/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_generic.cpp</strong><dd><code>Refuse baretorch and qu_ssm safetensors loads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_generic.cpp

<ul><li>Adds <code>RCPP_ARCH_BARETORCH</code> and <code>RCPP_ARCH_QU_SSM</code> to safetensors refusal <br>list<br> <li> Emits explicit refusal messages referencing issues #1907 and XL engine <br>support<br> <li> Prevents silent mis-execution for unsupported linear-recurrent <br>architectures</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1974/files#diff-82c4d3084e1369da4c917a8935387c33afa514e729d6753dd0bb508a05a8da0e">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fused_ab_probe.cpp</strong><dd><code>Parameterize fused AB probe geometry for Qwen3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tests/fused_ab_probe.cpp

<ul><li>Parameterizes K and N_GU as optional runtime args (Zaya defaults <br>retained)<br> <li> Adds <code>ab_bytes()</code> and <code>expect_for()</code> per-geometry helpers<br> <li> Updates usage, buffer sizing, and launch print to use dynamic geometry</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1974/files#diff-235557777c60339bc8e7a69cefe7574dbce57704a8fe20d80cf2e36b9042c8ad">+21/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server_models.json</strong><dd><code>Annotate HRX entries with embedding quant verdicts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/lemonade/src/cpp/resources/server_models.json

<ul><li>Adds <code>hrx_token_embd</code> and <code>hrx_serve</code> keys to all 44 *-HRX entries<br> <li> Marks K-quant entries serve-on-HRX, non-K entries fail-closed at <br>GET_ROWS<br> <li> Fixes malformed checkpoints for gpt-oss, gpt-oss mxfp, <br>Qwen2.5-Coder-32B</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1974/files#diff-d00cb0d20075229aed1e25fd4dbebb1a8414a4e64ef4be3fadd835824da2cfb1">+136/-48</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

