### PR TITLE
census: automate alias-autopr + escalate significant architecture arrivals

### DIFF
--- a/.github/workflows/census-autopr.yml
+++ b/.github/workflows/census-autopr.yml
@@ -1,0 +1,47 @@
+name: Census autopr
+
+# Auto-file DRAFT PRs proposing a one-line bitnet_model.h alias for uncovered
+# architecture classes that are plausible variants of a family the engine
+# already knows (e.g. `kimik3` -> `kimi_k3`). census_autopr.py (called from
+# hf_new_models.py) only guesses a candidate when the class is an edit-distance
+# / known-family match; genuinely-new architectures and SIGNIFICANT arrivals
+# (major family or vision/multimodal variant) are left as a manual alert — they
+# need a real engine implementation, not an alias.
+#
+# Deliberately separate from census-watch.yml, which is ALERT-ONLY (read-only
+# perms, no write token on schedule runs). This one runs the same watcher with
+# the write/PR permissions needed to open draft PRs.
+#
+# Scheduled after census-watch (04:30 UTC) so the alert fires first.
+
+on:
+  schedule:
+    - cron: "45 4 * * *"   # 04:45 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: census-autopr
+  cancel-in-progress: false
+
+jobs:
+  autopr:
+    name: File draft alias PRs for plausible new arch classes
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Run the watcher with alias-autopr enabled
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # CENSUS_SKIP_PR stays UNSET so census_autopr may file draft PRs.
+          python3 Testing/hf_new_models.py --limit 120 2>&1 | tee /tmp/census-autopr.log
+          echo "--- (draft PRs for plausible aliases; SIGNIFICANT/manual left as alerts) ---"

--- a/Testing/hf_new_models.py
+++ b/Testing/hf_new_models.py
@@ -21,10 +21,40 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(ROOT, "Testing"))
 from census_coverage import strip_arch, NON_TEXT_GEN, build_mapper, probe, UNKNOWN
 
+try:
+    from census_autopr import maybe_file_draft_pr
+except Exception as _e:  # never kill the watch on an autopr wiring issue
+    maybe_file_draft_pr = None
+    print(f"[watch] census_autopr import failed ({_e}) — alias autopr disabled",
+          file=sys.stderr)
+
 STATE = os.path.join(ROOT, "Testing", "hf_new_models_state.json")
 API = "https://huggingface.co/api/models"
 CFG = "https://huggingface.co/{mid}/resolve/main/config.json"
 MAX_SEEN = 5000  # cap state growth; oldest dropped
+
+# Significant-architecture escalation. These are major public model families;
+# when one ships a NEW architecture class (especially a vision/multimodal
+# variant, e.g. a DeepSeek V4-flash that adds image-text-to-text), it must not
+# be silently auto-aliased into a nearby sibling — it needs real engine support
+# and decode validation. Matching is on the stripped arch class substring.
+NOTABLE_FAMILIES = (
+    "deepseek", "qwen", "glm", "nemotron", "llama", "mistral", "phi",
+    "gemma", "kimi", "minicpm", "gpt-oss", "granite", "zamba", "zyphra",
+    "smollm", "olmo", "falcon", "rwkv",
+)
+VISION_TAGS = ("image-text-to-text", "image-to-text", "visual-question-answering",
+               "document-question-answering", "image-feature-extraction")
+
+
+def _is_significant(stripped, tags):
+    """True when a new class is a major-family arch or a vision/multimodal
+    variant of one — the arrivals that deserve real support, not an alias."""
+    low = stripped.lower()
+    if any(f in low for f in NOTABLE_FAMILIES):
+        return True
+    tags = tags or []
+    return bool(any(v in (t or "") for t in tags for v in VISION_TAGS))
 
 # Causal-decoder + VLM tags: new conditional-generation models (e.g. Muse
 # Glimmer) carry image-text-to-text, not text-generation. Gated orgs 401 on
@@ -130,6 +160,7 @@ def main():
     mapper = build_mapper()
     new_classes = {}   # stripped class -> [model ids]
     uncovered = {}     # stripped class -> [model ids]
+    class_tags = {}    # stripped class -> set(pipeline tags) for significance
     unverifiable = {}  # model id -> reason (gated/fetch-fail, no config)
     n_in_scope = n_covered = 0
 
@@ -172,6 +203,8 @@ def main():
             n_covered += 1
         for s, t in toks.items():
             (new_classes if t != UNKNOWN else uncovered).setdefault(s, []).append(mid)
+            if t == UNKNOWN:
+                class_tags.setdefault(s, set()).update(m.get("tags") or [])
         seen[mid] = True
         time.sleep(0.2)
 
@@ -186,10 +219,30 @@ def main():
           f"{len(unverifiable)} unverifiable (gated/no-config)")
     for s, ids in sorted(new_classes.items()):
         print(f"  covered family {s}: {len(ids)} model(s), e.g. {ids[0]}")
