### PR TITLE
site: census refresh — 560 tokens / 1,818 HF arch strings / 317,310 checkpoints

### DIFF
--- a/site/1bit-blog.html
+++ b/site/1bit-blog.html
@@ -437,7 +437,7 @@
             <span class="log-date">2026-08-31</span>
             <div class="log-body">
               <h3><a href="1bit-post-lemonade-v1181.html" class="log-link">Lemonade v11.8.1, and how we stay current with the SDK</a></h3>
-              <p>The embedded Lemonade server core is re-vendored to v11.8.1 — upstream sync landed, and the re-vendor loop keeps every release in step. Engine HF coverage: 554 architecture tokens, 1,798 HF arch strings, 317,310/317,310 checkpoints mapped.</p>
+              <p>The embedded Lemonade server core is re-vendored to v11.8.1 — upstream sync landed, and the re-vendor loop keeps every release in step. Engine HF coverage: 560 architecture tokens, 1,818 HF arch strings, 317,310/317,310 checkpoints mapped.</p>
               <div class="log-tags"><span class="log-tag">lemonade</span><span class="log-tag">upstream</span><span class="log-tag">sdk</span></div>
             </div>
           </article>
@@ -500,7 +500,7 @@
             <span class="log-date">2026-08-24</span>
             <div class="log-body">
               <h3><a href="1bit-post-lemonade-v1170.html" class="log-link">Lemonade v11.7.0, and how we stay current with the SDK</a></h3>
-              <p>The embedded Lemonade server core is re-vendored to v11.7.0 — new models, register/options/stats/metrics endpoints live, and a repeatable re-vendor loop so every upstream release lands without touching engine code. The engine's own HF coverage stays at 100%: 554 architecture tokens, 1,798 HF arch strings, 317,310/317,310 checkpoints mapped.</p>
+              <p>The embedded Lemonade server core is re-vendored to v11.7.0 — new models, register/options/stats/metrics endpoints live, and a repeatable re-vendor loop so every upstream release lands without touching engine code. The engine's own HF coverage stays at 100%: 560 architecture tokens, 1,818 HF arch strings, 317,310/317,310 checkpoints mapped.</p>
               <div class="log-tags"><span class="log-tag">lemonade</span><span class="log-tag">upstream</span><span class="log-tag">sdk</span></div>
             </div>
           </article>

--- a/site/1bit-models.html
+++ b/site/1bit-models.html
@@ -8,16 +8,16 @@
   <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
   <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>1bit.MONSTER: One engine, Any model.</title>
-  <meta name="description" content="554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability. Every family serves from one zero-copy memory pool — SharedBO, NPU + GPU + host — with one chained API call per layer." />
+  <meta name="description" content="560 architecture tokens, 1,818 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability. Every family serves from one zero-copy memory pool — SharedBO, NPU + GPU + host — with one chained API call per layer." />
   <meta property="og:site_name" content="1bit.MONSTER" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content="1bit.MONSTER: One engine, Any model." />
-  <meta property="og:description" content="554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability. Every family serves from one zero-copy memory pool — SharedBO, NPU + GPU + host — with one chained API call per layer." />
+  <meta property="og:description" content="560 architecture tokens, 1,818 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability. Every family serves from one zero-copy memory pool — SharedBO, NPU + GPU + host — with one chained API call per layer." />
   <meta property="og:url" content="https://1bit.monster/1bit-models.html" />
   <meta property="og:image" content="https://1bit.monster/assets/og-card.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="1bit.MONSTER: One engine, Any model." />
-  <meta name="twitter:description" content="554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability. Every family serves from one zero-copy memory pool — SharedBO, NPU + GPU + host — with one chained API call per layer." />
+  <meta name="twitter:description" content="560 architecture tokens, 1,818 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability. Every family serves from one zero-copy memory pool — SharedBO, NPU + GPU + host — with one chained API call per layer." />
   <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png" />
   <link rel="canonical" href="https://1bit.monster/1bit-models.html" />
   <style>
