### PR TITLE
fix(analytics): RUM site-tag auto-resolution + working country breakdown

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -170,15 +170,13 @@ jobs:
             echo "=== Visitors by country (top 10, 7d) ==="
             # httpRequestsAdaptiveGroups supports clientCountryName but only
             # 1-day windows (a 7d range errors out); loop the last 7 days and
-            # aggregate by country.
-            COUNTRY_JSON=""
-            for d in $(seq 0 6); do
+            # aggregate by country (codes are ISO alpha-2).
+            COUNTRIES=$(for d in $(seq 0 6); do
               DAY=$(date -u -d "$FROM + $d days" +%Y-%m-%d)
-              ROW=$(gql "{ viewer { zones(filter: {zoneTag: \"$ZONE_ID\"}) { httpRequestsAdaptiveGroups(limit: 100, filter: {date: \"$DAY\"}, orderBy: [count_DESC]) { dimensions { clientCountryName } count } } } }" | jq -r 'if .data then [.data.viewer.zones[0].httpRequestsAdaptiveGroups[]? | select(.dimensions.clientCountryName != null) | { country: .dimensions.clientCountryName, requests: .count }] | .[] | "\(.country)	\(.requests)" else empty end')
-              [ -n "$ROW" ] && COUNTRY_JSON="$COUNTRY_JSON\n$ROW"
-            done
-            if [ -n "$(echo "$COUNTRY_JSON" | sed '/^$/d')" ]; then
-              echo "$COUNTRY_JSON" | sed '/^$/d' | awk -F"\t" '{agg[$1]+=$2} END {for (c in agg) print c "\t" agg[c]}' | sort -t"$(printf '\t')" -k2 -rn | head -10 | awk -F"\t" '{print $1 "\t" $2 " req"}'
+              gql "{ viewer { zones(filter: {zoneTag: \"$ZONE_ID\"}) { httpRequestsAdaptiveGroups(limit: 100, filter: {date: \"$DAY\"}, orderBy: [count_DESC]) { dimensions { clientCountryName } count } } } }" | jq -r 'if .data then [.data.viewer.zones[0].httpRequestsAdaptiveGroups[]? | select(.dimensions.clientCountryName != null) | { country: .dimensions.clientCountryName, requests: .count }] | .[] | "\(.country)	\(.requests)" else empty end'
+            done | awk -F"\t" '/\t/ {agg[$1]+=$2} END {for (c in agg) print c "\t" agg[c]}' | sort -t"$(printf '\t')" -k2 -rn | head -10 | awk -F"\t" '{print $1 "\t" $2 " req"}')
+            if [ -n "$COUNTRIES" ]; then
+              echo "$COUNTRIES"
             else
               echo "country query failed: no country data in window"
             fi

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -168,18 +168,20 @@ jobs:
 
             echo ""
             echo "=== Visitors by country (top 10, 7d) ==="
