### PR TITLE
site: zaya post — shuttling fix numbers (+23% decode)

### DIFF
--- a/site/1bit-post-zaya-q4nx-hrx.html
+++ b/site/1bit-post-zaya-q4nx-hrx.html
@@ -182,9 +182,9 @@
             <tr><td>max |dlogit|</td><td>0.0041 &mdash; top-1 margin is 1,681&times; the noise</td></tr>
             <tr><td>top-5 tokens</td><td>identical to F32</td></tr>
             <tr><td>F32 port vs HF greedy</td><td>8/8 top-1</td></tr>
-            <tr><td>prefill (pp32)</td><td>35.9 t/s</td></tr>
-            <tr><td>decode (tg32)</td><td>8.4 t/s</td></tr>
-            <tr><td>decode, pre-optimization</td><td>1.22 t/s (&asymp;7&times; faster now)</td></tr>
+            <tr><td>prefill (pp32)</td><td>36.8 t/s</td></tr>
+            <tr><td>decode (tg32)</td><td>10.9 t/s</td></tr>
+            <tr><td>decode, pre-optimization</td><td>1.22 t/s (&asymp;9&times; faster now)</td></tr>
             <tr><td>prefill, pre-optimization</td><td>2.1 t/s (&asymp;17&times; faster now)</td></tr>
             <tr><td>llama-server prompt / decode</td><td>18.1 / 8.16 t/s</td></tr>
           </tbody>
@@ -200,7 +200,8 @@
 
         <h2>What&rsquo;s next</h2>
         <p>Profiling corrected the map. The F32 attention matmuls actually run on the <b>CPU</b> &mdash; the HRX2 backend never claimed plain MUL_MAT, and the CPU&rsquo;s AVX-512 handles them well (that CPU path is the real wall at ~11 t/s). Moving them to the NPU&rsquo;s naive f32 kernel is bit-correct but <b>slower</b> (9.9 t/s), so the gating stays.</p>
-        <p>The fused dequant+matmul lever is structurally blocked, not just slow: Q4NX packs 4-bit values with an 8-byte column stride, so the contiguous vector loads that make the in-tree Q4_K kernel fast don&rsquo;t apply. The practical levers are a competitive NPU f32 matmul kernel (helps the F32 path and any F32-attention model) or trimming the Q4NX MoE round-trip (F16 intermediate / expert cache).</p>
+        <p>The fused dequant+matmul lever is structurally blocked, not just slow: Q4NX packs 4-bit values with an 8-byte column stride, so the contiguous vector loads that make the in-tree Q4_K kernel fast don&rsquo;t apply.</p>
+        <p>The real win came from the split, not the kernels: the all-CPU F32 path runs 16.5 t/s while the hybrid CPU&harr;HRX2 split ran 11.0 &mdash; every HRX2-claimed pointwise op adds a crossing that costs more than the NPU saves. Restricting HRX2 to exactly the Q4NX matmuls (plus the recurrent state&rsquo;s ops) took the Q4NX decode from 8.9 to <b>10.9 t/s</b> (+23%). The remaining gap to the 16.5 t/s CPU ceiling is the price of 79% less memory.</p>
       </div>
     
     <section class="related">


### PR DESCRIPTION
### **User description**
Update the zaya post with the round-19 result: minimal HRX2 op claims (Q4NX matmuls + state ops only) took decode from 8.9 to 10.9 t/s; all-CPU F32 runs 16.5 t/s vs 11.0 hybrid, which motivated the fix.


___

### **PR Type**
Documentation


___

### **Description**
- Updated zaya post with round 19 numbers

- Decode improved 8.9 -> 10.9 t/s (+23%)

- Explained split overhead outweighs NPU savings

- Restricted HRX2 to Q4NX matmuls and state ops


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Round 19 benchmarks"] -- "update" --> B["Numbers table"]
  A -- "motivate" --> C["Split analysis"]
  C -- "explain" --> D["HRX2 restricted to Q4NX matmuls"]
  D -- "yield" --> E["decode 8.9 -> 10.9 t/s"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>1bit-post-zaya-q4nx-hrx.html</strong><dd><code>Update benchmark numbers and revise optimization explanation</code></dd></summary>
<hr>

site/1bit-post-zaya-q4nx-hrx.html

<ul><li>Updated prefill table value to 36.8 t/s and decode to 10.9 t/s<br> <li> Changed decode speedup factor from 7x to 9x<br> <li> Replaced blocked-levers paragraph with split-overhead analysis<br> <li> Added comparison: all-CPU F32 16.5 t/s vs hybrid 11.0 t/s</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2000/files#diff-c347aa722a17014cccd25f215bbcc1fae9d58161a1b743f48c4714ea766039d9">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