@@ -413,7 +413,7 @@
 
 </style>
   <script type="application/ld+json">
-  {"@context": "https://schema.org", "@type": "WebPage", "name": "1bit.MONSTER: One engine, Any model.", "description": "554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability. Every family serves from one zero-copy memory pool — SharedBO, NPU + GPU + host — with one chained API call per layer.", "url": "https://1bit.monster/1bit-models.html", "publisher": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}}
+  {"@context": "https://schema.org", "@type": "WebPage", "name": "1bit.MONSTER: One engine, Any model.", "description": "560 architecture tokens, 1,818 HF arch strings, 100% HuggingFace coverage. The validated model families the engine runs, with real parameter sizes and backend availability. Every family serves from one zero-copy memory pool — SharedBO, NPU + GPU + host — with one chained API call per layer.", "url": "https://1bit.monster/1bit-models.html", "publisher": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}}
   </script>
 
   <script src="theme.js"></script>
@@ -462,8 +462,8 @@
         <h1>One engine, Any model.</h1>
         <p class="lead">The engine reads the model header, picks the architecture and kernel path, and runs. No config, no per-model glue, no registry to maintain. And every family serves from one shared memory pool — NPU, GPU and host alias the same SharedBO pages, zero copies — with one chained API call per layer (the Windows NPU model, matched on Linux).</p>
         <div class="stat-row" data-od-id="coverage-stats">
-          <div class="stat" data-od-id="stat-tokens"><span class="n">554</span><span class="l">architecture tokens</span></div>
-          <div class="stat" data-od-id="stat-strings"><span class="n">1,798</span><span class="l">HF arch strings</span></div>
+          <div class="stat" data-od-id="stat-tokens"><span class="n">560</span><span class="l">architecture tokens</span></div>
+          <div class="stat" data-od-id="stat-strings"><span class="n">1,818</span><span class="l">HF arch strings</span></div>
           <div class="stat" data-od-id="stat-coverage"><span class="n">100%</span><span class="l">checkpoints mapped</span></div>
         </div>
       </div>

--- a/site/1bit-monster-v2.html
+++ b/site/1bit-monster-v2.html
@@ -526,11 +526,11 @@ $<span class="caret"></span></code></pre>
         <div class="band-head">
           <span class="band-dot"></span>
           <span class="band-title">engine census</span>
-          <span class="band-meta">317,310 checkpoints · 554 tokens</span>
+          <span class="band-meta">317,310 checkpoints · 560 tokens</span>
         </div>
         <div class="stack" style="max-width: 44ch;">
           <h2>Every checkpoint maps. Nothing is dropped.</h2>
-          <p class="lead">317,310 arch-bearing checkpoints resolve to 554 tokens, 32 families, 12 backends. Measured, not projected. And every model serves from one shared memory pool — NPU, GPU and host alias the same SharedBO pages, zero copies between lanes — with one chained API call per layer: the Windows NPU memory model, matched on Linux.</p>
+          <p class="lead">317,310 arch-bearing checkpoints resolve to 560 tokens, 32 families, 12 backends. Measured, not projected. And every model serves from one shared memory pool — NPU, GPU and host alias the same SharedBO pages, zero copies between lanes — with one chained API call per layer: the Windows NPU memory model, matched on Linux.</p>
         </div>
         <p class="meta census-line">100% coverage / 6 hardware targets probed / 0 Python / 1 pool · 0 copies</p>
         <div class="map-chain" data-od-id="census-map">
@@ -543,11 +543,11 @@ $<span class="caret"></span></code></pre>
             <div class="map-track"><span class="map-bar" style="width: 100%;"></span></div>
           </div>
           <div class="map-row" data-od-id="map-row-strings">
-            <div class="map-label"><span class="map-name">architecture strings</span><span class="map-count">1,798</span></div>
+            <div class="map-label"><span class="map-name">architecture strings</span><span class="map-count">1,818</span></div>
             <div class="map-track"><span class="map-bar" style="width: 58%;"></span></div>
           </div>
           <div class="map-row" data-od-id="map-row-tokens">
