### PR TITLE
feat(npu): #1934 — host-side per-group scale grid + CPU gate (enabling step for int4 restructure)

### DIFF
--- a/engine/npu/src/gu_i4_pack.h
+++ b/engine/npu/src/gu_i4_pack.h
@@ -42,6 +42,14 @@ struct GuI4Pack {
     std::vector<float>    scol;         // [N] float (host math / amax pass)
     std::vector<int8_t>   B_shadow;     // [K*N] row-major B'' (kernel-exact, for the
                                         // host amax pass + emulation)
+    // Issue #1934 (per-group-scale restructure): the full per-(row, 32-col-
+    // group) bf16 scale grid, indexed scl_g[r][i/32] for B element (row r,
+    // K index i). The current production path collapses these into the
+    // per-column ratioQ22 (K-uniform), capping FFN corr at ~0.972; the
+    // restructured kernel consumes this grid through C1. Populated by
+    // pack_gu_fused_i4_group_scales() — NOT wired into the production tile
+    // stream until the kernel restructure lands (per issue #1934).
+    std::vector<uint16_t> scl_g_bf16;   // [H * RC] bf16 bits (RC = raw.cols/32)
     static constexpr size_t TILE_BYTES = 64 * 128 / 2;   // nibbles (4096)
     // v65 tile layout (all within the aie2p-delivered [0..5632) region):
     //   [0,      4096)  nibbles (region A, 4096 B = 64x128 q4)
@@ -290,4 +298,33 @@ static inline GuI4Pack pack_gu_fused_i4(const RawQ4Tensor& raw, int expert,
                     }
         }
     return p;
+}
+
+// Issue #1934 (per-group-scale restructure) — host-side enabling artifact.
+// Emits the FULL per-(row, 32-col-group) bf16 scale grid the restructured
+// kernel needs to carry through C1, in the SAME interleaved gate/up row
+// layout as w_at() in pack_gu_fused_i4(). The current production kernel
+// collapses these into a per-column ratioQ22 (K-uniform) which caps FFN
+// corr at ~0.972; this grid is the finer scale data that fixes it.
+//
+// NOT wired into the production tile stream — populated standalone and
+// consumed by the CPU gate test (test_i4_group_scales.cpp) so the kernel
+// restructure has a verified host-side contract to build against.
+static inline void pack_gu_fused_i4_group_scales(const RawQ4Tensor& raw,
+                                                 int expert, int H, int n_ff,
+                                                 GuI4Pack& p) {
+    const size_t N = 2 * (size_t)n_ff;
+    const size_t gbase = (size_t)expert * N;
+    const int RC = raw.cols / 32;            // raw tensor scale stride (H/32)
+    p.scl_g_bf16.assign((size_t)N * RC, 0);  // [2*n_ff, RC] gate+up rows
+    for (size_t pp = 0; pp < (size_t)n_ff; pp++) {
+        // gate row = gbase + pp, up row = gbase + n_ff + pp (w_at layout)
+        for (int gate_up = 0; gate_up < 2; gate_up++) {
+            size_t r = gbase + (size_t)pp + (gate_up ? (size_t)n_ff : 0);
+            for (int i = 0; i < H; i++) {
+                uint16_t s16 = f32_to_bf16_impl(raw.scl[r * RC + i / 32]);
+                p.scl_g_bf16[(r - gbase) * RC + i / 32] = s16;
+            }
+        }
+    }
 }

