### PR TITLE
ci: fix stale 1bit-systems.service refs — production is embed-server.service on 8088

### DIFF
--- a/.github/workflows/end-to-end-smoke.yml
+++ b/.github/workflows/end-to-end-smoke.yml
@@ -50,15 +50,15 @@ jobs:
 
       - name: Stop production service (issue #1036)
         # This runner is the same box as the always-on production
-        # 1bit-systems.service (unified_server, port 8088). Every historical
-        # run of this workflow failed — the CI instance's health check never
-        # connected because it was contending with the production instance
-        # for the same physical GPU (both hold /dev/accel/accel0 /
-        # ROCm device access). Stop it for the duration of this job; restarted
-        # unconditionally in Cleanup below.
+        # embed-server.service (lemonade, port 8088 — moved off 8099 2026-09-01).
+        # The old unified_server / 1bit-systems.service no longer exists on
+        # this box. Historical runs failed because the CI instance contended
+        # with production for the same physical GPU (both hold
+        # /dev/accel/accel0 / ROCm access). Production now listens on 8088 and
+        # CI owns 8099, so no systemd stop is needed here — the 8099 squatter
+        # cleanup below is sufficient.
         run: |
-          sudo systemctl stop 1bit-systems.service || true
-          # Also kill stray manual servers (vision_server etc.) that can
+          # Kill stray manual servers (vision_server etc.) that can
           # squat on 8099 and answer health checks with the wrong schema.
           pkill -f "[v]ision_server.*8099|[v]ision .*8099" || true
           # -9 fallback: a wedged instance can survive SIGTERM and squat on 8099
@@ -74,7 +74,7 @@ jobs:
           # schema and makes the test "pass" against the squatter while the
           # real server fails to bind (issue #1257 incident class, observed
           # with a stray llama-server on 2026-08-08). Kill by port, not name.
-          # Only touch 8099 — production 1bit-systems.service uses 8088.
+          # Only touch 8099 — production embed-server.service uses 8088.
           fuser -k 8099/tcp 2>/dev/null || true
           sleep 2
 
@@ -231,4 +231,5 @@ jobs:
           pkill -f "unified_server.*8099|unified .*8099" 2>/dev/null || true
           pkill -f "[v]ision_server.*8099|[v]ision .*8099" 2>/dev/null || true
           rm -f /tmp/unified_server.lock
-          sudo systemctl start 1bit-systems.service || true
+          # Nothing to restore: production embed-server.service (8088) was
+          # never stopped — only 8099 squatters were killed.

--- a/.github/workflows/npu-reset.yml
+++ b/.github/workflows/npu-reset.yml
@@ -12,8 +12,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Stop services
         run: |
-          sudo systemctl stop 1bit-systems.service 2>/dev/null || true
-          sudo systemctl stop unified-router.service 2>/dev/null || true
+          # Production embed-server is a user service (embed-server.service,
+          # port 8088) and can hold /dev/accel/accel0, which blocks the NPU
+          # driver unload below. Stop it first. (1bit-systems.service /
+          # unified-router.service no longer exist on this box.)
+          sudo -u bcloud env XDG_RUNTIME_DIR=/run/user/1000 systemctl --user stop embed-server.service 2>/dev/null || true
           sleep 2
       - name: Swap firmware and reload driver
         run: |
@@ -34,4 +37,4 @@ jobs:
       - name: Restore services
         if: always()
         run: |
-          sudo systemctl start 1bit-systems.service 2>/dev/null || true
+          sudo -u bcloud env XDG_RUNTIME_DIR=/run/user/1000 systemctl --user start embed-server.service 2>/dev/null || true


### PR DESCRIPTION
### **User description**
## What

The e2e-smoke and npu-reset workflows stop/start `1bit-systems.service` and `unified-router.service`, which **no longer exist** on the strixhalo runner (they were no-ops with `|| true`).

- **`end-to-end-smoke.yml`**: drops the production-stop/restart entirely. Production is now `embed-server.service` (lemonade) on **8088** (moved off 8099 on 2026-09-01 — 8099 is CI-owned). The 8099 squatter cleanup (`fuser -k 8099/tcp`, issue #1257 class) is kept; nothing systemd-side needs stopping, so there's nothing to restore in Cleanup.
- **`npu-reset.yml`**: stops/restores the real user service (`embed-server.service` via `systemctl --user`) before `rmmod amdxdna`, so the NPU driver unload isn't blocked by a `/dev/accel/accel0` holder.

## Why

Observed live: the e2e-smoke workflow killed the production embed-server (8099) and its Cleanup only restored the nonexistent `1bit-systems.service`, leaving inference down after every CI run. See the [2026-09-01 strixhalo session](https://github.com/1bit-MONSTER/1bit-MONSTER/issues/2013).

## Test plan

- `yaml.safe_load` parses both workflows (1 job each)
- npu-reset stop/start form verified manually on strixhalo (user service + linger)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix stale systemd service references in CI workflows

- Smoke workflow stops touching production embed-server on 8088

- npu-reset stops and restores embed-server user service

- Keep 8099 squatter cleanup; no service to restore


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Smoke["e2e-smoke.yml"] -- "no systemd stop" --> Prod["embed-server.service :8088"]
  Smoke -- "kill 8099 squatters" --> CI["CI server :8099"]
  NPU["npu-reset.yml"] -- "stop/restore user service" --> Prod
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>end-to-end-smoke.yml</strong><dd><code>Update smoke workflow to stop touching production systemd service</code></dd></summary>
<hr>

.github/workflows/end-to-end-smoke.yml

<ul><li>Remove systemctl stop/start of nonexistent 1bit-systems.service<br> <li> Update comments to reflect embed-server.service on port 8088<br> <li> Keep 8099 squatter cleanup; cleanup has nothing to restore</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2014/files#diff-ce7583116dfeff04a5365187d78ae67293490e66e36673d3233b26e96f97023c">+11/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>npu-reset.yml</strong><dd><code>Stop and restore embed-server user service around NPU reset</code></dd></summary>
<hr>

.github/workflows/npu-reset.yml

<ul><li>Stop embed-server user service before NPU driver unload<br> <li> Restore embed-server user service after benchmark in cleanup<br> <li> Use systemctl --user as bcloud with XDG_RUNTIME_DIR</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2014/files#diff-747047dddc37307f23b9cc4551344e0672a8e76868593468c7cae89194af7392">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