+    significant = {}  # stripped class -> [ids] — major-family/vision arrivals
+    basic_uncovered = {}
     for s, ids in sorted(uncovered.items()):
+        if _is_significant(s, class_tags.get(s)):
+            significant[s] = ids
+        else:
+            basic_uncovered[s] = ids
+    for s, ids in sorted(significant.items()):
+        print(f"  !! SIGNIFICANT {s}: {len(ids)} model(s), e.g. {ids[0]}")
+        print(f"     -> major-family/vision arrival — needs REAL engine arch "
+              f"support + decode validation, NOT an alias")
+    for s, ids in sorted(basic_uncovered.items()):
         print(f"  !! UNCOVERED {s}: {len(ids)} model(s), e.g. {ids[0]}")
         print(f"     -> add to include/rocm_cpp/bitnet_model.h + selfcheck, "
               f"then re-run census_coverage.py")
+    # Auto-file draft PRs proposing a one-line alias for plausible
+    # family-variant classes. Significant arrivals are deliberately excluded —
+    # aliasing them would fake support. On genuine-new archs the autopr prints
+    # "manual" and they stay a daily alert for a real engine implementation.
+    if maybe_file_draft_pr is not None and basic_uncovered:
+        try:
+            maybe_file_draft_pr(list(basic_uncovered), models=basic_uncovered)
+        except Exception as _e:
+            print(f"[watch] census_autopr failed: {_e}", file=sys.stderr)
     for mid, why in sorted(unverifiable.items()):
         print(f"  ? UNVERIFIABLE {mid} ({why}) — gated repos need a token; "
               f"retried next run")


### PR DESCRIPTION
### **User description**
Two changes to keep the HF-coverage loop hand-off for every new architecture:

**1. Automate the alias-add step.** census_autopr.maybe_file_draft_pr existed but was never called. Now hf_new_models.py invokes it after detecting uncovered classes, so classes that are plausible family variants (edit-distance / known-family substring) get a DRAFT PR proposing the one-line bitnet_model.h alias. Genuinely-new architectures still print 'manual' and stay a daily alert.

**2. Escalate SIGNIFICANT arrivals.** Adds a curated NOTABLE_FAMILIES set + vision/multimodal detection (image-text-to-text etc.). A new architecture that is a major-family or vision variant (e.g. a DeepSeek V4-flash that adds vision) is printed as '!! SIGNIFICANT' and is NOT auto-aliased (an alias would fake support) — it's flagged for real engine arch support + decode validation.

**New workflow:** .github/workflows/census-autopr.yml (04:45 UTC daily) runs the watcher with the contents-read + pull-requests-write perms needed to file draft PRs; census-watch.yml stays alert-only (read-only, no token on schedule runs).

Validated: py_compile + helper logic (DeepSeek-family/vision -> significant; plain text-gen -> alias path) + YAML. This is CI/tooling that affects the 100%-coverage machinery and auto-opens draft PRs to the registry, so it needs review before merge.


___

### **PR Type**
Enhancement


___

### **Description**
- Wires census_autopr alias-autopr into daily coverage watcher

- Escalates major-family/vision arrivals to real-support alerts

- Excludes SIGNIFICANT classes from auto-alias to avoid fake support

- Adds scheduled census-autopr workflow with PR write perms


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hf_new_models.py</strong><dd><code>Wire alias-autopr and significant-arrival escalation into census </code><br><code>watcher</code></dd></summary>
<hr>

Testing/hf_new_models.py

<ul><li>Imports and invokes <code>census_autopr.maybe_file_draft_pr</code> after <br>uncovered-class detection<br> <li> Adds <code>NOTABLE_FAMILIES</code>, <code>VISION_TAGS</code>, and <code>_is_significant()</code> to classify <br>major-family/vision arrivals<br> <li> Collects pipeline tags for uncovered classes and separates output into <br><code>!! SIGNIFICANT</code> and <code>!! UNCOVERED</code><br> <li> Keeps genuine-new archs as manual daily alerts and excludes them from <br>auto-aliasing</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2046/files#diff-b2cdcca5305ff83c2aa31abfc2dd476b9458209d9ef12ace923ce85369618ef6">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>census-autopr.yml</strong><dd><code>Add daily workflow to auto-file draft alias PRs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/census-autopr.yml

<ul><li>New 04:45 UTC daily workflow separate from the alert-only <br><code>census-watch.yml</code><br> <li> Grants <code>contents: read</code> and <code>pull-requests: write</code> permissions plus <br><code>GH_TOKEN</code><br> <li> Runs <code>hf_new_models.py --limit 120</code> with alias-autopr enabled<br> <li> Scheduled after census-watch so alert results fire before draft PRs</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2046/files#diff-0f84ff0173547f1ac1e7e8aad568b593cee71209bc3dd72fb384507984b9efe0">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