--- a/engine/npu/tests/test_i4_group_scales.cpp
+++ b/engine/npu/tests/test_i4_group_scales.cpp
@@ -1,0 +1,130 @@
+// test_i4_group_scales.cpp — CPU gate for the #1934 per-group-scale pack.
+//
+// Verifies pack_gu_fused_i4_group_scales() emits the EXACT per-(row,
+// 32-col-group) bf16 scales from a real Q4NX GU tensor — the host-side
+// contract the restructured int4 kernel (C1 carrying per-group scales) will
+// consume. The current production path collapses these into a per-column
+// ratioQ22 (K-uniform, corr cap ~0.972); this grid is the finer data.
+//
+// Usage: /tmp/test_i4_group_scales zaya1-8b.q4nx [layer] [expert]
+//   (layer defaults to 1 = first MoE layer; expert defaults to 0)
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include "q4nx_raw.h"
+#include "gu_i4_pack.h"
+
+static int rc = 0;
+#define CHECK(cond, ...) do { if (!(cond)) { fprintf(stderr, "FAIL: "); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); rc = 1; } else { fprintf(stderr, "ok:   "); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); } } while (0)
+
+static int get_top_int(const char* js, size_t jl, const char* key) {
+    std::string k = std::string("\"") + key + "\":";
+    auto p = strstr(js, k.c_str());
+    if (!p || p - js + k.size() >= (long)jl) return 0;
+    return atoi(p + k.size());
+}
+static bool get_offsets(const char* js, size_t jl, const char* key,
+                        uint64_t* off, uint64_t* size) {
+    std::string k = std::string("\"") + key + "\":";
+    auto q = strstr(js, k.c_str());
+    if (!q) return false;
+    auto b = strchr(q + k.size(), '[');
+    if (!b) return false;
+    auto c = strchr(b, ',');
+    *off  = (uint64_t)strtoull(b + 1, nullptr, 10);
+    if (c) *size = (uint64_t)strtoull(c + 1, nullptr, 10) - *off;
+    return true;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) { fprintf(stderr, "usage: %s <model.q4nx> [layer] [expert]\n", argv[0]); return 2; }
+    const int L = argc > 2 ? atoi(argv[2]) : 1;
+    const int E = argc > 3 ? atoi(argv[3]) : 0;
+    const int H = 2048, n_ff = 2048;   // zaya1-8b
+
+    int fd = open(argv[1], O_RDONLY);
+    if (fd < 0) { perror("open"); return 2; }
+    struct stat st; fstat(fd, &st);
+    uint8_t* md = (uint8_t*)mmap(nullptr, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    close(fd);
+    if (md == MAP_FAILED) { perror("mmap"); return 2; }
+    uint64_t hsz; memcpy(&hsz, md, 8);
+    const char* js = (const char*)(md + 8);
+
+    char key[256];
+    snprintf(key, sizeof key, "model.layers.%d.mlp.experts.gate_up_proj.weight", L);
+    uint64_t off, size;
+    if (!get_offsets(js, hsz, key, &off, &size)) { fprintf(stderr, "no GU tensor at layer %d\n", L); return 2; }
+    int NC = get_top_int(js, hsz, "num_hidden_layers");
+    int n_exp = get_top_int(js, hsz, "num_experts");
+    int gu_i8_rows = (n_exp * 2 * n_ff / 32) * (H / 256);
+    auto raw_all = read_q4nx_raw(md, off, gu_i8_rows, H);
+    munmap(md, st.st_size);
+
+    // slice to expert E (rows [E*2n_ff, (E+1)*2n_ff): gate [0,n_ff), up [n_ff,2n_ff))
+    RawQ4Tensor raw_gu;
+    raw_gu.rows = 2 * n_ff; raw_gu.cols = H;
+    raw_gu.q4.assign((size_t)raw_gu.rows * H, 0);
+    raw_gu.scl.assign((size_t)raw_gu.rows * (H / 32), 0.0f);
+    raw_gu.zp.assign((size_t)raw_gu.rows * (H / 32), 0.0f);
+    const size_t gbase = (size_t)E * 2 * n_ff;
+    for (int r = 0; r < 2 * n_ff; r++) {
+        memcpy(&raw_gu.q4[(size_t)r * H], &raw_all.q4[(gbase + r) * H], sizeof(int8_t) * H);
+        memcpy(&raw_gu.scl[(size_t)r * (H / 32)], &raw_all.scl[(gbase + r) * (H / 32)],
+               sizeof(float) * (H / 32));
+    }
+    fprintf(stderr, "GU tensor: expert %d, rows=%d cols=%d (NC=%d n_exp=%d)\n",
+            E, raw_gu.rows, raw_gu.cols, NC, n_exp);
+
+    GuI4Pack p;
+    pack_gu_fused_i4_group_scales(raw_gu, 0, H, n_ff, p);
+
+    const int RC = H / 32;
+    CHECK((int)p.scl_g_bf16.size() == 2 * n_ff * RC,
+          "grid size %zu == 2*n_ff*RC %d", p.scl_g_bf16.size(), 2 * n_ff * RC);
+
+    // The emitted bf16 must equal the raw tensor's scale bits exactly.
+    // Note: the grid is indexed by the SLICED expert's local row (r-gbase),
+    // matching the gate/up interleaved layout the kernel will consume.
+    size_t bad = 0, checked = 0;
+    for (size_t r = 0; r < 2 * (size_t)n_ff; r++) {
+        for (int g = 0; g < RC; g++) {
+            uint16_t want = f32_to_bf16_impl(raw_gu.scl[r * RC + g]);
+            uint16_t got  = p.scl_g_bf16[r * RC + g];
+            checked++;
+            if (got != want) { if (bad < 5) fprintf(stderr, "  row %zu grp %d: got %04x want %04x\n", r, g, got, want); bad++; }
+        }
+    }
+    CHECK(bad == 0, "per-group scale grid byte-exact vs raw Q4NX (%zu checked, %zu bad)", checked, bad);
+
+    // Cross-check: reconstruct a sampled weight from the grid's bf16 scale
+    // bits and confirm it matches the raw float-scale reconstruction exactly.
+    // (Some zaya Q4NX rows carry NaN scales — padding/unused experts; those
+    // are identical in both reconstructions, so NaN==NaN counts as equal.)
+    size_t wbad = 0, wchecked = 0, wnan = 0;
+    for (size_t r = 0; r < 2 * (size_t)n_ff; r += 11) {
+        for (int i = 0; i < H; i += 17) {
+            uint32_t sbits = (uint32_t)p.scl_g_bf16[r * RC + i / 32] << 16;
+            float srow; memcpy(&srow, &sbits, 4);
+            float w_grid = (float)raw_gu.q4[r * H + i] * srow + raw_gu.zp[r * RC + i / 32];
+            uint16_t want_bits = f32_to_bf16_impl(raw_gu.scl[r * RC + i / 32]);
+            uint32_t wbits = (uint32_t)want_bits << 16;
+            float sraw; memcpy(&sraw, &wbits, 4);
+            float w_raw = (float)raw_gu.q4[r * H + i] * sraw + raw_gu.zp[r * RC + i / 32];
+            bool gnan = (w_grid != w_grid), rnan = (w_raw != w_raw);
+            if (gnan && rnan) { wnan++; continue; }          // matching NaN padding
+            if (w_grid != w_raw) { if (wbad < 3) fprintf(stderr, "  row %zu i %d: grid %.8g raw %.8g\n", r, i, w_grid, w_raw); wbad++; }
+            wchecked++;
+        }
+    }
+    CHECK(wbad == 0, "grid-derived weights == raw bf16-derived weights (%zu finite + %zu NaN-pad matched)", wchecked, wnan);
+
+    fprintf(stderr, "\n%s\n", rc ? "=== I4 GROUP-SCALES GATE FAILED ===" : "=== I4 GROUP-SCALES GATE PASSED (per-group scale grid byte-exact) ===");
+    return rc;
+}

