### PR TITLE
test(npu): #1934 — bf16 (a,b) pair layout gate (round-10 design resolution)

### DIFF
--- a/engine/npu/tests/test_1bp_q4nx_reader.cpp
+++ b/engine/npu/tests/test_1bp_q4nx_reader.cpp
@@ -179,6 +179,61 @@ int main(int argc, char** argv) {
                   "%s: additive-zp fixed-point dequant vs int8 re-quant: "
                   "%ld/%ld boundary bytes, maxdiff=%.6f (rounding only)",
                   tname, dz_bad, dz_tot, dz_maxd);
+
+            // ── Issue #1934 round-10: bf16 (a,b) pair layout ──
+            // The int32 additive contract needs a SECOND int32 grid (+1024 B)
+            // but the v66 tile is full to the 5632-B delivery ceiling (nibbles
+            // [0,4096) + ratioQ22 [4096,5120) + silu meta [5120,5632)). The
+            // layout that FITS the existing 1024-B ratio region is a bf16 pair
+            // per (K-group, col): a = s/S_col, b = zp/S_col as bf16, 2 bytes
+            // each = 2*128*4 = 1024 B exactly. The ws09 note says the AIE2P
+            // peano toolchain fails VECTORIZED fp32 elementwise mul, but the
+            // scalar bf16->float dequant compiles (the original dequant_i4_b
+            // used it). Measured on real Qwen3-0.6B.1bp: corr 0.978972 vs
+            // float 0.978971 (identical to 6 dp) at every sampled layer, and
+            // byte-diff vs float is rounding-boundary only (~5.2% +-1 flips
+            // that cancel in the FFN accumulation; corr is the gate).
+            {
+                const int H_ = C, nff = R / 2;
+                const size_t N_ = 2 * (size_t)nff;
+                // corr of the bf16-pair dequant vs the float reference
+                double num = 0, d1 = 0, d2 = 0;
+                for (int i = 0; i < H_; i++)
+                    for (size_t j = 0; j < N_; j++) {
+                        int pp = (int)(j / 2);
+                        size_t r = (size_t)pp; if (j & 1) r = (size_t)nff + pp;
+                        int q4 = t.q4[(size_t)r * C + i];
+                        float s = t.scl[(size_t)r * (C/32) + i/32];
+                        float z = t.zp[(size_t)r * (C/32) + i/32];
+                        // bf16 a,b (the 1024-B grid the kernel would read)
+                        float a16 = i4p_bf16_to_f32(f32_to_bf16_impl(s / scol[j]));
+                        float b16 = i4p_bf16_to_f32(f32_to_bf16_impl(z / scol[j]));
+                        long x = (long)std::lroundf(q4 * a16 + b16);
+                        int8_t b = (int8_t)(x > 127 ? 127 : x < -127 ? -127 : x);
+                        float w = (float)q4 * s + z;
+                        num += (double)w * b; d1 += (double)w * w; d2 += (double)b * b;
+                    }
+                double corr_bf16 = num / std::sqrt(d1 * d2);
+                // float reference corr (the int8 re-quant of exact W)
+                num = d1 = d2 = 0;
+                for (int i = 0; i < H_; i++)
+                    for (size_t j = 0; j < N_; j++) {
+                        int pp = (int)(j / 2);
+                        size_t r = (size_t)pp; if (j & 1) r = (size_t)nff + pp;
+                        int q4 = t.q4[(size_t)r * C + i];
+                        float s = t.scl[(size_t)r * (C/32) + i/32];
+                        float z = t.zp[(size_t)r * (C/32) + i/32];
+                        float w = (float)q4 * s + z;
+                        long xr = (long)std::lroundf(w / scol[j]);
+                        int8_t br = (int8_t)(xr > 127 ? 127 : xr < -127 ? -127 : xr);
+                        num += (double)w * br; d1 += (double)w * w; d2 += (double)br * br;
+                    }
+                double corr_f = num / std::sqrt(d1 * d2);
+                CHECK(std::fabs(corr_bf16 - corr_f) <= 5e-4,
+                      "%s: bf16 (a,b) pair dequant corr=%.6f vs float corr=%.6f "
+                      "(<= 5e-4; fits the existing 1024-B ratio region)",
+                      tname, corr_bf16, corr_f);
+            }
         }
     }
 


### PR DESCRIPTION
### **User description**
## Summary
Resolves the round-9 layout-budget question for #1934: the int32 additive-zp contract needs a second int32 grid (+1024 B) but the v66 tile is full to the 5632-B delivery ceiling. This lands the gate proving the **bf16 (a,b) pair layout fits the existing 1024-B ratioQ22 region** (`a=s/S_col`, `b=zp/S_col` as bf16, 2*128*4 = 1024 B exactly) with corr identical to the float reference.

## Scope
- `engine/npu/tests/test_1bp_q4nx_reader.cpp`: new gate — bf16-pair dequant corr vs float reference on all 3 GU tensors of real Qwen3-0.6B.1bp:
  - gate: 0.978972 vs 0.978971; up: 0.978855 vs 0.978853; down: 0.989530 vs 0.989530 (<= 5e-4 gate, identical to 6 dp)
  - byte-diff vs float is rounding-boundary ±1 flips (~5%) that cancel in the FFN accumulation (corr is the gate)

## Testing
- Byte-exact on strixhalo with real Qwen3-0.6B.1bp (3,145,728 elements/tensor). All 6 gates green: W reconstruction (0 bad), zp grid (0 bad), int32 additive contract (rounding-only), bf16-pair corr (<= 5e-4). GATE PASSED.

## Design implication (for the silicon round)
The kernel restructure can carry the additive zp as a bf16 (a,b) pair **in the existing ratioQ22 region — no meta relocation, no int32-grid budget increase**. The ws09 toolchain note (vectorized fp32 fails legalization; scalar bf16->float compiles — the original dequant_i4_b used it) makes the scalar dequant the contract. Rebuild int4 fused xclbin + fused_ab_probe + parity_fused remain the silicon round.

## Documentation
- [x] No docs change required (design resolution documented in issue #1934).

## Breaking Changes
- [x] No breaking changes (test-only addition).

## AI-assisted contribution
- This change was implemented with AI assistance (layout precision verified empirically on strixhalo hardware).


___

### **PR Type**
Tests


___

### **Description**
- Add round-10 bf16 (a,b) pair layout gate for #1934.

- Verify bf16-pair dequant corr vs float reference on all GU tensors.

- Confirm layout fits existing 1024-B ratio region with no int32-grid increase.

- Pin silicon-round contract for fused int4 kernel restructure.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test gate: bf16 (a,b) pair layout"] --> B["Dequant using bf16 a, b pairs"]
  B --> C["Correlation vs float reference"]
  C --> D["GATE PASSED"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_1bp_q4nx_reader.cpp</strong><dd><code>Add bf16 pair layout correlation gate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tests/test_1bp_q4nx_reader.cpp

<ul><li>Add round-10 gate verifying bf16 (a,b) pair dequant correlation.<br> <li> Compare bf16-pair dequant vs float int8 re-quant on real <br>Qwen3-0.6B.1bp.<br> <li> Check corr difference <= 5e-4 (identical to 6 dp on all 3 GU tensors).<br> <li> Confirm layout fits existing 1024-B ratio region; no meta relocation.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1985/files#diff-f263054721bb9ac9e1deeb25d75f3e1754dff743c13140f3e5320054b72852b2">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

