### PR TITLE
fix(analytics): print full RUM site tags in drift health check

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -95,7 +95,7 @@ jobs:
               jq -r 'if .data then
                        ([.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[] |
                          { tag: .dimensions.siteTag, path: .dimensions.requestPath, views: .sum.visits }]
-                        | .[] | "\(.tag[0:8])…\t\(.views)\t\(.path)")
+                        | .[] | "\(.tag)\t\(.views)\t\(.path)")
                      else "health query failed: \(.errors[0].message // "unknown")" end'
           else
             echo "Site token has data — no drift detected."


### PR DESCRIPTION
### **User description**
The drift health check truncates siteTag to 8 chars, which is not enough to identify the site actually collecting RUM data (dashboard token 33fb8448… maps to dataset tag 4a2e28e9…). Print the full tag so the report can be pointed at the right site.


___

### **PR Type**
Bug fix


___

### **Description**
- Print full RUM site tags in drift health check

- Removes 8-character truncation that hid the real site

- Helps identify the correct RUM collection site in reports


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Drift health check detects no data"] --> B["Query RUM site tags"]
  B --> C["Truncated tag (8 chars)"]
  C --> D["Unclear which site collected data"]
  B --> E["Full site tag"]
  E --> F["Report points to correct RUM site"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.yml</strong><dd><code>Print full RUM site tags when checking drift</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/analytics.yml

<ul><li>Changed jq output to print the complete siteTag value<br> <li> Removed the <code>[0:8]</code> truncation and trailing ellipsis</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1991/files#diff-607f949b9aca36160cbe6db71570383124fdf743994796f8091bb52cf1cc52a4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