--- a/third_party/lemonade/src/cpp/resources/server_models.json
+++ b/third_party/lemonade/src/cpp/resources/server_models.json
@@ -976,7 +976,8 @@
         ],
         "size": 18.6,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "YES"
+        "hrx_serve": "YES",
+        "hrx_embd_w": 2048
     },
     "Qwen3-Coder-30B-A3B-Instruct-GGUF": {
         "checkpoint": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
@@ -2572,7 +2573,8 @@
         ],
         "size": 0.69,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "YES"
+        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_embd_w": 1536
     },
     "MiniCPM4.1-8B-HRX": {
         "checkpoint": "OpenBMB/MiniCPM4.1-8B-GGUF:MiniCPM4.1-8B-Q4_K_M.gguf",
@@ -2584,7 +2586,8 @@
         ],
         "size": 4.97,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "YES"
+        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_embd_w": 4096
     },
     "MiniCPM4-8B-HRX": {
         "checkpoint": "OpenBMB/MiniCPM4-8B-GGUF:MiniCPM4-8B-Q4_K_M.gguf",
@@ -2595,7 +2598,8 @@
         ],
         "size": 4.97,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "YES"
+        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_embd_w": 4096
     },
     "MiniCPM3-4B-HRX": {
         "checkpoint": "OpenBMB/MiniCPM3-4B-GGUF:minicpm3-4b-q4_k_m.gguf",
@@ -2606,7 +2610,8 @@
         ],
         "size": 2.47,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2560
     },
     "Qwen3-0.6B-HRX": {
         "checkpoint": "unsloth/Qwen3-0.6B-GGUF:Q4_0",
@@ -2618,7 +2623,8 @@
         ],
         "size": 0.38,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 1024
     },
     "Tiny-Test-Model-HRX": {
         "checkpoint": "unsloth/gemma-3-270m-it-GGUF:gemma-3-270m-it-UD-IQ2_M.gguf",
@@ -2629,7 +2635,8 @@
         ],
         "size": 0.18,
         "hrx_token_embd": "Q5_1",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 640
     },
     "Qwen3-1.7B-HRX": {
         "checkpoint": "unsloth/Qwen3-1.7B-GGUF:Q4_0",
@@ -2641,7 +2648,8 @@
         ],
         "size": 1.06,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2048
     },
     "Qwen3-4B-HRX": {
         "checkpoint": "unsloth/Qwen3-4B-GGUF:Q4_0",
@@ -2653,7 +2661,8 @@
         ],
         "size": 2.38,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2560
     },
     "Qwen3-8B-HRX": {
         "checkpoint": "unsloth/Qwen3-8B-GGUF:Q4_1",
@@ -2665,7 +2674,8 @@
         ],
         "size": 5.25,
         "hrx_token_embd": "Q4_1",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 4096
     },
     "DeepSeek-Qwen3-8B-HRX": {
         "checkpoint": "unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF:Q4_1",
@@ -2677,7 +2687,8 @@
         ],
         "size": 5.25,
         "hrx_token_embd": "Q4_1",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 4096
     },
     "Qwen3-14B-HRX": {
         "checkpoint": "unsloth/Qwen3-14B-GGUF:Q4_0",
@@ -2689,7 +2700,8 @@
         ],
         "size": 8.54,
         "hrx_token_embd": "Q4_0",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 5120
     },
     "Qwen3-4B-Instruct-2507-HRX": {
         "checkpoint": "unsloth/Qwen3-4B-Instruct-2507-GGUF:Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
@@ -2701,7 +2713,8 @@
         ],
         "size": 2.5,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2560
     },
     "Qwen3-30B-A3B-HRX": {
         "checkpoint": "unsloth/Qwen3-30B-A3B-GGUF:Q4_0",
@@ -2713,7 +2726,8 @@
         ],
         "size": 17.4,
         "hrx_token_embd": "Q4_0",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2048
     },
     "Qwen3-Coder-30B-A3B-Instruct-HRX": {
         "checkpoint": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
@@ -2727,7 +2741,8 @@
         ],
         "size": 18.6,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "YES"
