### PR TITLE
feat(release): publish GHCR packages, zero releases/tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    tags: ['v*']
-  workflow_dispatch:    # manual runs (branch builds) — Create Release is guarded to tag-only so no junk release is published
+    branches: ['main']   # rebuild + republish GHCR packages on every main push
+  workflow_dispatch:     # manual rebuild + republish (no git tag, no GitHub Release)
 
 permissions: {}
 
@@ -17,7 +17,8 @@ jobs:
     # ONLY ROCm in the build — same environment CI's C++ job uses.
     timeout-minutes: 90
     permissions:
-      contents: write
+      contents: read
+      packages: write    # push OCI packages to GHCR (no releases, no tags)
     defaults:
       run:
         shell: bash -leo pipefail {0}
@@ -152,48 +153,30 @@ jobs:
           ARCH=x86_64 ./appimagetool --appimage-extract-and-run appimage-build \
             "1bit-monster-${VERSION}-x86_64.AppImage"
 
-      - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/')   # only on real tag pushes; skip manual workflow_dispatch runs
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228  # v3.0.2
-        with:
-          files: |
-            1bit-linux-x86_64.tar.gz
-            1bit-monster_*_amd64.deb
-            1bit-monster-*-x86_64.AppImage
-          generate_release_notes: true
-          prerelease: false
-          body: |
-            ## 1bit — Monorepo Release (Pure C++)
-
-            End-to-end C++ inference stack: no Rust, no Python, no Node.js.
-            Single CMake build produces all binaries.
-
-            ### Formats
-            - **Tarball** (`1bit-linux-x86_64.tar.gz`) — extract anywhere, `./run.sh chat`
-            - **Debian package** (`.deb`) — `sudo dpkg -i 1bit-monster_*_amd64.deb`, binaries land on `PATH`
-            - **AppImage** (`.AppImage`) — `chmod +x`, run directly, no install needed
-
-            ### Includes
-            - `1bit` — one ELF, every server + CLI, dispatched by subcommand:
-              - `1bit` (no args) — NPU-native coding agent CLI (chat, up, down, status, build, config, serve)
-              - `1bit zaya` — C++ HIP inference engine + OpenAI-compatible server; `--lemonade` runs the embedded Lemonade server core in-process
-              - `1bit unified` — multi-backend server with the **embedded Lemonade server core** (llama.cpp, FastFlowLM, whisper.cpp, stable-diffusion.cpp, kokoro, ryzenai-llm, vllm backends + policy router); `--lemonade` runs Lemonade's full server in-process
-              - `1bit router` — NPU+GPU routing proxy; decisions run through Lemonade's policy engine (keyword classifier → GPU, default → NPU)
-              - `1bit jarvis` / `1bit vision` / `1bit onebitd` — agent server, vision-language server, inference daemon
-            - `bitnet_tui` — C++ FTXUI terminal chat UI (separate binary)
-            - `librocm_cpp.so` — ternary GEMV/GEMM HIP kernels
-            - install script, docs, license
-
-            ### Requires
-            - AMD Strix Halo (gfx1151)
-            - ROCm 7.15.0a runtime (libhsa-runtime64) — TheRock nightly C++ SDK
-            - A model file (.h1b, .q4nx, .gguf)
-
-            ### Quick Start
-            ```bash
-            tar xzf 1bit-linux-x86_64.tar.gz
-            export HSA_OVERRIDE_GFX_VERSION=11.5.1
-            export HSA_ENABLE_SDMA=0
-            ./run.sh chat
-            ```
-            Then point any OpenAI client at `http://127.0.0.1:13305/v1`.
+      - name: Publish packages to GHCR (no releases, no tags)
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION="$(tr -d '[:space:]' < VERSION)"
+          SHA="$(git rev-parse --short HEAD)"
+          # oras is not preinstalled on runners; fetch the binary (a tool
+          # download — unrelated to GitHub Releases).
+          curl -sL -o oras.tgz https://github.com/oras-project/oras/releases/download/v1.2.2/oras_1.2.2_linux_amd64.tar.gz
+          tar -xzf oras.tgz oras
+          chmod +x oras
+          echo "$GHCR_TOKEN" | ./oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          ARTIFACT="ghcr.io/1bit-MONSTER/1bit-MONSTER"
+          # Rolling + immutable tags. No git tags, no GitHub Release.
+          for TAG in latest sha-${SHA}; do
+            ./oras push "${ARTIFACT}:${TAG}" \
+              --artifact-type application/vnd.1bit.package \
+              1bit-linux-x86_64.tar.gz:application/gzip \
+              1bit-monster_${VERSION}_amd64.deb:application/vnd.debian.binary-package \
+              1bit-monster-${VERSION}-x86_64.AppImage:application/vnd.appimage
+            echo "published ${ARTIFACT}:${TAG}"
+          done
+          echo ""
+          echo "Packages: https://github.com/orgs/1bit-MONSTER/packages?repo_name=1bit-MONSTER"
+          echo "Pull any time with:"
+          echo "  oras pull ghcr.io/1bit-MONSTER/1bit-MONSTER:latest"

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# download.sh — fetch 1bit packages from GHCR (no GitHub Releases, no git tags)
+#
+#   ./scripts/download.sh              # latest build
+#   ./scripts/download.sh sha-abc1234  # a specific immutable build
+#
+# Pulls from ghcr.io/1bit-MONSTER/1bit-MONSTER:<tag> and unpacks whatever
+# artifacts are in the package (tarball, .deb, AppImage).
+#
+# Requires: oras (auto-installed to ~/.local/bin if missing)
+set -euo pipefail
+
+REF="${1:-latest}"
+REGISTRY="ghcr.io/1bit-MONSTER/1bit-MONSTER"
+PKG_PAGE="https://github.com/orgs/1bit-MONSTER/packages?repo_name=1bit-MONSTER"
+ORAS_VERSION="v1.2.2"
+
+# ── oras bootstrap ────────────────────────────────────────────────────────
+if ! command -v oras >/dev/null 2>&1; then
+  echo "→ oras not found, installing ${ORAS_VERSION} to ~/.local/bin ..."
+  mkdir -p "$HOME/.local/bin"
+  curl -sL -o /tmp/oras.tgz \
+    "https://github.com/oras-project/oras/releases/download/${ORAS_VERSION}/oras_${ORAS_VERSION#v}_linux_amd64.tar.gz"
+  tar -xzf /tmp/oras.tgz -C "$HOME/.local/bin" oras
+  chmod +x "$HOME/.local/bin/oras"
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+echo "== Pulling ${REGISTRY}:${REF} =="
+oras pull "${REGISTRY}:${REF}"
+
+# ── unpack what we got ────────────────────────────────────────────────────
+if [ -f 1bit-linux-x86_64.tar.gz ]; then
+  echo "→ extracting 1bit-linux-x86_64.tar.gz"
+  tar xzf 1bit-linux-x86_64.tar.gz
+fi
+
+DEB="$(ls 1bit-monster_*_amd64.deb 2>/dev/null | head -1 || true)"
+if [ -n "$DEB" ]; then
+  echo "→ .deb: ${DEB}  (sudo dpkg -i ${DEB})"
+fi
+
+APP="$(ls 1bit-monster-*-x86_64.AppImage 2>/dev/null | head -1 || true)"
+if [ -n "$APP" ]; then
+  chmod +x "$APP"
+  echo "→ AppImage: ${APP}  (./${APP})"
+fi
+
+# ── usage hints ───────────────────────────────────────────────────────────
+echo ""
+if [ -x run.sh ]; then
+  cat <<'EOF'
+Quick start:
+  export HSA_OVERRIDE_GFX_VERSION=11.5.1
+  export HSA_ENABLE_SDMA=0
+  ./run.sh chat
+  # any OpenAI client → http://127.0.0.1:13305/v1
+EOF
+fi
+echo ""
+echo "Package page: ${PKG_PAGE}"
+echo "Other builds: oras pull ${REGISTRY}:<latest | sha-<short>>"


