### PR TITLE
fix(traffic-alert): mint GitHub App token instead of TRAFFIC_PAT

### DIFF
--- a/.github/workflows/traffic-alert.yml
+++ b/.github/workflows/traffic-alert.yml
@@ -131,16 +131,26 @@ jobs:
           TOP_PATH=$(echo "$PATH_JSON" | jq -r '.[0] | "\(.path) — \(.count) views" // "none"')
 
           # --- Spike detection ---
+          # Baseline is ~2k clones/day from CI/bots, so judge spikes against
+          # the trailing average (excluding today + yesterday) rather than a
+          # fixed threshold that would fire a spike issue every day.
           SPIKE=false
           SPIKE_MSG=""
-          if [ "$YESTERDAY" -gt 0 ] && [ "$DAY_BEFORE" -gt 0 ]; then
+          AVG7=$(echo "$CLONE_RESP" | jq '[.clones[:-2][].count] | if length > 0 then (add / length | floor) else 0 end')
+          if [ "${AVG7:-0}" -gt 0 ] 2>/dev/null && [ "$YESTERDAY" -gt 0 ]; then
+            RATIO=$(awk -v y="$YESTERDAY" -v a="$AVG7" 'BEGIN { printf "%.1f", y/a }')
+            if awk -v r="$RATIO" 'BEGIN { exit !(r >= 2.5) }'; then
+              SPIKE=true
+              SPIKE_MSG="SPIKE: ${YESTERDAY} clones yesterday vs ${AVG7} trailing avg (${RATIO}x)"
+            fi
+          elif [ "$YESTERDAY" -gt 0 ] && [ "$DAY_BEFORE" -gt 0 ]; then
             RATIO=$(( YESTERDAY / DAY_BEFORE ))
             if [ "$RATIO" -ge 3 ]; then
               SPIKE=true
               SPIKE_MSG="SPIKE: ${YESTERDAY} clones yesterday vs ${DAY_BEFORE} day before (${RATIO}x increase)"
             fi
           fi
-          if [ "$YESTERDAY" -gt 200 ]; then
+          if [ "${YESTERDAY:-0}" -gt 5000 ] 2>/dev/null; then
             SPIKE=true
             SPIKE_MSG="${SPIKE_MSG} HIGH_VOLUME: ${YESTERDAY} clones in a single day"
           fi
@@ -193,6 +203,9 @@ jobs:
       - name: Create Spike Issue
         if: steps.traffic.outputs.SPIKE == 'true'
         env:
+          # No checkout in this job, so gh can't detect the repo from git —
+          # point it at the repository explicitly.
+          GH_REPO: ${{ github.repository }}
           # Issue creation uses the built-in token (issues: write is enough).
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CY: ${{ steps.traffic.outputs.CLONE_YESTERDAY }}

--- a/.github/workflows/traffic-alert.yml
+++ b/.github/workflows/traffic-alert.yml
@@ -9,11 +9,12 @@ on:
 # The GitHub Traffic API requires push-level access, but instead of elevating
 # the built-in GITHUB_TOKEN to `contents: write` on a schedule-triggered
 # workflow (a supply-chain risk — see issue #159), we read traffic with a
-# fine-grained PAT (secrets.TRAFFIC_PAT) scoped to `Administration: read` /
-# traffic only. The built-in token keeps its least-privilege scope below.
+# short-lived GitHub App installation token minted from APP_ID +
+# APP_PRIVATE_KEY (scoped to `Administration: read` / traffic only). The
+# built-in token keeps its least-privilege scope below.
 permissions:
   issues: write
-  contents: read   # downgraded from write — use TRAFFIC_PAT secret for API
+  contents: read
   pull-requests: read
 
 jobs:
@@ -21,14 +22,50 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$APP_ID" ] || [ -z "$APP_PRIVATE_KEY" ]; then
+            echo "::warning::APP_ID / APP_PRIVATE_KEY secrets not set — skipping traffic fetch."
+            echo "TOKEN=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # RS256 JWT signed with the app private key (openssl only, no deps)
+          NOW=$(date +%s)
+          B64() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+          HEADER=$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | B64)
+          PAYLOAD=$(printf '{"iat":%s,"exp":%s,"iss":%s}' "$((NOW-60))" "$((NOW+540))" "$APP_ID" | B64)
+          SIG=$(printf '%s.%s' "$HEADER" "$PAYLOAD" | openssl dgst -sha256 -sign <(printf '%s' "$APP_PRIVATE_KEY") -binary | B64)
+          JWT="$HEADER.$PAYLOAD.$SIG"
+          AUTH="Authorization: Bearer $JWT"
+          INSTALL_ID=$(curl -s -H "$AUTH" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations" | \
+            jq -r --arg o "$GITHUB_REPOSITORY_OWNER" '.[] | select(.account.login == $o) | .id' | head -1)
+          if [ -z "$INSTALL_ID" ]; then
+            echo "::warning::GitHub App not installed on $GITHUB_REPOSITORY_OWNER — install it at https://github.com/apps/$GITHUB_REPOSITORY_OWNER/installations/new"
+            echo "TOKEN=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          TOKEN=$(curl -s -X POST -H "$AUTH" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations/$INSTALL_ID/access_tokens" | jq -r '.token // empty')
+          if [ -z "$TOKEN" ]; then
+            echo "::warning::Could not mint installation token — check the app's permissions"
+            echo "TOKEN=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+
       - name: Fetch GitHub Traffic Data
         id: traffic
         env:
