### PR TITLE
feat(npu): #1934 — 1BP-layout Q4NX raw reader (read_q4nx_raw_1bp) + byte-exact CPU gate

### DIFF
--- a/engine/npu/src/q4nx_raw.h
+++ b/engine/npu/src/q4nx_raw.h
@@ -74,3 +74,64 @@ static inline RawQ4Tensor read_q4nx_raw(const uint8_t* D, uint64_t off,
     }
     return t;
 }
+
+// Read a Q4NX tensor in the 1BP (onebp_format.h) tile layout — used by the
+// unified engine's NpuOnebpModel (get_tile_ptr / raw_tensor) — into the SAME
+// RawQ4Tensor contract as read_q4nx_raw(). The 1BP Q4NX tile format differs
+// from the torch2aie/zaya chunk format in THREE ways (measured 2026-08-30 on
+// Qwen3-0.6B.1bp; feeding 1BP bytes to read_q4nx_raw silently corrupts):
+//   1. nibbles are ROW-MAJOR, not lane-swizzled: byte = (r*256+c)/2, low
+//      nibble = even column (torch2aie: lane*2048 + c*8 + (r%16)/2, low =
+//      even row)
+//   2. nibbles are UNSIGNED 0..15 with an asymmetric bf16 zero-point
+//      (torch2aie: two's-complement signed, zp usually 0)
+//   3. scale < 1e-10 is clamped to 1.0 (torch2aie keeps it)
+// To preserve the exact value semantics W = q4*s + zp (the GuI4Pack and
+// zaya_moe contracts), the unsigned nibble v is re-mapped to a signed q4
+// with a FOLDED zero-point: q4 = v - 8, zp' = 8*s + zp (W unchanged). The
+// scale/zp layout (row-major per (row, col-group)) is identical to the
+// torch2aie reader.
+static inline RawQ4Tensor read_q4nx_raw_1bp(const uint8_t* tiles, int rows,
+                                            int cols) {
+    const int n_tc = cols / 256;
+    RawQ4Tensor t;
+    t.rows = rows;
+    t.cols = cols;
+    t.q4.assign((size_t)t.rows * cols, 0);
+    t.scl.assign((size_t)t.rows * (cols / 32), 0.0f);
+    t.zp.assign((size_t)t.rows * (cols / 32), 0.0f);
+    auto rdbf16 = [](const uint8_t* p) {
+        uint16_t v = (uint16_t)p[0] | ((uint16_t)p[1] << 8);
+        uint32_t bits = (uint32_t)v << 16;
+        float f; std::memcpy(&f, &bits, 4);
+        return f;
+    };
+    for (int tile_row = 0; tile_row < (rows + 31) / 32; tile_row++)
+        for (int tile_col = 0; tile_col < n_tc; tile_col++) {
+            const uint8_t* tile = tiles + (size_t)(tile_row * n_tc + tile_col) * 5120;
+            const uint16_t* scales = (const uint16_t*)tile;             // [32*8]
+            const uint16_t* zeros  = (const uint16_t*)(tile + 512);     // [32*8]
+            const uint8_t*  packed = tile + 1024;                       // [32*256/2]
+            for (int lr = 0; lr < 32; lr++) {
+                int row = tile_row * 32 + lr;
+                if (row >= t.rows) break;
+                for (int c = 0; c < 256; c++) {
+                    int col = tile_col * 256 + c;
+                    if (col >= cols) break;
+                    uint8_t b = packed[(lr * 256 + c) / 2];
+                    int v = (c % 2 == 0) ? (b & 0x0F) : ((b >> 4) & 0x0F);
+                    t.q4[(size_t)row * cols + col] = (int8_t)(v - 8);   // signed fold
+                }
+                for (int g = 0; g < 8; g++) {
+                    int cg = tile_col * 8 + g;
+                    if (cg >= cols / 32) break;
+                    float s = rdbf16((const uint8_t*)(scales + lr * 8 + g));
+                    if (s < 1e-10f) s = 1.0f;                            // 1BP clamp
+                    float zp = rdbf16((const uint8_t*)(zeros + lr * 8 + g));
+                    t.scl[(size_t)row * (cols / 32) + cg] = s;
+                    t.zp[(size_t)row * (cols / 32) + cg] = 8.0f * s + zp; // folded
+                }
+            }
+        }
+    return t;
+}

