### PR TITLE
feat(npu): #1934 — bf16-pair additive-zp kernel dequant (I4_BF16_PAIR) + packer mode + build variant

### DIFF
--- a/engine/npu/generators/build_p1i4_qwen3_iron.sh
+++ b/engine/npu/generators/build_p1i4_qwen3_iron.sh
@@ -2,6 +2,12 @@
 # Build the Qwen3-0.6B int4 fused GU→SiLU→D xclbin with the IRON toolchain.
 # vs the default venv (c9c5ecb7) — the newer backend may fix the scalar
 # multiply miscompile (issue #1769).
+#
+# I4_BF16_PAIR=1 (issue #1934 round-11): build the kernel with the additive
+# zero-point dequant (B'' = round(q4*a + b), a=s/S_col, b=zp/S_col as a bf16
+# pair in the [4096,5120) region) instead of the symmetric-only v66 ratioQ22.
+# Emits final_i8_GUSILU_i4_qwen3_0_6b_bf16pair.xclbin so the default build is
+# untouched; the zaya path (symmetric zp=0) keeps the verified ratioQ22 kernel.
 set -euo pipefail
 P=/home/bcloud/iron/lib/python3.14/site-packages/llvm-aie
 M=/home/bcloud/iron/lib/python3.14/site-packages/mlir_aie
@@ -10,8 +16,18 @@ G=$(cd "$(dirname "$0")" && pwd)
 W=/tmp/p1i4_iron.$$
 mkdir -p "$W"; trap 'rm -rf "$W"' EXIT
 
+MM_FLAGS="-DDIM_M=8 -DDIM_K=64 -DDIM_N=128 -Di8_i32_ONLY -DM8_VECTORIZED"
+XCLBIN="$G/../xclbins/final_i8_GUSILU_i4_qwen3_0_6b.xclbin"
+INSTS="$G/../xclbins/insts_i8_GUSILU_i4_qwen3_0_6b.txt"
+if [ "${I4_BF16_PAIR:-0}" = "1" ]; then
+    MM_FLAGS="$MM_FLAGS -DI4_BF16_PAIR"
+    XCLBIN="$G/../xclbins/final_i8_GUSILU_i4_qwen3_0_6b_bf16pair.xclbin"
+    INSTS="$G/../xclbins/insts_i8_GUSILU_i4_qwen3_0_6b_bf16pair.txt"
+    echo "building bf16-pair variant -> $(basename "$XCLBIN")"
+fi
+
 $P/bin/clang++ --target=aie2p-none-unknown-elf --std=c++20 -O2 \
-    -DDIM_M=8 -DDIM_K=64 -DDIM_N=128 -Di8_i32_ONLY -DM8_VECTORIZED \
+    $MM_FLAGS \
     -isystem $P/include/c++/v1 \
     -I /home/bcloud/Xilinx/2025.2/Vitis/aietools/include \
     -I $M/include/aie_kernels/aie2p \
@@ -47,6 +63,6 @@ cd "$W"
     --alloc-scheme=basic-sequential --no-xchesscc --no-xbridge \
     --aie-generate-xclbin --no-compile-host --unified --dynamic-objFifos \
     --aie-generate-npu-insts \
-    --xclbin-name="$G/../xclbins/final_i8_GUSILU_i4_qwen3_0_6b.xclbin" \
-    --npu-insts-name="$G/../xclbins/insts_i8_GUSILU_i4_qwen3_0_6b.txt" \
+    --xclbin-name="$XCLBIN" \
+    --npu-insts-name="$INSTS" \
     "$W/design.mlir" 2>&1 | tail -1

