### PR TITLE
feat(npu): #1934 — per-(row,32-col) zero-point grid + additive-zp dequant contract

### DIFF
--- a/engine/npu/src/gu_i4_pack.h
+++ b/engine/npu/src/gu_i4_pack.h
@@ -50,6 +50,18 @@ struct GuI4Pack {
     // pack_gu_fused_i4_group_scales() — NOT wired into the production tile
     // stream until the kernel restructure lands (per issue #1934).
     std::vector<uint16_t> scl_g_bf16;   // [H * RC] bf16 bits (RC = raw.cols/32)
+    // Issue #1934 (round-9): the per-(row, 32-col-group) bf16 zero-point grid,
+    // same indexing as scl_g_bf16. The v66 ratioQ22 dequant is SYMMETRIC-only
+    // (B'' = round(q4*s/S_col) drops zp): Zaya (zp=0) holds 0.9996 FFN corr,
+    // but the 1BP format carries an asymmetric bf16 zp (Qwen3-0.6B.1bp:
+    // |zp| mean 0.0129, same order as the scales) which drops B_shadow-vs-
+    // float corr to ~0.912. The restructured kernel must carry an ADDITIVE
+    // per-(row,32-col) zp term in C1: B'' = round((q4*s + zp)/S_col) =
+    // round(q4*a + b), b = zp/S_col. Populated by
+    // pack_gu_fused_i4_group_scales() — CPU-gated byte-exact in
+    // test_1bp_q4nx_reader.cpp (W = q4*s + zp' with the signed fold
+    // q4'=v-8, zp'=8s+zp preserved).
+    std::vector<uint16_t> zp_g_bf16;    // [H * RC] bf16 bits (RC = raw.cols/32)
     static constexpr size_t TILE_BYTES = 64 * 128 / 2;   // nibbles (4096)
     // v65 tile layout (all within the aie2p-delivered [0..5632) region):
     //   [0,      4096)  nibbles (region A, 4096 B = 64x128 q4)
@@ -317,6 +329,7 @@ static inline void pack_gu_fused_i4_group_scales(const RawQ4Tensor& raw,
     const size_t gbase = (size_t)expert * N;
     const int RC = raw.cols / 32;            // raw tensor scale stride (H/32)
     p.scl_g_bf16.assign((size_t)N * RC, 0);  // [2*n_ff, RC] gate+up rows
+    p.zp_g_bf16.assign((size_t)N * RC, 0);   // same layout, zero-point grid
     for (size_t pp = 0; pp < (size_t)n_ff; pp++) {
         // gate row = gbase + pp, up row = gbase + n_ff + pp (w_at layout)
         for (int gate_up = 0; gate_up < 2; gate_up++) {
@@ -324,6 +337,8 @@ static inline void pack_gu_fused_i4_group_scales(const RawQ4Tensor& raw,
             for (int i = 0; i < H; i++) {
                 uint16_t s16 = f32_to_bf16_impl(raw.scl[r * RC + i / 32]);
                 p.scl_g_bf16[(r - gbase) * RC + i / 32] = s16;
+                p.zp_g_bf16[(r - gbase) * RC + i / 32] =
+                    f32_to_bf16_impl(raw.zp[r * RC + i / 32]);
             }
         }
     }

--- a/engine/npu/tests/test_1bp_q4nx_reader.cpp
+++ b/engine/npu/tests/test_1bp_q4nx_reader.cpp
@@ -23,6 +23,7 @@
 //   /tmp/test_1bp_q4nx_reader models/Qwen3-0.6B.1bp [tensor...]
 #include "onebp_format.h"
 #include "q4nx_raw.h"
+#include "gu_i4_pack.h"
 #include "onebp_loader.cpp"   // NpuOnebpModel (defines class; no main)
 
 #include <cmath>
@@ -103,6 +104,82 @@ int main(int argc, char** argv) {
         CHECK(bad == 0 && nan == 0 && maxd <= 1e-3,
               "%s: W=q4*s+zp vs get_tensor_f32: %ld/%ld bad, nan=%ld, "
               "maxdiff=%.6f rmse=%.6f", tname, bad, tot, nan, maxd, rmse);
+
+        // ── Issue #1934 round-9: the per-(row,32-col) ZERO-POINT grid ──
+        // The v66 ratioQ22 dequant is symmetric-only (B'' = round(q4*s/S_col)
+        // drops zp). Zaya (zp=0) holds 0.9996 FFN corr; the 1BP format's
+        // asymmetric zp (|zp| mean 0.0129, same order as the scales) drops
+        // B_shadow-vs-float corr to ~0.912 (measured). The restructured
+        // kernel must carry an ADDITIVE per-(row,32-col) zp term in C1:
+        //   B'' = round((q4*s + zp)/S_col) = round(q4*a + b), b = zp/S_col.
+        // This gate pins the host-side contract: pack_gu_fused_i4_group_scales
+        // emits the zp grid byte-exactly from the raw tensor, and the additive
+        // dequant reproduces the engine's int8 re-quant to within the
+        // rounding-boundary tolerance (fixed-point (q4*16*rq + zpq)>>22 vs
+        // float round: measured 1390/3,145,728 bytes differ, all round-half
+        // boundaries).
+        {
+            GuI4Pack pg;
+            pack_gu_fused_i4_group_scales(t, 0, C, R / 2, pg);
+            long zp_bad = 0;
+            for (int r = 0; r < R; r++)
+                for (int g = 0; g < C / 32; g++) {
+                    // Compare the pack's bf16 bits against the tensor's bf16
+                    // bits (the pack re-rounds float->bf16; RNE is lossless
+                    // for values already bf16-representable, so bit equality
+                    // is the exact check).
+                    uint16_t pg_b = pg.zp_g_bf16[(size_t)r * (C / 32) + g];
+                    uint16_t t_b = f32_to_bf16_impl(t.zp[(size_t)r * (C / 32) + g]);
+                    if (pg_b != t_b) zp_bad++;
+                }
+            CHECK(zp_bad == 0,
+                  "%s: zp grid bf16-bits vs raw (folded) zp: %ld/%ld bad",
+                  tname, zp_bad, (long)R * (C / 32));
+
+            // Additive-zp dequant vs engine int8 re-quant: per-column
+            // S_col = amax/127 over K (packer convention).
+            const int H_ = C, nff = R / 2;
+            const size_t N_ = 2 * (size_t)nff;
+            std::vector<float> scol(N_, 1.0f);
+            for (size_t j = 0; j < N_; j++) {
+                float amax = 0;
+                for (int i = 0; i < H_; i++) {
+                    int pp = (int)(j / 2);
+                    size_t r = (size_t)pp; if (j & 1) r = (size_t)nff + pp;
+                    float w = (float)t.q4[(size_t)r * C + i] * t.scl[(size_t)r * (C/32) + i/32]
+                            + t.zp[(size_t)r * (C/32) + i/32];
+                    float a = std::fabs(w); if (a > amax) amax = a;
+                }
+                if (amax > 1e-12f) scol[j] = amax / 127.0f;
+            }
+            long dz_bad = 0, dz_tot = (long)H_ * (long)N_;
+            double dz_maxd = 0;
+            for (int i = 0; i < H_; i++)
+                for (size_t j = 0; j < N_; j++) {
+                    int pp = (int)(j / 2);
+                    size_t r = (size_t)pp; if (j & 1) r = (size_t)nff + pp;
+                    int q4 = t.q4[(size_t)r * C + i];
+                    float s = t.scl[(size_t)r * (C/32) + i/32];
+                    float z = t.zp[(size_t)r * (C/32) + i/32];
+                    // fixed-point additive form the kernel will use:
+                    // rq = (s/16)/S_col * 2^22 ; zpq = z/S_col * 2^22
+                    long rq = (long)std::lroundf((s * 0.0625f) / scol[j] * 4194304.0f);
+                    long zpq = (long)std::lroundf(z / scol[j] * 4194304.0f);
+                    long x = ((long)q4 * 16 * rq + zpq + (1L << 21)) >> 22;
+                    int8_t b = (int8_t)(x > 127 ? 127 : x < -127 ? -127 : x);
+                    // engine reference: int8 re-quant of the exact float W
+                    float w = (float)q4 * s + z;
+                    long xr = (long)std::lroundf(w / scol[j]);
+                    int8_t br = (int8_t)(xr > 127 ? 127 : xr < -127 ? -127 : xr);
+                    double d = std::fabs((double)b - br);
+                    if (d > dz_maxd) dz_maxd = d;
+                    if (b != br) dz_bad++;   // round-boundary bytes only
+                }
+            CHECK(dz_bad * 1000 <= dz_tot,   // <= 0.1% round-boundary diff
+                  "%s: additive-zp fixed-point dequant vs int8 re-quant: "
+                  "%ld/%ld boundary bytes, maxdiff=%.6f (rounding only)",
+                  tname, dz_bad, dz_tot, dz_maxd);
+        }
     }
 
     fprintf(stderr, "\n%s\n", failures ? "GATE FAILED" : "GATE PASSED");


### PR DESCRIPTION
### **User description**
## Summary
Fixes the #1934 host-side contract gap found in round-8: the v66 ratioQ22 dequant is **symmetric-only** (`B = round(q4*s/S_col)` drops zp). Zaya (zp=0) holds 0.9996 FFN corr, but the 1BP format carries an asymmetric bf16 zero-point (Qwen3-0.6B.1bp: |zp| mean 0.0129, same order as scales) which drops B_shadow-vs-float corr to **~0.912** (measured on all 3 GU tensors). The restructured kernel must carry an **additive per-(row,32-col) zp term in C1**: `B = round((q4*s+zp)/S_col) = round(q4*a + b)`, b = zp/S_col.

## Scope
- `engine/npu/src/gu_i4_pack.h`: `GuI4Pack.zp_g_bf16` grid (`[2*n_ff, RC]` bf16 bits, same indexing as `scl_g_bf16`), populated by `pack_gu_fused_i4_group_scales()`.
- `engine/npu/tests/test_1bp_q4nx_reader.cpp`: two new gates on real Qwen3-0.6B.1bp — (1) zp grid bf16-bits byte-exact vs raw folded zp (0/98,304 bad/tensor); (2) fixed-point additive dequant `(q4*16*rq + zpq)>>22` (rq=(s/16)/S_col*2^22, zpq=z/S_col*2^22) matches the engine int8 re-quant within round-boundary bytes only (1390/1423/906 of 3,145,728 — lroundf vs round-half-away tie-break). **GATE PASSED**.

## Testing
- Byte-exact on strixhalo with real Qwen3-0.6B.1bp (all 3 GU tensors, 3,145,728 elements each).
- Existing `read_q4nx_raw_1bp` reconstruction gate still green (0/3,145,728 bad).
- Diagnostic chain: element corr without-zp 0.912 / with-zp 0.979 (vs zaya symmetric baseline 0.992 element / 0.9996 FFN).

## Documentation
- [x] No docs change required (finding + contract in issue #1934).

## Breaking Changes
- [x] No breaking changes (additive fields/function; existing tests unaffected).

## AI-assisted contribution
- This change was implemented with AI assistance (hypothesis verified empirically on strixhalo hardware).


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add per-(row,32-col) zero-point bf16 grid for asymmetric dequant

- Mirror `scl_g_bf16` indexing and populate from raw folded `zp`

- Gate byte-exact zp bits and additive fixed-point dequant in tests

- Kernel restructure and xclbin rebuild remain the silicon round


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["raw 1BP tensor (q4, scl, zp)"] --> B["pack_gu_fused_i4_group_scales"]
  B --> C["scl_g_bf16 grid"]
  B --> D["zp_g_bf16 grid (new)"]
  C --> E["additive dequant (q4*16*rq + zpq)>>22"]
  D --> E
  E --> F["engine int8 re-quant bytes"]
  D --> G["tests: byte-exact zp bits + <=0.1% boundary bytes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gu_i4_pack.h</strong><dd><code>Add zero-point grid to GuI4Pack</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/gu_i4_pack.h

<ul><li>Add <code>zp_g_bf16</code> per-(row,32-col) zero-point grid to <code>GuI4Pack</code><br> <li> Same indexing and layout as the existing <code>scl_g_bf16</code> grid<br> <li> Populate grid in <code>pack_gu_fused_i4_group_scales</code> from raw <code>zp</code> via bf16 <br>conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1984/files#diff-9b71d224944bb6e7af40f37e35eac50e26579074eeed27dac15d1f42ec285f87">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_1bp_q4nx_reader.cpp</strong><dd><code>Gate zero-point grid and additive dequant contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tests/test_1bp_q4nx_reader.cpp

<ul><li>Gate packed <code>zp_g_bf16</code> bf16 bits against raw folded zero-points <br>(byte-exact)<br> <li> Add additive-zp fixed-point dequant reference <code>(q4*16*rq + zpq)>>22</code><br> <li> Compare against engine int8 re-quant with <=0.1% round-boundary <br>allowance</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1984/files#diff-f263054721bb9ac9e1deeb25d75f3e1754dff743c13140f3e5320054b72852b2">+77/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

