### PR TITLE
site: engine + models claim pages carry the unified memory pool win (SharedBO zero-copy, one chained API call per layer)

### DIFF
--- a/site/1bit-models.html
+++ b/site/1bit-models.html
@@ -8,16 +8,16 @@
   <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
   <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: One engine, Any model.</title>
-  <meta name="description" content="554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability." />
+  <meta name="description" content="554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability. Every family serves from one zero-copy memory pool — SharedBO, NPU + GPU + host — with one chained API call per layer." />
   <meta property="og:site_name" content="1bit.MONSTER" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content="1bit.MONSTER: One engine, Any model." />
-  <meta property="og:description" content="554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability." />
+  <meta property="og:description" content="554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability. Every family serves from one zero-copy memory pool — SharedBO, NPU + GPU + host — with one chained API call per layer." />
   <meta property="og:url" content="https://1bit.monster/1bit-models.html" />
   <meta property="og:image" content="https://1bit.monster/assets/og-card.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="1bit.MONSTER: One engine, Any model." />
-  <meta name="twitter:description" content="554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability." />
+  <meta name="twitter:description" content="554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability. Every family serves from one zero-copy memory pool — SharedBO, NPU + GPU + host — with one chained API call per layer." />
   <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png" />
   <link rel="canonical" href="https://1bit.monster/1bit-models.html" />
   <style>
@@ -413,7 +413,7 @@
 
 </style>
   <script type="application/ld+json">
-  {"@context": "https://schema.org", "@type": "WebPage", "name": "1bit.MONSTER: One engine, Any model.", "description": "554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability.", "url": "https://1bit.monster/1bit-models.html", "publisher": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}}
+  {"@context": "https://schema.org", "@type": "WebPage", "name": "1bit.MONSTER: One engine, Any model.", "description": "554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability. Every family serves from one zero-copy memory pool — SharedBO, NPU + GPU + host — with one chained API call per layer.", "url": "https://1bit.monster/1bit-models.html", "publisher": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}}
   </script>
 
   <script src="theme.js"></script>
@@ -460,7 +460,7 @@
     <section class="section hero-center" data-od-id="hero">
       <div class="container">
         <h1>One engine, Any model.</h1>
-        <p class="lead">The engine reads the model header, picks the architecture and kernel path, and runs. No config, no per-model glue, no registry to maintain.</p>
+        <p class="lead">The engine reads the model header, picks the architecture and kernel path, and runs. No config, no per-model glue, no registry to maintain. And every family serves from one shared memory pool — NPU, GPU and host alias the same SharedBO pages, zero copies — with one chained API call per layer (the Windows NPU model, matched on Linux).</p>
         <div class="stat-row" data-od-id="coverage-stats">
           <div class="stat" data-od-id="stat-tokens"><span class="n">554</span><span class="l">architecture tokens</span></div>
           <div class="stat" data-od-id="stat-strings"><span class="n">1,798</span><span class="l">HF arch strings</span></div>

--- a/site/1bit-monster-v2.html
+++ b/site/1bit-monster-v2.html
@@ -8,16 +8,16 @@
   <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
   <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: One engine. Any model. Zero Python.</title>
-  <meta name="description" content="A model-agnostic, hardware-agnostic pure-C++ inference engine. One engine, NPU + GPU + CPU, 100% HuggingFace architecture coverage, zero Python. MIT." />
+  <meta name="description" content="A model-agnostic, hardware-agnostic pure-C++ inference engine. One engine, NPU + GPU + CPU, 100% HuggingFace architecture coverage, zero Python. MIT. Models share one zero-copy memory pool — NPU, GPU and host — with one chained API call per layer: the Windows NPU (MCDM) memory model, matched on Linux." />
   <meta property="og:site_name" content="1bit.MONSTER" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content="1bit.MONSTER: One engine. Any model. Zero Python." />
-  <meta property="og:description" content="A model-agnostic, hardware-agnostic pure-C++ inference engine. One engine, NPU + GPU + CPU, 100% HuggingFace architecture coverage, zero Python. MIT." />
+  <meta property="og:description" content="A model-agnostic, hardware-agnostic pure-C++ inference engine. One engine, NPU + GPU + CPU, 100% HuggingFace architecture coverage, zero Python. MIT. Models share one zero-copy memory pool — NPU, GPU and host — with one chained API call per layer: the Windows NPU (MCDM) memory model, matched on Linux." />
   <meta property="og:url" content="https://1bit.monster/1bit-monster-v2.html" />
   <meta property="og:image" content="https://1bit.monster/assets/og-card.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="1bit.MONSTER: One engine. Any model. Zero Python." />