### PR DESCRIPTION
### **User description**
## What
Replace the tag-triggered **GitHub Release** flow with **GHCR OCI packages** — no git tags, no Release page, zero releases.

## How
- Trigger: `push: main` + `workflow_dispatch` (was `tags: ['v*']`)
- Builds the same three artifacts: `1bit-linux-x86_64.tar.gz`, `1bit-monster_*_amd64.deb`, `1bit-monster-*-x86_64.AppImage`
- Pushes them as **OCI artifacts** to `ghcr.io/1bit-MONSTER/1bit-MONSTER` via `oras`:
  - `latest` (rolling) + `sha-<short>` (immutable) image tags
  - Auth = built-in `GITHUB_TOKEN` with `packages: write` — no PAT/SSH
- Users pull without auth:
  ```bash
  oras pull ghcr.io/1bit-MONSTER/1bit-MONSTER:latest
  ```

## Result
Packages page with download counts, zero releases, zero git tags. If you ever want versioned snapshots, push a git tag — but nothing requires it.


___

### **PR Type**
Enhancement


___

### **Description**
- Replace tag-triggered GitHub Releases with GHCR OCI packages

- Publish tarball, .deb, and AppImage as latest and sha-<short> tags

- Add `scripts/download.sh` to pull and unpack packages from GHCR

- Tighten workflow permissions from `contents: write` to `packages: write`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MainPush["push to main / workflow_dispatch"] --> Build["Build tarball, .deb, AppImage"]
  Build --> Publish["oras push to ghcr.io/1bit-MONSTER/1bit-MONSTER"]
  Publish --> Tags["latest + sha-<short>"]
  User["User"] --> Download["scripts/download.sh"]
  Download --> Pull["oras pull"]
  Pull --> Artifacts["tarball, .deb, AppImage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Switch release pipeline to GHCR OCI packages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Trigger changed from <code>tags: ['v*']</code> to <code>branches: ['main']</code> plus manual <br>dispatch<br> <li> Replaced <code>softprops/action-gh-release</code> with an <code>oras</code> push step to GHCR<br> <li> Uses <code>GITHUB_TOKEN</code> with <code>packages: write</code> permission instead of <code>contents: </code><br><code>write</code><br> <li> Publishes tarball, .deb, and AppImage with rolling <code>latest</code> and <br>immutable <code>sha-<short></code> tags</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2019/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+31/-48</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>download.sh</strong><dd><code>Add script to download 1bit packages from GHCR</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/download.sh

<ul><li>Adds a shell script that wraps <code>oras pull</code> for GHCR packages<br> <li> Defaults to <code>latest</code> tag, supports <code>sha-<short></code> builds<br> <li> Auto-installs <code>oras</code> to <code>~/.local/bin</code> if missing<br> <li> Unpacks tarball and prints usage hints for .deb and AppImage</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2019/files#diff-9efde1984550fe955a3b6803a4dacc65e724805880e4e39555a2327d07835f7b">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

