### PR TITLE
fix(analytics): RUM tag drift + country breakdown (both report 0/empty today)

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -175,18 +175,18 @@ jobs:
 
             echo ""
             echo "=== Visitors by country (top 10, 7d) ==="
-            # httpRequestsAdaptiveGroups is capped at a 1-day range, so use the
-            # 1d-groups dataset (same 7-day window as the pageviews query above)
-            # and aggregate per-day rows by country.
-            gql "{ viewer { zones(filter: {zoneTag: \"$ZONE_ID\"}) { httpRequests1dGroups(limit: 100, filter: {date_geq: \"$FROM\", date_leq: \"$TODAY\"}) { dimensions { date clientCountryName } count } } } }" | \
-              jq -r 'if .data then
-                       ([.data.viewer.zones[0].httpRequests1dGroups[] |
-                         { country: (.dimensions.clientCountryName // "Unknown"), requests: .count }]
-                        | group_by(.country)
-                        | map({ country: .[0].country, requests: (map(.requests) | add) })
-                        | sort_by(-.requests) | .[:10][]
-                        | "\(.country)\t\(.requests) req")
-                     else "country query failed: \(.errors[0].message // "unknown")" end'
+            # httpRequestsAdaptiveGroups is the only zone dataset exposing
+            # clientCountryName, but it caps at a 1-day range — so query
+            # day-by-day and aggregate across the window.
+            for i in 0 1 2 3 4 5 6; do
+              DAY=$(date -u -d "$FROM + $i days" +%Y-%m-%d)
+              gql "{ viewer { zones(filter: {zoneTag: \"$ZONE_ID\"}) { httpRequestsAdaptiveGroups(limit: 100, filter: {date_geq: \"$DAY\", date_leq: \"$DAY\"}, orderBy: [count_DESC]) { dimensions { clientCountryName } count } } } }" | \
+                jq -r 'if .data then
+                         ([.data.viewer.zones[0].httpRequestsAdaptiveGroups[] |
+                           { country: (.dimensions.clientCountryName // "Unknown"), requests: .count }]
+                          | .[] | "\(.country)\t\(.requests)")
+                       else "country query failed: \(.errors[0].message // "unknown")" end'
+            done | awk -F'\t' '{s[$1]+=$2} END {for (c in s) print s[c]"\t"c}' | sort -rn | head -10 | awk -F'\t' '{print $2"\t"$1" req"}'
           else
             echo "Zone 1bit.monster not visible to the analytics token (need Zone: Read on the WA token)."
           fi

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -160,11 +160,17 @@ jobs:
 
             echo ""
             echo "=== Visitors by country (top 10, 7d) ==="
-            gql "{ viewer { zones(filter: {zoneTag: \"$ZONE_ID\"}) { httpRequestsAdaptiveGroups(limit: 10, filter: {date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [count_DESC]) { dimensions { clientCountryName } count } } } }" | \
+            # httpRequestsAdaptiveGroups is capped at a 1-day range, so use the
+            # 1d-groups dataset (same 7-day window as the pageviews query above)
+            # and aggregate per-day rows by country.
+            gql "{ viewer { zones(filter: {zoneTag: \"$ZONE_ID\"}) { httpRequests1dGroups(limit: 100, filter: {date_geq: \"$FROM\", date_leq: \"$TODAY\"}) { dimensions { date clientCountryName } count } } } }" | \
               jq -r 'if .data then
-                       ([.data.viewer.zones[0].httpRequestsAdaptiveGroups[] |
+                       ([.data.viewer.zones[0].httpRequests1dGroups[] |
                          { country: (.dimensions.clientCountryName // "Unknown"), requests: .count }]
-                        | .[] | "\(.country)\t\(.requests) req")
+                        | group_by(.country)
+                        | map({ country: .[0].country, requests: (map(.requests) | add) })
+                        | sort_by(-.requests) | .[:10][]
+                        | "\(.country)\t\(.requests) req")
                      else "country query failed: \(.errors[0].message // "unknown")" end'
           else
             echo "Zone 1bit.monster not visible to the analytics token (need Zone: Read on the WA token)."

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -61,15 +61,31 @@ jobs:
           fi
           echo "Site token: ${SITE_TOKEN:0:8}… (read from site/analytics.js)"
           # The dashboard embed token (SITE_TOKEN, read from analytics.js) maps to
-          # this dataset siteTag: Cloudflare attributes beacon events to the tag
-          # below, so querying by the embed token returns 0. Resolved 2026-08-31
-          # via the drift health check after re-creating the Web Analytics site.
-          SITE_TAG="${SITE_TAG:-4a2e28e96a7446c6a9933a0f816efc24}"
-          echo "Query tag: ${SITE_TAG:0:8}… (dataset siteTag for the embed token above)"
+          # a dataset siteTag; querying by the wrong tag returns 0. The mapping has
+          # rotated before (2026-08-31), so we auto-discover the active tag below
+          # instead of trusting a hardcoded value.
+          SITE_TAG="${SITE_TAG:-8734933780a54a7eb50fc0ead7e0f6d3}"
+          echo "Query tag (default): ${SITE_TAG:0:8}… (dataset siteTag for the embed token above)"
 
           TODAY=$(date -u +%Y-%m-%d)
           FROM=$(date -u -d "7 days ago" +%Y-%m-%d)
           echo "Window: $FROM .. $TODAY"
+
+          echo ""
+          echo "--- RUM tag discovery (drift-safe) ---"
+          # Find whatever siteTag actually has RUM data in this window so the
+          # totals/pages/referrers below report real numbers even if the beacon
+          # token → dataset tag mapping rotated.
+          DISCOVER_JSON=$(gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 1, filter: {date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { siteTag } sum { visits } } } } }")
+          DISCOVERED_TAG=$(echo "$DISCOVER_JSON" | jq -r '.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[0].dimensions.siteTag // empty')
+          DISCOVERED_VISITS=$(echo "$DISCOVER_JSON" | jq -r '.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[0].sum.visits // 0')
+          if [ -n "$DISCOVERED_TAG" ] && [ "$DISCOVERED_TAG" != "$SITE_TAG" ]; then
+            echo "⚠ Tag drift: configured $SITE_TAG has no data — discovered active tag $DISCOVERED_TAG ($DISCOVERED_VISITS visits). Using it."
+            SITE_TAG="$DISCOVERED_TAG"
+          else
+            echo "Tag ${SITE_TAG:0:8}… is active ($DISCOVERED_VISITS visits in window)."
+          fi
+          echo "Query tag: ${SITE_TAG:0:8}…"
 
           echo ""
           echo "--- Totals ---"
@@ -91,10 +107,9 @@ jobs:
           echo ""
           echo "--- RUM health check (token drift detection) ---"
           # If the beacon token reports no data but the account has RUM data, the
-          # site tag in analytics.yml has drifted from the real RUM site. Discover
-          # the actual siteTag(s) so the report keeps working (2026-08-31: embed
-          # token 33fb8448… maps to dataset tag 4a2e28e9…; the old site 87349337…
-          # still holds legacy data).
+          # site tag has drifted from the real RUM site (2026-08-31: embed token
+          # 33fb8448… mapped to dataset tag 4a2e28e9… while legacy data sat under
+          # 87349337…; discovery above now handles this automatically).
           if [ "${TOTAL_VISITS:-0}" -eq 0 ] 2>/dev/null; then
             echo "⚠ Site token ${SITE_TOKEN:0:8}… has NO data in this window — checking for token drift:"
             gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 10, filter: {date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { siteTag requestPath } sum { visits } } } } }" | \


### PR DESCRIPTION
### **User description**
## Problems fixed (verified with test runs on this branch)

### 1. RUM report always showed `Total visits: 0`
The workflow hard-coded siteTag `4a2e28e9...` which has **no data**. The live RUM data sits under `87349337...` (34 visits in the last 7d). 
**Fix:** auto-discover the active siteTag up front (drift-safe) and use it for totals/pages/referrers. Test run now reports `Total visits: 34`.

### 2. `Visitors by country` always failed
`httpRequestsAdaptiveGroups` caps at a 1-day range (original bug), and `httpRequests1dGroups` doesn't expose `clientCountryName` (attempt 2).
**Fix:** loop the adaptive query per-day over the 7-day window and aggregate with awk. Test run now prints countries (CA 2741, US 1733, RU 1075, …).

## Verified test run: https://github.com/1bit-MONSTER/1bit-MONSTER/actions/runs/33529531456

Also surfaced along the way (needs repo owner, not code):
- `TRAFFIC_PAT` secret unset → Traffic Alert bot has reported zeros for 5+ days
- `CLOUDFLARE_WA_TOKEN` lacks `Web Analytics: Edit` → RUM bootstrap workflow can't create/refresh sites


___

### **PR Type**
Bug fix


___

### **Description**
- Auto-discover active RUM siteTag to fix zero totals

- Country breakdown queries adaptive per day over 7d

- Aggregate daily country results with awk

- Update default siteTag and drift health comments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RUM report"] --> B["Auto-discover active siteTag"]
  B --> C["Totals, pages, referrers"]
  C --> D["Country per-day queries"]
  D --> E["Awk aggregation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.yml</strong><dd><code>Fix RUM tag drift and per-day country aggregation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/analytics.yml

<ul><li>Added drift-safe RUM siteTag auto-discovery before <br>totals/pages/referrers<br> <li> Updated default SITE_TAG to active tag and use discovered tag fallback<br> <li> Rewrote country breakdown to loop <code>httpRequestsAdaptiveGroups</code> <br>day-by-day<br> <li> Aggregated daily country rows with awk and updated drift comments</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2017/files#diff-607f949b9aca36160cbe6db71570383124fdf743994796f8091bb52cf1cc52a4">+36/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

