### PR TITLE
site: zaya Q4NX post — round 28 corr 1.00000 (byte-identical to the real FastFlowLM runtime) reflected in meta, cards & RSS

### DIFF
--- a/site/1bit-blog.html
+++ b/site/1bit-blog.html
@@ -236,7 +236,7 @@
             <span class="log-date">2026-09-01</span>
             <div class="log-body">
               <h3><a href="1bit-post-zaya-q4nx-hrx.html" class="log-link">Zaya 8B Q4NX on the AMD NPU</a></h3>
-              <p>Zyphra Zaya 8B, 4-bit Q4NX, running entirely on the Strix Halo NPU via the HRX lane — logits corr 0.99999999 vs the F32 reference, decode 8.4 t/s (7&times; faster than the original dispatch), served over HTTP. Rounds 26-27: the F32-twin proof that the corr gap is summation order, and the real Qwen3-0.6B on the XDNA 2 NPU (29.6/92.8 t/s).</p>
+              <p>Zyphra Zaya 8B, 4-bit Q4NX, running entirely on the Strix Halo NPU via the HRX lane — decode 8.4 t/s (7&times; faster than the original dispatch), served over HTTP. Rounds 26-28: the F32-twin proof that the corr gap is summation order, the real Qwen3-0.6B on the XDNA 2 NPU (29.6/92.8 t/s), and then byte-identity — Qwen3-0.6B prefill logits corr 1.00000 vs the real FastFlowLM runtime on the same xclbin.</p>
               <div class="log-tags"><span class="log-tag">zaya</span><span class="log-tag">q4nx</span><span class="log-tag">hrx</span><span class="log-tag">npu</span></div>
             </div>
           </article>

--- a/site/1bit-post-zaya-q4nx-hrx.html
+++ b/site/1bit-post-zaya-q4nx-hrx.html
@@ -8,16 +8,16 @@
   <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
   <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Zaya 8B Q4NX on the AMD NPU | 1bit.MONSTER</title>
-  <meta name="description" content="The full HRX lane journey: serving Zyphra Zaya 8B, 4-bit Q4NX, entirely on the AMD Strix Halo NPU — logits corr 0.99999999, 8.4 t/s decode, llama-server over HTTP." />
+  <meta name="description" content="The full HRX lane journey: serving Zyphra Zaya 8B, 4-bit Q4NX, entirely on the AMD Strix Halo NPU — 8.4 t/s decode, llama-server over HTTP. Round 28 caps it: Qwen3-0.6B prefill logits corr 1.00000 — byte-identical to the real FastFlowLM runtime on the same xclbin." />
   <meta property="og:site_name" content="1bit.MONSTER" />
   <meta property="og:type" content="article" />
   <meta property="og:title" content="Zaya 8B Q4NX on the AMD NPU | 1bit.MONSTER" />
-  <meta property="og:description" content="The full HRX lane journey: serving Zyphra Zaya 8B, 4-bit Q4NX, entirely on the AMD Strix Halo NPU — logits corr 0.99999999, 8.4 t/s decode, llama-server over HTTP." />
+  <meta property="og:description" content="The full HRX lane journey: serving Zyphra Zaya 8B, 4-bit Q4NX, entirely on the AMD Strix Halo NPU — 8.4 t/s decode, llama-server over HTTP. Round 28 caps it: Qwen3-0.6B prefill logits corr 1.00000 — byte-identical to the real FastFlowLM runtime on the same xclbin." />
   <meta property="og:url" content="https://1bit.monster/1bit-post-zaya-q4nx-hrx.html" />
   <meta property="og:image" content="https://1bit.monster/assets/og-card.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Zaya 8B Q4NX on the AMD NPU | 1bit.MONSTER" />
-  <meta name="twitter:description" content="The full HRX lane journey: serving Zyphra Zaya 8B, 4-bit Q4NX, entirely on the AMD Strix Halo NPU." />
+  <meta name="twitter:description" content="The full HRX lane journey: serving Zyphra Zaya 8B, 4-bit Q4NX, entirely on the AMD Strix Halo NPU — and round 28: Qwen3-0.6B prefill logits corr 1.00000, byte-identical to the real FastFlowLM runtime." />
   <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png" />
   <link rel="canonical" href="https://1bit.monster/1bit-post-zaya-q4nx-hrx.html" />
   <style>