--- a/engine/npu/tests/test_1bp_q4nx_reader.cpp
+++ b/engine/npu/tests/test_1bp_q4nx_reader.cpp
@@ -1,0 +1,110 @@
+// test_1bp_q4nx_reader.cpp — CPU gate for the 1BP-layout Q4NX raw reader
+// (read_q4nx_raw_1bp, issue #1934 wiring enabling artifact).
+//
+// The unified engine's NpuOnebpModel (1BP format, include/onebp_format.h)
+// stores Q4NX tiles in a DIFFERENT layout than the torch2aie/zaya .q4nx
+// chunks: row-major unsigned nibbles + asymmetric bf16 zero-points + a
+// scale clamp, vs lane-swizzled two's-complement signed + zp=0. Feeding 1BP
+// bytes to the zaya reader (read_q4nx_raw) silently corrupts every element
+// (measured: 3,068,977/3,145,728 mismatch on Qwen3-0.6B.1bp blk.1.ffn_gate).
+//
+// This gate verifies read_q4nx_raw_1bp reconstructs the EXACT float values
+// the engine's own dequant (NpuOnebpModel::get_tensor_f32 -> dequant_tile)
+// produces, through the signed fold q4' = v-8, zp' = 8*s+zp (W = q4'*s + zp'
+// = v*s + zp unchanged):
+//   W[i][j] = (float)q4[i][j] * scl[i][j/32] + zp[i][j/32]
+// must equal get_tensor_f32() to bf16 precision (<= 2^-8 relative; the 1BP
+// scale/zp are bf16 so the fold is exact except for the v-8 integer move).
+//
+// Build (CPU only):
+//   g++ -std=c++26 -O2 -I include -I engine/npu/src \
+//       engine/npu/tests/test_1bp_q4nx_reader.cpp engine/npu/src/onebp_loader.cpp \
+//       -o /tmp/test_1bp_q4nx_reader
+//   /tmp/test_1bp_q4nx_reader models/Qwen3-0.6B.1bp [tensor...]
+#include "onebp_format.h"
+#include "q4nx_raw.h"
+#include "onebp_loader.cpp"   // NpuOnebpModel (defines class; no main)
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+static int failures = 0;
+#define CHECK(cond, ...)                                                  \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            fprintf(stderr, "FAIL: ");                                    \
+            fprintf(stderr, __VA_ARGS__);                                 \
+            fprintf(stderr, "\n");                                        \
+            failures++;                                                   \
+        } else {                                                          \
+            fprintf(stderr, "ok:   ");                                    \
+            fprintf(stderr, __VA_ARGS__);                                 \
+            fprintf(stderr, "\n");                                        \
+        }                                                                 \
+    } while (0)
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <model.1bp> [tensor...]\n", argv[0]);
+        return 2;
+    }
+    NpuOnebpModel mdl;
+    if (!mdl.open(argv[1])) { fprintf(stderr, "FAIL: open %s\n", argv[1]); return 1; }
+    fprintf(stderr, "1BP model %s (H=%d L=%d quant=%d tiles=%ux%u gs=%u)\n",
+            argv[1], mdl.header().hidden_size, mdl.header().num_layers,
+            (int)mdl.header().quant, mdl.header().tile_rows,
+            mdl.header().tile_cols, mdl.header().group_size);
+    CHECK(mdl.header().quant == ONEBP_Q4NX, "model quant is Q4NX (%d)",
+          (int)mdl.header().quant);
+
+    const char* tensors[] = {
+        "blk.1.ffn_gate.weight",
+        "blk.1.ffn_up.weight",
+        "blk.1.ffn_down.weight",
+    };
+    const int nt = argc > 2 ? argc - 2 : 3;
+    for (int ti = 0; ti < nt; ti++) {
+        const char* tname = argc > 2 ? argv[2 + ti] : tensors[ti];
+        auto* te = mdl.find_tensor(tname);
+        if (!te) { CHECK(false, "%s: not found", tname); continue; }
+        if (te->ndim != 2) { CHECK(false, "%s: ndim %d (need 2)", tname, te->ndim); continue; }
+
+        std::vector<float> f32;
+        if (!mdl.get_tensor_f32(tname, f32)) { CHECK(false, "%s: get_tensor_f32", tname); continue; }
+        const uint8_t* raw = mdl.raw_tensor(tname);
+        if (!raw) { CHECK(false, "%s: raw_tensor", tname); continue; }
+
+        const int R = te->rows, C = te->cols;
+        RawQ4Tensor t = read_q4nx_raw_1bp(raw, R, C);
+        CHECK(t.rows == R && t.cols == C, "%s: dims %dx%d", tname, t.rows, t.cols);
+
+        // Byte-exact reconstruction gate: W = q4*s + zp vs engine f32.
+        long bad = 0, nan = 0, tot = (long)R * C;
+        double maxd = 0, sumsq = 0;
+        for (int r = 0; r < R; r++)
+            for (int c = 0; c < C; c++) {
+                float s = t.scl[(size_t)r * (C / 32) + c / 32];
+                float z = t.zp[(size_t)r * (C / 32) + c / 32];
+                float w = (float)t.q4[(size_t)r * C + c] * s + z;
+                float ref = f32[(size_t)r * C + c];
+                double d = std::fabs((double)w - ref);
+                if (d > maxd) maxd = d;
+                sumsq += d * d;
+                if (d > 1e-3) bad++;
+                if (std::isnan(w)) nan++;
+            }
+        // The fold q4'=v-8, zp'=8s+zp is EXACT in reals; the only loss is
+        // the 1BP scale/zp being bf16 (the engine uses the same bf16 bytes),
+        // so W must match to well within 1e-3 (bf16 eps ~ 2^-8 = 3.9e-3).
+        double rmse = std::sqrt(sumsq / (double)tot);
+        CHECK(bad == 0 && nan == 0 && maxd <= 1e-3,
+              "%s: W=q4*s+zp vs get_tensor_f32: %ld/%ld bad, nan=%ld, "
+              "maxdiff=%.6f rmse=%.6f", tname, bad, tot, nan, maxd, rmse);
+    }
+
+    fprintf(stderr, "\n%s\n", failures ? "GATE FAILED" : "GATE PASSED");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
### **User description**
## Summary
Fixes the data-path blocker for #1934 wiring: the unified engine 1BP format stores Q4NX tiles in a different layout than the torch2aie/zaya `.q4nx` chunks the int4 fused packer consumes. Adds `read_q4nx_raw_1bp()` (signed fold q4'=v-8, zp'=8s+zp) + a byte-exact CPU gate on real Qwen3-0.6B.1bp.

