### PR TITLE
docs-site: add Context7 chat widget to every docs page

### DIFF
--- a/scripts/gen_docs_site.py
+++ b/scripts/gen_docs_site.py
@@ -423,6 +423,7 @@ def page_shell(out: Path, *, title: str, lead: str, breadcrumb: str, nav_groups:
   <span>Docs generated from <a href="{REPO_BASE}">the repo</a> · <a href="https://1bit.monster">Main site</a> · <a href="https://discord.gg/Qy38d4Xu2h" target="_blank" rel="noopener">Discord</a></span>
 </div></footer>
 <script>{SEARCH_JS}</script>
+<script src="https://context7.com/widget.js" data-library="/1bit-monster/1bit-monster"></script>
 </body>
 </html>"""
     out.write_text(html_doc, encoding="utf-8")


### PR DESCRIPTION
### **User description**
Adds the Context7 AI chat widget to all docs.1bit.monster pages by injecting the script tag into the `page_shell` template in `scripts/gen_docs_site.py`:

```html
<script src="https://context7.com/widget.js" data-library="/1bit-monster/1bit-monster"></script>
```

Regenerated locally — widget present on all 46 docs pages. The deploy workflow (deploy-docs.yml) regenerates + deploys to Cloudflare Pages on main push with this path.


___

### **PR Type**
Enhancement


___

### **Description**
- Add Context7 chat widget to every docs page

- Inject widget script into `page_shell` template

- Point widget library at `/1bit-monster/1bit-monster`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["page_shell template"] -- "inject script tag" --> B["Generated docs pages"]
  B -- "loads on every page" --> C["Context7 chat widget"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gen_docs_site.py</strong><dd><code>Add Context7 chat widget to docs template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/gen_docs_site.py

<ul><li>Adds Context7 widget <code><script></code> tag to the <code>page_shell</code> HTML template<br> <li> Sets <code>data-library="/1bit-monster/1bit-monster"</code> for the widget<br> <li> Makes the chat widget appear on every generated docs page<br> <li> Places the script after the search JS, before <code></body></code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2024/files#diff-42ca4c028795117861af2b98a0394b2b036c499c8c8188e919aba4d3a4fa2ef4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