@@ -118,7 +118,7 @@
     }
   </style>
   <script type="application/ld+json">
-  {"@context": "https://schema.org", "@type": "BlogPosting", "headline": "Zaya 8B Q4NX on the AMD NPU | 1bit.MONSTER", "description": "The full HRX lane journey: serving Zyphra Zaya 8B, 4-bit Q4NX, entirely on the AMD Strix Halo NPU.", "url": "https://1bit.monster/1bit-post-zaya-q4nx-hrx.html", "mainEntityOfPage": "https://1bit.monster/1bit-post-zaya-q4nx-hrx.html", "image": "https://1bit.monster/assets/og-card.png", "datePublished": "2026-08-31", "dateModified": "2026-09-01", "author": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}, "publisher": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}}
+  {"@context": "https://schema.org", "@type": "BlogPosting", "headline": "Zaya 8B Q4NX on the AMD NPU | 1bit.MONSTER", "description": "The full HRX lane journey: serving Zyphra Zaya 8B, 4-bit Q4NX, entirely on the AMD Strix Halo NPU — 8.4 t/s decode, llama-server over HTTP. Round 28 caps it: Qwen3-0.6B prefill logits corr 1.00000 — byte-identical to the real FastFlowLM runtime on the same xclbin.", "url": "https://1bit.monster/1bit-post-zaya-q4nx-hrx.html", "mainEntityOfPage": "https://1bit.monster/1bit-post-zaya-q4nx-hrx.html", "image": "https://1bit.monster/assets/og-card.png", "datePublished": "2026-08-31", "dateModified": "2026-09-02", "author": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}, "publisher": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}}
   </script>
 </head>
 <body>
@@ -199,7 +199,7 @@
         <h2>Why 0.99999999 and not 1.0</h2>
         <p>Because the two runs sum the same math in different orders. The weights are bit-identical between the Q4NX and F32 models; the last 1e-8 of correlation is float32 rounding between the NPU reduction tree and the CPU one &mdash; 1,681&times; below the top-1 margin. It rounds to 1.00000000 and the output is identical.</p>
 
-        <h2>What&rsquo;s next (rounds 24&ndash;27)</h2>
+        <h2>What&rsquo;s next (rounds 24&ndash;28)</h2>
         <p><b>The converter went general.</b> <span class="mono">make-q4nx-model.py</span> now reads the architecture from any GGUF, quantizes Q4_K/Q5_K/Q6_K/Q8_0/F16/BF16 sources to Q4NX (numpy dequant ports verified bit-exact vs ggml), handles MoE 3-D expert tensors and per-type keep shapes. The whole local roster was converted and validated on HRX20: Qwen3-0.6B, Qwen2.5-3B/0.5B, MiniCPM5-1B, MiniCPM4-8B generate coherently; the two MoE models (Qwen3-Coder-30B-A3B, GLM-4.7-Flash) now run their expert matmuls on the NPU; Qwen3-Next-80B runs too &mdash; it needed the pointwise ncols caps raised to 1M (the recurrent-state SCALE builds 524288-wide views in the worst-case reserve graph), and now says &ldquo;Paris.&rdquo; like its Q4_K reference.</p>
         <p><b>The MoE bug that looked like noise.</b> The first MoE runs were complete garbage while every sub-component verified (per-pair mm corr 0.998, down mm corr 1.0000). Layer 0 was fine but layer 1&rsquo;s input had already drifted to corr 0.63. Root cause: <span class="mono">MUL_MAT_ID</span> treated src1 as the shared form <span class="mono">[k, ntokens]</span> (gate/up experts) for every dispatch &mdash; the down experts feed a <b>per-expert</b> src1 <span class="mono">[k, n_expert_used, ntokens]</span>, and the old code always read column <span class="mono">t&middot;k</span>: every expert silently computed with expert-0&rsquo;s activation. The &ldquo;corr 1.0000&rdquo; down check passed precisely because it replicated the bug. Fixed (fork 49f07b6): per-slot src1 columns <span class="mono">(i + t&middot;n_expert_used)</span> through both the grouped tables and the per-pair path, plus a new <span class="mono">src1_cols_count</span> config in the two table-scatter kernels. Down MMID now corr 1.0000 vs numpy (L0/L1/L10/L47); the 30B Q4NX matches the Q4_K_M reference nearly token-for-token &mdash; &ldquo;The capital of France is&rdquo; &rarr; &ldquo;Paris.&rdquo; for both.</p>
         <p><b>Numbers on the fixed 30B MoE</b> (HRX20, -t 16, ngl 99): pp32 49.2 t/s, pp128 67.5 t/s, tg32 14.3 t/s. An external iGPU reference on the same SoC (Q4_K_M, Vulkan) decodes the 30B-A3B at 86.1 t/s &mdash; the iGPU stays ahead at small-batch decode; the NPU&rsquo;s edge remains memory (6.96 vs 32.93 GiB) and large-batch prefill (zaya pp512 171 t/s).</p>