-          GH_TOKEN: ${{ secrets.TRAFFIC_PAT || secrets.GITHUB_TOKEN }}
-          HAS_PAT: ${{ secrets.TRAFFIC_PAT != '' }}
+          GH_TOKEN: ${{ steps.app-token.outputs.TOKEN }}
         run: |
-          if [ -z "${{ secrets.TRAFFIC_PAT }}" ]; then
-            echo "::warning::TRAFFIC_PAT not set — skipping traffic fetch. Set TRAFFIC_PAT secret to enable."
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::No app token available — skipping traffic fetch (check APP_ID / APP_PRIVATE_KEY secrets and the app install)."
             # Export empty/default outputs so downstream steps don't crash
             {
               echo "CLONE_14D=0"
@@ -37,11 +74,11 @@ jobs:
               echo "CLONE_YESTERDAY_UNIQ=0"
               echo "VIEW_14D=0"
               echo "VIEW_UNIQUES_14D=0"
-              echo "TOP_REFERRER=unavailable (TRAFFIC_PAT not set)"
-              echo "TOP_PATH=unavailable (TRAFFIC_PAT not set)"
+              echo "TOP_REFERRER=unavailable (no app token)"
+              echo "TOP_PATH=unavailable (no app token)"
               echo "SPIKE=false"
               echo "SPIKE_MSG<<SPIKE_EOF"
-              echo "TRAFFIC_PAT secret not configured — set it to enable traffic monitoring"
+              echo "GitHub App token unavailable — check APP_ID / APP_PRIVATE_KEY secrets and the app install"
               echo "SPIKE_EOF"
             } >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/traffic-alert.yml
+++ b/.github/workflows/traffic-alert.yml
@@ -46,7 +46,7 @@ jobs:
             "https://api.github.com/app/installations" | \
             jq -r --arg o "$GITHUB_REPOSITORY_OWNER" '.[] | select(.account.login == $o) | .id' | head -1)
           if [ -z "$INSTALL_ID" ]; then
-            echo "::warning::GitHub App not installed on $GITHUB_REPOSITORY_OWNER — install it at https://github.com/apps/$GITHUB_REPOSITORY_OWNER/installations/new"
+            echo "::warning::GitHub App not installed on $GITHUB_REPOSITORY_OWNER — install it at https://github.com/apps/1bit-traffice-bot/installations/new"
             echo "TOKEN=" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
### **User description**
## Problem
The Traffic Alert bot has silently reported **all zeros** for 5+ days: the `TRAFFIC_PAT` secret was never set, and the workflow degrades to empty outputs when it's missing.

## Fix
Mint a **short-lived GitHub App installation token** at runtime (`APP_ID` + `APP_PRIVATE_KEY` secrets, RS256 JWT via openssl — no dependencies), instead of requiring a long-lived PAT:
- The app (`1bit-traffice-bot`, id 4794985) is scoped to `Administration: read` — exactly what the traffic API needs
- Tokens auto-rotate hourly; no long-lived credential in the repo
- Built-in `GITHUB_TOKEN` stays at least-privilege (issues: write only) — preserves the issue #159 supply-chain decision

## To activate
1. Install the app on the org: https://github.com/apps/1bit-traffice-bot/installations/new
2. Re-run the workflow — it will report real traffic numbers.

Verified locally: the openssl JWT flow authenticates against GitHub correctly (empty install list is the only blocker).


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Mint short-lived GitHub App token replacing unset TRAFFIC_PAT

- Keep GITHUB_TOKEN least-privilege; no contents write on schedule

- Detect spikes vs 7-day average, raise volume threshold

- Fix spike issue repo detection via explicit GH_REPO


___

### Diagram Walkthrough


```mermaid
flowchart TD
  Sched["schedule / workflow_dispatch"] --> WF["traffic-alert.yml"]
  WF --> MT["Mint App token from APP_ID + private key"]
  MT --> TF["Fetch GitHub Traffic API"]
  TF --> SD["Spike detection vs trailing 7-day avg"]
  SD --> CI["Create spike issue"]
  GT["GITHUB_TOKEN issues:write"] --> CI
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>traffic-alert.yml</strong><dd><code>Switch to GitHub App token and refine traffic spike detection</code></dd></summary>
<hr>

.github/workflows/traffic-alert.yml

<ul><li>Replace <code>TRAFFIC_PAT</code> dependency with a runtime-minted GitHub App <br>installation token<br> <li> Add openssl-based RS256 JWT generation using <code>APP_ID</code>/<code>APP_PRIVATE_KEY</code> <br>secrets<br> <li> Keep built-in <code>GITHUB_TOKEN</code> least-privileged; avoid <code>contents: write</code><br> <li> Improve spike detection using trailing 7-day average and raise <br>HIGH_VOLUME threshold to 5000/day<br> <li> Fix spike issue repo detection by setting <code>GH_REPO</code> explicitly</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2018/files#diff-1860cebf83c1b030406bb40a0a3c30205f87d01b06616daea4c5a22752a9e4b0">+62/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

