### PR TITLE
post: significant arrivals also fire an announcement post on detection

### DIFF
--- a/.github/workflows/census-autopr.yml
+++ b/.github/workflows/census-autopr.yml
@@ -46,17 +46,18 @@ jobs:
           python3 Testing/hf_new_models.py --limit 120 2>&1 | tee /tmp/census-autopr.log
           echo "--- (draft PRs for plausible aliases; SIGNIFICANT/manual left as alerts) ---"
 
-      - name: Generate blog posts for covered significant arrivals
+      - name: Generate blog posts for significant arrivals (announce + covered)
         id: sigpost
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # A significant architecture arrival gets a blog entry the moment the
-          # engine maps it (covered=True in significant_arrivals.json, written by
-          # hf_new_models.py). Uncovered arrivals are left as alerts — a post
-          # claiming support would be false. significant_model_post.py dedupes
-          # via Testing/significant_posts.json so each arrival posts once.
+          # A significant architecture arrival gets a blog entry: an ANNOUNCEMENT
+          # (arrival detected, support in progress) the moment it is spotted, and
+          # a COVERED post ("the engine now maps it") once support lands.
+          # significant_model_post.py dedupes by (mode, model) so each stage
+          # posts once. Uncovered arrivals get the announcement, not a false
+          # "the engine runs it" claim.
           python3 - <<'PY'
           import json, subprocess, sys
           try:
@@ -65,11 +66,11 @@ jobs:
               print("no significant_arrivals.json yet"); sys.exit(0)
           made = 0
           for arch, e in sorted(data.items()):
-              if not e.get("covered"):
-                  continue
+              mode = "covered" if e.get("covered") else "announcement"
               r = subprocess.run(
                   ["python3", "Testing/significant_model_post.py", "--arch", arch,
-                   "--model", e.get("model", "?"), "--family", e.get("family", "")],
+                   "--model", e.get("model", "?"), "--family", e.get("family", ""),
+                   "--mode", mode],
                   capture_output=True, text=True)
               out = (r.stdout or r.stderr).strip()
               print(out)

--- a/Testing/significant_model_post.py
+++ b/Testing/significant_model_post.py
@@ -50,24 +50,30 @@ def _slug(v: str) -> str:
     return s or "model"
 
 
-def _meta(model_id, arch, family, desc):
-    title = f"The engine now runs {family or arch}"
+def _meta(model_id, arch, family, desc, mode="covered"):
+    fam = family or arch
+    if mode == "announcement":
+        title = f"A new significant architecture arrived: {fam}"
+        slug = f"1bit-post-announcement-{_slug(model_id)}"
+    else:
+        title = f"The engine now runs {fam}"
+        slug = f"1bit-post-significant-{_slug(model_id)}"
     jsonld = {
         "@context": "https://schema.org", "@type": "BlogPosting",
         "headline": f"{title} | 1bit.MONSTER",
         "description": desc,
-        "url": f"{SITE_URL}/1bit-post-significant-{_slug(model_id)}.html",
-        "mainEntityOfPage": f"{SITE_URL}/1bit-post-significant-{_slug(model_id)}.html",
+        "url": f"{SITE_URL}/{slug}.html",
+        "mainEntityOfPage": f"{SITE_URL}/{slug}.html",
         "image": OG_IMG,
         "datePublished": "2026-09-02", "dateModified": "2026-09-02",
         "author": AUTHOR, "publisher": AUTHOR,
     }
