### PR TITLE
fix(analytics): surface per-day country query failures on stderr

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -173,7 +173,13 @@ jobs:
             # aggregate by country (codes are ISO alpha-2).
             COUNTRIES=$(for d in $(seq 0 6); do
               DAY=$(date -u -d "$FROM + $d days" +%Y-%m-%d)
-              gql "{ viewer { zones(filter: {zoneTag: \"$ZONE_ID\"}) { httpRequestsAdaptiveGroups(limit: 100, filter: {date: \"$DAY\"}, orderBy: [count_DESC]) { dimensions { clientCountryName } count } } } }" | jq -r 'if .data then [.data.viewer.zones[0].httpRequestsAdaptiveGroups[]? | select(.dimensions.clientCountryName != null) | { country: .dimensions.clientCountryName, requests: .count }] | .[] | "\(.country)	\(.requests)" else empty end'
+              if RESP=$(gql "{ viewer { zones(filter: {zoneTag: \"$ZONE_ID\"}) { httpRequestsAdaptiveGroups(limit: 100, filter: {date: \"$DAY\"}, orderBy: [count_DESC]) { dimensions { clientCountryName } count } } } }"); then
+                ERR=$(printf '%s' "$RESP" | jq -r '.errors[0].message // empty')
+                [ -z "$ERR" ] || echo "country query failed (day $DAY): $ERR" >&2
+                printf '%s' "$RESP" | jq -r 'if .data then [.data.viewer.zones[0].httpRequestsAdaptiveGroups[]? | select(.dimensions.clientCountryName != null) | { country: .dimensions.clientCountryName, requests: .count }] | .[] | "\(.country)	\(.requests)" else empty end'
+              else
+                echo "country query failed (day $DAY): HTTP error" >&2
+              fi
             done | awk -F"\t" '/\t/ {agg[$1]+=$2} END {for (c in agg) print c "\t" agg[c]}' | sort -t"$(printf '\t')" -k2 -rn | head -10 | awk -F"\t" '{print $1 "\t" $2 " req"}')
             if [ -n "$COUNTRIES" ]; then
               echo "$COUNTRIES"


### PR DESCRIPTION
### **User description**
## What
In `.github/workflows/analytics.yml`, the per-day country query loop no longer swallows failures: each day's GraphQL response is checked for `.errors` and for an HTTP failure, and the message (with the failing day) goes to **stderr**. Data rows still flow to the `awk` aggregation on stdout.

## Why
Carries over the pr_agent nit from closed PR #2017: previously a failing daily query hit `else empty`, so a partial failure silently under-counted that day (or, if all seven days failed, produced an empty breakdown) with no trace in the logs. Error text can never appear as a fake `country query failed: …` entry in the top-10.

## Behavior (verified with a mocked-gql simulation)
- Success days → `US\t10`-style rows only on stdout.
- GraphQL error day → `country query failed (day YYYY-MM-DD): rate limited` on stderr.
- HTTP failure day → `country query failed (day YYYY-MM-DD): HTTP error` on stderr.
- No abort under the step's default `set -euo pipefail` shell.
- YAML parses; `bash -n` on the step body passes.

Closes the follow-up discussed on #2017.


___

### **PR Type**
Bug fix


___

### **Description**
- Surface per-day country query failures on stderr

- Check GraphQL `.errors` and HTTP errors per day

- Keep stdout clean for awk aggregation

- Prevent silent under-counting in country breakdown


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Daily country query"] --> B{"HTTP/GraphQL failure?"}
  B -- "yes" --> C["Error to stderr"]
  B -- "no" --> D["Country rows to stdout"]
  D --> E["awk aggregation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.yml</strong><dd><code>Surface per-day country query failures on stderr</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/analytics.yml

<ul><li>Wraps each daily <code>gql</code> call in an <code>if</code> to catch HTTP failures<br> <li> Detects GraphQL <code>.errors</code> and prints failing day to stderr<br> <li> Keeps stdout free of error text for clean awk aggregation</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2030/files#diff-607f949b9aca36160cbe6db71570383124fdf743994796f8091bb52cf1cc52a4">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

