### PR TITLE
site: homepage 'latest' card leads with the SharedBO zero-copy pool

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -447,7 +447,7 @@
         </div>
         <a class="latest-link" data-od-id="latest-zaya" href="1bit-post-zaya-q4nx-hrx.html">
           <span class="latest-badge"><span class="dot"></span>latest</span>
-          <span class="latest-title">Zaya 8B Q4NX now runs entirely on the Strix Halo NPU via the HRX lane — decode 8.4 t/s (7× faster than the original dispatch), served over HTTP — with Qwen3-0.6B prefill logits corr 1.00000, byte-identical to the real FastFlowLM runtime — and the Windows-NPU memory model matched on Linux: one heap, one chained API call per layer, SharedBO zero-copy pages.</span>
+          <span class="latest-title">Every model sits in one shared pool — SharedBO pages that NPU, GPU and host all alias, zero copies between lanes. Zaya 8B Q4NX runs entirely on the Strix Halo NPU via the HRX lane (decode 8.4 t/s, served over HTTP), Qwen3-0.6B prefill logits are byte-identical to the real FastFlowLM runtime (corr 1.00000), and the Windows-NPU memory model — one heap, one chained API call per layer — is matched on Linux.</span>
           <span class="latest-more">read the post <span class="ar">→</span></span>
         </a>
         <div class="site-grid" data-od-id="pillars">


### PR DESCRIPTION
### **User description**
Rewrites the homepage 'latest' banner card to headline the largest win: **one shared pool — SharedBO pages that NPU, GPU and host all alias, zero copies between lanes** — with the Zaya-on-NPU, corr-1.00000 and Windows-NPU/MCDM items carried as the supporting claims.


___

### **PR Type**
Documentation


___

### **Description**
- Rewrites homepage latest card to headline SharedBO zero-copy pool

- Keeps Zaya NPU, corr 1.00000, and Windows-NPU items as supporting claims

- Updates only site/index.html


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Headline homepage latest card with SharedBO zero-copy pool</code></dd></summary>
<hr>

site/index.html

<ul><li>Reorders the homepage 'latest' card to start with the shared SharedBO <br>zero-copy pool<br> <li> Presents Zaya 8B Q4NX NPU decode and Qwen3 prefill fidelity as <br>supporting results<br> <li> Mentions the Windows-NPU memory model being matched on Linux as a <br>secondary claim</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2039/files#diff-aef9cf1e2772f3835b32360da3eb558ecc9624843d3a91fe6a2c7e64b7a2c5e6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