## Scope
- `engine/npu/src/q4nx_raw.h`: new `read_q4nx_raw_1bp()` — 1BP tile layout (row-major unsigned nibbles, asymmetric bf16 zp, scale clamp) to shared `RawQ4Tensor` contract.
- `engine/npu/tests/test_1bp_q4nx_reader.cpp`: CPU gate — W=q4*s+zp vs `NpuOnebpModel::get_tensor_f32`, all 3 GU tensors: 0/3,145,728 bad, maxdiff=0.000000, GATE PASSED.

## Testing
- Measured on strixhalo with the real Qwen3-0.6B.1bp (3,145,728 elements/tensor): reconstruction byte-exact vs the engine dequant on ffn_gate/ffn_up/ffn_down.
- Backward-compatible: existing read_q4nx_raw + all i4 gates unaffected (test_i4_group_scales re-run, PASSED).
- Diagnostic (posted to #1934): v66 ratioQ22 contract is symmetric-only; 1BP asymmetric zp (mean 0.0129) drops B_shadow corr to 0.9125 — the kernel restructure must carry a per-(row,32-col) additive zp in C1.

## Documentation
- [x] No docs change required (finding documented in the issue).

## Breaking Changes
- [x] No breaking changes (new function + new test only).

## AI-assisted contribution
- This change was implemented with AI assistance (layout differences measured empirically on strixhalo hardware).


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add 1BP-layout Q4NX raw reader `read_q4nx_raw_1bp()` in `engine/npu/src/q4nx_raw.h`

- Convert 1BP tiles to shared `RawQ4Tensor` via signed fold `q4'=v-8`, `zp'=8*s+zp`

- Add CPU gate `test_1bp_q4nx_reader.cpp` verifying byte-exact reconstruction on Qwen3-0.6B.1bp

- Cover three layout differences: row-major unsigned nibbles, asymmetric bf16 zp, scale clamp


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["1BP Q4NX tiles (NpuOnebpModel)"] --> B["read_q4nx_raw_1bp()"]
  B --> C["RawQ4Tensor (q4, scl, zp)"]
  C --> D["GuI4Pack / fused int4 path"]
  C --> E["CPU gate test_1bp_q4nx_reader"]
  E --> F["W = q4*s + zp == get_tensor_f32"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>q4nx_raw.h</strong><dd><code>Add 1BP-layout Q4NX raw reader function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/q4nx_raw.h

<ul><li>Add <code>read_q4nx_raw_1bp()</code> for the 1BP Q4NX tile layout<br> <li> Handle row-major unsigned nibbles, asymmetric bf16 zero-points, and <br>scale clamp<br> <li> Map unsigned nibble <code>v</code> to signed <code>q4 = v - 8</code> with folded <code>zp' = 8*s + zp</code><br> <li> Produce same <code>RawQ4Tensor</code> contract as the existing torch2aie reader</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1983/files#diff-b9cdcb141fd2e8729674c6390eb6bd42dea9ceae8d2826f5ce26bd112ab11d50">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_1bp_q4nx_reader.cpp</strong><dd><code>Add byte-exact CPU gate for 1BP reader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tests/test_1bp_q4nx_reader.cpp

<ul><li>New CPU-only gate verifying <code>read_q4nx_raw_1bp()</code> reconstruction<br> <li> Compares <code>W = q4*s + zp</code> against <code>NpuOnebpModel::get_tensor_f32</code> exactly<br> <li> Tests all three GU tensors of real Qwen3-0.6B.1bp with maxdiff <= 1e-3<br> <li> Reports GATE PASSED / GATE FAILED based on mismatch count</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1983/files#diff-f263054721bb9ac9e1deeb25d75f3e1754dff743c13140f3e5320054b72852b2">+110/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