-            <div class="map-label"><span class="map-name">architecture tokens</span><span class="map-count">554</span></div>
+            <div class="map-label"><span class="map-name">architecture tokens</span><span class="map-count">560</span></div>
             <div class="map-track"><span class="map-bar" style="width: 49%;"></span></div>
           </div>
           <div class="map-row" data-od-id="map-row-families">

--- a/site/1bit-post-1775-models.html
+++ b/site/1bit-post-1775-models.html
@@ -8,16 +8,16 @@
   <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
   <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>One engine, 1,775 models | 1bit.MONSTER</title>
-  <meta name="description" content="One C++ binary, 554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage, 317,310 checkpoints mapped. Every model you can download." />
+  <meta name="description" content="One C++ binary, 560 architecture tokens, 1,818 HF arch strings, 100% HuggingFace coverage, 317,310 checkpoints mapped. Every model you can download." />
   <meta property="og:site_name" content="1bit.MONSTER" />
   <meta property="og:type" content="article" />
   <meta property="og:title" content="One engine, 1,775 models | 1bit.MONSTER" />
-  <meta property="og:description" content="One C++ binary, 554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage, 317,310 checkpoints mapped. Every model you can download." />
+  <meta property="og:description" content="One C++ binary, 560 architecture tokens, 1,818 HF arch strings, 100% HuggingFace coverage, 317,310 checkpoints mapped. Every model you can download." />
   <meta property="og:url" content="https://1bit.monster/1bit-post-1775-models.html" />
   <meta property="og:image" content="https://1bit.monster/assets/og-card.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="One engine, 1,775 models | 1bit.MONSTER" />
-  <meta name="twitter:description" content="One C++ binary, 554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage, 317,310 checkpoints mapped. Every model you can download." />
+  <meta name="twitter:description" content="One C++ binary, 560 architecture tokens, 1,818 HF arch strings, 100% HuggingFace coverage, 317,310 checkpoints mapped. Every model you can download." />
   <meta name="twitter:image" content="https://1bit.monster/assets/og-card.png" />
   <link rel="canonical" href="https://1bit.monster/1bit-post-1775-models.html" />
 <style>
@@ -304,7 +304,7 @@
 
 </style>
   <script type="application/ld+json">
-  {"@context": "https://schema.org", "@type": "BlogPosting", "headline": "One engine, 1,775 models | 1bit.MONSTER", "description": "One C++ binary, 554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage, 317,310 checkpoints mapped. Every model you can download.", "url": "https://1bit.monster/1bit-post-1775-models.html", "mainEntityOfPage": "https://1bit.monster/1bit-post-1775-models.html", "image": "https://1bit.monster/assets/og-card.png", "datePublished": "2026-08-25", "dateModified": "2026-08-25", "author": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}, "publisher": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}}
+  {"@context": "https://schema.org", "@type": "BlogPosting", "headline": "One engine, 1,775 models | 1bit.MONSTER", "description": "One C++ binary, 560 architecture tokens, 1,818 HF arch strings, 100% HuggingFace coverage, 317,310 checkpoints mapped. Every model you can download.", "url": "https://1bit.monster/1bit-post-1775-models.html", "mainEntityOfPage": "https://1bit.monster/1bit-post-1775-models.html", "image": "https://1bit.monster/assets/og-card.png", "datePublished": "2026-08-25", "dateModified": "2026-08-25", "author": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}, "publisher": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}}
   </script>
 
   <script src="theme.js"></script>
@@ -357,7 +357,7 @@
       <div class="prose">
         <h2>The claim</h2>
         <p>Go to HuggingFace. Pick any text-generation model. Any architecture — Llama, Qwen, Mistral, Gemma, Zamba, Jamba, Cohere, Falcon, DeepSeek-MoE, MiniMax, BitNet, T5 — and the 1bit.MONSTER engine can run it. Not a wrapper. Not a per-model build. One binary that auto-detects the architecture from the file and dispatches to the right backend.</p>