+        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_embd_w": 2048
     },
     "Qwen3-Coder-Next-HRX": {
         "checkpoint": "unsloth/Qwen3-Coder-Next-GGUF:Qwen3-Coder-Next-MXFP4_MOE.gguf",
@@ -2741,7 +2756,8 @@
         ],
         "size": 48.0,
         "hrx_token_embd": "Q8_0",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2048
     },
     "Nemotron-3-Nano-30B-A3B-HRX": {
         "checkpoint": "unsloth/Nemotron-3-Nano-30B-A3B-GGUF:Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
@@ -2752,7 +2768,8 @@
         ],
         "size": 22.8,
         "hrx_token_embd": "Q5_0",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2688
     },
     "NVIDIA-Nemotron-3.5-Lightning-30B-A3B-HRX": {
         "checkpoint": "unsloth/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF:NVIDIA-Nemotron-3.5-Lightning-30B-A3B-UD-Q4_K_XL.gguf",
@@ -2767,7 +2784,8 @@
         ],
         "size": 25.5,
         "hrx_token_embd": "Q8_0",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2688
     },
     "Bonsai-8B-gguf-HRX": {
         "checkpoint": "prism-ml/Bonsai-8B-gguf:Q1_0",
@@ -2779,7 +2797,8 @@
         ],
         "size": 1.16,
         "hrx_token_embd": "UNK(41)",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 4096
     },
     "Bonsai-4B-gguf-HRX": {
         "checkpoint": "prism-ml/Bonsai-4B-gguf:Q1_0",
@@ -2791,7 +2810,8 @@
         ],
         "size": 0.572,
         "hrx_token_embd": "UNK(41)",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2560
     },
     "Bonsai-1.7B-gguf-HRX": {
         "checkpoint": "prism-ml/Bonsai-1.7B-gguf:Q1_0",
@@ -2803,7 +2823,8 @@
         ],
         "size": 0.25,
         "hrx_token_embd": "UNK(41)",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2048
     },
     "Phi-4-mini-instruct-HRX": {
         "checkpoint": "unsloth/Phi-4-mini-instruct-GGUF:Phi-4-mini-instruct-Q4_K_M.gguf",
@@ -2814,7 +2835,8 @@
         ],
         "size": 2.49,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 3072
     },
     "LFM2-1.2B-HRX": {
         "checkpoint": "LiquidAI/LFM2-1.2B-GGUF:LFM2-1.2B-Q4_K_M.gguf",
@@ -2825,7 +2847,8 @@
         ],
         "size": 0.731,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2048
     },
     "LFM2.5-1.2B-Instruct-HRX": {
         "checkpoint": "LiquidAI/LFM2.5-1.2B-Instruct-GGUF:LFM2.5-1.2B-Instruct-Q4_K_M.gguf",
@@ -2836,7 +2859,8 @@
         ],
         "size": 0.731,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2048
     },
     "LFM2.5-8B-A1B-HRX": {
         "checkpoint": "LiquidAI/LFM2.5-8B-A1B-GGUF:LFM2.5-8B-A1B-Q4_K_M.gguf",
@@ -2847,7 +2871,8 @@
         ],
         "size": 5.16,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2048
     },
     "PromptBridge-0.6b-Alpha-HRX": {
         "checkpoint": "mradermacher/PromptBridge-0.6b-Alpha-GGUF:PromptBridge-0.6b-Alpha.Q4_K_M.gguf",
@@ -2858,7 +2883,8 @@
         ],
         "size": 0.397,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 1024
     },
     "Jan-nano-128k-HRX": {
         "checkpoint": "Menlo/Jan-nano-128k-gguf:jan-nano-128k-Q4_K_M.gguf",
@@ -2869,7 +2895,8 @@
         ],
         "size": 2.5,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2560
     },
     "Jan-v1-4B-HRX": {
         "checkpoint": "janhq/Jan-v1-4B-GGUF:Jan-v1-4B-Q4_K_M.gguf",
@@ -2880,7 +2907,8 @@
         ],
         "size": 2.5,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2560
     },
     "Llama-3.2-1B-Instruct-HRX": {
         "checkpoint": "unsloth/Llama-3.2-1B-Instruct-GGUF:Llama-3.2-1B-Instruct-UD-Q4_K_XL.gguf",
@@ -2891,7 +2919,8 @@
         ],
         "size": 0.834,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2048
     },
     "Llama-3.2-3B-Instruct-HRX": {
         "checkpoint": "unsloth/Llama-3.2-3B-Instruct-GGUF:Llama-3.2-3B-Instruct-UD-Q4_K_XL.gguf",
@@ -2902,7 +2931,8 @@
         ],
         "size": 2.06,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 3072
     },
     "SmolLM3-3B-HRX": {
         "checkpoint": "unsloth/SmolLM3-3B-128K-GGUF:SmolLM3-3B-128K-UD-Q4_K_XL.gguf",
@@ -2913,7 +2943,8 @@
         ],
         "size": 1.94,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2048
     },
     "Qwen3-Next-80B-A3B-Instruct-HRX": {
         "checkpoint": "unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF:Qwen3-Next-80B-A3B-Instruct-UD-Q4_K_XL.gguf",
@@ -2925,7 +2956,8 @@
         ],
         "size": 46.1,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "YES"
