### PR TITLE
fix(hrx/lemonade): #1944 — provable GET_ROWS serve gate (q4_K + hidden_size==2048 + Qwen3-MoE graph)

### DIFF
--- a/third_party/lemonade/src/cpp/resources/server_models.json
+++ b/third_party/lemonade/src/cpp/resources/server_models.json
@@ -2573,7 +2573,7 @@
         ],
         "size": 0.69,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_serve": "NO (GET_ROWS: hidden_size != 2048)",
         "hrx_embd_w": 1536
     },
     "MiniCPM4.1-8B-HRX": {
@@ -2586,7 +2586,7 @@
         ],
         "size": 4.97,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_serve": "NO (GET_ROWS: hidden_size != 2048)",
         "hrx_embd_w": 4096
     },
     "MiniCPM4-8B-HRX": {
@@ -2598,7 +2598,7 @@
         ],
         "size": 4.97,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_serve": "NO (GET_ROWS: hidden_size != 2048)",
         "hrx_embd_w": 4096
     },
     "MiniCPM3-4B-HRX": {
@@ -2741,7 +2741,7 @@
         ],
         "size": 18.6,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_serve": "YES",
         "hrx_embd_w": 2048
     },
     "Qwen3-Coder-Next-HRX": {
@@ -2956,7 +2956,7 @@
         ],
         "size": 46.1,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_serve": "NO (load-time abort: SCALE / cross-layer attention unsupported \u2014 non-Qwen3-MoE graph)",
         "hrx_embd_w": 2048
     },
     "Devstral-Small-2507-HRX": {
@@ -2970,7 +2970,7 @@
         ],
         "size": 14.3,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_serve": "NO (GET_ROWS: hidden_size != 2048)",
         "hrx_embd_w": 5120
     },
     "Qwen2.5-Coder-32B-Instruct-HRX": {
@@ -3054,7 +3054,7 @@
         ],
         "size": 67.7,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_serve": "NO (GET_ROWS: hidden_size != 2048)",
         "hrx_embd_w": 4096
     },
     "GLM-4.7-Flash-HRX": {
@@ -3067,7 +3067,7 @@
         ],
         "size": 17.5,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_serve": "NO (GET_ROWS gate ok, but RMS_NORM after embd unsupported \u2014 non-Qwen graph)",
         "hrx_embd_w": 2048
     },
     "Playable1-HRX": {
@@ -3080,7 +3080,7 @@
         ],
         "size": 4.68,
         "hrx_token_embd": "Q4_K",
