### PR TITLE
site: zaya post — round 21 correction (grouping was wrong math; now 77.4 t/s verified)

### DIFF
--- a/site/1bit-post-zaya-q4nx-hrx.html
+++ b/site/1bit-post-zaya-q4nx-hrx.html
@@ -182,10 +182,10 @@
             <tr><td>max |dlogit|</td><td>0.0041 &mdash; top-1 margin is 1,681&times; the noise</td></tr>
             <tr><td>top-5 tokens</td><td>identical to F32</td></tr>
             <tr><td>F32 port vs HF greedy</td><td>8/8 top-1</td></tr>
-            <tr><td>prefill (pp32)</td><td>72.1 t/s</td></tr>
-            <tr><td>decode (tg32)</td><td>10.9 t/s</td></tr>
+            <tr><td>prefill (pp32)</td><td>77.4 t/s</td></tr>
+            <tr><td>decode (tg32)</td><td>11.2 t/s</td></tr>
             <tr><td>decode, pre-optimization</td><td>1.22 t/s (&asymp;9&times; faster now)</td></tr>
-            <tr><td>prefill, pre-optimization</td><td>2.1 t/s (&asymp;34&times; faster now)</td></tr>
+            <tr><td>prefill, pre-optimization</td><td>2.1 t/s (&asymp;37&times; faster now)</td></tr>
             <tr><td>llama-server prompt / decode</td><td>18.1 / 8.16 t/s</td></tr>
           </tbody>
         </table>
@@ -202,7 +202,8 @@
         <p>Profiling corrected the map. The F32 attention matmuls actually run on the <b>CPU</b> &mdash; the HRX2 backend never claimed plain MUL_MAT, and the CPU&rsquo;s AVX-512 handles them well (that CPU path is the real wall at ~11 t/s). Moving them to the NPU&rsquo;s naive f32 kernel is bit-correct but <b>slower</b> (9.9 t/s), so the gating stays.</p>
         <p>The fused dequant+matmul lever is structurally blocked, not just slow: Q4NX packs 4-bit values with an 8-byte column stride, so the contiguous vector loads that make the in-tree Q4_K kernel fast don&rsquo;t apply.</p>
         <p>The real win came from the split, not the kernels: the all-CPU F32 path runs 16.5 t/s while the hybrid CPU&harr;HRX2 split ran 11.0 &mdash; every HRX2-claimed pointwise op adds a crossing that costs more than the NPU saves. Restricting HRX2 to exactly the Q4NX matmuls (plus the recurrent state&rsquo;s ops) took the Q4NX decode from 8.9 to <b>10.9 t/s</b> (+23%). The remaining gap to the 16.5 t/s CPU ceiling is the price of 79% less memory.</p>
-        <p>Prefill&rsquo;s gap was the per-token expert dequant: MUL_MAT_ID_Q4NX dispatched one dequant per (selected, token) pair, so a 32-token batch dequantized every expert once per token. A new table-scatter matmul kernel (one dispatch reads/writes arbitrary output columns through i32 tables) groups tokens by expert &mdash; <b>one dequant per distinct expert per batch</b>. Prefill went from 36.8 to <b>72.1 t/s</b> (+96%), decode untouched (size-1 groups keep the proven path).</p>
+        <p>Prefill&rsquo;s gap was the per-token expert dequant: MUL_MAT_ID_Q4NX dispatched one dequant per (selected, token) pair, so a 32-token batch dequantized every expert once per token. Grouping tokens by expert gives <b>one dequant per distinct expert per batch</b>. Prefill went from 36.8 to <b>77.4 t/s</b> (+110%), decode untouched (size-1 groups keep the proven path).</p>
+        <p><b>Correction (round 21):</b> the first grouping attempt (a table-scatter matmul kernel that read/wrote arbitrary output columns through i32 tables) reported 72.1 t/s but was <b>measuring wrong math</b> &mdash; the kernel&rsquo;s &ldquo;use tables&rdquo; condition compared the config constant against 1 with a not-equal test, folded false at JIT time, and the tables were silently never used; the 2-token verification passed only because slot==token for 2-token groups. A 32-token prefill dump against the F32 reference caught it (corr 0.37, wrong top-1). The real fix dequants each distinct expert once and runs the proven per-slot matmul for every token in the group &mdash; verified corr 0.9999996, top-1 identical to F32 at 32 tokens, and faster (77.4 t/s). Lesson: multi-token prefill correctness can&rsquo;t be verified with a 2-token dump.</p>
       </div>
     
     <section class="related">


### PR DESCRIPTION
### **User description**
Round 20's table-scatter kernel silently never used its tables (use_col_tables folded false at JIT time), so pp32 72.1 was measuring wrong math. A new 32-token prefill dump caught it (corr 0.37 vs F32; the 2-token dump can't see it because slot==token for 2-token groups). The real fix dequants each distinct expert once + runs the proven per-slot matmul per token: pp32 36.8 -> 77.4 t/s (+110%), corr 0.9999996, top-1 identical to F32 at 32 tokens. Site-only change.


___

### **PR Type**
Documentation


___

### **Description**
- Update prefill/decode benchmarks to 77.4/11.2 t/s

- Add correction: table-scatter kernel used wrong math

- Explain fix: one dequant per expert, per-slot matmul

- Emphasize 32-token dump needed to catch regression


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Round 20: table-scatter kernel reports 72.1 t/s"] --> B["2-token dump misses wrong math"]
  B --> C["32-token dump catches corr 0.37"]
  C --> D["Fix: dequant once per expert + per-slot matmul"]
  D --> E["Verified 77.4 t/s, corr 0.9999996"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>1bit-post-zaya-q4nx-hrx.html</strong><dd><code>Correct round 21 benchmark post with verified numbers</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/1bit-post-zaya-q4nx-hrx.html

<ul><li>Updated benchmark table: pp32 72.1 -> 77.4 t/s, tg32 10.9 -> 11.2 t/s<br> <li> Changed pre-optimization speedup line from 34x to 37x<br> <li> Replaced table-scatter kernel claim with grouping-by-expert <br>explanation<br> <li> Added round 21 correction paragraph describing wrong math and fix</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2009/files#diff-c347aa722a17014cccd25f215bbcc1fae9d58161a1b743f48c4714ea766039d9">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