+        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_embd_w": 2048
     },
     "Devstral-Small-2507-HRX": {
         "checkpoint": "mistralai/Devstral-Small-2507_gguf:Q4_K_M",
@@ -2938,7 +2970,8 @@
         ],
         "size": 14.3,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "YES"
+        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_embd_w": 5120
     },
     "Qwen2.5-Coder-32B-Instruct-HRX": {
         "checkpoint": "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF:qwen2.5-coder-32b-instruct-fp16-00001-of-00009.gguf",
@@ -2950,7 +2983,8 @@
         ],
         "size": 19.9,
         "hrx_token_embd": "F16",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 5120
     },
     "gpt-oss-120b-HRX": {
         "checkpoint": "unsloth/gpt-oss-120b-GGUF:Q4_K_M",
@@ -2963,7 +2997,8 @@
         ],
         "size": 62.8,
         "hrx_token_embd": "Q5_0",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2880
     },
     "gpt-oss-20b-HRX": {
         "checkpoint": "unsloth/gpt-oss-20b-GGUF:Q4_K_M",
@@ -2976,7 +3011,8 @@
         ],
         "size": 11.6,
         "hrx_token_embd": "Q5_0",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2880
     },
     "gpt-oss-120b-mxfp-HRX": {
         "checkpoint": "ggml-org/gpt-oss-120b-GGUF:gpt-oss-120b-MXFP4.gguf",
@@ -2990,7 +3026,8 @@
         ],
         "size": 63.4,
         "hrx_token_embd": "Q8_0",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2880
     },
     "gpt-oss-20b-mxfp4-HRX": {
         "checkpoint": "ggml-org/gpt-oss-20b-GGUF:gpt-oss-20b-MXFP4.gguf",
@@ -3004,7 +3041,8 @@
         ],
         "size": 12.1,
         "hrx_token_embd": "Q8_0",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2880
     },
     "GLM-4.5-Air-UD-Q4K-XL-HRX": {
         "checkpoint": "unsloth/GLM-4.5-Air-GGUF:UD-Q4_K_XL",
@@ -3016,7 +3054,8 @@
         ],
         "size": 67.7,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "YES"
