### PR TITLE
feat(census): registry tokens for breeze (TTS) + hy_v4 — issue #2031

### DIFF
--- a/include/rocm_cpp/bitnet_model.h
+++ b/include/rocm_cpp/bitnet_model.h
@@ -592,6 +592,9 @@ typedef enum {
     RCPP_ARCH_ARO_BABYLM = 992,      // aro_babylm — ARO-BabyLM (attention gates + memory layers + local/global attention; registry token, engine support XL, generic loader refuses)
     RCPP_ARCH_BREEZE_TTS = 993,      // breeze — Breeze-TTS (BreezeForConditionalGeneration, text-to-speech; registry token, engine support XL, generic loader refuses)
     RCPP_ARCH_HYV4 = 994,            // hy_v4 — HYV4ForCausalLM (Gated-MLA + indexed-latent MoE text LM; registry token, engine support XL, generic loader refuses)
+    RCPP_ARCH_BANANAMIND21CODER = 995,  // bananamind21_coder — BananaMind21CoderForCausalLM (BananaMind-2.1 code LM; registry token, engine support XL, PICO-family candidate)
+    RCPP_ARCH_BANANAMIND21LITE = 996,   // bananamind21_lite_25m — BananaMind21Lite25MForCausalLM (registry token, engine support XL, PICO-family candidate)
+    RCPP_ARCH_CONCEPT_DOMINANT_GPTBERT = 997, // concept_dominant_gptbert — ConceptDominantGPTBertForPreTraining (GPT/BERT-hybrid pre-training class; registry token, engine support XL, generic loader refuses)
     // Sentinel for unmapped architecture strings. Unmapped archs used to
     // silently become RCPP_ARCH_BITNET (wrong activation / attention for
     // most families) — now they fail loudly at discovery/load (decision
@@ -2476,6 +2479,20 @@ static inline rcpp_arch_t rcpp_arch_from_string(const char* s) {
     if (strcmp(s, "breeze") == 0) return RCPP_ARCH_BREEZE_TTS;         // BreezeForConditionalGeneration (issue #2031, registry token)
     if (strcmp(s, "hy_v4") == 0) return RCPP_ARCH_HYV4;               // HYV4ForCausalLM — HF model_type (issue #2031, registry token)
     if (strcmp(s, "hyv4") == 0) return RCPP_ARCH_HYV4;                // HYV4ForCausalLM — census stripped arch name
+    // Fifth-run crop (same census gate run): BananaMind-2.1-Coder/Lite are
+    // standard-layout causal LMs (RMSNorm + GQA + rope_theta 1e5, no exotic
+    // keys) in the bananamind21 release line — PICO-family candidates per the
+    // 09-01 bananamind21test alias, but kept as registry tokens until a
+    // config-mapping round verifies the loader contract (the 2.1-Pico-Preview
+    // config carries loop_*/refresh_kernel_* keys, so the line is NOT plain
+    // llama). concept_dominant_gptbert is a GPT/BERT-hybrid PRE-TRAINING
+    // class (ConceptDominantGPTBertForPreTraining) — not causal inference.
+    if (strcmp(s, "bananamind21_coder") == 0) return RCPP_ARCH_BANANAMIND21CODER;   // HF model_type (issue #2031)
+    if (strcmp(s, "bananamind21coder") == 0) return RCPP_ARCH_BANANAMIND21CODER;    // census stripped arch name
+    if (strcmp(s, "bananamind21_lite_25m") == 0) return RCPP_ARCH_BANANAMIND21LITE; // HF model_type (issue #2031)
+    if (strcmp(s, "bananamind21lite25m") == 0) return RCPP_ARCH_BANANAMIND21LITE;   // census stripped arch name
+    if (strcmp(s, "concept_dominant_gptbert") == 0) return RCPP_ARCH_CONCEPT_DOMINANT_GPTBERT; // HF model_type (issue #2031)
+    if (strcmp(s, "conceptdominantgptbertforpretraining") == 0) return RCPP_ARCH_CONCEPT_DOMINANT_GPTBERT; // census stripped class name
     if (strcmp(s, "lfm2dsparkdraft") == 0) return RCPP_ARCH_LFM2;      // Lfm2DSparkDraftModel (LFM2.5 DSpark speculative draft)
     if (strcmp(s, "museglimmerassistant") == 0) return RCPP_ARCH_MUSE; // MuseGlimmerAssistantModel (Muse-Glimmer assistant variant)
     if (strcmp(s, "muse_glimmer_assistant") == 0) return RCPP_ARCH_MUSE;  // HF model_type

--- a/include/rocm_cpp/bitnet_model.h
+++ b/include/rocm_cpp/bitnet_model.h
@@ -590,6 +590,8 @@ typedef enum {
     RCPP_ARCH_BARETORCH = 990,       // baretorch — cs_lrad chunked-state linear-recurrent (issue #1907: registry token only; engine support XL, generic loader refuses)
     RCPP_ARCH_QU_SSM = 991,          // qu_ssm — Quamba-style linear-recurrent SSM (d_state/d_ff/d_model; registry token, engine support XL, generic loader refuses)
     RCPP_ARCH_ARO_BABYLM = 992,      // aro_babylm — ARO-BabyLM (attention gates + memory layers + local/global attention; registry token, engine support XL, generic loader refuses)
+    RCPP_ARCH_BREEZE_TTS = 993,      // breeze — Breeze-TTS (BreezeForConditionalGeneration, text-to-speech; registry token, engine support XL, generic loader refuses)
+    RCPP_ARCH_HYV4 = 994,            // hy_v4 — HYV4ForCausalLM (Gated-MLA + indexed-latent MoE text LM; registry token, engine support XL, generic loader refuses)
     // Sentinel for unmapped architecture strings. Unmapped archs used to
     // silently become RCPP_ARCH_BITNET (wrong activation / attention for
     // most families) — now they fail loudly at discovery/load (decision
@@ -2461,6 +2463,19 @@ static inline rcpp_arch_t rcpp_arch_from_string(const char* s) {
     if (strcmp(s, "qu_ssm") == 0) return RCPP_ARCH_QU_SSM;             // QUSSMForCausalLM (Quamba-style SSM, registry token)
     if (strcmp(s, "arobabylm") == 0) return RCPP_ARCH_ARO_BABYLM;      // AROBabyLMForCausalLM — attention gates + memory + local/global attn (registry token, census 2026-09-01)
     if (strcmp(s, "qussm") == 0) return RCPP_ARCH_QU_SSM;              // stripped arch name (census)
+    // ── 2026-09-02 census watcher fourth-run findings (issue #2031) ──
+    // breeze = Breeze-TTS-2 (xy979475348/Breeze-TTS-2, class
+    // BreezeForConditionalGeneration, model_type breeze, pipeline text-to-
+    // speech) — a TTS decoder, not a text causal LM; registry token so the
+    // census counts it covered while the loader refuses cleanly. hy_v4 =
+    // HYV4ForCausalLM (Vaibhavhome30/Hy4-preview-FP8, pipeline text-geration)
+    // — a Gated-MLA + routed-MoE text LM with indexer/layer-type/learnable-
+    // sink config keys (not standard llama/qwen layout); registry token now,
+    // candidate for the Gated-MLA loader family (Moonlight/Kimi-K3/DSV4)
+    // once its layer math is config-mapped — no silent llama-layout fallback.
+    if (strcmp(s, "breeze") == 0) return RCPP_ARCH_BREEZE_TTS;         // BreezeForConditionalGeneration (issue #2031, registry token)
+    if (strcmp(s, "hy_v4") == 0) return RCPP_ARCH_HYV4;               // HYV4ForCausalLM — HF model_type (issue #2031, registry token)
+    if (strcmp(s, "hyv4") == 0) return RCPP_ARCH_HYV4;                // HYV4ForCausalLM — census stripped arch name
     if (strcmp(s, "lfm2dsparkdraft") == 0) return RCPP_ARCH_LFM2;      // Lfm2DSparkDraftModel (LFM2.5 DSpark speculative draft)
     if (strcmp(s, "museglimmerassistant") == 0) return RCPP_ARCH_MUSE; // MuseGlimmerAssistantModel (Muse-Glimmer assistant variant)
     if (strcmp(s, "muse_glimmer_assistant") == 0) return RCPP_ARCH_MUSE;  // HF model_type

--- a/src/backend_generic.cpp
+++ b/src/backend_generic.cpp
@@ -632,13 +632,16 @@ struct GenericBackend : Backend {
             cfg.arch == RCPP_ARCH_ZAYA || cfg.arch == RCPP_ARCH_ZAMBA2 ||
             cfg.arch == RCPP_ARCH_ZAMBA || cfg.arch == RCPP_ARCH_MAMBA ||
             cfg.arch == RCPP_ARCH_QWEN35 || cfg.arch == RCPP_ARCH_BARETORCH ||
-            cfg.arch == RCPP_ARCH_QU_SSM || cfg.arch == RCPP_ARCH_ARO_BABYLM) {
+            cfg.arch == RCPP_ARCH_QU_SSM || cfg.arch == RCPP_ARCH_ARO_BABYLM ||
+            cfg.arch == RCPP_ARCH_BREEZE_TTS || cfg.arch == RCPP_ARCH_HYV4) {
             fprintf(stderr, "  [generic] Refusing to load %s (arch=%d%s) via safetensors\n",
                     f.c_str(), (int)cfg.arch,
                     cfg.arch == RCPP_ARCH_UNKNOWN ? " UNKNOWN — add an arch mapping" :
                     cfg.arch == RCPP_ARCH_BARETORCH ? " BARETORCH — cs_lrad registry token, engine support XL (issue #1907)" :
                     cfg.arch == RCPP_ARCH_QU_SSM ? " QU_SSM — Quamba-style SSM registry token, engine support XL" :
-                    cfg.arch == RCPP_ARCH_ARO_BABYLM ? " ARO_BABYLM — attention-gate + memory + local/global attn registry token, engine support XL (census 2026-09-01)" : "");
+                    cfg.arch == RCPP_ARCH_ARO_BABYLM ? " ARO_BABYLM — attention-gate + memory + local/global attn registry token, engine support XL (census 2026-09-01)" :
+                    cfg.arch == RCPP_ARCH_BREEZE_TTS ? " BREEZE_TTS — text-to-speech registry token, engine support XL (issue #2031)" :
+                    cfg.arch == RCPP_ARCH_HYV4 ? " HYV4 — Gated-MLA text LM registry token, engine support XL (issue #2031)" : "");
             return false;
         }
 
@@ -1513,7 +1516,9 @@ struct GenericBackend : Backend {
         // their own dedicated backends.
         if (hdr_cfg.arch == RCPP_ARCH_ZAYA || hdr_cfg.arch == RCPP_ARCH_ZAMBA2 ||
             hdr_cfg.arch == RCPP_ARCH_ZAMBA || hdr_cfg.arch == RCPP_ARCH_MAMBA ||
-            hdr_cfg.arch == RCPP_ARCH_QWEN35) {
+            hdr_cfg.arch == RCPP_ARCH_QWEN35 || hdr_cfg.arch == RCPP_ARCH_BARETORCH ||
+            hdr_cfg.arch == RCPP_ARCH_QU_SSM || hdr_cfg.arch == RCPP_ARCH_ARO_BABYLM ||
+            hdr_cfg.arch == RCPP_ARCH_BREEZE_TTS || hdr_cfg.arch == RCPP_ARCH_HYV4) {
             const char* hint = "";
             if (hdr_cfg.arch == RCPP_ARCH_QWEN35)
                 hint = " — Qwen3.5 Gate-Delta requires NPU (FLM/XRT) or HIP backend";

--- a/src/backend_generic.cpp
+++ b/src/backend_generic.cpp
@@ -633,7 +633,9 @@ struct GenericBackend : Backend {
             cfg.arch == RCPP_ARCH_ZAMBA || cfg.arch == RCPP_ARCH_MAMBA ||
             cfg.arch == RCPP_ARCH_QWEN35 || cfg.arch == RCPP_ARCH_BARETORCH ||
             cfg.arch == RCPP_ARCH_QU_SSM || cfg.arch == RCPP_ARCH_ARO_BABYLM ||
-            cfg.arch == RCPP_ARCH_BREEZE_TTS || cfg.arch == RCPP_ARCH_HYV4) {
+            cfg.arch == RCPP_ARCH_BREEZE_TTS || cfg.arch == RCPP_ARCH_HYV4 ||
+            cfg.arch == RCPP_ARCH_BANANAMIND21CODER || cfg.arch == RCPP_ARCH_BANANAMIND21LITE ||
+            cfg.arch == RCPP_ARCH_CONCEPT_DOMINANT_GPTBERT) {
             fprintf(stderr, "  [generic] Refusing to load %s (arch=%d%s) via safetensors\n",
                     f.c_str(), (int)cfg.arch,
                     cfg.arch == RCPP_ARCH_UNKNOWN ? " UNKNOWN — add an arch mapping" :
@@ -641,7 +643,10 @@ struct GenericBackend : Backend {
                     cfg.arch == RCPP_ARCH_QU_SSM ? " QU_SSM — Quamba-style SSM registry token, engine support XL" :
                     cfg.arch == RCPP_ARCH_ARO_BABYLM ? " ARO_BABYLM — attention-gate + memory + local/global attn registry token, engine support XL (census 2026-09-01)" :
                     cfg.arch == RCPP_ARCH_BREEZE_TTS ? " BREEZE_TTS — text-to-speech registry token, engine support XL (issue #2031)" :
-                    cfg.arch == RCPP_ARCH_HYV4 ? " HYV4 — Gated-MLA text LM registry token, engine support XL (issue #2031)" : "");
+                    cfg.arch == RCPP_ARCH_HYV4 ? " HYV4 — Gated-MLA text LM registry token, engine support XL (issue #2031)" :
+                    cfg.arch == RCPP_ARCH_BANANAMIND21CODER ? " BANANAMIND21CODER — BananaMind-2.1 registry token, PICO-family candidate (issue #2031)" :
+                    cfg.arch == RCPP_ARCH_BANANAMIND21LITE ? " BANANAMIND21LITE — BananaMind-2.1 registry token, PICO-family candidate (issue #2031)" :
+                    cfg.arch == RCPP_ARCH_CONCEPT_DOMINANT_GPTBERT ? " CONCEPT_DOMINANT_GPTBERT — pre-training-class registry token (issue #2031)" : "");
             return false;
         }
 
@@ -1518,7 +1523,9 @@ struct GenericBackend : Backend {
             hdr_cfg.arch == RCPP_ARCH_ZAMBA || hdr_cfg.arch == RCPP_ARCH_MAMBA ||
             hdr_cfg.arch == RCPP_ARCH_QWEN35 || hdr_cfg.arch == RCPP_ARCH_BARETORCH ||
             hdr_cfg.arch == RCPP_ARCH_QU_SSM || hdr_cfg.arch == RCPP_ARCH_ARO_BABYLM ||
-            hdr_cfg.arch == RCPP_ARCH_BREEZE_TTS || hdr_cfg.arch == RCPP_ARCH_HYV4) {
+            hdr_cfg.arch == RCPP_ARCH_BREEZE_TTS || hdr_cfg.arch == RCPP_ARCH_HYV4 ||
+            hdr_cfg.arch == RCPP_ARCH_BANANAMIND21CODER || hdr_cfg.arch == RCPP_ARCH_BANANAMIND21LITE ||
+            hdr_cfg.arch == RCPP_ARCH_CONCEPT_DOMINANT_GPTBERT) {
             const char* hint = "";
             if (hdr_cfg.arch == RCPP_ARCH_QWEN35)
                 hint = " — Qwen3.5 Gate-Delta requires NPU (FLM/XRT) or HIP backend";


### PR DESCRIPTION
### **User description**
Fixes the census coverage breach from issue #2031 (fourth census watcher run).

**Two uncovered classes → registry tokens (safe refusal), not aliases:**
- `breeze` — `BreezeForConditionalGeneration` (Breeze-TTS-2), pipeline **text-to-speech** → a TTS decoder, not a text causal LM the engine can run. Token `RCPP_ARCH_BREEZE_TTS = 993`.
- `hy_v4` — `HYV4ForCausalLM` (Hy4-preview-FP8), pipeline text-generation, but its config keys (`gated_mla`, `q_lora_rank`/`kv_lora_rank`, `qk_nope_head_dim`, `index_*`, `learnable_sink`, `layer_types`, routed-MoE) do **not** match the llama/qwen layout — a Gated-MLA + indexed-latent architecture. Token `RCPP_ARCH_HYV4 = 994`; documented as a candidate for the Gated-MLA loader family (Moonlight / Kimi-K3 / DeepSeek-V4) once config-mapped.

**Mechanics** (same pattern as #1907's `baretorch`/`qu_ssm`): the census counts the classes as covered while the generic loader refuses loudly on **both** the safetensors and GGUF paths — no silent mis-execution with wrong layer math.

Verified: class names + model_types against live HF configs (2026-09-02); `bitnet_model.h` compiles clean (`-fsyntax-only`).


___

### **PR Type**
Enhancement


___

### **Description**
- Add 993-997 registry tokens for census-uncovered families.

- Map breeze, hy_v4, BananaMind-2.1, and GPT-BERT model types.

- Extend safetensors and GGUF guards to refuse unsupported architectures.

- Count census families covered without silent mis-execution.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Census["Census gate flags uncovered HF models"] --> Map["Enum tokens 993-997 and arch string mappings"]
  Map --> ST["Generic safetensors guard refuses load"]
  Map --> GGUF["Generic GGUF loader guard refuses load"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitnet_model.h</strong><dd><code>Maps census-flagged HF families to registry arch tokens</code>&nbsp; &nbsp; </dd></summary>
<hr>

include/rocm_cpp/bitnet_model.h

<ul><li>Adds registry tokens <code>RCPP_ARCH_BREEZE_TTS</code>, <code>RCPP_ARCH_HYV4</code>, <br><code>RCPP_ARCH_BANANAMIND21CODER</code>, <code>RCPP_ARCH_BANANAMIND21LITE</code>, and <br><code>RCPP_ARCH_CONCEPT_DOMINANT_GPTBERT</code> (993-997).<br> <li> Adds <code>rcpp_arch_from_string</code> mappings for HF model_type and stripped <br>arch names.<br> <li> Documents why these families are registry tokens instead of aliases: <br>TTS decoder, Gated-MLA layout, BananaMind-2.1 config keys, and <br>pre-training class.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2038/files#diff-12d8fec0ba47f1c901fbf55f16f798edaba0a693e7c892bfd9302e0b1a87318a">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_generic.cpp</strong><dd><code>Refuses newly registered unsupported architectures in generic backend</code></dd></summary>
<hr>

src/backend_generic.cpp

<ul><li>Extends the safetensors architecture guard with the new breeze, hy_v4, <br>BananaMind-2.1, and GPT-BERT registry tokens.<br> <li> Adds targeted refusal hints for the newly registered architectures.<br> <li> Extends the GGUF loader guard to also refuse baretorch, qu_ssm, <br>aro_babylm, and the new registry tokens.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2038/files#diff-82c4d3084e1369da4c917a8935387c33afa514e729d6753dd0bb508a05a8da0e">+15/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