-    return title, json.dumps(jsonld, separators=(",", ":"))
+    return title, slug, json.dumps(jsonld, separators=(",", ":"))
 
 
-def render(model_id, arch, family, date, desc, body_paras, style, nav, foot):
-    title, jsonld = _meta(model_id, arch, family, desc)
-    fname = f"1bit-post-significant-{_slug(model_id)}.html"
+def render(model_id, arch, family, date, desc, body_paras, style, nav, foot, mode="covered"):
+    title, slug, jsonld = _meta(model_id, arch, family, desc, mode=mode)
+    fname = f"{slug}.html"
     body = "\n".join(f"        <p>{p}</p>" for p in body_paras)
     html = f"""<!doctype html>
 <html lang="en">
@@ -139,40 +145,62 @@ def main():
     ap.add_argument("--family", default=None, help="family name for the title, e.g. DeepSeek V4")
     ap.add_argument("--date", default="2026-09-02")
     ap.add_argument("--desc", default=None)
+    ap.add_argument("--mode", choices=["announcement", "covered"], default="covered",
+                    help="announcement = arrival detected, support in progress; "
+                         "covered = the engine now maps it")
     args = ap.parse_args()
 
     models = json.loads(STATE.read_text()) if STATE.exists() else {}
-    if args.model in models:
-        print(f"[sigpost] already generated a post for {args.model} ({models[args.model]}) — skip")
+    key = f"{args.mode}:{args.model}"
+    if key in models:
+        print(f"[sigpost] already generated a {args.mode} post for {args.model} "
+              f"({models[key]}) — skip")
         return 0
 
     family = args.family or args.arch
-    desc = args.desc or (f"A significant new model architecture arrived — {args.arch} "
-                         f"(example: {args.model}) — and the engine now maps it to a token. "
-                         f"This post scaffolds the entry; details are a draft.")
-    body = [
-        f"<b>{family}</b> is a <b>significant architecture arrival</b> — "
-        f"a major-family or vision/multimodal model the engine did not previously map. "
-        f"Example checkpoint on HuggingFace: <span class=\"mono\">{args.model}</span> "
-        f"(stripped class <span class=\"mono\">{args.arch}</span>).",
-        "The engine maps it to an architecture token, so the whole class now resolves to one binary — "
-        "the census claim stays at 100% coverage.",
-        "<b>Draft scaffold:</b> fill in what the architecture actually does, kernel/backend support, "
-        "and decode-validation status before publishing. This entry exists so the blog updates the way "
-        "the Lemonade SDK loop does — a new post per significant arrival, not just a number change.",
-        "The daily census keeps this live: the new-model watcher catches the arrival, the autopr drafts "
-        "the alias, and this post is generated so the change is discoverable.",
-    ]
+    if args.mode == "announcement":
+        desc = args.desc or (f"A significant new model architecture just arrived — {family} "
+                             f"(example: {args.model}). The engine is on it: this is the "
+                             f"announcement, with support and decode validation in progress.")
+        body = [
+            f"<b>{family}</b> is a <b>significant architecture arrival</b> — a major-family or "
+            f"vision/multimodal model we don't fully map yet. "
+            f"Example checkpoint on HuggingFace: <span class=\"mono\">{args.model}</span> "
+            f"(stripped class <span class=\"mono\">{args.arch}</span>).",
+            "This is the announcement: the model exists, the engine is tracking it, and support + "
+            "decode validation are underway. When it lands, a follow-up post says so.",
+            "<b>Draft scaffold:</b> fill in what the architecture actually does and the "
+            "support/validation status before publishing. This entry exists so the blog updates the "
+            "way the Lemonade SDK loop does — a new post per significant arrival, not just a number change.",
+        ]
+    else:
+        desc = args.desc or (f"A significant new model architecture arrived — {family} "
+                             f"(example: {args.model}) — and the engine now maps it to a token. "
+                             f"This post scaffolds the entry; details are a draft.")
+        body = [
+            f"<b>{family}</b> is a <b>significant architecture arrival</b> — "
+            f"a major-family or vision/multimodal model the engine did not previously map. "
+            f"Example checkpoint on HuggingFace: <span class=\"mono\">{args.model}</span> "
+            f"(stripped class <span class=\"mono\">{args.arch}</span>).",
+            "The engine maps it to an architecture token, so the whole class now resolves to one binary — "
+            "the census claim stays at 100% coverage.",
+            "<b>Draft scaffold:</b> fill in what the architecture actually does, kernel/backend support, "
+            "and decode-validation status before publishing.",
+            "The daily census keeps this live: the new-model watcher catches the arrival, the autopr drafts "
+            "the alias, and this post is generated so the change is discoverable.",
+        ]
 
     dry = os.getenv("CENSUS_DRY_RUN") == "1"
     tpl = TEMPLATE.read_text(encoding="utf-8")
     style, nav, foot = _carve(tpl)
-    fname, html = render(args.model, args.arch, family, args.date, desc, body, style, nav, foot)
+    fname, html = render(args.model, args.arch, family, args.date, desc, body, style, nav, foot,
+                         mode=args.mode)
     print(f"[sigpost] {'DRY-RUN ' if dry else ''}would write site/{fname} ({len(html)//1024} KB)")
     if dry:
         return 0
     (SITE / fname).write_text(html, encoding="utf-8")
-    models[args.model] = {"arch": args.arch, "family": family, "date": args.date, "file": fname}
+    models[key] = {"arch": args.arch, "family": family, "date": args.date, "file": fname,
+                   "mode": args.mode}
     STATE.write_text(json.dumps(models, indent=1, sort_keys=True))
     print(f"[sigpost] wrote site/{fname}")
     return 0


### PR DESCRIPTION
### **User description**
Adds the ANNOUNCEMENT stage: a SIGNIFICANT architecture arrival now gets a blog entry the moment it is detected (support in progress), not only once it is covered.

- significant_model_post.py gains  (default covered). announcement title = 'A new significant architecture arrived: <family>'; body = arrival + 'support/decode validation in progress' (never claims 'the engine runs it' while unsupported). covered title/body unchanged. Slug/filename differ per mode; dedupe keys on (mode, model) so both stages post once each.
- census-autopr.yml generates a post for EVERY significant arrival: mode=announcement when not yet covered, mode=covered once the engine maps it.

Validated: py_compile + YAML; tested both modes -> two distinct files with correct titles, and per-mode dedupe. Demo posts not committed. Tooling, review before merge.


___

### **PR Type**
Enhancement


___

### **Description**
- Significant arrivals now get announcement posts immediately

- Add mode-aware post rendering with per-mode dedupe

- Census autopr announces before coverage, then posts coverage

- Announcement wording avoids false “engine runs it” claims


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["significant_arrivals.json"] --> B["census-autopr.yml"]
  B --> C{"Engine covers it?"}
  C -- "no" --> D["sigpost --mode announcement"]
  C -- "yes" --> E["sigpost --mode covered"]
  D --> F["Announcement post: support in progress"]
  E --> G["Covered post: engine now maps it"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>significant_model_post.py</strong><dd><code>Add announcement mode and per-mode dedupe to sigpost</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Testing/significant_model_post.py

<ul><li>Add <code>announcement</code> mode with distinct title, slug, description, and body<br> <li> Dedupe state now keyed by <code>mode:model</code> so both stages post once<br> <li> Render mode-aware filename and CLI <code>--mode</code> option<br> <li> Covered mode defaults preserved for existing behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2055/files#diff-ce5eeb862069bd9e79febd8879e91905ab1e16bd4079ca16455eaf4d5342c100">+56/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>census-autopr.yml</strong><dd><code>Autopr emits announcement and covered posts per arrival</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/census-autopr.yml

<ul><li>Generate posts for every significant arrival, not only covered ones<br> <li> Select mode based on <code>covered</code> flag in <code>significant_arrivals.json</code><br> <li> Pass <code>--mode</code> to <code>significant_model_post.py</code><br> <li> Update workflow comments to describe announce/covered stages</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2055/files#diff-0f84ff0173547f1ac1e7e8aad568b593cee71209bc3dd72fb384507984b9efe0">+10/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