+        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_embd_w": 4096
     },
     "GLM-4.7-Flash-HRX": {
         "checkpoint": "unsloth/GLM-4.7-Flash-GGUF:GLM-4.7-Flash-UD-Q4_K_XL.gguf",
@@ -3028,7 +3067,8 @@
         ],
         "size": 17.5,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "YES"
+        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_embd_w": 2048
     },
     "Playable1-HRX": {
         "checkpoint": "playable/Playable1-GGUF:Playable1-q4_k_m.gguf",
@@ -3040,7 +3080,8 @@
         ],
         "size": 4.68,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "YES"
+        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_embd_w": 3584
     },
     "granite-4.0-h-tiny-HRX": {
         "checkpoint": "unsloth/granite-4.0-h-tiny-GGUF:Q4_K_M",
@@ -3052,7 +3093,8 @@
         ],
         "size": 4.25,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 1536
     },
     "LFM2-8B-A1B-HRX": {
         "checkpoint": "LiquidAI/LFM2-8B-A1B-GGUF:Q4_K_M",
@@ -3063,7 +3105,8 @@
         ],
         "size": 5.04,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2048
     },
     "LFM2-24B-A2B-HRX": {
         "checkpoint": "LiquidAI/LFM2-24B-A2B-GGUF:Q4_K_M",
@@ -3074,6 +3117,7 @@
         ],
         "size": 14.4,
         "hrx_token_embd": "Q6_K",
-        "hrx_serve": "NO (GET_ROWS)"
+        "hrx_serve": "NO (GET_ROWS)",
+        "hrx_embd_w": 2048
     }
 }

--- a/third_party/lemonade/tools/annotate_hrx_embedding_quants.py
+++ b/third_party/lemonade/tools/annotate_hrx_embedding_quants.py
@@ -12,7 +12,8 @@ Usage:
     python3 third_party/lemonade/tools/annotate_hrx_embedding_quants.py
         [--limit N]          # only first N entries (quick sanity)
         [--write]            # write the annotation into server_models.json