--- a/site/blog.xml
+++ b/site/blog.xml
@@ -6,7 +6,7 @@
     <description>How the 1-bit inference engine actually gets built — NPU, ROCm, kernels, formats.</description>
     <language>en</language>
     <atom:link href="https://1bit.monster/blog.xml" rel="self" type="application/rss+xml" />
-    <lastBuildDate>Mon, 31 Aug 2026 17:22:44 +0000</lastBuildDate>
+    <lastBuildDate>Wed, 02 Sep 2026 11:13:47 +0000</lastBuildDate>
     <item>
       <title>Lemonade v11.8.1, and how we stay current with the SDK</title>
       <link>https://1bit.monster/1bit-post-lemonade-v1181.html</link>
@@ -18,8 +18,8 @@
       <title>Zaya 8B Q4NX on the AMD NPU</title>
       <link>https://1bit.monster/1bit-post-zaya-q4nx-hrx.html</link>
       <guid isPermaLink="true">https://1bit.monster/1bit-post-zaya-q4nx-hrx.html</guid>
-      <pubDate>Tue, 01 Sep 2026 00:00:00 +0000</pubDate>
-      <description>The full HRX lane journey: serving Zyphra Zaya 8B, 4-bit Q4NX, entirely on the AMD Strix Halo NPU — logits corr 0.99999999, 8.4 t/s decode, llama-server over HTTP. Rounds 26-27: the F32-twin proof that the corr gap is summation order, and the real Qwen3-0.6B model running on the XDNA 2 NPU (29.6/92.8 t/s).</description>
+      <pubDate>Mon, 31 Aug 2026 00:00:00 +0000</pubDate>
+      <description>The full HRX lane journey: serving Zyphra Zaya 8B, 4-bit Q4NX, entirely on the AMD Strix Halo NPU — 8.4 t/s decode, llama-server over HTTP. Round 28 caps it: Qwen3-0.6B prefill logits corr 1.00000 — byte-identical to the real FastFlowLM runtime on the same xclbin.</description>
     </item>
     <item>
       <title>HRX: we put AMD&#x27;s experimental IREE runtime inside our engine</title>

--- a/site/index.html
+++ b/site/index.html
@@ -246,7 +246,7 @@
         </div>
         <a class="latest-link" data-od-id="latest-zaya" href="1bit-post-zaya-q4nx-hrx.html">
           <span class="latest-badge"><span class="dot"></span>latest</span>
-          <span class="latest-title">Zaya 8B Q4NX now runs entirely on the Strix Halo NPU via the HRX lane — logits corr 0.99999999 vs the F32 reference, decode 8.4 t/s (7× faster than the original dispatch), served over HTTP.</span>
+          <span class="latest-title">Zaya 8B Q4NX now runs entirely on the Strix Halo NPU via the HRX lane — decode 8.4 t/s (7× faster than the original dispatch), served over HTTP — and round 28 lands byte-identity: Qwen3-0.6B prefill logits corr 1.00000, byte-identical to the real FastFlowLM runtime on the same xclbin.</span>
           <span class="latest-more">read the post <span class="ar">→</span></span>
         </a>
         <div class="site-grid" data-od-id="pillars">