-        "hrx_serve": "SUSPECT (q4_K, unverified shape)",
+        "hrx_serve": "NO (GET_ROWS: hidden_size != 2048)",
         "hrx_embd_w": 3584
     },
     "granite-4.0-h-tiny-HRX": {

--- a/third_party/lemonade/tools/annotate_hrx_embedding_quants.py
+++ b/third_party/lemonade/tools/annotate_hrx_embedding_quants.py
@@ -34,13 +34,19 @@ GGUF_FTYPE_NAMES = {
     24: "IQ1_M", 25: "BF16",
 }
 
-# HRX GET_ROWS serve set — EMPIRICALLY VERIFIED 2026-08-30 on strixhalo.
-# Only Q4_K fuses cleanly on the ggml-hrx bundle; q6_K FAILS at GET_ROWS
-# (Qwen3-0.6B "Q4_K_M" file carries q6_K embeds → "decode() failed: Compute
-# error"). Q5_K/Q8_K/Q3_K/Q2_K are unverified on this bundle — keep them out
-# of the serve set until llama.cpp PR #27218 (GET_ROWS coverage) lands and a
-# re-probe confirms each ftype.
+# HRX GET_ROWS serve set — gate is PROVABLE from llama.cpp PR #27218
+# (ggml-hrx dispatch-qwen-preamble.cpp, match_qwen_token_embedding):
+#   weight->type == Q4_K
+#   is_supported_hidden_size(hidden_size)  -> hidden_size == 2048
+#   is_supported_vocabulary_count(vocab)   -> vocab <= 262144
+#   is_supported_token_count(token_count)  -> token_count <= 2048
+# Anything else (q6_K/q5_x/q8_0/Q4_0/Q4_1/F16/MXFP4, or q4_K at w != 2048)
+# fails closed at the scheduler: "unsupported HRX node 0: GET_ROWS".
+# Empirically confirmed on strixhalo (2026-08-30): Qwen3-30B-A3B-Instruct-2507
+# (q4_K w=2048) decodes 36.31 tok/s; MiniCPM5-1B (q4_K w=1536) and
+# MiniCPM4-8B (q4_K w=4096) both fail at GET_ROWS.
 K_QUANTS = {"Q4_K"}
+HRX_GET_ROWS_HIDDEN = 2048
 
 
 _HF_FILE_CACHE: dict[str, list[str]] = {}
@@ -205,22 +211,34 @@ def main() -> int:
                 verdicts[name] = ("?", "metadata-too-large")
                 print(f"{name:45s} {'?':10s} {'metadata-too-large':12s}")
                 continue
-            # Issue #1944 (shape refinement): the GET_ROWS ceiling is not
-            # purely quant-gated. Empirically (strixhalo 2026-08-30):
-            #   Qwen3-30B-A3B-Instruct-2507 (q4_K, w=2048) — DECODES (36.31
-            #     tok/s, verified)
-            #   MiniCPM5-1B (q4_K, w=1536) — GET_ROWS Compute error
-            # So q4_K is NECESSARY but not SUFFICIENT; only the 30B-A3B
-            # entry has been verified end-to-end. Other q4_K entries are
-            # marked SUSPECT (unverified shape) until a per-shape probe or
-            # llama.cpp PR #27218 lands. GGUF dims are reversed, so the
+            # Issue #1944 (shape refinement): the GET_ROWS ceiling is NOT
+            # purely quant-gated — PR #27218's qwen_token_embedding dispatch
+            # hard-codes hidden_size == 2048. So q4_K is necessary but not
+            # sufficient: q4_K at w != 2048 fails closed at GET_ROWS
+            # (MiniCPM5-1B w=1536, MiniCPM4-8B w=4096 — both measured on
+            # strixhalo 2026-08-30). Verified end-to-end on strixhalo:
+            #   30B-A3B-Instruct-2507  (q4_K w=2048) — 36.31 tok/s
+            #   Coder-30B-A3B-Instruct (q4_K w=2048) — 71.16 tok/s
+            #   GLM-4.7-Flash          (q4_K w=2048) — GET_ROWS gate OK,
+            #     then fails at RMS_NORM after the embedding (non-Qwen
+            #     graph; the HRX bundle only ships the Qwen3-MoE corpus)
+            #   Qwen3-Next-80B-A3B     (q4_K w=2048) — load-time abort on
+            #     SCALE (cross-layer attention, also outside the corpus)
+            # So the full serve condition is q4_K AND w==2048 AND a
+            # Qwen3-MoE-shaped graph. GGUF dims are reversed, so the
             # embedding width is the MIN of the two leading dims.
             embd_w = int(min(dims[:2])) if len(dims) >= 2 else int(dims[0] or 0)
-            if ftype in K_QUANTS:
-                if name == "Qwen3-30B-A3B-Instruct-2507-HRX":
-                    serve = "YES"   # empirically verified (36.31 tok/s)
+            if ftype in K_QUANTS and embd_w == HRX_GET_ROWS_HIDDEN:
+                if name in ("Qwen3-30B-A3B-Instruct-2507-HRX", "Qwen3-Coder-30B-A3B-Instruct-HRX"):
+                    serve = "YES"   # empirically verified (36.31 / 71.16 tok/s)
+                elif name == "GLM-4.7-Flash-HRX":
+                    serve = "NO (GET_ROWS gate ok, but RMS_NORM after embd unsupported — non-Qwen graph)"
+                elif name == "Qwen3-Next-80B-A3B-Instruct-HRX":
+                    serve = "NO (load-time abort: SCALE / cross-layer attention unsupported — non-Qwen3-MoE graph)"
                 else:
-                    serve = "SUSPECT (q4_K, unverified shape)"
+                    serve = "SUSPECT (q4_K w=2048, GET_ROWS gate ok, unverified e2e)"
+            elif ftype in K_QUANTS:
+                serve = "NO (GET_ROWS: hidden_size != 2048)"
             else:
                 serve = "NO (GET_ROWS)"
             verdicts[name] = (ftype, serve, embd_w)
@@ -232,7 +250,7 @@ def main() -> int:
     n_yes = sum(1 for v in verdicts.values() if v[1] == "YES")
     n_susp = sum(1 for v in verdicts.values() if v[1] and v[1].startswith("SUSPECT"))
     n_no = sum(1 for v in verdicts.values() if v[1] and v[1].startswith("NO"))
-    print(f"\n{len(verdicts)} entries: {n_yes} verified-serve, {n_susp} SUSPECT (q4_K unverified shape), "
+    print(f"\n{len(verdicts)} entries: {n_yes} verified-serve, {n_susp} SUSPECT (q4_K w=2048 unverified e2e), "
           f"{n_no} fail-closed, {len(verdicts) - n_yes - n_susp - n_no} unknown/error")
 
     if args.write:


### PR DESCRIPTION
### **User description**
## Summary
Fixes #1944 (and completes the #1943/#1955 annotation). The GET_ROWS ceiling is now **provable from source + measured on silicon**, replacing conservative SUSPECT verdicts with a full classification of all 44 *-HRX entries.

- llama.cpp PR #27218 `dispatch-qwen-preamble.cpp` (`match_qwen_token_embedding`) hard-codes: `Q4_K AND hidden_size == 2048` (vocab ≤ 262144, tokens ≤ 2048). Anything else → `unsupported HRX node 0: GET_ROWS` → decode fails.
- The HRX bundle ships only the Qwen3-MoE kernel corpus, so the graph must also be Qwen3-MoE-shaped.
- Measured on strixhalo (gfx1151): 30B-A3B-Instruct-2507 (w=2048) 36.31 tok/s ✓; Coder-30B-A3B-Instruct (w=2048) 71.16 tok/s ✓; MiniCPM5-1B (w=1536) ✗; MiniCPM4-8B (w=4096) ✗; GLM-4.7-Flash (w=2048, non-Qwen graph) ✗ RMS_NORM after embd; Qwen3-Next-80B (w=2048, non-Qwen3-MoE graph) ✗ load-time SCALE abort.

Full serve condition: **q4_K AND w==2048 AND Qwen3-MoE-shaped graph** → 2 verified serve / 42 fail-closed, 0 SUSPECT.

## Scope
- `annotate_hrx_embedding_quants.py`: encode the provable gate (K_QUANTS + HRX_GET_ROWS_HIDDEN=2048) + measured verdicts for the w=2048 q4_K entries.
- `server_models.json`: 6 q4_K w≠2048 entries SUSPECT→NO (width gate); GLM-4.7-Flash→NO (RMS_NORM); Qwen3-Next-80B→NO (SCALE/CLA at load); Qwen3-Coder-30B-A3B→YES (71.16 tok/s measured). 44/44 HRX entries classified.

## Testing
- GGUF header walk verified against 4 downloaded files (width = dims[0]).
- 4 new HRX llama-server probes on strixhalo: MiniCPM4-8B fail, Coder-30B-A3B serve (71.16/110.98 tok/s), GLM-4.7-Flash RMS_NORM fail, Next-80B SCALE abort. No build change (Python + registry only).

## Documentation
- [x] No docs change required (issue comments carry the measurements; docs/research/hrx-engine-goal.md §P2 already documents the re-probe recipe).

## Breaking Changes
- [x] No breaking changes (annotation-only; no engine behavior change).

## AI-assisted contribution
- This change was implemented with AI assistance (measured on strixhalo hardware, gate verified against llama.cpp PR #27218 source).


___

### **PR Type**
Bug fix


___

### **Description**
- Encode provable GET_ROWS gate: Q4_K plus hidden_size 2048

- Suspect entries with hidden_size != 2048 fail closed

- Qwen3-Coder-30B-A3B verified: YES at 71.16 tok/s

- GLM/Qwen3-Next NO: RMS_NORM/SCALE unsupported


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HRX *-HRX entries"] --> B["annotate_hrx_embedding_quants.py"]
  B -- "Q4_K & hidden_size==2048?" --> C["Qwen3-MoE-shaped graph?"]
  C -- "yes" --> D["YES verified serve"]
  C -- "no" --> E["NO fail-closed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>annotate_hrx_embedding_quants.py</strong><dd><code>Encode provable GET_ROWS gate in annotation tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/lemonade/tools/annotate_hrx_embedding_quants.py

<ul><li>Refactors serve gate to match llama.cpp PR #27218: Q4_K + <br>hidden_size==2048<br> <li> Adds <code>HRX_GET_ROWS_HIDDEN = 2048</code>; q4_K at w != 2048 now classified NO<br> <li> Adds measured verdicts for Qwen3-Coder (YES), GLM-4.7-Flash and <br>Qwen3-Next (NO)</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1980/files#diff-da115295498e124e6bb891eee2875a2821509dd53318cb2fa9c6209cfd50c0ac">+38/-20</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server_models.json</strong><dd><code>Update HRX serve verdicts in model registry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/lemonade/src/cpp/resources/server_models.json

<ul><li>Flips 6 q4_K entries with <code>hidden_size != 2048</code> to NO (GET_ROWS)<br> <li> Marks Qwen3-Coder-30B-A3B-Instruct-HRX as YES (verified serve)<br> <li> Marks GLM-4.7-Flash and Qwen3-Next-80B-A3B as NO with graph reasons</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1980/files#diff-d00cb0d20075229aed1e25fd4dbebb1a8414a4e64ef4be3fadd835824da2cfb1">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