-            # httpRequestsAdaptiveGroups only allows 1-day windows (a 7d range
-            # errors: "cannot request a time range wider than 1d"); use
-            # httpRequests1dGroups (multi-day OK) and aggregate by country.
-            gql "{ viewer { zones(filter: {zoneTag: \"$ZONE_ID\"}) { httpRequests1dGroups(limit: 1000, filter: {date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [date_ASC]) { dimensions { date clientCountryName } sum { requests } } } } }" | \
-              jq -r 'if .data then
-                       ([.data.viewer.zones[0].httpRequests1dGroups[] |
-                         { country: (.dimensions.clientCountryName // "Unknown"), requests: .sum.requests }]
-                        | group_by(.country)
-                        | map({ country: .[0].country, requests: (map(.requests) | add) })
-                        | sort_by(-.requests) | .[:10][]
-                        | "\(.country)	\(.requests) req")
-                     else "country query failed: \(.errors[0].message // "unknown")" end'
+            # httpRequestsAdaptiveGroups supports clientCountryName but only
+            # 1-day windows (a 7d range errors out); loop the last 7 days and
+            # aggregate by country.
+            COUNTRY_JSON=""
+            for d in $(seq 0 6); do
+              DAY=$(date -u -d "$FROM + $d days" +%Y-%m-%d)
+              ROW=$(gql "{ viewer { zones(filter: {zoneTag: \"$ZONE_ID\"}) { httpRequestsAdaptiveGroups(limit: 100, filter: {date: \"$DAY\"}, orderBy: [count_DESC]) { dimensions { clientCountryName } count } } } }" | jq -r 'if .data then [.data.viewer.zones[0].httpRequestsAdaptiveGroups[]? | select(.dimensions.clientCountryName != null) | { country: .dimensions.clientCountryName, requests: .count }] | .[] | "\(.country)	\(.requests)" else empty end')
+              [ -n "$ROW" ] && COUNTRY_JSON="$COUNTRY_JSON\n$ROW"
+            done
+            if [ -n "$(echo "$COUNTRY_JSON" | sed '/^$/d')" ]; then
+              echo "$COUNTRY_JSON" | sed '/^$/d' | awk -F"\t" '{agg[$1]+=$2} END {for (c in agg) print c "\t" agg[c]}' | sort -t"$(printf '\t')" -k2 -rn | head -10 | awk -F"\t" '{print $1 "\t" $2 " req"}'
+            else
+              echo "country query failed: no country data in window"
+            fi
           else
             echo "Zone 1bit.monster not visible to the analytics token (need Zone: Read on the WA token)."
           fi

--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -60,16 +60,24 @@ jobs:
             exit 0
           fi
           echo "Site token: ${SITE_TOKEN:0:8}… (read from site/analytics.js)"
-          # The dashboard embed token (SITE_TOKEN, read from analytics.js) maps to
-          # this dataset siteTag: Cloudflare attributes beacon events to the tag
-          # below, so querying by the embed token returns 0. Resolved 2026-08-31
-          # via the drift health check after re-creating the Web Analytics site.
-          SITE_TAG="${SITE_TAG:-4a2e28e96a7446c6a9933a0f816efc24}"
-          echo "Query tag: ${SITE_TAG:0:8}… (dataset siteTag for the embed token above)"
+          # NOTE: the dashboard embed token (SITE_TOKEN, read from analytics.js)
+          # does NOT reliably map to the dataset that actually receives beacon
+          # events — it drifted 2026-08-31 (re-created the Web Analytics site)
+          # and again 2026-09-01 (the live beacon still lands in dataset
+          # 87349337… while 4a2e28e9… stays empty). The active siteTag is
+          # therefore resolved from the live data below (hardcoded fallback).
 
           TODAY=$(date -u +%Y-%m-%d)
           FROM=$(date -u -d "7 days ago" +%Y-%m-%d)
           echo "Window: $FROM .. $TODAY"
+
+          # Resolve the ACTIVE RUM dataset: the siteTag whose dataset has the
+          # most visits in the window (authoritative — the embed-token mapping
+          # has drifted twice). Falls back to the hardcoded tag if empty.
+          RESOLVE_JSON=$(gql "{ viewer { accounts(filter: {accountTag: \"$ACCOUNT_ID\"}) { rumPageloadEventsAdaptiveGroups(limit: 1, filter: {date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [sum_visits_DESC]) { dimensions { siteTag } sum { visits } } } } }")
+          SITE_TAG=$(echo "$RESOLVE_JSON" | jq -r '.data.viewer.accounts[0].rumPageloadEventsAdaptiveGroups[0].dimensions.siteTag // empty')
+          [ -n "$SITE_TAG" ] || SITE_TAG="${SITE_TAG:-4a2e28e96a7446c6a9933a0f816efc24}"
+          echo "Query tag: ${SITE_TAG:0:8}… (resolved from live RUM data; fallback 4a2e28e9…)"
 
           echo ""
           echo "--- Totals ---"
@@ -160,11 +168,17 @@ jobs:
 
             echo ""
             echo "=== Visitors by country (top 10, 7d) ==="
-            gql "{ viewer { zones(filter: {zoneTag: \"$ZONE_ID\"}) { httpRequestsAdaptiveGroups(limit: 10, filter: {date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [count_DESC]) { dimensions { clientCountryName } count } } } }" | \
+            # httpRequestsAdaptiveGroups only allows 1-day windows (a 7d range
+            # errors: "cannot request a time range wider than 1d"); use
+            # httpRequests1dGroups (multi-day OK) and aggregate by country.
+            gql "{ viewer { zones(filter: {zoneTag: \"$ZONE_ID\"}) { httpRequests1dGroups(limit: 1000, filter: {date_geq: \"$FROM\", date_leq: \"$TODAY\"}, orderBy: [date_ASC]) { dimensions { date clientCountryName } sum { requests } } } } }" | \
               jq -r 'if .data then
-                       ([.data.viewer.zones[0].httpRequestsAdaptiveGroups[] |
-                         { country: (.dimensions.clientCountryName // "Unknown"), requests: .count }]
-                        | .[] | "\(.country)\t\(.requests) req")
+                       ([.data.viewer.zones[0].httpRequests1dGroups[] |
+                         { country: (.dimensions.clientCountryName // "Unknown"), requests: .sum.requests }]
+                        | group_by(.country)
+                        | map({ country: .[0].country, requests: (map(.requests) | add) })
+                        | sort_by(-.requests) | .[:10][]
+                        | "\(.country)	\(.requests) req")
                      else "country query failed: \(.errors[0].message // "unknown")" end'
           else
             echo "Zone 1bit.monster not visible to the analytics token (need Zone: Read on the WA token)."


### PR DESCRIPTION
### **User description**
Fixes the two broken fields in the traffic report feed:

1. **RUM stayed 0** — the workflow queried a hardcoded siteTag (4a2e28e9…) that the live beacon doesn't land in (mapping drifted 08-31 and again 09-01; data lives under 87349337…). Now resolves the active tag from live RUM data (most-visited siteTag in the window), hardcoded only as fallback.
2. **Visitors by country was empty** — httpRequestsAdaptiveGroups errors on ranges >1 day (verified: 'cannot request a time range wider than 1d'); httpRequests1dGroups rejects clientCountryName. Now loops the last 7 days of 1-day adaptive queries and aggregates by country (ISO alpha-2).

Verified live on this branch: RUM Total visits 35, countries CA 2741 / US 1733 / RU 1075 / …


___

### **PR Type**
Bug fix


___

### **Description**
- Auto-resolve active RUM siteTag from live data

- Fallback to hardcoded tag when resolution fails

- Replace failing 7-day country query with daily loop

- Aggregate daily country data via awk, top 10


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Query RUM siteTags (7d)"] --> B["Pick most-visited siteTag"]
  B --> C["Query totals & pages by siteTag"]
  D["Loop 7 daily adaptive queries"] --> E["Aggregate by country (awk)"]
  E --> F["Output top 10 countries"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.yml</strong><dd><code>Fix RUM siteTag resolution and country breakdown query</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/analytics.yml

<ul><li>Resolve active RUM dataset siteTag by querying live siteTags and <br>picking the most-visited one; keep hardcoded tag as fallback.<br> <li> Replace the single 7-day <code>httpRequestsAdaptiveGroups</code> country query <br>(which errors on ranges >1 day) with a loop of seven daily adaptive <br>queries.<br> <li> Aggregate daily country results with <code>awk</code>, sort by request count, and <br>emit the top 10 with a fallback message when no data exists.<br> <li> Expand comments documenting the Cloudflare RUM siteTag drift and HTTP <br>Analytics API constraints.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2020/files#diff-607f949b9aca36160cbe6db71570383124fdf743994796f8091bb52cf1cc52a4">+26/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

