### PR TITLE
site: zaya post — round 20 prefill numbers (36.8 -> 72.1 t/s)

### DIFF
--- a/site/1bit-post-zaya-q4nx-hrx.html
+++ b/site/1bit-post-zaya-q4nx-hrx.html
@@ -182,10 +182,10 @@
             <tr><td>max |dlogit|</td><td>0.0041 &mdash; top-1 margin is 1,681&times; the noise</td></tr>
             <tr><td>top-5 tokens</td><td>identical to F32</td></tr>
             <tr><td>F32 port vs HF greedy</td><td>8/8 top-1</td></tr>
-            <tr><td>prefill (pp32)</td><td>36.8 t/s</td></tr>
+            <tr><td>prefill (pp32)</td><td>72.1 t/s</td></tr>
             <tr><td>decode (tg32)</td><td>10.9 t/s</td></tr>
             <tr><td>decode, pre-optimization</td><td>1.22 t/s (&asymp;9&times; faster now)</td></tr>
-            <tr><td>prefill, pre-optimization</td><td>2.1 t/s (&asymp;17&times; faster now)</td></tr>
+            <tr><td>prefill, pre-optimization</td><td>2.1 t/s (&asymp;34&times; faster now)</td></tr>
             <tr><td>llama-server prompt / decode</td><td>18.1 / 8.16 t/s</td></tr>
           </tbody>
         </table>
@@ -202,6 +202,7 @@
         <p>Profiling corrected the map. The F32 attention matmuls actually run on the <b>CPU</b> &mdash; the HRX2 backend never claimed plain MUL_MAT, and the CPU&rsquo;s AVX-512 handles them well (that CPU path is the real wall at ~11 t/s). Moving them to the NPU&rsquo;s naive f32 kernel is bit-correct but <b>slower</b> (9.9 t/s), so the gating stays.</p>
         <p>The fused dequant+matmul lever is structurally blocked, not just slow: Q4NX packs 4-bit values with an 8-byte column stride, so the contiguous vector loads that make the in-tree Q4_K kernel fast don&rsquo;t apply.</p>
         <p>The real win came from the split, not the kernels: the all-CPU F32 path runs 16.5 t/s while the hybrid CPU&harr;HRX2 split ran 11.0 &mdash; every HRX2-claimed pointwise op adds a crossing that costs more than the NPU saves. Restricting HRX2 to exactly the Q4NX matmuls (plus the recurrent state&rsquo;s ops) took the Q4NX decode from 8.9 to <b>10.9 t/s</b> (+23%). The remaining gap to the 16.5 t/s CPU ceiling is the price of 79% less memory.</p>
+        <p>Prefill&rsquo;s gap was the per-token expert dequant: MUL_MAT_ID_Q4NX dispatched one dequant per (selected, token) pair, so a 32-token batch dequantized every expert once per token. A new table-scatter matmul kernel (one dispatch reads/writes arbitrary output columns through i32 tables) groups tokens by expert &mdash; <b>one dequant per distinct expert per batch</b>. Prefill went from 36.8 to <b>72.1 t/s</b> (+96%), decode untouched (size-1 groups keep the proven path).</p>
       </div>
     
     <section class="related">


### PR DESCRIPTION
### **User description**
Round 20 result: grouped MoE token dispatch (table-scatter matmul kernel) takes Q4NX prefill pp32 from 36.8 to 72.1 t/s (+96%). Decode unchanged (10.9 t/s). corr 0.9999999861, top-5 identical. Site-only change to 1bit-post-zaya-q4nx-hrx.html.


___

### **PR Type**
Documentation


___

### **Description**
- Update zaya Q4NX post with round 20 prefill numbers

- Explain grouped MoE token dispatch table-scatter kernel speedup

- Reflect new speedup ratio in pre-optimization comparison


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>1bit-post-zaya-q4nx-hrx.html</strong><dd><code>Update zaya round 20 prefill benchmark numbers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/1bit-post-zaya-q4nx-hrx.html

<ul><li>Update prefill (pp32) result from 36.8 to 72.1 t/s<br> <li> Update pre-optimization speedup from ~17x to ~34x<br> <li> Add "What's next" paragraph explaining the table-scatter matmul kernel <br>groups tokens by expert<br> <li> Clarify decode is untouched by the new kernel</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2001/files#diff-c347aa722a17014cccd25f215bbcc1fae9d58161a1b743f48c4714ea766039d9">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