-  <meta name="twitter:description" content="A model-agnostic, hardware-agnostic pure-C++ inference engine. One engine, NPU + GPU + CPU, 100% HuggingFace architecture coverage, zero Python. MIT." />
+  <meta name="twitter:description" content="A model-agnostic, hardware-agnostic pure-C++ inference engine. One engine, NPU + GPU + CPU, 100% HuggingFace architecture coverage, zero Python. MIT. Models share one zero-copy memory pool — NPU, GPU and host — with one chained API call per layer: the Windows NPU (MCDM) memory model, matched on Linux." />
   <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png" />
   <link rel="canonical" href="https://1bit.monster/1bit-monster-v2.html" />
   <style>
@@ -449,7 +449,7 @@
 
 </style>
   <script type="application/ld+json">
-  {"@context": "https://schema.org", "@type": "WebPage", "name": "1bit.MONSTER: One engine. Any model. Zero Python.", "description": "A model-agnostic, hardware-agnostic pure-C++ inference engine. One engine, NPU + GPU + CPU, 100% HuggingFace architecture coverage, zero Python. MIT.", "url": "https://1bit.monster/1bit-monster-v2.html", "publisher": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}}
+  {"@context": "https://schema.org", "@type": "WebPage", "name": "1bit.MONSTER: One engine. Any model. Zero Python.", "description": "A model-agnostic, hardware-agnostic pure-C++ inference engine. One engine, NPU + GPU + CPU, 100% HuggingFace architecture coverage, zero Python. MIT. Models share one zero-copy memory pool — NPU, GPU and host — with one chained API call per layer: the Windows NPU (MCDM) memory model, matched on Linux.", "url": "https://1bit.monster/1bit-monster-v2.html", "publisher": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}}
   </script>
 
   <script src="theme.js"></script>
@@ -530,9 +530,9 @@ $<span class="caret"></span></code></pre>
         </div>
         <div class="stack" style="max-width: 44ch;">
           <h2>Every checkpoint maps. Nothing is dropped.</h2>
-          <p class="lead">317,310 arch-bearing checkpoints resolve to 554 tokens, 32 families, 12 backends. Measured, not projected.</p>
+          <p class="lead">317,310 arch-bearing checkpoints resolve to 554 tokens, 32 families, 12 backends. Measured, not projected. And every model serves from one shared memory pool — NPU, GPU and host alias the same SharedBO pages, zero copies between lanes — with one chained API call per layer: the Windows NPU memory model, matched on Linux.</p>
         </div>
-        <p class="meta census-line">100% coverage / 6 hardware targets probed / 0 Python</p>
+        <p class="meta census-line">100% coverage / 6 hardware targets probed / 0 Python / 1 pool · 0 copies</p>
         <div class="map-chain" data-od-id="census-map">
           <div class="map-head">
             <span class="map-title">coverage map</span>


### PR DESCRIPTION
### **User description**
Propagates the headline win to the engine-wide claim surfaces, mirroring the wording approved on the homepage 'latest' card:

- site/1bit-monster-v2.html: census lead + census console line ('1 pool · 0 copies') + meta/og/twitter/JSON-LD.
- site/1bit-models.html: hero lead + meta/og/twitter/JSON-LD.

Claim level kept consistent with the verified sources (SharedBO substrate proven zero-copy 2026-08-29/30; one-heap/one-EXEC_CMD probe-verified on kernel 7.1.5; Windows NPU/MCDM model per one-heap-pivot.md).


___

### **PR Type**
Enhancement


___

### **Description**
- Unified pool claim propagated to engine and models claim pages.

- SharedBO zero-copy wording added to meta, OG, Twitter, JSON-LD.

- Census lead and line updated: one pool, zero copies.

- Claim wording kept consistent with verified one-call sources.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Unified memory pool claim: SharedBO, zero-copy, one chained API call per layer"] --> B["1bit-monster-v2.html — meta, OG, Twitter, JSON-LD, census lead, census line"]
  A --> C["1bit-models.html — meta, OG, Twitter, JSON-LD, hero lead"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>1bit-monster-v2.html</strong><dd><code>Engine page adds unified memory pool claim and census tag</code></dd></summary>
<hr>

site/1bit-monster-v2.html

<ul><li>Extends meta description, OG, Twitter, and JSON-LD with SharedBO <br>unified memory pool claim<br> <li> Adds lead sentence about one shared pool, zero copies, and chained API <br>call to census section<br> <li> Appends "1 pool · 0 copies" to the census line</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2040/files#diff-660454a43550f83ec1a7072fd71caf420fb57f185d39b06424d8be01258beff3">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>1bit-models.html</strong><dd><code>Models page lead and meta reflect shared pool and zero-copy</code></dd></summary>
<hr>

site/1bit-models.html

<ul><li>Extends meta description, OG, Twitter, and JSON-LD with new memory <br>pool claim<br> <li> Updates hero lead to mention shared zero-copy SharedBO pool and one <br>chained API call per layer</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2040/files#diff-a903b0186fc3c43439874cf7d6feff4094a6338e719dff93ad748c2309aa9ee3">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

