### PR TITLE
lemonade: stream stall bound falls back to global_timeout when unset

### DIFF
--- a/third_party/lemonade/docs/guide/configuration/README.md
+++ b/third_party/lemonade/docs/guide/configuration/README.md
@@ -130,7 +130,6 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
     "vulkan_bin": "builtin",
     "width": 512
   },
-  "stream_stall_timeout": 120,
   "telemetry": {
     "enabled": false,
     "hide_inputs": false,
@@ -205,7 +204,7 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
 | `log_max_file_size_mb` | int | 10 | Max active log file size in MB before triggering rotation (steady-state footprint bounded to ~`log_max_file_size_mb * (log_max_files + 1)`) |
 | `log_max_files` | int | 5 | Max number of rotated log backup files to retain (.1 through .N); legacy oversized files are rotated into .1 and pruned over cycles |
 | `global_timeout` | int | 600 | Timeout in seconds for HTTP, inference, and readiness checks |
-| `stream_stall_timeout` | int | 120 | How long a streaming response may deliver no bytes before the backend forward is aborted (0 disables the bound). Raised above the default for backends with long first-token or inter-token gaps |
+| `stream_stall_timeout` | int | follows `global_timeout` | How long a streaming response may deliver no bytes before the backend forward is aborted (0 disables the bound). When unset, the bound respects `global_timeout`; set explicitly to override. Raise for backends with long first-token or inter-token gaps |
 | `max_loaded_models` | int | 1 | Max models per type slot. Use -1 for unlimited |
 | `broadcast` | bool | true | Enable or disable UDP broadcasting for server discovery |
 | `extra_models_dir` | string | "" | Secondary directory recursively scanned for GGUF model files. Empty disables extra discovery; existing paths must be readable by `lemond` |

--- a/third_party/lemonade/src/cpp/include/lemon/utils/http_client.h
+++ b/third_party/lemonade/src/cpp/include/lemon/utils/http_client.h
@@ -122,8 +122,9 @@ public:
 
     // Stream stall bound (seconds) for post_stream requests that carry no
     // total timeout: how long a stream may deliver nothing before it is
-    // treated as dead. 0 disables the bound. Defaults to the historical
-    // hardcoded 120s; configurable via "stream_stall_timeout" in config.json.
+    // treated as dead. 0 disables the bound. The server sets this at startup
+    // from config: an explicit "stream_stall_timeout" wins, otherwise it
+    // follows "global_timeout".
     static void set_stream_stall_timeout(long seconds) {
         stream_stall_timeout_seconds_.store(seconds);
     }

--- a/third_party/lemonade/src/cpp/resources/defaults.json
+++ b/third_party/lemonade/src/cpp/resources/defaults.json
@@ -92,7 +92,6 @@
     "vulkan_bin": "builtin",
     "width": 512
   },
-  "stream_stall_timeout": 120,
   "telemetry": {
     "enabled": false,
     "hide_inputs": false,

--- a/third_party/lemonade/src/cpp/server/runtime_config.cpp
+++ b/third_party/lemonade/src/cpp/server/runtime_config.cpp
@@ -416,7 +416,9 @@ long RuntimeConfig::stream_stall_timeout() const {
         config_["stream_stall_timeout"].is_number_integer()) {
         return config_["stream_stall_timeout"].get<long>();
     }
-    return 120;
+    // No explicit stream_stall_timeout: the streaming stall bound respects
+    // the global timeout (upstream review feedback on the new-key proposal).
+    return config_["global_timeout"].get<long>();
 }
 
 int RuntimeConfig::max_loaded_models() const {

--- a/third_party/lemonade/src/cpp/server/utils/http_client.cpp
+++ b/third_party/lemonade/src/cpp/server/utils/http_client.cpp
@@ -32,8 +32,9 @@ std::atomic<int64_t> HttpClient::download_rate_limit_bytes_per_second_{0};
 
 // Stream stall bound (seconds): how long a stream may deliver nothing before
 // it is treated as dead. Well above any inter-token gap, well below "never".
-// Overridable via "stream_stall_timeout" in config.json (0 disables); this is
-// the historical hardcoded default.
+// The server sets this from config at startup: explicit stream_stall_timeout
+// wins, otherwise it follows global_timeout. This atomic only holds the
+// pre-config default for direct library users.
 std::atomic<long> HttpClient::stream_stall_timeout_seconds_{120};
 
 // Serializes transfers so concurrent downloads cannot exceed the cap in aggregate.


### PR DESCRIPTION
### **User description**
Aligns the vendored lemonade streaming stall timeout with upstream review feedback (lemonade-sdk PR #3425): a new config key may be unnecessary — the stall bound should respect the existing global timeout.

- stream_stall_timeout remains as an explicit override (0 disables)
- when the key is absent, the bound now follows global_timeout
- key removed from defaults so the fallback engages out of the box

Verified e2e: override wins (3s bound + global_timeout=600 aborts at ~9s), fallback engages (no key + global_timeout=3 aborts at ~9s), 0 disables.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Fallback to `global_timeout` when `stream_stall_timeout` unset

- Keep explicit `stream_stall_timeout` override; `0` disables

- Remove `stream_stall_timeout` from defaults and docs

- Document fallback to `global_timeout` in configuration guide


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["stream_stall_timeout configured?"] -->|"yes"| B["explicit override wins (0 disables)"]
  A -->|"no"| C["bound follows global_timeout"]
  D["global_timeout default 600"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtime_config.cpp</strong><dd><code>Fall back to global_timeout for stall bound</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/lemonade/src/cpp/server/runtime_config.cpp

<ul><li>Returns <code>global_timeout</code> when no explicit <code>stream_stall_timeout</code> exists<br> <li> Replaces the previous hardcoded <code>120</code> fallback<br> <li> Explicit integer key still takes precedence</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1977/files#diff-c917c9dea2188d8aa1dac83c2e70ff0bde93509f37f729fdfb3d82542de755a5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_client.cpp</strong><dd><code>Clarify stream stall timeout default comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/lemonade/src/cpp/server/utils/http_client.cpp

<ul><li>Updates the comment on <code>stream_stall_timeout_seconds_</code><br> <li> Clarifies the atomic now holds only the pre-config default for library <br>users</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1977/files#diff-845cb7d73086d2a535d85bb7a6ad23ee29600f17b2c404a429ff2c5554c4d784">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>http_client.h</strong><dd><code>Document stream stall timeout precedence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/lemonade/src/cpp/include/lemon/utils/http_client.h

<ul><li>Clarifies the setter docs for <code>stream_stall_timeout</code><br> <li> States that explicit config wins, otherwise it follows <code>global_timeout</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1977/files#diff-a34d6b44add07a97f75093d7f2b4fc16e9b52f2c6cc8563fc7f485d837a3d8a6">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document stall timeout fallback to global_timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/lemonade/docs/guide/configuration/README.md

<ul><li>Removes <code>stream_stall_timeout</code> from the example config<br> <li> Updates the table default to “follows <code>global_timeout</code>”<br> <li> Documents explicit override behavior where <code>0</code> disables the bound</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1977/files#diff-9393140392693f4795eb8339c9d8fe0b328dc182ba2d09007a9e437e209b6b0e">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>defaults.json</strong><dd><code>Drop stream_stall_timeout from defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/lemonade/src/cpp/resources/defaults.json

<ul><li>Removes the hardcoded <code>stream_stall_timeout: 120</code> default<br> <li> Allows the <code>global_timeout</code> fallback to engage out of the box</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1977/files#diff-4e470842630e5f931f74536fc2840c42ba3d43ccad0b45e0f3dfb28b0eb14368">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