### PR DESCRIPTION
### **User description**
Follow-up to #2028: the post body already carries round 28 (prefill logits byte-identical to the real FastFlowLM runtime on the same xclbin — corr 1.000000, argmax and top-5 identical), but every summary surface still advertised the old headline:

- post meta/og/twitter descriptions and JSON-LD: `logits corr 0.99999999, 8.4 t/s decode` → headline round 28: Qwen3-0.6B prefill logits corr 1.00000 — byte-identical to the real FastFlowLM runtime on the same xclbin
- `What's next (rounds 24–27)` heading → `rounds 24–28` (round 28 was appended by #2028 without renumbering)
- blog-index card and homepage 'latest' card now lead with the byte-identity claim; Zaya-vs-F32 0.99999999 rows in the body tables stay accurate
- blog.xml regenerated via scripts/gen_rss.py (description = post meta; pubDate returns to git_firstmod 2026-08-31, matching JSON-LD datePublished)
- JSON-LD dateModified → 2026-09-02


___

### **PR Type**
Documentation


___

### **Description**
- Update Q4NX post meta and JSON-LD descriptions

- Refresh homepage and blog cards with byte-identity headline

- Retitle round summary heading to rounds 24-28

- Regenerate RSS with corrected date and description


___

### Diagram Walkthrough


```mermaid
flowchart LR
  BODY["Q4NX post body: Round 28 already present"] --> META["Meta / og / twitter / JSON-LD -> corr 1.00000"]
  META --> CARDS["Blog index and homepage cards updated"]
  META --> HEAD["Heading rounds 24-27 -> 24-28"]
  META --> RSS["blog.xml regenerated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>1bit-blog.html</strong><dd><code>Update blog index card with round 28 result</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/1bit-blog.html

<ul><li>Refreshes the blog index card for the zaya Q4NX post<br> <li> Replaces the old <code>corr 0.99999999</code> summary with the round 28 <br>byte-identity result<br> <li> Adds Qwen3-0.6B prefill logits <code>corr 1.00000</code> vs FastFlowLM runtime</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2034/files#diff-bc701bd8bd62d9a63fc488c881b0ae6e4b6c2680e1b21fae947f2a2eaf38979a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>1bit-post-zaya-q4nx-hrx.html</strong><dd><code>Sync post meta, JSON-LD and heading to round 28</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/1bit-post-zaya-q4nx-hrx.html

<ul><li>Updates meta, <code>og:description</code>, and <code>twitter:description</code> to headline <code>corr </code><br><code>1.00000</code><br> <li> Edits JSON-LD description and bumps <code>dateModified</code> to 2026-09-02<br> <li> Renames <code>What's next (rounds 24–27)</code> heading to rounds 24–28</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2034/files#diff-c347aa722a17014cccd25f215bbcc1fae9d58161a1b743f48c4714ea766039d9">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Update homepage latest card with byte-identity milestone</code>&nbsp; </dd></summary>
<hr>

site/index.html

<ul><li>Rewrites the homepage 'latest' card text to lead with round 28<br> <li> Drops the old <code>corr 0.99999999</code> wording in favor of byte-identity and <br>decode speed</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2034/files#diff-aef9cf1e2772f3835b32360da3eb558ecc9624843d3a91fe6a2c7e64b7a2c5e6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>blog.xml</strong><dd><code>Regenerate RSS with updated zaya entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/blog.xml

<ul><li>Regenerates the RSS feed with <code>lastBuildDate</code> 2026-09-02<br> <li> Updates the zaya item description to round 28 <code>corr 1.00000</code><br> <li> Restores the zaya item <code>pubDate</code> to 2026-08-31</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2034/files#diff-27b0b2ea248ccd941ac38fd012b423b7995d95f623a062775839fedda6ceb698">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