-        <p>The daily census keeps the claim honest: <b>554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage, 317,310 checkpoints mapped.</b> A workflow re-checks the numbers every night and updates the site when they move. That number is live, not a marketing figure.</p>
+        <p>The daily census keeps the claim honest: <b>560 architecture tokens, 1,818 HF arch strings, 100% HuggingFace coverage, 317,310 checkpoints mapped.</b> A workflow re-checks the numbers every night and updates the site when they move. That number is live, not a marketing figure.</p>
         <h2>Why it works: the token catalog</h2>
         <p>Every HF architecture string — <span class="mono">llama3</span>, <span class="mono">qwen2.5_moe</span>, <span class="mono">zamba2</span>, all 1,775 of them — normalizes down to one of 552 architecture tokens. The token captures what actually changes between model families: attention variant, MoE routing, norm placement, RoPE scheme, tie weights. Everything else is shared.</p>
         <p>A new model family lands on HF → the daily new-model watcher drafts the mapping → the engine gets the token → the site's numbers update. The gap between a model appearing and the engine running it is measured in days, not quarters.</p>
@@ -366,7 +366,7 @@
         <table><thead><tr><th>Format</th><th>Read</th><th>Convert</th><th>Typical use</th></tr></thead><tbody><tr><td>GGUF</td><td>native</td><td>—</td><td>off-the-shelf models</td></tr><tr><td>Q4NX 1BP</td><td>native</td><td>from GGUF</td><td>our 1-bit pipeline</td></tr><tr><td>INT8</td><td>native</td><td>from GGUF</td><td>big-batch CPU</td></tr><tr><td>TQ2</td><td>native</td><td>—</td><td>compressed weights</td></tr></tbody></table>
         <h2>What 1-bit buys you</h2>
         <p>A 70B-class model packed to 1-bit fits in the memory of a laptop with room to spare. The engine's measured path on the Ryzen AI NPU went from 244 ms/tok to 3.4 ms/tok across the optimization sprint — that's a 70× improvement on the same silicon, no new hardware.</p>
-        <div class="callout"><p>317,310 arch-bearing checkpoints resolve to 554 tokens, and 552 tokens resolve to one engine. That's the whole pitch.</p></div>
+        <div class="callout"><p>317,310 arch-bearing checkpoints resolve to 560 tokens, and 552 tokens resolve to one engine. That's the whole pitch.</p></div>
         <h2>Try it</h2>
         <p><span class="mono">build/1bit unified --port 8088 --weights models/</span> — point it at a directory of GGUFs, hit <span class="mono">/v1/models</span>, and pick any of them. The server loads what you ask for, on the backend that's fastest for your hardware, no config file required.</p>
       </div>

--- a/site/1bit-post-lemonade-v1170.html
+++ b/site/1bit-post-lemonade-v1170.html
@@ -363,7 +363,7 @@
         <p>The 1bit engine embeds <b>Lemonade's server core</b> in-process — all 14 backends and the policy router, compiled into the same <span class="mono">build/1bit</span> binary. That means upstream's release cadence is our release cadence: every time <span class="mono">lemonade-sdk/lemonade</span> ships, the engine inherits its new models, backends, and API surface the day we re-vendor. The relationship is documented in <code>docs/guides/Lemonade-Compat.md</code> and the vendoring rules live in <code>third_party/lemonade/UPSTREAM.md</code>.</p>
 
         <h2>v11.7.0: what came in</h2>
