### PR TITLE
fix(analytics): query RUM by dataset siteTag (4a2e28e9…)

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -60,6 +60,12 @@ jobs:
             exit 0
           fi
           echo "Site token: ${SITE_TOKEN:0:8}… (read from site/analytics.js)"
+          # The dashboard embed token (SITE_TOKEN, read from analytics.js) maps to
+          # this dataset siteTag: Cloudflare attributes beacon events to the tag
+          # below, so querying by the embed token returns 0. Resolved 2026-08-31
+          # via the drift health check after re-creating the Web Analytics site.
+          SITE_TAG="${SITE_TAG:-4a2e28e96a7446c6a9933a0f816efc24}"
+          echo "Query tag: ${SITE_TAG:0:8}… (dataset siteTag for the embed token above)"
 
           TODAY=$(date -u +%Y-%m-%d)
           FROM=$(date -u -d "7 days ago" +%Y-%m-%d)
@@ -67,28 +73,28 @@ jobs:
 
           echo ""
           echo "--- Totals ---"
-          TOTAL_JSON=$(gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 1, filter: {siteTag: \"$SITE_TOKEN\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}) { sum { visits } } } } }")
+          TOTAL_JSON=$(gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 1, filter: {siteTag: \"$SITE_TAG\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}) { sum { visits } } } } }")
           TOTAL_VISITS=$(echo "$TOTAL_JSON" | jq -r '.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[0].sum.visits // 0')
           echo "Total visits: $TOTAL_VISITS (window $FROM .. $TODAY)"
           echo "$TOTAL_JSON" | jq -r 'if .errors then "query errors: \(.errors[0].message)" else empty end'
 
           echo ""
           echo "--- Top pages ---"
-          gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 10, filter: {siteTag: \"$SITE_TOKEN\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { requestPath } sum { visits } } } } }" | \
+          gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 10, filter: {siteTag: \"$SITE_TAG\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { requestPath } sum { visits } } } } }" | \
             jq -r 'if .data then ([.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[] | { path: .dimensions.requestPath, views: .sum.visits }] | sort_by(-.views) | .[:10][] | "\(.views)\t\(.path)") else "RUM query failed: \(.errors[0].message // "unknown")" end'
 
           echo ""
           echo "--- Top referrers (how people got here) ---"
-          gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 10, filter: {siteTag: \"$SITE_TOKEN\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { refererHost } sum { visits } } } } }" | \
+          gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 10, filter: {siteTag: \"$SITE_TAG\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { refererHost } sum { visits } } } } }" | \
             jq -r 'if .data then ([.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[] | { referer: .dimensions.refererHost, views: .sum.visits }] | sort_by(-.views) | .[:10][] | "\(.views)\t\(.referer)") else "RUM query failed: \(.errors[0].message // "unknown")" end'
 
           echo ""
           echo "--- RUM health check (token drift detection) ---"
           # If the beacon token reports no data but the account has RUM data, the
-          # site token in analytics.js has drifted from the real RUM site. Discover
-          # the actual siteTag(s) so the report keeps working (2026-08-26: the
-          # beacon was serving a stale token 33fb8448… while the real RUM site
-          # 87349337… collected the data).
+          # site tag in analytics.yml has drifted from the real RUM site. Discover
+          # the actual siteTag(s) so the report keeps working (2026-08-31: embed
+          # token 33fb8448… maps to dataset tag 4a2e28e9…; the old site 87349337…
+          # still holds legacy data).
           if [ "${TOTAL_VISITS:-0}" -eq 0 ] 2>/dev/null; then
             echo "⚠ Site token ${SITE_TOKEN:0:8}… has NO data in this window — checking for token drift:"
             gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 10, filter: {date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { siteTag requestPath } sum { visits } } } } }" | \
@@ -107,7 +113,7 @@ jobs:
           # because Cloudflare Web Analytics does not log query strings (documented
           # limitation). 404.html fires the RUM beacon on the /s/ URL, so requestPath
           # records the full attribution before redirecting to the target.
-          ATTRIBUTION_JSON=$(gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 50, filter: {siteTag: \"$SITE_TOKEN\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { requestPath } sum { visits } } } } }")
+          ATTRIBUTION_JSON=$(gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 50, filter: {siteTag: \"$SITE_TAG\", date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { requestPath } sum { visits } } } } }")
           ATTRIBUTED=$(echo "$ATTRIBUTION_JSON" | jq -r '
             if .data then
               ([.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[]


### PR DESCRIPTION
### **User description**
The dashboard embed token (33fb8448…) is what the beacon sends, but Cloudflare attributes the events to dataset siteTag 4a2e28e96a7446c6a9933a0f816efc24. Querying by the embed token returns 0 visits; this switches the RUM queries (totals, top pages, referrers, attribution) to the dataset tag. Keep the beacon on the embed token.


___

### **PR Type**
Bug fix


___

### **Description**
- Switch RUM GraphQL queries from embed token to dataset siteTag

- Add overridable `SITE_TAG` variable defaulting to `4a2e28e9…`

- Update drift health-check comments to reflect embed-token-to-siteTag mapping

- Keep beacon in `site/analytics.js` unchanged on the embed token


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["analytics.js embed token"] -- "beacon sends" --> D["Cloudflare RUM"]
  A -- "maps to" --> B["dataset siteTag 4a2e28e9…"]
  B -- "used in GraphQL filters" --> C["RUM queries: totals, pages, referrers, attribution"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.yml</strong><dd><code>Switch RUM queries to dataset siteTag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/analytics.yml

<ul><li>Introduce <code>SITE_TAG</code> variable defaulting to dataset siteTag <code>4a2e28e9…</code>, <br>overridable via environment<br> <li> Replace <code>SITE_TOKEN</code> with <code>SITE_TAG</code> in totals, top pages, referrers, and <br>attribution GraphQL queries<br> <li> Update comments explaining the embed-token-to-siteTag mapping and the <br>token drift health check<br> <li> Keep the beacon in <code>site/analytics.js</code> unchanged (still sends the embed <br>token)</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1992/files#diff-607f949b9aca36160cbe6db71570383124fdf743994796f8091bb52cf1cc52a4">+14/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