--- a/engine/npu/generators/mm_kernel_reference.cc
+++ b/engine/npu/generators/mm_kernel_reference.cc
@@ -885,21 +885,51 @@ extern "C" void matmul_i8_i32_i4(const int8_t *__restrict pA,
             for (unsigned jt = 0; jt < 4; ++jt) {
                 unsigned j = jg + jt;   // col-tile index 0..15
                 const uint8_t* nib = pB4 + i * 512 + j * 32;
+                const v64int4* pv = (const v64int4*)nib;
+                auto u = unpack_i4_sx(pv);
+                u = u + u; u = u + u; u = u + u; u = u + u;   // q4<<4
+#ifdef I4_BF16_PAIR
+                // Issue #1934 (round-10 layout): the additive zero-point
+                // term as a bf16 (a, b) pair per (K-group, col) — a = s/S_col,
+                // b = zp/S_col, 2 bytes each, 2*128*4 = 1024 B, exactly the
+                // v66 ratioQ22 region [4096, 5120). The symmetric-only v66
+                // ratio drops zp (1BP asymmetric zp: B_shadow corr 0.912,
+                // round-9/10 gates); the restructured kernel dequants
+                // B'' = sat8(round(q4*a + b)) with the additive term. Scalar
+                // bf16->float dequant is toolchain-legal (the ws09 note: only
+                // VECTORIZED fp32 fails peano legalization; dequant_i4_b used
+                // scalar float). Region layout (packed by the host):
+                //   [4096 + group*512 + col*4 + 0] = bf16 a (s/S_col)
+                //   [4096 + group*512 + col*4 + 2] = bf16 b (zp/S_col)
+                // group = k/32 within the 64-tile = i/4 for k-chunk i.
+                const uint8_t* ab = pB4 + 4096 + (size_t)(i / 4) * 512 + (size_t)j * 32;
+                for (int e = 0; e < 64; e++) {
+                    uint16_t a16 = (uint16_t)ab[(e & 7) * 4] | ((uint16_t)ab[(e & 7) * 4 + 1] << 8);
+                    uint16_t b16 = (uint16_t)ab[(e & 7) * 4 + 2] | ((uint16_t)ab[(e & 7) * 4 + 3] << 8);
+                    // bf16 -> f32: value bits in the top half (no libm;
+                    // union bit-cast is the portable no-memcpy form).
+                    union { uint32_t u; float f; } a_ = { (uint32_t)a16 << 16 };
+                    union { uint32_t u; float f; } b_ = { (uint32_t)b16 << 16 };
+                    float af = a_.f, bf = b_.f;
+                    // q4 = (q4<<4)>>4 — sign-extended nibble (already in u)
+                    float v = (float)(int8_t)(u[e] >> 4) * af + bf;
+                    int r = silu_roundf(v);   // round-half-away (no-libm)
+                    Bb[jt][e] = (int8_t)(r > 127 ? 127 : r < -127 ? -127 : r);
+                }
+#else
                 // v65 ratioQ22 (int32) at [4096 + group*512 + col*4] — the
                 // old bf16 s/S_col reads at [4096..4864) were removed in the
                 // v65 pack (they overlapped the ratio region). group = k/32
                 // within the 64-tile = i/4 for k-chunk i.
                 const int32_t* rq = (const int32_t*)(pB4 + 4096 + (size_t)(i / 4) * 512
                                                      + (size_t)j * 32);
-                const v64int4* pv = (const v64int4*)nib;
-                auto u = unpack_i4_sx(pv);
-                u = u + u; u = u + u; u = u + u; u = u + u;   // q4<<4
                 for (int e = 0; e < 64; e++) {
                     // B'' = sat8(round((q4<<4) * ratioQ22 / 2^22))
                     int x = (int)(int8_t)u[e] * rq[e & 7];
                     int r = (x + (1 << 21)) >> 22;
                     Bb[jt][e] = (int8_t)(r > 127 ? 127 : r < -127 ? -127 : r);
                 }
+#endif
             }
             aie::vector<int8, 64> B0 = aie::load_v<64>(Bb[0]);
             aie::vector<int8, 64> B1 = aie::load_v<64>(Bb[1]);

--- a/engine/npu/src/gu_i4_pack.h
+++ b/engine/npu/src/gu_i4_pack.h
@@ -180,7 +180,8 @@ static inline void write_gu_i4_bo(uint8_t* bo, const GuI4Pack& p) {
 }
 
 static inline GuI4Pack pack_gu_fused_i4(const RawQ4Tensor& raw, int expert,
-                                        int H, int n_ff) {
+                                        int H, int n_ff,
+                                        bool bf16_pair = false) {
     const size_t N = 2 * (size_t)n_ff;
     const size_t gbase = (size_t)expert * N;
     const int CG = (int)(N / 32);            // INTERLEAVED col-groups of 32
@@ -258,6 +259,9 @@ static inline GuI4Pack pack_gu_fused_i4(const RawQ4Tensor& raw, int expert,
                             int q4 = raw.q4[r * H + i];
                             uint16_t s16 = f32_to_bf16_impl(raw.scl[r * RC + (i / 32)]);
                             uint32_t sbits = (uint32_t)s16 << 16; float srow; memcpy(&srow, &sbits, 4);
+                            // FOLDED zero-point (read_q4nx_raw_1bp: q4'=v-8,
+                            // zp'=8s+zp preserves W = q4'*s + zp' = v*s + zp).
+                            float zp_cur = raw.zp[r * RC + (i / 32)];
                             // Canonical kernel dequant (byte-pinned):
                             //   w16 = q4<<4 (exact); ratio = (s/16)/S_col;
                             //   B'' = sat8(round(w16 * ratio))
@@ -274,38 +278,65 @@ static inline GuI4Pack pack_gu_fused_i4(const RawQ4Tensor& raw, int expert,
                                 p.tiles[byte_off] = (uint8_t)((p.tiles[byte_off] & 0xF0) | (q4 & 0x0F));
                             else
                                 p.tiles[byte_off] = (uint8_t)((p.tiles[byte_off] & 0x0F) | ((q4 & 0x0F) << 4));
-                            // v65 ratioQ22 at [4096 + group*512 + col*4] (group =
-                            // k/32, col within tile): the aie2p object-fifo
-                            // delivers only [0..5632) of each 8192-B B tile, so
-                            // the ratio moved DOWN from the old [5120..6144)
-                            // region (which straddled the 5632 boundary — group-1
-                            // dequant read never-delivered bytes, measured
-                            // 2026-08-24). The old per-tile bf16 s/S_col bytes at
-                            // [4096..4864) are UNUSED by the int4 kernel (it
-                            // dequants via the ratio alone), so the ratio
-                            // overwrites them. Q22 (2^22): Q32 overflowed for
-                            // ratio>0.5 (93.6% of real ratios).
-                            int rq = (int)std::roundf(ratio * 4194304.0);
+                            // Region at [4096 + group*512 + col*4], group =
+                            // k/32, col within tile (the aie2p object-fifo
+                            // delivers only [0..5632) of each 8192-B B tile).
+                            // v65/v66: ratioQ22 int32 (the symmetric-only
+                            // dequant B'' = round(q4*ratio/2^18), drops zp).
+                            // bf16_pair (issue #1934, round-10 layout): the
+                            // additive zero-point term as a bf16 (a, b) pair
+                            // per (K-group, col) — a = s/S_col, b = zp/S_col,
+                            // 2 bytes each = the SAME 1024 B region; the
+                            // restructured kernel (I4_BF16_PAIR) dequants
+                            // B'' = sat8(round(q4*a + b)). Q22 (2^22): Q32
+                            // overflowed for ratio>0.5 (93.6% of real ratios).
                             size_t r_off = tbase + 4096 + (size_t)((i0 * 8 + i2) / 32) * 512
                                            + (i1 * 8 + i3) * 4;
-                            p.tiles[r_off]     = (uint8_t)(rq & 0xFF);
-                            p.tiles[r_off + 1] = (uint8_t)((rq >> 8) & 0xFF);
-                            p.tiles[r_off + 2] = (uint8_t)((rq >> 16) & 0xFF);
-                            // v66: B_shadow = the kernel's EXACT B'' — computed
-                            // from the SAME ratioQ22 int32 that rides the tile
-                            // (sat8(round-half-away(q4·rq / 2^18))), NOT the
-                            // float ratio: the float path ±1 flips at round
-                            // boundaries (measured 292,796/8,388,608 on the old
-                            // bf16-S_col contract) and broke the byte-identity
-                            // gate. B_shadow is the host reference for the C1
-                            // corr gate, so it must match the NPU byte-for-byte.
-                            int xq = q4 * rq;
-                            int ax = xq < 0 ? -xq : xq;
-                            int rr = (ax + (1 << 17)) >> 18;   // round-half-away
-                            rr = xq < 0 ? -rr : rr;
-                            p.B_shadow[(size_t)i * N + j] =
-                                (int8_t)(rr > 127 ? 127 : rr < -127 ? -127 : rr);
-                            p.tiles[r_off + 3] = (uint8_t)((rq >> 24) & 0xFF);
+                            if (bf16_pair) {
+                                // a = s/S_col, b = zp'/S_col as bf16 bits,
+                                // where zp' is the FOLDED zero-point from
+                                // read_q4nx_raw_1bp (q4'=v-8, zp'=8s+zp, so
+                                // q4'*s + zp' = v*s + zp exactly). The kernel
+                                // (I4_BF16_PAIR) dequants B''=round(q4'*a+b)
+                                // with q4' the sign-extended nibble. Divide
+                                // by the FULL-precision S_col (p.scol[j]) so
+                                // the bf16 a/b match the round-10 verified
+                                // gate byte-for-byte.
+                                uint16_t ab = f32_to_bf16_impl(srow / p.scol[j]);
+                                uint16_t bb = f32_to_bf16_impl(zp_cur / p.scol[j]);
+                                p.tiles[r_off]     = (uint8_t)(ab & 0xFF);
+                                p.tiles[r_off + 1] = (uint8_t)((ab >> 8) & 0xFF);
+                                p.tiles[r_off + 2] = (uint8_t)(bb & 0xFF);
+                                p.tiles[r_off + 3] = (uint8_t)((bb >> 8) & 0xFF);
+                                // B_shadow = the kernel's EXACT B'' for the
+                                // bf16-pair contract: sat8(round(q4*a + b)).
+                                float av = i4p_bf16_to_f32(ab);
+                                float bv = i4p_bf16_to_f32(bb);
+                                float fv = (float)q4 * av + bv;
+                                int fr = (int)std::roundf(fv);
+                                p.B_shadow[(size_t)i * N + j] =
+                                    (int8_t)(fr > 127 ? 127 : fr < -127 ? -127 : fr);
+                            } else {
+                                int rq = (int)std::roundf(ratio * 4194304.0);
+                                p.tiles[r_off]     = (uint8_t)(rq & 0xFF);
+                                p.tiles[r_off + 1] = (uint8_t)((rq >> 8) & 0xFF);
+                                p.tiles[r_off + 2] = (uint8_t)((rq >> 16) & 0xFF);
+                                p.tiles[r_off + 3] = (uint8_t)((rq >> 24) & 0xFF);
+                                // v66: B_shadow = the kernel's EXACT B'' — computed
+                                // from the SAME ratioQ22 int32 that rides the tile
+                                // (sat8(round-half-away(q4·rq / 2^18))), NOT the
+                                // float ratio: the float path ±1 flips at round
+                                // boundaries (measured 292,796/8,388,608 on the old
+                                // bf16-S_col contract) and broke the byte-identity
+                                // gate. B_shadow is the host reference for the C1
+                                // corr gate, so it must match the NPU byte-for-byte.
+                                int xq = q4 * rq;
+                                int ax = xq < 0 ? -xq : xq;
+                                int rr = (ax + (1 << 17)) >> 18;   // round-half-away
+                                rr = xq < 0 ? -rr : rr;
+                                p.B_shadow[(size_t)i * N + j] =
+                                    (int8_t)(rr > 127 ? 127 : rr < -127 ? -127 : rr);
+                            }
                         }
                     }
         }


### PR DESCRIPTION
### **User description**
## Summary
Lands the **kernel-side restructure** for #1934: the v66 ratioQ22 dequant is symmetric-only (drops zp). This adds the additive per-(K-group,col) zero-point term as a **bf16 (a,b) pair** in the existing [4096,5120) ratioQ22 region — the layout contract pinned in #1985.

## Scope
- `engine/npu/generators/mm_kernel_reference.cc`: `matmul_i8_i32_i4` gains `I4_BF16_PAIR` — reads bf16 `a=s/S_col`, `b=zp/S_col` per (K-group,col), dequants `B = sat8(round(q4*a + b))` with scalar float (toolchain-legal per ws09: only VECTORIZED fp32 fails peano legalization; union bit-cast, no libm). Default ratioQ22 path byte-identical (zaya untouched).
- `engine/npu/src/gu_i4_pack.h`: `pack_gu_fused_i4(bf16_pair=true)` writes the bf16 pair (folded zp' from `read_q4nx_raw_1bp`) + B_shadow matching the new kernel contract.
- `engine/npu/generators/build_p1i4_qwen3_iron.sh`: `I4_BF16_PAIR=1` emits `final_i8_GUSILU_i4_qwen3_0_6b_bf16pair.xclbin`; default build unchanged.

## Testing (strixhalo, real Qwen3-0.6B.1bp, 3,145,728 elements/tensor)
- **kernel-emul(tile bytes) vs pack.B_shadow: 0/3,145,728 bad, maxdiff=0** (all 3 GU tensors) — the exact kernel arithmetic on the actual tile bytes.
- bf16-pair pack B_shadow corr vs float: 0.978972/0.978855/0.989530 — byte-equal to the round-10 verified contract.
- bf16-pair xclbin builds end-to-end (77 KB, rc=0); existing gates (group-scales, 1bp reader) still PASS.

## Documentation
- [x] No docs change required (contract chain in issue #1934).

## Breaking Changes
- [x] No breaking changes (guard-gated kernel path; default build identical; additive packer param defaults to existing behavior).

## AI-assisted contribution
- This change was implemented with AI assistance (kernel arithmetic verified byte-exact via emulation on strixhalo hardware).


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Kernel-side bf16 (a,b) additive-zp dequant for #1934

- Packer writes folded bf16 zero-point pairs in ratio region

- Build script adds I4_BF16_PAIR bf16pair xclbin variant

- Default ratioQ22/zaya paths remain byte-identical


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pack_gu_fused_i4 bf16_pair"] --> B["bf16 (a,b) pair in ratioQ22 region"]
  B --> C["I4_BF16_PAIR kernel dequant"]
  C --> D["sat8(round(q4*a + b))"]
  D --> E["bf16pair xclbin variant"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mm_kernel_reference.cc</strong><dd><code>Add bf16-pair additive-zp kernel dequant variant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/mm_kernel_reference.cc

<ul><li>Adds <code>I4_BF16_PAIR</code> compile-time branch in <code>matmul_i8_i32_i4</code><br> <li> Reads bf16 <code>a=s/S_col</code>, <code>b=zp/S_col</code> per (K-group,col) from <code>[4096,5120)</code><br> <li> Dequants <code>B'' = sat8(round(q4*a + b))</code> with scalar float, no libm<br> <li> Default ratioQ22 path unchanged for zaya</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1986/files#diff-bfbf7dfd57573c1b95ed14f18638a299a33c1fe23d883599c3517bf08c68ae30">+33/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gu_i4_pack.h</strong><dd><code>Pack bf16 (a,b) pairs and matching B_shadow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/gu_i4_pack.h

<ul><li>Adds <code>bf16_pair</code> mode flag to <code>pack_gu_fused_i4</code><br> <li> Writes folded bf16 <code>a</code>,<code>b</code> pairs into the v66 ratio region<br> <li> Computes exact <code>B_shadow</code> via <code>sat8(round(q4*a+b))</code> for gating<br> <li> Preserves original ratioQ22 pack and B_shadow path by default</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1986/files#diff-9b71d224944bb6e7af40f37e35eac50e26579074eeed27dac15d1f42ec285f87">+62/-31</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_p1i4_qwen3_iron.sh</strong><dd><code>Add I4_BF16_PAIR build variant option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/build_p1i4_qwen3_iron.sh

<ul><li>Parameterizes <code>MM_FLAGS</code>, <code>XCLBIN</code>, and <code>INSTS</code> with <code>I4_BF16_PAIR</code> option<br> <li> Emits <code>final_i8_GUSILU_i4_qwen3_0_6b_bf16pair.xclbin</code> when enabled<br> <li> Default build outputs original xclbin/insts names unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1986/files#diff-9373045b32ddf7054fc90e3969fe20eb4347be988393b06be0eb61900e14c6f1">+19/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