-        <p>This release brought new models, a management API, and observability — all now live in the embedded core. (The engine's own HF coverage is separate and larger: <b>554 architecture tokens / 1,798 HF arch strings, 317,310 of 317,310 arch-bearing text-gen checkpoints mapped — 100% of HuggingFace</b>. The numbers below are what the Lemonade core itself gained.)</p>
+        <p>This release brought new models, a management API, and observability — all now live in the embedded core. (The engine's own HF coverage is separate and larger: <b>560 architecture tokens / 1,818 HF arch strings, 317,310 of 317,310 arch-bearing text-gen checkpoints mapped — 100% of HuggingFace</b>. The numbers below are what the Lemonade core itself gained.)</p>
         <table>
           <thead><tr><th>Area</th><th>What landed</th></tr></thead>
           <tbody>

--- a/site/1bit-post-lemonade-v1181.html
+++ b/site/1bit-post-lemonade-v1181.html
@@ -10,7 +10,7 @@
   <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
   <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Lemonade v11.8.1: the 15-backend SDK lands ds4 for Strix Halo | 1bit.MONSTER</title>
-  <meta name="description" content="The embedded Lemonade server core is re-vendored to v11.8.1 — upstream sync landed; see the post for what changed. Engine HF coverage: 554 architecture tokens, 1,798 HF arch strings, 317,310/317,310 checkpoints mapped." />
+  <meta name="description" content="The embedded Lemonade server core is re-vendored to v11.8.1 — upstream sync landed; see the post for what changed. Engine HF coverage: 560 architecture tokens, 1,818 HF arch strings, 317,310/317,310 checkpoints mapped." />
   <meta property="og:site_name" content="1bit.MONSTER" />
   <meta property="og:type" content="article" />
   <meta property="og:title" content="Lemonade v11.8.1: the 15-backend SDK lands ds4 for Strix Halo | 1bit.MONSTER" />

--- a/site/index.html
+++ b/site/index.html
@@ -392,7 +392,7 @@
 
 </style>
   <script type="application/ld+json">
-  [{"@context": "https://schema.org", "@type": "WebSite", "name": "1bit.MONSTER", "url": "https://1bit.monster", "description": "The 1-bit inference engine. One engine, any model — 554 architecture tokens, 1,798 HF arch strings, 100% HuggingFace coverage, running on Ryzen AI NPUs and ROCm.", "potentialAction": {"@type": "SearchAction", "target": {"@type": "EntryPoint", "urlTemplate": "https://1bit.monster/search.html?q={search_term_string}"}, "query-input": "required name=search_term_string"}}, {"@context": "https://schema.org", "@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster", "logo": "https://1bit.monster/assets/apple-touch-icon.png", "sameAs": ["https://github.com/1bit-MONSTER"]}]
+  [{"@context": "https://schema.org", "@type": "WebSite", "name": "1bit.MONSTER", "url": "https://1bit.monster", "description": "The 1-bit inference engine. One engine, any model — 560 architecture tokens, 1,818 HF arch strings, 100% HuggingFace coverage, running on Ryzen AI NPUs and ROCm.", "potentialAction": {"@type": "SearchAction", "target": {"@type": "EntryPoint", "urlTemplate": "https://1bit.monster/search.html?q={search_term_string}"}, "query-input": "required name=search_term_string"}}, {"@context": "https://schema.org", "@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster", "logo": "https://1bit.monster/assets/apple-touch-icon.png", "sameAs": ["https://github.com/1bit-MONSTER"]}]
   </script>
 
   <script src="theme.js"></script>

--- a/site/search.html
+++ b/site/search.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
   <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
   <title>Search | 1bit.MONSTER</title>
-  <meta name="description" content="Search every page, post, benchmark and doc on 1bit.MONSTER — the 1-bit inference engine with 554 architecture tokens, 1,798 HF arch strings and 100% HuggingFace coverage." />
+  <meta name="description" content="Search every page, post, benchmark and doc on 1bit.MONSTER — the 1-bit inference engine with 560 architecture tokens, 1,818 HF arch strings and 100% HuggingFace coverage." />
   <meta property="og:site_name" content="1bit.MONSTER" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Search | 1bit.MONSTER" />
@@ -245,7 +245,7 @@
 
 </style>
   <script type="application/ld+json">
-  {"@context": "https://schema.org", "@type": "WebPage", "name": "Search | 1bit.MONSTER", "description": "Search every page, post, benchmark and doc on 1bit.MONSTER \u2014 the 1-bit inference engine with 554 architecture tokens, 1,798 HF arch strings and 100% HuggingFace coverage.", "url": "https://1bit.monster/search.html", "publisher": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}}
+  {"@context": "https://schema.org", "@type": "WebPage", "name": "Search | 1bit.MONSTER", "description": "Search every page, post, benchmark and doc on 1bit.MONSTER \u2014 the 1-bit inference engine with 560 architecture tokens, 1,818 HF arch strings and 100% HuggingFace coverage.", "url": "https://1bit.monster/search.html", "publisher": {"@type": "Organization", "name": "1bit.MONSTER", "url": "https://1bit.monster"}}
   </script>
 
   <script src="theme.js"></script>


### PR DESCRIPTION
### **User description**
Refreshes the drifted census numbers across all site pages via scripts/seo_sync.py (the census updated since the site was last synced): 554→560 architecture tokens, 1,798→1,818 HF arch strings, checkpoints unchanged at 317,310. Touches the engine census band/map, models stats, and the meta/og/twitter/JSON-LD descriptions on 8 pages.


___

### **PR Type**
Documentation


___

### **Description**
- Refresh census figures across 8 site pages
  - Generated by scripts/seo_sync.py nightly sync

- Update architecture tokens 554→560, strings 1,798→1,818

- Keep checkpoint count pinned at 317,310

- Sync stats, census map, meta, and JSON-LD copy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Census["Census refresh (554→560 tokens)"] -- "seo_sync.py" --> Pages["8 site pages"]
  Pages -- "log blurbs" --> Blog["1bit-blog.html"]
  Pages -- "stats and meta" --> Models["1bit-models.html"]
  Pages -- "band and map" --> V2["1bit-monster-v2.html"]
  Pages -- "blog post bodies" --> Posts["lemonade / 1775 posts"]
  Pages -- "SEO descriptions" --> SEO["meta / og / twitter / JSON-LD"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>1bit-blog.html</strong><dd><code>Update two log-row blurbs with new census figures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2045/files#diff-bc701bd8bd62d9a63fc488c881b0ae6e4b6c2680e1b21fae947f2a2eaf38979a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>1bit-models.html</strong><dd><code>Refresh models page stats and SEO descriptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2045/files#diff-a903b0186fc3c43439874cf7d6feff4094a6338e719dff93ad748c2309aa9ee3">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>1bit-monster-v2.html</strong><dd><code>Update census band, lead copy, and coverage map</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2045/files#diff-660454a43550f83ec1a7072fd71caf420fb57f185d39b06424d8be01258beff3">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>1bit-post-1775-models.html</strong><dd><code>Refresh census numbers in meta and post paragraphs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2045/files#diff-c27c25a32609f8aec2b9de96df5c8ad21ceb2dc1f9bfb240789e114d2f72c497">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>1bit-post-lemonade-v1170.html</strong><dd><code>Bump engine coverage parenthesis to new census figures</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2045/files#diff-8ed67592d5f7b63878893d1290c77d2a1ce7e2be17ab0d9fe5061c1e04033d82">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>1bit-post-lemonade-v1181.html</strong><dd><code>Update meta description with refreshed coverage numbers</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2045/files#diff-643044bc9d668d30620c1dd056a5c0cc78ef9cd2270e2280b809c1dc01fa3642">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.html</strong><dd><code>Update JSON-LD site description with refreshed census</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2045/files#diff-aef9cf1e2772f3835b32360da3eb558ecc9624843d3a91fe6a2c7e64b7a2c5e6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>search.html</strong><dd><code>Update search page meta and structured data numbers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2045/files#diff-81a3597002b0ff92b2b143f798d62c2b2a317e64543096af3ccf3722a7313df0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

