### PR TITLE
site: correct zaya post what's-next (CPU attention wall, fused lever blocked)

### DIFF
--- a/site/1bit-post-zaya-q4nx-hrx.html
+++ b/site/1bit-post-zaya-q4nx-hrx.html
@@ -199,7 +199,8 @@
         <p>Because the two runs sum the same math in different orders. The weights are bit-identical between the Q4NX and F32 models; the last 1e-8 of correlation is float32 rounding between the NPU reduction tree and the CPU one &mdash; 1,681&times; below the top-1 margin. It rounds to 1.00000000 and the output is identical.</p>
 
         <h2>What&rsquo;s next</h2>
-        <p>The wall is now the F32 attention path itself (the F32 port does pp32 120 / tg32 10.9 t/s on the same lane). The Q4NX MoE sits 20% behind it, bandwidth-bound. The big lever is a vectorized fused dequant+matmul kernel &mdash; our scalar attempt was 55&times; slower and got reverted; the Q4_K kernel in-tree shows the required design.</p>
+        <p>Profiling corrected the map. The F32 attention matmuls actually run on the <b>CPU</b> &mdash; the HRX2 backend never claimed plain MUL_MAT, and the CPU&rsquo;s AVX-512 handles them well (that CPU path is the real wall at ~11 t/s). Moving them to the NPU&rsquo;s naive f32 kernel is bit-correct but <b>slower</b> (9.9 t/s), so the gating stays.</p>
+        <p>The fused dequant+matmul lever is structurally blocked, not just slow: Q4NX packs 4-bit values with an 8-byte column stride, so the contiguous vector loads that make the in-tree Q4_K kernel fast don&rsquo;t apply. The practical levers are a competitive NPU f32 matmul kernel (helps the F32 path and any F32-attention model) or trimming the Q4NX MoE round-trip (F16 intermediate / expert cache).</p>
       </div>
     
     <section class="related">


### PR DESCRIPTION
### **User description**
Follow-up profiling corrected the post's closing claims: the F32 attention MUL_MATs run on CPU (HRX2 never claimed MUL_MAT), and moving them to the NPU's f32 kernel regresses; the fused dequant+matmul lever is structurally blocked by Q4NX's column-strided packed layout.


___

### **PR Type**
Documentation


___

### **Description**
- Corrects the zaya post's what's-next claims

- Clarifies F32 attention matmuls run on CPU (~11 t/s)

- Explains fused dequant+matmul blocked by Q4NX column stride

- Points to NPU f32 kernel and MoE round-trip as levers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Profiling"] --> B["F32 attention MUL_MAT on CPU"]
  B --> C["AVX-512 wall ~11 t/s"]
  A --> D["NPU naive f32 kernel 9.9 t/s"]
  D --> E["Slower; gating stays"]
  F["Q4NX 8-byte column stride"] --> G["Fused dequant+matmul blocked"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>1bit-post-zaya-q4nx-hrx.html</strong><dd><code>Corrected What's Next claims with accurate profiling data</code></dd></summary>
<hr>

site/1bit-post-zaya-q4nx-hrx.html

<ul><li>Rewrites the What's next section with corrected profiling findings<br> <li> States F32 attention matmuls run on CPU, not NPU; moving them is <br>slower<br> <li> Notes Q4NX packed layout structurally blocks fused dequant+matmul <br>kernel<br> <li> Adds NPU f32 matmul kernel and MoE round-trip trimming as practical <br>levers</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/1999/files#diff-c347aa722a17014cccd25f215bbcc1fae9d58161a1b743f48c4714ea766039d9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