-                              # (adds "hrx_token_embd" + "hrx_serve" per entry)
+                              # (adds "hrx_token_embd" + "hrx_serve" + "hrx_embd_w"
+                              #  per entry)
 
 Requires: gguf package (pip install gguf) or the bundled GGUF reader.
 """
@@ -155,14 +156,15 @@ def read_gguf_ftype(data: bytes) -> tuple[str | None, int]:
         for _ in range(n_tensors):
             name, off = read_str(off)
             (n_dims,) = struct.unpack_from("<I", data, off); off += 4
+            dims = struct.unpack_from(f"<{n_dims}Q", data, off)
             off += 8 * n_dims
             (ftype,) = struct.unpack_from("<I", data, off); off += 4
             off += 8  # offset_to_data
             if name == "token_embd.weight":
-                return GGUF_FTYPE_NAMES.get(ftype, f"UNK({ftype})"), n_kv
-        return None, n_kv
+                return GGUF_FTYPE_NAMES.get(ftype, f"UNK({ftype})"), dims, n_kv
+        return None, (), n_kv
     except (struct.error, UnicodeDecodeError, IndexError, OverflowError):
-        return None, 0
+        return None, (), 0
 
 
 def main() -> int:
@@ -191,38 +193,57 @@ def main() -> int:
             # GGUF metadata (kv + tensor names) can be several MB when the
             # tokenizer arrays are large — fetch in growing chunks until the
             # walk finds token_embd.weight or we give up at 64 MB.
-            ftype = None
+            ftype, dims = None, ()
             for size in (1 << 20, 4 << 20, 16 << 20, 64 << 20):
                 data = fetch_header(url, size)
                 if data[:4] != b"GGUF":
                     break
-                ftype, _ = read_gguf_ftype(data)
+                ftype, dims, _ = read_gguf_ftype(data)
                 if ftype:
                     break
             if not ftype:
                 verdicts[name] = ("?", "metadata-too-large")
                 print(f"{name:45s} {'?':10s} {'metadata-too-large':12s}")
                 continue
-            serve = "YES" if ftype in K_QUANTS else "NO (GET_ROWS)"
-            verdicts[name] = (ftype, serve)
-            print(f"{name:45s} {ftype:10s} {serve:12s}")
+            # Issue #1944 (shape refinement): the GET_ROWS ceiling is not
+            # purely quant-gated. Empirically (strixhalo 2026-08-30):
+            #   Qwen3-30B-A3B-Instruct-2507 (q4_K, w=2048) — DECODES (36.31
+            #     tok/s, verified)
+            #   MiniCPM5-1B (q4_K, w=1536) — GET_ROWS Compute error
+            # So q4_K is NECESSARY but not SUFFICIENT; only the 30B-A3B
+            # entry has been verified end-to-end. Other q4_K entries are
+            # marked SUSPECT (unverified shape) until a per-shape probe or
+            # llama.cpp PR #27218 lands. GGUF dims are reversed, so the
+            # embedding width is the MIN of the two leading dims.
+            embd_w = int(min(dims[:2])) if len(dims) >= 2 else int(dims[0] or 0)
+            if ftype in K_QUANTS:
+                if name == "Qwen3-30B-A3B-Instruct-2507-HRX":
+                    serve = "YES"   # empirically verified (36.31 tok/s)
+                else:
+                    serve = "SUSPECT (q4_K, unverified shape)"
+            else:
+                serve = "NO (GET_ROWS)"
+            verdicts[name] = (ftype, serve, embd_w)
+            print(f"{name:45s} {ftype:10s} {serve:24s} w={embd_w}")
         except Exception as exc:  # noqa: BLE001
-            verdicts[name] = ("ERR", str(exc)[:40])
+            verdicts[name] = ("ERR", str(exc)[:40], 0)
             print(f"{name:45s} {'ERR':10s} {str(exc)[:40]:12s}")
 
     n_yes = sum(1 for v in verdicts.values() if v[1] == "YES")
+    n_susp = sum(1 for v in verdicts.values() if v[1] and v[1].startswith("SUSPECT"))
     n_no = sum(1 for v in verdicts.values() if v[1] and v[1].startswith("NO"))
-    print(f"\n{len(verdicts)} entries: {n_yes} K-quant (serve on HRX), "
-          f"{n_no} non-K (fail-closed), "
-          f"{len(verdicts) - n_yes - n_no} unknown/error")
+    print(f"\n{len(verdicts)} entries: {n_yes} verified-serve, {n_susp} SUSPECT (q4_K unverified shape), "
+          f"{n_no} fail-closed, {len(verdicts) - n_yes - n_susp - n_no} unknown/error")
 
     if args.write:
-        for name, (ftype, serve) in verdicts.items():
+        for name, (ftype, serve, embd_w) in verdicts.items():
             if name in registry and ftype not in ("?", "ERR"):
                 registry[name]["hrx_token_embd"] = ftype
                 registry[name]["hrx_serve"] = serve
+                if embd_w:
+                    registry[name]["hrx_embd_w"] = embd_w
         # Match the registry's original formatting exactly (indent=4, no
-        # sort_keys) so the diff is surgical — only the two new keys per
+        # sort_keys) so the diff is surgical — only the new keys per
         # entry are added, nothing re-ordered or re-indented.
         REGISTRY.write_text(json.dumps(registry, indent=4) + "\n")
         print(f"wrote annotations to {REGISTRY}")


### PR DESCRIPTION
### **User description**
## #1934 enabling artifact — verified per-group scale grid

The current int4 production path collapses the Q4NX per-(row,32-col) bf16 scales into a per-column ratioQ22 (K-uniform), capping FFN corr at ~0.972. This adds the **full per-(row,32-col-group) scale grid** the restructured kernel needs to carry through C1, plus a CPU gate:

- `GuI4Pack.scl_g_bf16`: [2*n_ff, RC] grid in the gate/up interleaved layout (same `w_at()` row indexing as `pack_gu_fused_i4`)
- `pack_gu_fused_i4_group_scales()`: emits the grid standalone — **NOT wired into the production tile stream** (per the issue's constraint until the kernel restructure lands)
- `test_i4_group_scales.cpp`: CPU gate, **verified on real zaya1-8b data**:
  - grid byte-exact vs raw Q4NX: **262144/262144, 0 bad**
  - weight reconstruction matches the raw bf16 path: 44774 finite + 359 NaN-pad rows matched

The kernel restructure (dequant per-group scale + C1 accumulation boundary) builds on this verified host contract. Graph change: LOW risk, 0 affected processes.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add per-(row,32-col) bf16 scale grid to int4 pack (#1934)
  - `pack_gu_fused_i4_group_scales()` emits full grid for C1 restructure
  - CPU gate test verifies grid byte-exact vs raw Q4NX scales

- Refine HRX embedding quant annotations (#1944)
  - Capture embedding width from GGUF dims
  - q4_K alone insufficient; unverified entries marked SUSPECT


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RawQ4Tensor"] --> B["pack_gu_fused_i4_group_scales()"]
  B --> C["scl_g_bf16 grid"]
  C --> D["test_i4_group_scales.cpp"]
  E["GGUF header"] --> F["annotate_hrx_embedding_quants.py"]
  F --> G["hrx_embd_w + hrx_serve verdicts"]
  G --> H["server_models.json"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gu_i4_pack.h</strong><dd><code>Add per-group scale grid to int4 pack</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/gu_i4_pack.h

<ul><li>Adds <code>scl_g_bf16</code> grid member for full per-row, 32-col bf16 scales<br> <li> New <code>pack_gu_fused_i4_group_scales()</code> emits gate/up interleaved scale <br>grid<br> <li> Not wired into production tile stream; standalone for kernel <br>restructure</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1978/files#diff-9b71d224944bb6e7af40f37e35eac50e26579074eeed27dac15d1f42ec285f87">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>annotate_hrx_embedding_quants.py</strong><dd><code>Annotate HRX embedding width and shape-dependent verdicts</code></dd></summary>
<hr>

third_party/lemonade/tools/annotate_hrx_embedding_quants.py

<ul><li>Reads embedding tensor dims from GGUF header<br> <li> Adds embedding width annotation and refined serve verdicts<br> <li> Marks unverified q4_K entries as SUSPECT based on shape</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1978/files#diff-da115295498e124e6bb891eee2875a2821509dd53318cb2fa9c6209cfd50c0ac">+36/-15</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_i4_group_scales.cpp</strong><dd><code>CPU gate test for per-group scale grid</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tests/test_i4_group_scales.cpp

<ul><li>New CPU gate verifying grid byte-exact vs raw Q4NX scales<br> <li> Cross-checks grid-derived weights match raw bf16 reconstruction<br> <li> Supports NaN-pad rows and expert/layer slicing</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1978/files#diff-74492bbadb55137f85faf6775406710d02a5c5c4b7eff43dcc5b0fb44ab3bb7f">+130/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server_models.json</strong><dd><code>Update HRX registry with embedding widths and verdicts</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/lemonade/src/cpp/resources/server_models.json

<ul><li>Adds <code>hrx_embd_w</code> width to all HRX entries<br> <li> Downgrades q4_K entries to SUSPECT except verified Qwen3-30B-A3B</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1978/files#diff-d00cb0d20075229aed1e25fd4dbebb1a8414a4e64ef4be3fadd835824da2cfb1">+89/-45</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

