### PR TITLE
docs(journey): normalize the timeline — chronological, date-standardized headings, merge duplicate Aug-07

### DIFF
--- a/docs/journey.md
+++ b/docs/journey.md
@@ -4,7 +4,56 @@
 >
 > Every crash, breakthrough, and bug below is documented in real-time. ~600 hours of engineering, all open source, MIT. Since UPDATE 34 the through-line is one binary (`build/1bit`) and one language direction: C++23 for compute kernels, **Mojo 1.0 as the unified language** for everything around them — servers, converters, tooling, control planes. No interpreter at runtime, anywhere.
 
-## 2026-04-16 → 2026-06-27 — GENESIS: the ROCm burn, before the NPU
+## Table of Contents
+
+- [2026-04-16 — GENESIS: the ROCm burn, before the NPU](#2026-04-16-genesis-the-rocm-burn-before-the-npu)
+- [2026-06-28 — early sprint: first GEMMs, peak TFLOPS, stress tests](#2026-06-28-early-sprint-first-gemms-peak-tflops-stress-tests)
+- [2026-06-28 — Findings](#2026-06-28-findings)
+- [2026-06-28 — Late Testing — FLM HTTP Single-Connection Limit](#2026-06-28-late-testing-flm-http-single-connection-limit)
+- [2026-06-28 — Late Testing — `cmds2seq()` Discovery & Instruction Pipeline](#2026-06-28-late-testing-cmds2seq-discovery-instruction-pipeline)
+- [2026-06-28 — Deep Research — Definitive Findings](#2026-06-28-deep-research-definitive-findings)
+- [2026-06-28 — Q4NX Format Fully Reverse-Engineered](#2026-06-28-q4nx-format-fully-reverse-engineered)
+- [2026-06-28 — NaN debugging + Fused engine rewrite](#2026-06-28-nan-debugging-fused-engine-rewrite)
+- [2026-06-29 — Full Optimization Sprint](#2026-06-29-full-optimization-sprint)
+- [2026-07-01 — PR-Agent Live, Landing Page Deployed, 242 ms/tok Verified](#2026-07-01-pr-agent-live-landing-page-deployed-242-mstok-verified)
+- [2026-07-01 — 1bit-systems Rebuilt — 246 ms/tok Production Engine](#2026-07-01-1bit-systems-rebuilt-246-mstok-production-engine)
+- [2026-07-01 — INT8 Engine Complete — 219 ms/tok, Context Pool](#2026-07-01-int8-engine-complete-219-mstok-context-pool)
+- [2026-07-02 — Production Release — v2026.07.02-all5models](#2026-07-02-production-release-v20260702-all5models)
+- [2026-07-02 — All 5 Models at v12 Batch Speed, 0 Crashes](#2026-07-02-all-5-models-at-v12-batch-speed-0-crashes)
+- [2026-07-02 — Session Close — Full NPU Engine State](#2026-07-02-session-close-full-npu-engine-state)
+- [2026-07-02 — Merged with Remote Auto-Detect Engine](#2026-07-02-merged-with-remote-auto-detect-engine)
+- [2026-07-02 — Fused XCLBIN — First Attempt, Q4NX Blocker](#2026-07-02-fused-xclbin-first-attempt-q4nx-blocker)
+- [2026-07-02 — Multi-Model XCLBINs, Model-Agnostic Engine](#2026-07-02-multi-model-xclbins-model-agnostic-engine)
+- [2026-07-02 — M=32 Target, NPU LM Head, FLM Comparison](#2026-07-02-m32-target-npu-lm-head-flm-comparison)
+- [2026-07-02 — M=16 Batch Decode — 16 ms/tok, 15.2× Speedup](#2026-07-02-m16-batch-decode-16-mstok-152-speedup)
+- [2026-07-02 — Full Profile + 50 ms/tok Batch-4 Decode](#2026-07-02-full-profile-50-mstok-batch-4-decode)
+- [2026-07-02 — Production Stack, Release, Site Refresh](#2026-07-02-production-stack-release-site-refresh)
+- [2026-07-03 — v12 Was Never Output-Validated — 3 Real Bugs Found, Still Incoherent](#2026-07-03-v12-was-never-output-validated-3-real-bugs-found-still-incoherent)
+- [2026-07-03 — Fused XCLBIN Resumed — Schedule Fixed, Deadlock Isolated, New Kernel Bug Found](#2026-07-03-fused-xclbin-resumed-schedule-fixed-deadlock-isolated-new-kernel-bug-found)
+- [2026-07-03 — Triton-XDNA Eval, memlock Fix, Spec-Decode Reality Check](#2026-07-03-triton-xdna-eval-memlock-fix-spec-decode-reality-check)
+- [2026-07-05 — All 3 Bugs Confirmed Fixed — AIE Micro-Tiling Root Cause Resolved](#2026-07-05-all-3-bugs-confirmed-fixed-aie-micro-tiling-root-cause-resolved)
+- [2026-07-05 — Q4NX/GGUF fully decoded, NPU GEMM root-caused, first validated 1-bit number, DSpark](#2026-07-05-q4nxgguf-fully-decoded-npu-gemm-root-caused-first-validated-1-bit-number-dspark)
+- [2026-07-06 — Fused Layer Engine Goes Production — 291 Tok/s (3× v12)](#2026-07-06-fused-layer-engine-goes-production-291-toks-3-v12)
+- [2026-07-16 — FLM fully replaced, model-agnostic broadening, TQ2 ternary](#2026-07-16-flm-fully-replaced-model-agnostic-broadening-tq2-ternary)
+- [2026-07-20 — Mamba1 GPU Backend — 79.4 Tok/s, 9 Bugs Killed](#2026-07-20-mamba1-gpu-backend-794-toks-9-bugs-killed)
+- [2026-08-03 — Memory Campaign — Arena-Frag Leak Fixed, Top-1 Backend Init, 10-Bug Audit](#2026-08-03-memory-campaign-arena-frag-leak-fixed-top-1-backend-init-10-bug-audit)
+- [2026-08-07 — the unified control plane lands — one-heap pool, all models resident, spec-decode in-server (zoo 5/5)](#2026-08-07-the-unified-control-plane-lands-one-heap-pool-all-models-resident-spec-decode-in-server-zoo-55)
+- [2026-08-08 — The TileFuse Day — NPU Kernel from Scratch, Q4NX Pivot, Converter Ladder](#2026-08-08-the-tilefuse-day-npu-kernel-from-scratch-q4nx-pivot-converter-ladder)
+- [2026-08-09 — amdxdna Wedge Saga, 35B MoE Goes Live, Vivado-Free FPGA Toolchain](#2026-08-09-amdxdna-wedge-saga-35b-moe-goes-live-vivado-free-fpga-toolchain)
+- [2026-08-10 — NPU Firmware RE via Raw IOCTLs, Driver Regression Fixed, JARVIS Ships](#2026-08-10-npu-firmware-re-via-raw-ioctls-driver-regression-fixed-jarvis-ships)
+- [2026-08-12 — The Burn & the Mojo Shift — One Through-Line, One Unified Language](#2026-08-12-the-burn-the-mojo-shift-one-through-line-one-unified-language)
+- [2026-08-15 — FLM Is Fully Gone — Byte-Identical Streams, True Batch, 2× on the 35B](#2026-08-15-flm-is-fully-gone-byte-identical-streams-true-batch-2-on-the-35b)
+- [2026-08-15 — 100% HF Coverage: every arch-bearing checkpoint maps to an engine token](#2026-08-15-100-hf-coverage-every-arch-bearing-checkpoint-maps-to-an-engine-token)
+- [2026-08-16 — the frontier gates: 5/5 validated, then the repo tried to eat it](#2026-08-16-the-frontier-gates-55-validated-then-the-repo-tried-to-eat-it)
+- [2026-08-19 — the two-PC fleet: harnesses on the LAN, six deployment bugs fixed](#2026-08-19-the-two-pc-fleet-harnesses-on-the-lan-six-deployment-bugs-fixed)
+- [2026-08-19 — the mesh: installs wake up, find each other, JARVIS gets a fleet brain](#2026-08-19-the-mesh-installs-wake-up-find-each-other-jarvis-gets-a-fleet-brain)
+- [2026-08-24 — Lemonade v11.7.0 re-vendored: the SDK sync loop, made repeatable](#2026-08-24-lemonade-v1170-re-vendored-the-sdk-sync-loop-made-repeatable)
+- [2026-08-27 — Lemonade v11.8.0 re-vendored: the 15th backend lands (ds4, Strix Halo only)](#2026-08-27-lemonade-v1180-re-vendored-the-15th-backend-lands-ds4-strix-halo-only)
+- [2026-08-29 — the HRX engine week (in-process fused decode, honest ceiling)](#2026-08-29-the-hrx-engine-week-in-process-fused-decode-honest-ceiling)
+
+---
+
+## 2026-04-16 — GENESIS: the ROCm burn, before the NPU
 
 
 
@@ -40,897 +89,7 @@ Validation harness for Q2_0 on Strix Halo (05-06), site branding refresh (05-11)
 
 ---
 
-## Table of Contents
-
-- [2026-04-16 → 2026-06-27 — GENESIS: the ROCm burn, before the NPU](#2026-04-16--2026-06-27--genesis-the-rocm-burn-before-the-npu)
-- [UPDATE 34 (2026-08-12): The Burn & the Mojo Shift — One Through-Line, One Unified Language](#update-34-2026-08-12-the-burn--the-mojo-shift--one-through-line-one-unified-language)
-- [UPDATE 35 (2026-08-15): FLM Is Fully Gone — Byte-Identical Streams, True Batch, 2× on the 35B](#update-35-2026-08-15-flm-is-fully-gone--byte-identical-streams-true-batch-2-on-the-35b)
-- [UPDATE 33 (2026-08-10): NPU Firmware RE via Raw IOCTLs, Driver Regression Fixed, JARVIS Ships](#update-33-2026-08-10-npu-firmware-re-via-raw-ioctls-driver-regression-fixed-jarvis-ships)
-- [UPDATE 32 (2026-08-09): amdxdna Wedge Saga, 35B MoE Goes Live, Vivado-Free FPGA Toolchain](#update-32-2026-08-09-amdxdna-wedge-saga-35b-moe-goes-live-vivado-free-fpga-toolchain)
-- [UPDATE 31 (2026-08-08): The TileFuse Day — NPU Kernel from Scratch, Q4NX Pivot, Converter Ladder](#update-31-2026-08-08-the-tilefuse-day--npu-kernel-from-scratch-q4nx-pivot-converter-ladder)
-- [UPDATE 30 (2026-08-07): The One-Heap Pool — All Models Resident, Spec-Decode In-Server](#update-30-2026-08-07-the-one-heap-pool--all-models-resident-spec-decode-in-server)
-- [UPDATE 29 (2026-08-03): Memory Campaign — Arena-Frag Leak Fixed, Top-1 Backend Init, 10-Bug Audit](#update-29-2026-08-03-memory-campaign--arena-frag-leak-fixed-top-1-backend-init-10-bug-audit)
-- [UPDATE 28 (2026-07-20): Mamba1 GPU Backend — 79.4 Tok/s, 9 Bugs Killed](#update-28-2026-07-20-mamba1-gpu-backend--794-toks-9-bugs-killed)
-- [UPDATE 27 (2026-07-06): Fused Layer Engine Goes Production — 291 Tok/s (3× v12)](#update-27-2026-07-06-fused-layer-engine-goes-production--291-toks-3-v12)
-- [UPDATE 26 (2026-07-05): All 3 Bugs Confirmed Fixed — AIE Micro-Tiling Root Cause Resolved](#update-26-2026-07-05-all-3-bugs-confirmed-fixed--aie-micro-tiling-root-cause-resolved)
-- [UPDATE 25 (2026-07-03): v12 Was Never Output-Validated — 3 Real Bugs Found, Still Incoherent](#update-25-2026-07-03-v12-was-never-output-validated--3-real-bugs-found-still-incoherent)
-- [UPDATE 24 (2026-07-03): Fused XCLBIN Resumed — Schedule Fixed, Deadlock Isolated, New Kernel Bug Found](#update-24-2026-07-03-fused-xclbin-resumed--schedule-fixed-deadlock-isolated-new-kernel-bug-found)
-- [UPDATE 23 (2026-07-02 15:32 ADT): Production Release — v2026.07.02-all5models](#update-23-2026-07-02-1532-adt-production-release--v20260702-all5models)
-- [UPDATE 22 (2026-07-02 15:13 ADT): All 5 Models at v12 Batch Speed, 0 Crashes](#update-22-2026-07-02-1513-adt-all-5-models-at-v12-batch-speed-0-crashes)
-- [UPDATE 21 (2026-07-02 12:01 ADT): Session Close — Full NPU Engine State](#update-21-2026-07-02-1201-adt-session-close--full-npu-engine-state)
-- [UPDATE 21b (2026-07-02): Merged with Remote Auto-Detect Engine](#update-21b-2026-07-02-merged-with-remote-auto-detect-engine)
-- [UPDATE 20 (2026-07-02 05:17–07:27 ADT): Fused XCLBIN — First Attempt, Q4NX Blocker](#update-20-2026-07-02-05170727-adt-fused-xclbin--first-attempt-q4nx-blocker)
-- [UPDATE 19 (2026-07-02 06:24–06:27 ADT): Multi-Model XCLBINs, Model-Agnostic Engine](#update-19-2026-07-02-06240627-adt-multi-model-xclbins-model-agnostic-engine)
-- [UPDATE 18 (2026-07-02 04:01 ADT): M=32 Target, NPU LM Head, FLM Comparison](#update-18-2026-07-02-0401-adt-m32-target-npu-lm-head-flm-comparison)
-- [UPDATE 17 (2026-07-02 03:00 ADT): M=16 Batch Decode — 16 ms/tok, 15.2× Speedup](#update-17-2026-07-02-0300-adt-m16-batch-decode--16-mstok-152-speedup)
-- [UPDATE 16 (2026-07-02 02:00 ADT): Full Profile + 50 ms/tok Batch-4 Decode](#update-16-2026-07-02-0200-adt-full-profile--50-mstok-batch-4-decode)
-- [UPDATE 15 (2026-07-01 15:00 ADT): PR-Agent Live, Landing Page Deployed, 242 ms/tok Verified](#update-15-2026-07-01-1500-adt-pr-agent-live-landing-page-deployed-242-mstok-verified)
-- [UPDATE 14 (2026-07-01 08:30 ADT): 1bit-systems Rebuilt — 246 ms/tok Production Engine](#update-14-2026-07-01-0830-adt-1bit-systems-rebuilt--246-mstok-production-engine)
-- [UPDATE 13 (2026-07-01 04:00 ADT): INT8 Engine Complete — 219 ms/tok, Context Pool](#update-13-2026-07-01-0400-adt-int8-engine-complete--219-mstok-context-pool)
-- [Session 2026-06-28 — early sprint: first GEMMs, peak TFLOPS, stress tests](#session-2026-06-28--early-sprint-first-gemms-peak-tflops-stress-tests)
-- [Session 2025-06-28 Findings](#session-2025-06-28-findings)
-- [Session 2025-06-28 Late Testing — FLM HTTP Single-Connection Limit](#session-2025-06-28-late-testing--flm-http-single-connection-limit)
-- [Session 2025-06-28 Late Testing — `cmds2seq()` Discovery & Instruction Pipeline](#session-2025-06-28-late-testing--cmds2seq-discovery--instruction-pipeline)
-- [Session 2026-06-28 Deep Research — Definitive Findings](#session-2026-06-28-deep-research--definitive-findings)
-- [Session 2026-06-28 — Q4NX Format Fully Reverse-Engineered](#session-2026-06-28--q4nx-format-fully-reverse-engineered)
-- [Session 2026-06-28 — NaN debugging + Fused engine rewrite](#session-2026-06-28--nan-debugging--fused-engine-rewrite)
-- [Session 2026-06-29 — Full Optimization Sprint](#session-2026-06-29--full-optimization-sprint)
-- [Session 2026-07-02/03 — Production Stack, Release, Site Refresh](#session-2026-07-0203--production-stack-release-site-refresh)
-- [Session 2026-07-03/04 — Triton-XDNA Eval, memlock Fix, Spec-Decode Reality Check](#session-2026-07-0304--triton-xdna-eval-memlock-fix-spec-decode-reality-check)
-- [Session 2026-07-05/06 — Q4NX/GGUF fully decoded, NPU GEMM root-caused, first validated 1-bit number, DSpark](#session-2026-07-0506--q4nxgguf-fully-decoded-npu-gemm-root-caused-first-validated-1-bit-number-dspark)
-- [Session 2026-07-16/20 — FLM fully replaced, model-agnostic broadening, TQ2 ternary](#session-2026-07-1620--flm-fully-replaced-model-agnostic-broadening-tq2-ternary)
-- [2026-08-07 — the unified control plane lands (pool wired, spec decode in-server, zoo 5/5)](#2026-08-07--the-unified-control-plane-lands-pool-wired-spec-decode-in-server-zoo-55)
-- [2026-08-15 — 100% HF Coverage: every arch-bearing checkpoint maps to an engine token](#2026-08-15--100-hf-coverage-every-arch-bearing-checkpoint-maps-to-an-engine-token)
-- [2026-08-16 — the frontier gates: 5/5 validated, then the repo tried to eat it](#2026-08-16--the-frontier-gates-55-validated-then-the-repo-tried-to-eat-it)
-- [2026-08-19 — the two-PC fleet: harnesses on the LAN, six deployment bugs fixed](#2026-08-19--the-two-pc-fleet-harnesses-on-the-lan-six-deployment-bugs-fixed)
-- [2026-08-19/20 — the mesh: installs wake up, find each other, JARVIS gets a fleet brain](#2026-08-1920--the-mesh-installs-wake-up-find-each-other-jarvis-gets-a-fleet-brain)
-- [2026-08-24 — Lemonade v11.7.0 re-vendored: the SDK sync loop, made repeatable](#2026-08-24--lemonade-v1170-re-vendored-the-sdk-sync-loop-made-repeatable)
-- [2026-08-27 — Lemonade v11.8.0 re-vendored: the 15th backend lands (ds4, Strix Halo only)](#2026-08-27--lemonade-v1180-re-vendored-the-15th-backend-lands-ds4-strix-halo-only)
-
----
-
-## UPDATE 34 (2026-08-12): The Burn & the Mojo Shift — One Through-Line, One Unified Language
-
-**We burned the repo down to its through-line and picked the language that will carry it forward. Everything that wasn't the engine or the app that proves it is gone — SaaS, agent stack, voice cloning, the JARVIS v1 side-servers. And the glue language that used to be three (Python for tooling, C++ for the engine, JS for the web) is now one: Mojo 1.0, released this week, is the unified language we're building the control plane in.**
-
-### The burn: what got cut, and why it's not coming back
-
-The roadmap was rewritten around a single sentence — *engine (NPU + GPU + CPU, one binary) → JARVIS (voice assistant, reference app)* — and then the repo was made to match it. One commit, ~19k lines deleted (`cbce9630`):
-
-- **SaaS**: `tools/jarvis/auth.cpp`, `billing.cpp`, `usage.cpp`, `beacon.cpp` — the product layer for a product that doesn't exist yet. Gone. So is the Cloudflare auth worker (`workers/`) and the Zaya Co-Host dashboard (`site/dashboard/`) that talked to those APIs.
-- **Voice cloning**: the whole `zaya_audio/` training stack (codec training, voice packs, RVQ-VAE adapters, ONNX export) — a personal quest, not a product. `src/codec_decoder.cpp` went with it.
-- **Agent stack**: RAG, planner, personas, prompts, skills, the daily-routine/awareness scripts — AMD Gaia's turf, not ours. The engine serves it via Lemonade; it doesn't ship one.
-- **JARVIS v1's HTTP hop + WebSocket side-server**: `jarvis_server.cpp`, `audio_stream.cpp`, and upstream's new `voice_session.cpp`/`ws_proto.cpp` — replaced by the in-process pipeline: `mic → VAD → STT (libwhisper, now HIP-accelerated via `src/whisper_hip.hip`) → LLM (in-process BackendManager) → TTS → speaker`. One process, one pipeline, no WebSocket.
-- **Kept on purpose**: `agent_watchdog.cpp` (engine thermal/strategy, live in unified_server) and the whisper HIP port that the JARVIS blocker (P1) needed.
-
-CI, packaging, and scope-guard were updated in the same pass — `test_auth`/`test_billing` and the WS tests dropped, `jarvis_server` symlinks gone, the ALLOWED path list now reflects the real repo. The Python server for the AMD-gui Adrenalin replica was also burned, but that's the next section.
-
-### The Mojo shift: why we stopped writing glue in three languages
-
-This week Mojo hit 1.0. We'd been watching it since the 0.x betas — a language that is to Python what C++23 is to C, with first-class GPU/NPU kernels and the ability to call C libraries directly — and the 1.0 release is the moment we committed: **from here on, new non-kernel code is written in Mojo, not Python.**
-
-- **The AMD-gui Adrenalin replica backend** (a stdlib-Python sysfs/HTTP server for the Radeon Software control surface on Linux) is being rewritten in Mojo 1.0 as a single self-contained binary — same wire contract, zero Python at runtime. Hand-rolled libc HTTP over `external_call` (the stdlib's own mechanism), hand-rolled JSON (the payloads are fixed-shape), zero community packages (the ecosystem's pins are pre-1.0; `mojo==1.0.0` is the only pin we need). It replaces a Python interpreter dependency with one ELF, the same move we made for the NPU stack with C++.
-- **The pattern is the point**: every layer of this project now follows the same rule — one binary, no interpreter at runtime, sysfs/PCI/proc access from the metal. C++23 stays for the compute kernels where it's earned its place; Mojo becomes the unified language for everything around them: servers, converters, tooling, control planes.
-- **Why it's safe this time**: Mojo 1.0's stdlib was verified against the `v1.0.0` tag before we pinned it (no `std.net` yet — hence the libc sockets; no regex — hence the fixed-pattern parsers; `Process` API has no SIGTERM — hence the lazy-reap design). The version pin is the discipline: `mojo==1.0.0`, no `max==25.2`-style beta pins anywhere.
-
-### Status
-
-- **Repo**: one through-line (engine → JARVIS), one binary (`build/1bit`), one language direction (C++23 for kernels, Mojo 1.0 for everything else). Rebased onto 333 commits of upstream (`3f507b07`) with the burn on top — builds clean.
-- **JARVIS P1** (whisper on the engine): `whisper_hip.hip` wired into the forward pass; scalar fallback retained; `WHISPER_GPU=0` escape hatch.
-- **Next**: land the Mojo rewrite of the Adrenalin control plane (M0–M2: toolchain, JSON+sysfs, HTTP+GETs), then WS-09 (the single router) and the WS-11 NVMe expert streaming work from the roadmap.
-
----
-
-## UPDATE 35 (2026-08-15): FLM Is Fully Gone — Byte-Identical Streams, True Batch, 2× on the 35B
-
-**The last FLM artifact is dead. The open instruction generator now emits byte-identical streams to FLM's proprietary dumps (verified with `cmp` on all 4 ops), the open aiecc toolchain builds the xclbins (microkernel compiled with peano clang — no xchesscc), and true batch decode replaces the invalid fake-batch that had inflated our "-B 8" numbers. Validated head-to-head: we match FLM exactly at M=128 and beat it 11-15% with M=32 kernels on the 0.6B, and 2× on the 35B-A3B.**
-
-### The FLM-free zone, completed in one day
-
-1. **Instruction streams: byte-identical.** Reverse-engineered the complete FLM stream spec from the dumps (M=128 kernel = 4×32-row slices; N in 1024-tiles, K in 64-chunks; per-block bd rotation; the 12R-TCT sync pattern; all offsets/strides/values as formulas). The reworked `gemm_generate_sequence_i8` emits identical bytes — the old open generator was 230× slower (per-tile RTP config).
-2. **Xclbins: open-built.** The v27 MLIR-AIE flow + a peano-clang-compiled microkernel (`-Di8_i32_ONLY`, the repo's `.o` was gitignored/missing) produce xclbin+insts pairs; M=32 decode-optimized kernels beat FLM.
-3. **True batch decode.** The "-B 8 = 7.4 tok/s" claim was a fake batch (issue #111 — top-K candidates as sequential tokens, non-causal). Rewrote it: BS=8 independent sequences, per-sequence KV caches, causal attention, per-seq LM head, NPU am=B. Tokens verified identical to BS=1.
-4. **35B 2×.** The CPU MoE FFN dequantized experts fresh per token (~33M floats/layer/token). A per-layer dequant LRU cache (16 slots) cut the FFN 107.5→61.6 ms/layer; with BS=8 grouped expert execution: 2900→1450 ms/tok, tokens identical.
-
-### Validated numbers (Qwen3-0.6B, universal engine)
-
-| Config | ms/tok |
-|---|---|
-| FLM M=128 (BS=1) | 255-262 |
-| Open M=32 (BS=1) | 230-233 (~11% better) |
-| Open M=32 (BS=8) | 235-237 |
-| 35B-A3B BS=8 + cache | 1450 (vs 2900 = 2×) |
-
-Also shipped: 1BP v4 dedup (shared Zamba blocks stored once, alias index entries), IQ1_S/IQ1_M block-size fixes (206/230 → 50/56 — every IQ1 file offset was wrong), spec-decode draft-vocab overflow fix (was segfaulting), fused-engine port to the validated execution model (fixing a shared-weight-BO bug), symlink model cache.
-
-## UPDATE 33 (2026-08-10): NPU Firmware RE via Raw IOCTLs, Driver Regression Fixed, JARVIS Ships
-
-**Raw ioctls now drive the NPU directly and produce bit-exact GEMM output — the first compute outside FLM's own stack. A driver regression that made the 35B MoE model spit garbage was root-caused to amdxdna 0.16.0 and fixed by reverting to the in-tree 0.7.0 build. JARVIS shipped NPU-FLM speech-to-text, SSE streaming, and a loopback-trusted web UI (PR #1576), plus a deadlock fix that had been hanging every chat request. eeg-medical was archived — its foundation-model retraining was redundant with ZUNA1.1, which already trains on the same TUH-EEG corpus.**
-
-### Raw-ioctl NPU firmware RE: verified GEMM outside FLM (00:38–02:45)
-
-A full day's arc from static dead-end to working silicon access, independent of FLM's binary:
-
-1. **Firmware image fully mapped, proven not encrypted.** A block-entropy scan of the entire 429,680-byte firmware image found no 4KB window exceeding entropy 7.8 — the whole thing is a **signed pure-data container**, not a compressed or encrypted payload (~460KB is zero-fill). Static analysis exhausted; pivoted to live instrumentation.
-2. **Live mailbox protocol captured with zero risk.** `echo "module amdxdna +p" > .../dynamic_debug/control` turned on 36 stock trace sites — no rebuild, no interruption of live inference — and decoded the full startup sequence and message header format.
-3. **The `EXEC_DPU` silent-failure trap.** The command header's COUNT field (not BO size) determines payload length; `COUNT=0` triggers a silent `-EINVAL` with no dmesg line at all — only visible via ftrace.
-4. **Real DPU instructions executed via raw ioctls**, correctly reporting an expected error for unmapped weights — proving the full loop (cmd BO → `CHAIN_EXEC_NPU`/0x18 → real firmware execution → status) works end to end.
-5. **v28 MoE launch fusion** (`NPU_MOE_FUSED=1`): new `MOE_GUSGU`/`MOE_DSD` xclbins merge 4 FFN launches/layer into 2 via N/K concat of routed+shared experts. Correctness fix caught in testing: the DSD weight BO must be **block-diagonal**, not a naive concat, or the gate blend stops being separable. `test_moe_fused_math.cpp` passes at 1.64% max deviation (<5% tolerance).
-6. **A "verified GEMM" claim, self-corrected within the hour.** The first PASS was a verify-code bug — `bf16((uint16_t)exp)` reinterpreted truncated integers as bf16 bits, so an all-zero output "matched" by coincidence while the real device status was `ERROR(5)`. Real root cause: `CONFIG_CU` needs `cu_bo` to contain an actual **Program Device Image (PDI)**, not a raw instruction blob; also, xclbin kernels output **int32**, not int16.
-7. **PDI extraction perfected via bpftrace/uprobes.** kprobes on the driver's response handler decoded the exact rejection code (`APP_LOAD_PDI_FAIL`, `0x3000003`); uprobes on XRT shim's `get_pdi` revealed the true PDI offset inside the xclbin's `AIE_PARTITION` section — first guess `0xd8` was still wrong.
-8. **MILESTONE (02:39): verified GEMM via raw ioctls, full pipeline.** Corrected PDI offset to `0xD0`. Real bit-exact GEMMs: 128×3072×1024 (0/131072 wrong, ~10ms) and 128×12288×2560 (0/327680 wrong, 20.5ms, 393 GOP/s). Full 8-step recipe documented: PDI = xclbin `AIE_PARTITION[0xD0:]`; A/B/C buffers must be SHMEM, not BO_DEV; instructions are BO_DEV; specific kernel-arg blob layout; `cfg=0x804`; 16-tile hwctx.
-9. **All four qwen3-0.6b NPU ops verified bit-exact via raw ioctls**: QKV 128×1024×4096, O 128×2048×1024, GU 128×1024×6144, D 128×3072×1024 — zero mismatches on any of them.
-10. **The exec path wedged again** after ~40 IOMMU faults from loading new PDIs (the running production server, whose contexts predate the wedge, was unaffected) — recovery is reboot-only, same NPU driver story as always.
-
-Bonus same-session fix: **zaya NPU tokenizer** — real BPE `model.htok` generation (new `tools/hf_tokenizer_to_htok.py`) plus a weak-symbol linker bug where `tests/zaya_server.cpp`'s local `SimpleTokenizer` was silently shadowed by the shared implementation, producing garbage decode. Throughput: **3.3 → 42 tok/s**.
-
-### amdxdna driver regression: 0.16.0 broke the 35B, reverting to 0.7.0 fixed it
-
-Separate from the wedge-recovery saga in UPDATE 32, this is a correctness regression on a *specific newer driver version*:
-
-1. **04:57 — #1568 reproduced live**: a fresh 35B session goes straight to garbage soup — not the usual deterministic `/` fallback — proving the corruption is **cumulative NPU/firmware state**, not per-process. An existing `llama3.2:1b` context is unaffected; only *new*-context creation wedges at the firmware level. Degradation model formalized: coherent → token soup → empty output → deterministic `/` (end state), recovery = reboot only.
-2. **A separate, unrelated bug fixed along the way**: `mlir_aie`'s `NPU_CONTEXT_CACHE_SIZE["npu2"]` was hardcoded to 32, overcommitting this Strix Halo's real firmware hwctx pool of **exactly 16** (measured with a purpose-built `ctxpool` harness — the first guess of "≈6-7" was wrong; only direct measurement gave the right number). This caused `AIE2_STATUS_MGMT_ERT_NOAVAIL` under parallel pytest (`-n auto`). Fixed via `XRT_CONTEXT_CACHE_SIZE=1`: **5/5 PASS in 79s vs 225s serial (2.8×)**. Patched first in site-packages, then made reinstall-proof via `iron-repo/conftest.py`. Upstream PR filed: `mlir-aie#3526`.
-3. **13:00 — kernel moved to HWE 7.0.0-29-generic.** Initial (wrong) theory: NPU only supports ~3 concurrent contexts, blamed for 35B startup failures.
-4. **13:13 — correction**: 4 small NPU contexts work concurrently just fine. The real finding — **the 35B produces garbage even standalone with a free context**, a genuine regression against the last known-good 2026-07-31 benchmark, which ran on amdxdna 0.7.
-5. **13:53 — FIXED.** Reverting to the kernel's in-tree amdxdna **0.7.0** driver (`/usr/lib/modules/7.0.0-29-generic/.../amdxdna.ko.zst`) — the exact version from the last known-good bench — correctly runs the 35B end-to-end (zaya → flm → NPU, "4" for "2+2"). A second bug fixed in the same pass: `zaya-qwen36.service` had a `Requires=zaya-gpu8b.service` chain that pulled up the entire small-model fleet on start, starving the 35B of NPU columns and crash-looping it — fixed by dropping the `Requires`/`After`/wait-port. **Confirmed: the 35B and the 3-small-model fleet are mutually exclusive** (a column/resource budget constraint, not a context-count cap).
-6. **14:47 — two landmines left by the driver swap, both fixed post-reboot**: a stale `modules.dep` still pointing at the moved-aside DKMS `.ko` (fixed with `depmod -a`), and a stale `/etc/modprobe.d/amdxdna.conf` still setting `force_iova=1` (a 0.16/7.1.5-only parameter that the 0.7.0 in-tree driver rejects with a misleading "Unknown symbol" error). Also fixed: `zaya-gpu8b.service` stuck in a permanent start-pre kill loop. All chains verified post-fix: 14.1/21.5/13.9 tok/s across llama3.2/qwen06/gpu8b.
-7. **Capstone assessment**: the NPU firmware is genuinely locked (RSA-2048 signed, no dev build, unsigned builds refuse to load — no third-party firmware is possible), but the platform is **not crippled** — the DRM driver is open GPL, the mailbox protocol is now fully decoded, raw-ioctl exec is proven bit-exact, and the 16-context hwctx pool is a real RTOS/SRAM constant, not an artificial throttle.
-
-### JARVIS: deadlock fix, NPU-FLM STT, SSE, session KV reuse (PR #1576, `7d4b7549`)
-
-Three commits landed on `main` together:
-
-- **`34a55cb7`** — `build_context` double-lock deadlock fix (non-recursive mutex swap). This bug **hung every `/v1/chat/completions` request**.
-- **`1c5dfb9d`** (= `8ed882a9`) — `flm_tag_for_model` widened the 1.7B tag bucket to `H<=2048`.
-- **`f0d745f2`** (= `550d0299`) — speech-to-text via FLM's whisper HTTP endpoint (`:8496`, override `JARVIS_STT_URL`), **replacing the whisper.cpp+ffmpeg fork/exec path**; a loopback-trusted web UI auth bypass; `stream:true` requests answered as a single SSE chunk; and a long-prompt model-selection fix (was targeting a nonexistent `qwen3.5:9b`, now correctly `qwen3:4b`). `ctest -L host`: 10/11 pass.
-
-Two more fixes landed the same day:
-
-- **`zaya-npu.service` crash-loop fixed**: the lazily-spawned `flm serve` child was dying with "could not raise memlock limit to 1465 MB" then `mmap() EAGAIN` — systemd's default `LimitMEMLOCK=8MB` masked the bug in manual shell testing (interactive shells get unlimited). Fix: `LimitMEMLOCK=infinity` in `scripts/zaya-npu.service`. Result: coherent responses at ~3.3 tok/s, `x-backend: NPU FLM`.
-- **FLM multi-turn KV reuse**, two build steps ~10 minutes apart: first, `src/npu_flm_delta.h` — pure prefix-delta decision logic (send only the delta if the new prompt extends the previous one, with self-healing fallback to a full reset) — because the text-REPL path was sending `<<RESET>>` before *every* query, forcing a full re-prefill each turn despite FLM's own REPL keeping KV resident. Second, a request-level session layer on top: `session_id` in the request body, `Backend::continue_text(delta)` virtual, `g_flm_session_id`/`g_flm_session_last` tracked under a dedicated mutex.
-- **New documented constraint**: STT and the 35B contend for the same NPU context and cannot coexist — `flm-whisper` holding a context makes the 35B fail its coherence probe and fall through every backend. Confirmed fixed once `flm-whisper` is stopped (`zaya-qwen36` then passes 6/6 coherent probes at 3.2–3.8s). Design-state fleet: `npu :8088`, `qwen06 :8089`, `gpu8b :8090`, `whisper :8496` active, `qwen36` stopped on contention.
-- The most recent commit in this whole window, `e8bd91ed fix(npu): retry FLM spawn/probe on NPU contention; stop leaking flm-real children`, directly addresses this contention.
-
-### JARVIS mobile: a Flutter app for the voice pipeline (spans 2026-08-08 → 2026-08-10)
-
-Design doc (`docs/superpowers/specs/2026-08-08-jarvis-mobile-design.md`, approved 08-08) establishes the architecture: **the phone is a thin terminal** — mic, speaker, VPN client only. The full pipeline (VAD → Whisper → router → LLM → codec TTS → cloned voice) runs entirely on the Strix Halo box; no on-device inference, no audio persistence. Transport is WebSocket + Opus (not WebRTC — ~200ms latency judged acceptable). iOS is a confirmed target (cloud Mac mini via rentamac.io, Xcode 26.6, Flutter 3.44.9, existing Apple Developer account).
-
-Three milestones landed:
-
-- **M1 — server-side gap-fill**: `/v1/voice/session` full-duplex WebSocket path with an auth hook, a `VoiceSession` VAD state machine, an RFC-compliant WS handshake/parser (fixed for standards-conformant clients), and `WS_STREAM_BIND` (default loopback; `0.0.0.0` lets the phone reach the port over LAN/VPN, paired with `JARVIS_WS_TOKEN`). Docs: `docs/mobile/RUNBOOK.md`, `scripts/jarvis-gateway.service`.
-- **M2 — the Flutter app itself**: Android+iOS scaffold, protocol layer, session controller; a gateway WS client and audio IO services with tests; connect/voice screens with state lights and transcript UI; a live-gateway integration test with a stub server for simulator E2E.
-- **M3 — resilience and packaging**: connection-loss UX (stop mic, offline state, Reconnect button), reconnect mic-failure handling, a double-tap reconnect guard, and a final review pass fixing manifest permissions, a save-race, pulse lifecycle, and player disposal.
-
-CI enablement: `4b67b4ab` allowed `mobile/` through the scope-guard workflow (previously blocked, since JARVIS mobile is Jarvis's offline layer within engine scope, not a separate product).
-
-### Ops/infra: the reboot "watchdog" nuance, netconsole, firewall, fail2ban
-
-The CHANGELOG's "reboot.sh watchdog EBUSY fix" entry is correct about the code change (`273a50c5` — `scripts/reboot.sh` no longer aborts under `set -e` when `exec 9<>"$WD"` returns EBUSY because systemd already holds `/dev/watchdog` via `RuntimeWatchdogSec=60`) but doesn't explain what was actually causing the box to hang:
-
-- Across the last several boots, the reset-reason register shows the watchdog fired **only once** — the deliberate `reboot.sh --force` test. Every other "hang" was a **slow-but-clean software reset** (~1–1.5 min unexplained stall in the post-journal shutdown phase). Suspects, unconfirmed: amdgpu display (`REG_WAIT timeout optc35_disable_crtc` logged at every boot) or the USB4/Thunderbolt controllers.
-- A **separate, genuinely broken bug** was found and fixed: the watchdog safety net had been non-functional since it was created — the kernel package's own modprobe blacklist was silently deny-listing `sp5100_tco` at boot, so `/dev/watchdog` only existed after someone manually ran `modprobe sp5100_tco`. Fixed by shadowing the blacklist entry in `/etc/modprobe.d/`.
-- A **netconsole capture rig** was installed (UDP listener on a second box, `netconsole-capture.service`; sender configfs target on strix; `loglevel=8` added past the `quiet` filter) to catch the stall's last kernel messages the next time it happens.
-- **ufw/Docker firewall bypass fixed**: ufw doesn't filter Docker-published ports — they traverse the `FORWARD`/`DOCKER` chains, bypassing `INPUT` deny. Verified empirically (Supabase Postgres `:54322` reachable from LAN despite ufw). Fixed with a `DOCKER-USER` iptables rule made persistent via a oneshot systemd unit (Docker recreates its chain fresh on daemon start). Resolves #1571. Also found and closed: 2 accepted SSH password logins from a LAN IP ~30s after a brute-force burst — password auth disabled, fail2ban (sshd jail) and `ufw limit 22/tcp` added, closing #1572.
-
-### eeg-medical archived — redundant with ZUNA1.1
-
-`tools/zuna_port.cpp` (the ZUNA1.1 C++ port, hyperparameters verified against the paper: dim=1024, 16 layers, 8 heads, 382.1M weights) already existed in this engine before this session started — an earlier session had missed that and begun redundant work. Investigating further: **ZUNA1.1 is confirmed trained on the TUH EEG corpus** (per its paper, arXiv 2607.27308, and its predecessor ZUNA1, arXiv 2602.18478) — meaning the project's own TUH→B2 sync (5TB, running since UPDATE 31) would produce duplicate data toward a duplicate objective. Decision executed, fully reversible: `github.com/1bit-MONSTER/eeg-medical` archived — its shipped work (retraining EEG foundation models on data ZUNA1.1 already trained on) was redundant, and its README's core claim ("ZUNA1.1 trained on research data, not clinical") is factually wrong — TUH is clinical data. `tools/zuna_port.cpp` stays in 1bit-MONSTER as the canonical copy; the TUH→B2 sync was killed ~2 days into a ~17-day run. The `eeg-medical.1bit.systems` DNS record was deleted, though the underlying Cloudflare Pages project itself couldn't be (the API token lacked `Pages:Edit` scope) — that token should be rotated.
-
-### Housekeeping: issue triage, repo audit, PR #1573 consolidation
-
-- **29 open issues triaged**: 9 resolved with commit citations, 2 stale, 13 roadmap, 2 actionable security items (#1571, #1572 — both closed same day, above), 3 left unresolved (#1570 Qwen2.5-3B collapse, #1568 35B MoE — root-caused later the same day, above, #1536 amdxdna panic).
-- **Repo audit** found: ~1.6MB of stale/byte-duplicate xclbin backups, ~130MB of tracked build artifacts under `engine/npu/xclbins`, `third_party/lemonade` vendored as 784 plain tracked files (784 files, 13.6MB) unlike the other proper-submodule `third_party/` dirs, and `third_party/FastFlowLM/UPSTREAM.md` sitting untracked *inside* the submodule (would vanish on re-clone). No secrets found.
-- **PR #1573** (`feat/rebuild-all`, ~62 commits — the entire 35B MoE + Q4NX + JARVIS workstream from UPDATE 31/32) merged after two CI fixes (`4b67b4ab` scope-guard, `b46fc033` build the new host tests in the required C++ check). Follow-ons acted on the audit findings directly: `7c4a525b` moved `UPSTREAM.md` out of the submodule, `cab9a678` dropped 24 stale xclbin files. A draft release `v2026.08.10` was created (no git tag — draft releases don't create tag refs). Outcome: 11 issues closed, 18 remain open.
-- **`gh-ops.yml`** (`d11e969b`): new weekly+manual workflow reporting code scanning, dependabot, secret scanning, failed runs, and billing via the `gh` CLI, opening a single security-triage issue when alerts exist. Companion fixes for paginated alert fetches, `GH_TOKEN`, and `GH_REPO` env wiring.
-
----
-
-## UPDATE 32 (2026-08-09): amdxdna Wedge Saga, 35B MoE Goes Live, Vivado-Free FPGA Toolchain
-
-**The NPU driver's wedge-and-hang problem is root-caused to a firmware fatal error with no recovery path, and fixed with a new hardware-reset primitive wired into the scheduler timeout — signed and running as amdxdna 0.16.0. The 35B MoE model goes end-to-end for the first time, warming up to 44-70 tok/s. A Vivado-free open-source FPGA bitstream toolchain is built and verified round-trip bit-exact.**
-
-### The amdxdna driver wedge / kernel panic saga
-
-The longest single investigative thread of the whole window:
-
-1. **Firmware static RE dead-ends confirmed.** `npu.dev.sbin` is byte-identical (SHA256 match) to the stock `npu.sbin` — no relaxed-validation dev build exists. The suspicious 64KB blob (entropy ~7.0) isn't zlib, lzma, XOR, or any known cipher, and no ARM/Thumb/x86 code decodes from it. An earlier finding was corrected in the process: the supposed "code section"/"v5 gate targets" are actually a log-descriptor table, not gate-check code. A vulnerability map (`VULN_MAP.md`) confirmed all known driver CVEs are already fixed in 7.1.5 — the only live attack surface is the mailbox protocol (~23 opcodes).
-2. **13:04 — first kernel panic from `rmmod amdxdna`.** `BUG: unable to handle page fault … RIP amdxdna_pci_driver_exit` on kernel 7.1.5-070105. Root cause: a client-lifetime use-after-free race during device removal (`amdxdna_remove()` frees client structs while open FDs can still call `amdxdna_drm_close()`). An upstream fix exists (applied to `drm-misc-fixes` 2026-06-29) but was confirmed **absent** from the running module via objdump. New standing rule: never `rmmod amdxdna` — reboot to reload instead.
-3. **16:58 — kernel upgraded to 7.2.0-rc5, all-layers sweep 5/5 PASS, no wedge** across ~500+ hwctx cycles (vs. a previous ~20-cycle wedge trigger). Declared "fixed permanently" at 17:00, self-corrected at 17:01 (overclaim — one clean session doesn't prove "permanent" or "everything," and a separate, unrelated Qwen2.5-3B degeneration was still broken). The correction proved warranted: **the wedge recurred at 19:22** on the same kernel.
-4. **Root cause found: a firmware fatal error with no driver recovery path.** The wedge isn't a driver hang — it's the AIE firmware hitting a fatal error, DPU program counter stuck at `0xffffffff` (executing garbage). Once dead, every mailbox call fails, and the driver's existing recovery paths only retry *through* the dead mailbox. A real recovery mechanism (`aie2_xdna_reset`, an SMU power cycle) already existed in the driver but was only ever invoked at init time. **Fix**: a new `aie2_hw_reset()` — full suspend-all-contexts → hw_stop → hw_start → resume-all-contexts power cycle — wired into `aie2_sched_job_timedout`, built for 7.2.0-rc5.
-5. **19:43 — patched driver installed**, initially unsigned; the Secure Boot signing recipe was documented (MOK key already enrolled, `sign-file` + `zstd` + `depmod` + `modprobe`). Custom build registers as amdxdna **0.16.0** (newer than the stock 0.10.0).
-6. **The `rmmod` rule is obsolete for 0.16.0** (the UAF fix is binary-verified present) but **still applies** to any stock kernel (7.1.5, 7.2.0-rc5, mainline 7.2-rc6 unpatched).
-7. **A separate "reboot hangs" mystery resolved to the same root cause**: 7 kernel panics since Aug 6, all `rmmod`-triggered — because reboots had been preceded by a manual `rmmod amdxdna` to swap in instrumented driver builds. New rule: never `rmmod` as part of a reboot; the kernel tears down hardware fine without the module's exit path.
-8. **Final validation**: post-cold-reboot, the patched signed 0.16.0 driver ran `test_all_layers.py` **5/5 PASS in 631.98s with zero wedge/fatal messages** — the self-heal path never even had to trigger on this workload.
-
-*(Three sessions later, in UPDATE 33, this same 0.16.0 driver turns out to have introduced a separate correctness regression specific to the 35B MoE model — a different bug on the same subsystem, not a contradiction of the fix above.)*
-
-### 35B MoE: full pipeline + batched prefill/decode performance
-
-1. **02:39 — NPU worker path unblocked.** Fixed a `.1bp` manifest-lookup segfault (a misread header field produced a garbage 12.9GB "JSON length"); rewrote `tools/tq2_to_q4nx.cpp` (Q4NX-quantized 1BP → `.q4nx`, closing #1467), round-trip exact (diff 0.0). Batch scaling reached **12.6k rows/s at batch 64**.
-2. **03:08 — NPU MoE decode 2.8× faster: 4.9s/tok → 1.73s/tok.** Three changes in `npu_engine_universal.cpp`: a fused transposed-dequant writing directly into `[K,N]` layout (eliminating a separate f32 intermediate + transpose pass, cutting per-miss cost 28ms → 14.6ms); `EXP_CACHE_SZ` 128 → 256 (4.42 → 3.35s/tok); and hot-expert pre-warming (`NPU_ROUTE_STATS`/`NPU_WARM_EXPERTS`/`NPU_WARM_TOP` — 1089 experts pre-packed in 12.6s). Result: zero decode-phase cache misses, `moe_ffn` averaging 26.6ms/layer.
-3. **Correction: decode is launch-bound, not attention-bound.** Stage timers showed FFN dominating (31.5ms of ~47ms/layer) via 4 serial NPU launches, each paying ~5-9ms dispatch latency regardless of the tiny actual compute (~3μs for 16.7M MACs). Two attempted fixes were tried and reverted: async launch-overlap (kernels share AIE columns and just serialize, adding jitter) and a CPU shared-expert fallback (slower, plus box contention). The real lever — batching decode launches across tokens, or fusing per-layer xclbins (realized as v28 fusion in UPDATE 33) — was identified but parked here.
-4. **Batched MoE prefill: rejected, then fixed with per-token ascale.** First attempt (`NPU_MOE_BATCH=1`) was 13-24% faster wall-clock but numerically divergent beyond M=1 — one shared `dynamic_ascale` over all M×H tokens collapsed per-token dynamic ranges, and the error compounded over 40 layers until it flipped argmax choices. An old code comment rejecting batching ("2.25× more MACs, sequential is faster") turned out to be right about the *outcome* but wrong about the *reason* — batching genuinely is faster. Fix: a new `go_rows` primitive in the i8 GEMM (`quantize_async_rows`/`dequant_only_rows`) computing per-token scales from each token's full expert set. Result: bit-identical through layer 19 at M=9, only FP accumulation-order noise beyond that (~1.2% relative — same order as existing int8 quant noise), while retaining **13-17% speedup at M=9, 24% at M=32**.
-5. **The full pipeline fixed — 4 stacked Q4NX bugs**, root-causing the earlier "qwen3:4b tag + L=0 + degenerate" symptom: the layer scan looked for `"model.layers."` (plural) but the 35B's header uses `"model.layer."` (singular); the architecture was derived from the file's basename (always wrong for FLM's `<ModelName>/model.q4nx` layout) — fixed to read the parent directory name instead; no tag mapping existed for arch "qwen3.6" — added in *both* `src/backend_npu_flm.cpp` and `tests/backends/backend_npu.cpp` (the mismatch between the two cost several rebuild cycles before it was caught); and a 64KB header-size cap rejected the 35B outright (its real header is 85,552 bytes) — raised to 256KB.
-6. **Coherence-probe positional bug fixed**: `coherence_probe()` fed every prompt token at `pos=0`, so the NPU-FLM backend — which fires its query the moment `pos` resets to 0, i.e. on what it reads as "prompt complete" — queried FLM with only a 2-token prompt, false-rejecting qwen3:4b's legitimate `<think>` start token. One-line fix: feed prefill at real positions. Regression-verified across llama3.2:1b, qwen3:4b (previously rejected), and qwen3.6-moe:35b-a3b.
-7. **22:29 — culminating result: 35B MoE at 44-70 tok/s through the full pipeline.** Zaya (:8088) → NPU FLM → qwen3.6-moe:35b-a3b: **69.9 tok/s warmed** (64 tok/0.9s), **44.1 tok/s** on a second request (48 tok/1.1s), cold-spawn **9.5 tok/s** (6 tok/631ms) — consistent with the A3B active-parameter count matching dense qwen3:4b's 67.5 tok/s.
-8. **Later the same day — a new, wider problem surfaced.** After ~1h of model churn, zaya-spawned `flm` worker processes started dying (`defunct`) and returning single-byte garbage (`0xAE`), tripping probe failures and a systemd restart loop. Filed as #1568 (alongside #1569 GGUF misroute, #1570 Qwen2.5-3B parked, #1571 Supabase exposed on `0.0.0.0`, #1572 SSH brute-force + password auth). `zaya-npu.service` was temporarily reverted to serve only Llama-3.2-1B. *(Root-caused the next day — see UPDATE 33's driver-regression section — as the 0.16.0 driver, not this session's application-level fixes.)*
-
-### Vivado-free FPGA bitstream toolchain
-
-A self-contained track: nextpnr-xilinx + prjxray + openFPGALoader built from scratch on the Strix box (18:28–19:00), producing a `blinky.bit` (2.19MB) with IDCODE `0x0362d093` verified against real hardware. Rebuilt persistently at `/home/bcloud/fpga-toolchain/` after a cold reboot wiped `/tmp` (the recipe needed a split cmake version — 3.28.4 for prjxray, 3.31.6 for nextpnr — plus several GCC13+/GCC15 `<cstdint>` fixes). Correctness was proven, not just well-formedness: all 4974 fasm2frames-emitted frames (497,374 words) came back byte-identical to the bitstream via `bitread` — **546,208 words compared, zero differences.**
-
-### Scope decisions: JARVIS stays, ZUNA moves out
-
-JARVIS stays in the `1bit-MONSTER` repo (it's an application of the engine, not a separate product — unlike ZUNA, extracted to its own `~/zuna` repo, itself flagged as an open scope-boundary question that gets resolved by archiving eeg-medical entirely in UPDATE 33).
-
----
-
-## UPDATE 31 (2026-08-08): The TileFuse Day — NPU Kernel from Scratch, Q4NX Pivot, Converter Ladder
-
-**The single busiest day in the window: an original NPU int4 GEMV kernel built from scratch (inspired by, but not copied from, the TileFuse paper — its actual kernel code was never public), a pivot to official Q4NX weights after community GGUF conversions proved unusable, a 15× serve-mode speedup, MoE expert ops running on the real 22GB 35B model for the first time, a from-scratch ONNX INT8 pipeline, and a four-rung Qwen2.5 converter debugging ladder (1.5B → 3B → 7B) that found a different silent corruption bug at every rung.**
-
-### An original NPU int4 GEMV kernel (TileFuse-inspired), milestones M1→M4
-
-Official Q4NX weights turned out to be a dead end for custom-converted models (confirmed later the same day — see the Q4NX pivot below), so the day pivots to building an NPU int4 GEMV kernel from first principles. The TileFuse paper (arXiv 2606.11357) describes the dataflow, but its actual kernel code was never released — only a static docs site — so the AIE kernel itself is original work guided by the paper's description, not a port.
-
-- **M1 — the pre-tiler.** `docs/research/tilefuse_prep.py`: 128×64 tiles, int4 codes packed as adjacent-column nibbles, bf16 per-channel scales, int8 code-domain zero-points. Round-trip passed on synthetic data (max err 0.0087 vs. an int4 physics ceiling of 0.0101) and on a real Llama-3.2-1B `q_proj` slice (err 0.0288 vs. ceiling 0.0383). Three bugs fixed en route: int4 bytes pack adjacent *columns*, not row-pairs; the zero-point must be stored in the int8 code domain, not as a raw float minimum (storing `round(lo)` produced a 30× error); and constant-column tiles need `scale=|lo|`.
-- **M2 — converter, CPU reference, and toolchain, three steps.** A new C++ converter (`tools/gguf_to_tilefuse.cpp`) passed CHECK on all 113 2D tensors of Llama-3.2-1B-Instruct.Q8_0, producing a 656.5MB `.tfb`, after fixing four bugs (GGUF shape is file-order but data is logical row-major — must not transpose; a manifest-offset patch bug that shifted every tile read by one; the constant-column scale fix; the zero-point bug, both restated from M1). A CPU reference GEMV (`tools/tf_gemv.cpp`) then passed CHECK on 30 tensors after fixing an accumulation bug (`out[c]=acc` was overwriting instead of accumulating) and a gate-indexing crash. A subtle gotcha cost real time: `struct.unpack('<e')` is IEEE fp16, not bfloat16 — it silently misled probes by ~100×. Finally the IRON toolchain itself came up clean (`~/iron` venv, python3.14, mlir-aie + llvm-aie wheels), validated on-NPU with a stock axpy (96/96) and stock GEMV (95/95).
-- **The qgemv kernel runs on real NPU silicon, 10/10.** `aie_kernels/aie2p/qgemv.cc` fuses int4 unpack, dequant, and dot product on a 4352-byte tile FIFO — exact match vs. CPU on both 1-tile and 4-tile configurations, after fixing a kernel arg-count mismatch (garbage via a null pointer) and a zero-point duplication bug where the generator used `np.repeat` instead of `np.tile`, producing a block layout `[64][64]` instead of the correct interleaved one.
-- **"THE Q4NX WALL IS BROKEN"** — a real-model validation loading `blk.0.attn_k.weight` from a real community Llama-3.2-1B `.tfb` passed 5/5, chunked into 8-tile passes to respect a 32-worker placement limit. This "5/5" later turned out to be a false positive — see M3.
-- **A vectorization attempt** (16-lane row-group dot products) passed both test suites but was *not* faster yet (7.25s vs. 4.05s — vector setup overhead dominates at this granularity; the paper's 64×8 block structure is needed to actually win).
-- **An alternate performance path: bf16.** `gguf_to_tilefuse --bf16` mode is near-lossless (err 0.0002); stock IRON GEMV on a real bf16 `.tfb` measured **175μs / 24GB/s** on a K=512,N=2048 tensor — about 8× faster than the int4 qgemv kernel's ~1340μs at this point in the day.
-- **M3 exposed two false-positive bugs.** First, `test_real_model.py`'s earlier "5/5 PASS" was fake: `XRTTensor.from_torch` copies its input, so the test was reading back the *input* tensor, not the kernel's actual output buffer — the physics-bound gate even passed for an all-zero output. Fixed by reading via `buf.to_torch()`. Second, a **launch-alternation quirk**: consecutive QGEMV launches alternate between stale and valid output (even calls garbage, odd calls correct, deterministically) — stock GEMV doesn't show this; suspected an mlir-aie runtime FIFO ping-pong bug. Workaround: call twice per launch, keep the second result. A third, separate bug (the same `np.tile`-vs-`np.repeat` issue from the kernel work) had also silently narrowed `test_real_model.py` and the M3 sweep to only 16 distinct input values, with a bound loose enough to swallow the wrong math. Genuine corrected numbers: real-model max err/bound **0.0718**; M3 re-run **2/2 PASS in 12:42**.
-- **M4, performance, multiple steps.** A bf16 host-dequant path hit **100μs/launch** at batch 1 (109μs at batch 4, 127μs at batch 8; err ~0.035 from bf16 rounding) vs. the int4 fused kernel's ~1100μs/launch, though batch 16 hit a placement wall ("no ShimNOCTile has sufficient DMA capacity"). A full-array mem-tile dataflow (per the paper's §4.4) then reached **197μs for 2048 outputs in one launch** at batch 32 (err ~0.05), and re-ran the M3 int4 sweep 3× faster (2/2 in 4:24) — but exposed a new cap: `QGEMV` silently truncates batches above 32. An honest per-token benchmark landed at **~0.9s/token** — 4714 launches × ~189μs, with the ~185μs launch floor dominating (the kernel itself is only ~2μs) — identifying layer-level batching as the next lever. That lever landed same-day: batching to **17 launches/token (16 blocks + embed) cut the time to ~390ms/token** (from 892ms), and revealed a new floor: the bf16 path moves 2.5GB of weights per token at ~10GB/s effective shim DMA, making it DMA-bound rather than launch-bound, while the int4 fused path moves 4× less data (656MB/token) but is compute-bound at ~1ms/tile for scalar dequant — flagging vectorized in-kernel dequant as the path toward ~100-150ms/token.
-- **An all-layers bf16 sweep passed 5/5** after four more bugs: a false positive from reading the test's own allocated output tensor instead of the real one; a bf16 construction bug (`.view(np.uint16)` interleaves the low/high halves of each pair instead of `.astype(bfloat16)`); a K-chunk reference using a column slice instead of a row slice; and a quadratic loader re-slicing a 533MB array inside a loop (hours → fixed to 0.3s). Full round-trip: 114/114 PASS.
-
-### The Q4NX pivot: official FastFlowLM weights vs. community GGUF conversions
-
-1. **Verified with official weights.** `third_party/FLM_Q4NX_Converter` vendored; the pipeline works end-to-end with *official* pulled weights (`llama3.2:1b`, ~4.8 tok/s including spawn), but **community GGUF conversions produce degenerate output (loops)** — establishing the day's key limitation. Three bugs fixed along the way: a missing `FLM_CONFIG_PATH` on the per-request child process; a coherence probe wrongly rejecting char-shifted NPU output (fixed with an `all_char_band` exemption); and a Llama tag-mapping fix disambiguating on both H and L.
-2. **FastFlowLM confirmed open-sourced (MIT)**, having moved from the FastFlowLM org to the ROCm org the day before (v0.9.46). Vendored at `third_party/FastFlowLM`. Two candidate decode dispatch paths were found for the degeneration bug: `generate_dequant_q4_1_seq` vs. `generate_dequant_q80_packed_in_q4nx_seq`.
-3. **`tools/batch_convert_q4nx.sh` shipped** (`86269a99`, `d110bee1`), finding the converter's actual bug: an uncommented upstream debug line (`sys.argv` override to `'gemma4-2b-mmproj.gguf'`) clobbered every CLI invocation — the converter had been **totally unusable** before this fix.
-4. **The fusion engine rebuilt** (`engine/npu/build_npu.sh`, 19 variants) with a per-tensor-scale `packB` fix replacing broken per-32-group scales; batch scaling proved essentially free up to 16 rows (1.9ms@1 → 2.2ms@16 → 6.4ms@64).
-5. **Mystery solved: NPU2 is a different architecture, not a repack.** Official q4nx linears store raw I8 at `K=5120` (vs. vanilla GGUF's K=1024-2048); an earlier "±15 std5.6 vs. GGUF ±0.1" observation was actually I8 bytes being misdecoded as Q4_1 nibbles — no repack of a vanilla GGUF can produce official Q4NX's layout.
-6. **The pivot's verdict** (branch `feat/q4nx-pivot`): a runnable q4nx model must come from `flm pull`, not conversion. Also decided: **`flm serve` works fine with official weights** (~45 tok/s vs. ~4.8 tok/s per-request spawn) — the earlier belief that "serve mode degenerates" turns out to have been an artifact of broken *converted* weights, not a problem with serve mode itself.
-
-### Serve-mode migration + a tokenizer band bug
-
-`SimpleTokenizer`'s decode fallback used stale character-shift bands that no longer matched the encoder's real bands (ids 132-226 should map to -100, 300-555 to -300) — ids 201-226 silently decoded to control characters, which is why short test strings looked fine while longer prose came out garbled. Verified end-to-end: **71.4 tok/s via `flm serve` vs. 4.8 tok/s per-spawn — about 15×**. A separate "16-char truncation" symptom turned out to be a red herring: a legacy endpoint defaulting `n_predict` to 16 instead of reading `max_tokens`. Both fixes landed as `87846a51`. In a case of parallel-agent convergence, another agent had independently built an equivalent serve backend (`86269a99`, `d110bee1`) — this session's changes were reconciled in its favor.
-
-### 35B MoE: expert worker ops verified, then a 5.8× xclbin rebuild
-
-1. MoE expert worker ops 40/41 ran on the real 22GB Qwen3.6-35B-A3B model for the first time, after fixing three bugs: `find_tensor_info` returned data offsets as **int32**, overflowing negative for offsets ≥2^31 and silently corrupting per-layer dimension detection on any model over 2GB (cascading to a SIGSEGV in `std_attn_step`) — fixed to `uint64_t`; an NPU out-of-memory at ~1.2GB BOs (dense QKV/O alone is 1080MB on the 35B) — fixed by making shared-expert BOs NL=1 with a host-side packed int8 cache; and a worker-op protocol payload-ordering bug. At this point, NPU MoE still lost to CPU: full decode was 2,823ms/tok on CPU fallback vs. 8,999ms/tok with `NPU_MOE=1` (3.2× slower — old xclbins).
-2. **The MoE xclbins rebuilt as v27** (multi-row, 32-core; `build_moe_v27.sh`): op40 (expert GU) dropped from 39ms to **6.7ms**, op41 (D) from 20ms to **7.3ms** — a **5.8× speedup**. Full decode improved 9.0s → 7.2s → 5.8s/tok across the session (progression tied to `EXP_CACHE_SZ` 32→128 plus OpenMP tuning) — still losing to CPU's 2.8s/tok at batch 1. A `NPU_TIMING` breakdown explained why: an all-hit pack costs 2.0ms, but each cache **miss** costs ~25-30ms, and the 35B's routing churns through 100+ distinct experts per layer, giving an LRU miss rate of 50-80% at batch 1. The insight that mattered: **a fully warm path would be ~25ms/token across all 40 layers — 40 tok/s** — the number that gets realized on 2026-08-09/10 (see UPDATE 32).
-
-### An ONNX INT8 QDQ converter/loader pipeline, built from a protobuf bug up
-
-1. `src/onnx_loader.cpp` had been **parsing the wrong protobuf field numbers entirely**, finding zero tensors in any real ONNX file (`GraphProto.initializer` is field 12, not 5; `TensorProto.name` is field 12, not 8; `raw_data` is field 14, not 9 — all verified empirically against real wire format). Rewritten, with `DequantizeLinear` node parsing added and a new **WMMA_I8** path: INT8 QDQ → dequant → Hadamard-rotate in block-128 → per-row requant.
-2. `bitnet_decode --config` reads an HF `config.json` sidecar and auto-loads `.onnx` paths; a new `std_arch` dispatch fixed a crash where any non-Qwen3/non-BitNet architecture (e.g. Phi) hit null sub-norm pointers.
-3. Full serving verified with zero extra code: `bitnet_decode --server` (OpenAI-compatible + SSE) served qwen3-0.6b INT8 correctly, **57 tok/s, 877ms for 50 tokens**, streaming confirmed working.
-4. In retrospect, this pipeline required finding and fixing **six independently fatal bugs**: the protobuf field numbers; a converter reading Q8_0 as unsigned int8 instead of signed (misreading any value >127, ~1.86× std error); the big one — the loader uploaded F32 norm weights but the rmsnorm kernel read them as FP16, so every value's low 16 bits were denormal-tiny and even-indexed outputs underflowed to zero; a Qwen3 `head_dim=128 ≠ hidden_size/num_heads` mismatch requiring the o-proj quantize step to use `nh*hd` width, not the naive hidden size; a `hipMemsetAsync` racing `decode_stream` without an explicit stream argument; and the `std_arch` dispatch crash from item 2.
-
-### Llama-3.2-1B verification and a logit-flatness investigation
-
-Llama-3.2-1B INT8 verified correct (Berlin, blue) with **PPL 49 vs. 828 for gibberish — 17× discrimination**, confirming tied embeddings are correct for this model (not a conversion bug). A separate concern — that logits looked suspiciously flat — was **not proven to be quantization-caused**: the numpy fp16 reference used to test it had six of its own bugs (wrong RoPE convention, wrong prompt token ids, a missing QDQ dequant step, a single shared KV list instead of one per layer, a layer-0-only comparison instead of full-stack, and mismatched single-token vs. full-prompt inputs). The GPU-side verification held up throughout (position-0/layer-0 query within 0.7% of fp32, 4/4 correct answers, PPL 49 vs. 828). Separately, arch-aware chat templates were added, and a key finding closed the loop on repetition loops: the **base (non-instruct)** Llama-3.2-1B shows the identical "which is" repetition loop as the instruct model — proving loops are a known trait of the 1B model itself, not a quantization or template bug.
-
-### INT8 weight error budget
-
-Measured against the GGUF Q8_0 source on llama-3.2-1b/qwen3-0.6b: plain per-row INT8 gives 0.98%/0.91% mean relative error; the Hadamard-rotation WMMA path improves that to **0.854%/0.847%**; adding QuIP-style sign flips on top made **no further difference at W8A8** (the existing rotation already captures the benefit — sign-flips only matter at W4A4). Conclusion: ~0.85% weight-side error rules out weight quantization as the cause of the small models' repetition/flatness behavior.
-
-### The Qwen2.5 converter debugging ladder: 1.5B → 3B → 7B
-
-Four rungs, each hiding a different silent corruption bug:
-
-1. **Qwen2.5-1.5B**: both the official and an independent community GGUF turned out **corrupted** — input norms ~2000× off, linear weights 106% wrong vs. the HF safetensors source. Fixed by bypassing GGUF entirely with a new `tools/safetensors_to_onnx_int8.py` reading bf16 safetensors directly, plus adding attention-bias support (Qwen2.5 has q/k/v biases that llama.cpp GGUFs drop, and with the model's characteristically tiny norm weights, the bias term dominates attention scores if missing). Result: correct answers, **PPL 17.5**, 28/28 tests including a new GQA test. A *separate*, still-unresolved collapse remains on the INT8 GPU serving path specifically (PPL 1.19M, V-cache zeroed at pos≥1) — extensively debugged (hook-presence changes behavior, `HIP_LAUNCH_BLOCKING` doesn't help) but never isolated; parked.
-2. **Qwen2.5-3B**: converted cleanly but degenerated at runtime (PPL 52k, a "Located 当前位置" loop) — parked mid-day, then **solved same day**: the converter was silently falling back to a stale 1.5B config (`num_hidden_layers=28`) instead of the real 3B's **36**, dropping the last 8 layers with no error. Fixed by deriving layer count from the tensor-name index, never from config. Result: **PPL 31**, coherent ("Paris", "Eiffel Tower").
-3. **Qwen2.5-7B**: **PPL 13.6 — the best in the zoo.** Two bugs: an untied `lm_head` was never being emitted for models with `tie_word_embeddings=false`, so the 7B ran with a *tied* head (using the embedding table as the output head) and produced garbage — caught via a parameter-count check (7.07B in the ONNX vs. 7.62B expected, a 545M gap matching exactly the missing `lm_head`); and a `config.json` path-resolution bug for directory sources (`os.path.dirname(dir)` resolved to the *parent* directory, missing the local config and silently falling back to the same stale 1.5B config that bit the 3B rung above). Verified: rich, coherent text with correct chat-template turn-ending.
-
-### Zaya GGUF/.1bp conversion: the 74B download, an 8B NaN, and a MoE converter fix
-
-1. A **74B Q4_K_M GGUF (45.76GB, 1923 tensors)** was downloaded, unblocking two parked issues.
-2. **Zaya1-8B NaN root-caused**: `cca_conv_grp.weight` was reading garbage, exploding the conv output into `inf*0` NaN through RoPE. The GGUF itself was confirmed clean — the bug was in the WIP `gguf_to_onebp` converter's 3D-tensor handling, ultimately traced to a **GGUF dtype-30 mixup**: `GgufReader` treated dtype 30 as a legacy "F32_V3" 4-byte float, but current llama.cpp defines dtype 30 as `GGML_TYPE_BF16`. Zaya's `cca_conv_grp.weight` is genuinely BF16 — reading it as f32 consumed twice the intended byte span, desyncing every subsequent tensor read.
-3. **The #1522 converter had two separate root causes**, found by running the real 45.76GB file through it: a shape heuristic voted row-major for Zaya's `[rows,cols,experts]` layout, inferring 4096 "experts" and producing 242GB of fp32 garbage — fixed by trusting the `<arch>.expert_count` metadata instead of guessing; and `token_embd.weight` (1.07B elements) tripped a `1<<30` element cap and was silently skipped while its bytes stayed reserved in the index, desyncing every later offset in the file — the cap was raised to `1<<31` and made a fatal error instead of a silent skip. Verified via round-trip dequant against the source GGUF: Pearson r=0.994-0.999, zero NaNs. Output: `ZAYA1-74B.1bp`, **43.6 GiB** (PR #1546).
-4. **An architecture fact worth recording**: ZAYA1's layers **alternate** — even layers are CCA-attention-only, odd layers are MoE-only, and **no dense FFN exists anywhere** in the model. A missing sublayer's weights should produce a null pointer and a skip, never a silent zero-fill. Relatedly, no working reference implementation of Zaya's router "EDA" temporal-state semantics exists anywhere (even the llama.cpp Zaya fork refuses to load the 8B GGUFs and degenerates on the 74B) — the engine loads the 8B `.1bp` end-to-end, but its output isn't conditioned on the prompt, and this remains unresolved for lack of anything to verify against. The 74B additionally needs ~145GB of fp16 GPU expert buffers against a 62GB Strix pool — current fp16-only expert kernels can't run it at all yet.
-
-### The rest of 2026-08-08
-
-- **A third NPU driver wedge this session** (`DRM_IOCTL_AMDXDNA_CREATE_HWCTX err=-22`, after 20+ xclbin load/unload cycles) persisted without self-clearing, forcing a reboot — bridging directly into UPDATE 32's wedge saga.
-- **The self-hosted CI runner was removed.** `strix-halo-runner` uninstalled locally (2.4GB freed); NPU-only workflows deleted (`bench.yml`, `npu-reset.yml`, `npu-pool-probe.yml`, `end-to-end-smoke.yml`); hardware jobs removed from the remaining shared workflows. Rationale: NPU/GPU jobs need `/dev/kfd`/`/dev/accel`, which GitHub-hosted runners don't have — CI is now fully GitHub-hosted.
-- **The TUH EEG data-access workstream began** (background context for UPDATE 33's later eeg-medical archival decision): access approved via NEDC, a full rsync sync pipeline built (sftp proved rate-limited/reset after ~136GiB, so rsync-only, chunked ≤100GiB, cron-scheduled), targeting a ≈5TB/414k-file corpus at ~29MB/s (~17-day ETA).
-- A HIP backend bug where `sample_token` returned -1 (forward/lm_head emulation for the split ZAYA HIP boundary) was fixed.
-- **Background/context, not engine work**: AMD's acquisition of Taalas (announced Aug 6 — a hardwired-model-silicon compiler claiming ~16-17k tok/s/user for a single hardwired model) prompted a staged-plan validation of a "1-bit FPGA LLM box" concept — judged a plausible ~50-150 tok/s niche for a 1B 1-bit model on an Alveo U250, with zero ASIC mask-cost, though far short of Taalas's on-die-ROM throughput; a Strix Halo upgrade-path discussion (128GB unified RAM as the biggest lever for fitting 70B Q4 fully in memory, NVMe weight-streaming, small FPGA "Taalas toy" boards); and a Vitis/Unified SDI 2026.1 toolchain install.
-
----
-
-## UPDATE 30 (2026-08-07): The One-Heap Pool — All Models Resident, Spec-Decode In-Server
-
-**The unified server now boots with every model in the zoo resident in one mmap'd pool (11 slots, ~6 GB on Strix), runs lossless speculative decoding in-process (`--draft-model`), and finally produces coherent answers from all 9 models end-to-end — Zamba2, the NPU FLM path, and the HIP 1BP backends all fixed. 13 commits landed on main via PR #1535.**
-
-### The unified model pool (#1535)
-
-The pool idea from UPDATE 29's roadmap is now end-to-end. `UnifiedModelPool` was generalized: any model file (gguf/q4nx/h1b/1bp) is mmap'd resident — `.1bp` gets header-parsed metadata, everything else generic. `--pool` makes the server load every discovered model at boot; `POST /v1/pool` reports residency, `/v1/models` tags pooled models. One process, one API, all models resident. Measured through the single endpoint: Qwen3-4B (NPU FLM) 20.8 tok/s, Llama-3.2-1B/Qwen3-0.6B (Vulkan) 12.4, Bonsai (HIP 1BP) 3.1, Zamba2 Q8_0 (HIP) 2.2; zoo-smoke 5/5 PASS.
-
-### In-server speculative decode
-
-Phase 2 core is now a server flag, not a demo. The backend interface gained the three spec-decode primitives (`decode_one` / `verify_batch` / `rollback`), implemented by the ggml-vulkan backend with multi-token `llama_decode` (per-position logits + KV rollback via `llama_memory_seq_rm`). `--draft-model` loads a second side-by-side ggml-vulkan backend; `--spec-decode` runs the lossless loop (draft proposes N greedy tokens, target verifies in one batch, longest consistent prefix accepted, rejected positions rolled back and fix re-decoded). Two real bugs found along the way: `reset()` was a no-op — every request extended ONE unbounded sequence, so KV never actually cleared per request; and the first-token bug — draft and target logits share a vocab size but NOT a vocab, and a shared buffer made the first output token the draft's argmax.
-
-### Zamba2 end-to-end (5dcef800)
-
-Zamba2-1.2B-Instruct-v2 now generates coherent answers through the unified server on the HIP GPU engine — verified vs HF transformers with identical top-1 (`'4<|im_end|>'` greedy). Three root causes, all found:
-
-1. **The GGUF on disk was corrupt** — ~60% of weight elements didn't match the checkpoint (spot-checked ssm_in, embedding). Re-converted a clean F16 GGUF from the safetensors.
-2. **Converter bugs**: `use_shared_attention_adapter=True` never folded the q/k/v LoRA adapters (only the FFN gate_up one was) — every attention head computed with raw weights; and the tokenizer vocab was never written, so `.htok` synthesis failed and the server fell back to the previous model's tokenizer (Qwen3 ids fed to a 32k-vocab model).
-3. **Merges format**: `tokenizer.json` merges are `[a, b]` pairs, the gguf lib wants `'a b'` strings.
-
-### Model zoo sweep: 8/9 coherent (04271bd8, 0bab2f6e)
-
-Full regression sweep of all 9 models through the unified server — 8/9 now generate coherent responses. Tokenizer synthesis was the big one: the server now builds a fresh `.htok` from the model's own or sibling GGUF (`GgufReader::write_htok`), because the checked-in `tokenizer.htok` was a stale Llama-era v1 file and without it every non-NPU model decoded as ASCII-garbage `[id]` soup. Plus: byte-piece fallbacks for non-GPT-2 vocabs, the ggml_vulkan sampler chain switched from greedy (which made small models loop) to temp 0.8/top_p 0.95/dist, and a nasty `cur_p.selected` bug — it's an INDEX into the candidates array, not the token id.
-
-NPU FLM went end-to-end too: an ODR collision where two distinct `OnebpModel` classes (CPU vs NPU) shared one dtor symbol meant every NPU-side object was destroyed with the wrong layout → SIGSEGV after any failed 1BP open (fixed by renaming the NPU-side class to `NpuOnebpModel`). The FLM backend got a `generate_text()` hook driving the subprocess REPL with the whole prompt (FLM tokenizes internally; a token loop can't drive it), with REPL artifacts (ANSI codes, `<<RESET>>` echoes, `[FLM]` log lines) stripped from responses. And the Qwen3-4B-NPU2 model cache was corrupt — bad download pre-reboot.
-
-### Zaya 1BP + routing (9ed7eb94, 7ae82829, 4c68f3ff)
-
-The HIP 1BP backend is wired into the router chain with logits-based sampling (temperature/top-p/repetition penalty — replacing argmax), `rope_theta` passed from the `.1bp` header, and per-arch chat templates — verified with a real-prompt coherence probe.
-
-### CI + housekeeping
-
-- The e2e smoke job no longer breaks when built without the llama.cpp submodule (`backend_ggml_vulkan.h` self-stubs the factory, mirroring the `.cpp`'s `#else` stub); submodule pinned to the fork so CI can fetch the zamba2-quantize commit.
-- ShellCheck SC2034 in `scripts/zoo-smoke.sh` fixed (unused loop var — was blocking the required C++ check on every PR).
-- **Branch cleanup**: 7 stale remote branches deleted (3 dependabot bumps, superseded fingerprint-dispatch docs, merged/closed eeg-zuna-research, zamba2-ssm-a-convention, ws05 per-vocab-ppl-gates), 4 stale PRs closed. `origin/main` had been sitting at Aug 5 — the whole Aug 7 work landed via PR #1535.
-- **CI flake found, not fixed**: the smoke-test's NPU `mmap EAGAIN` failures are the `pool-probe` job wedging the amdxdna driver (`Can not get flush memory` in dmesg) — the server runs clean locally with the NPU free. Root-caused in the wiki; workaround is a reboot before needing smoke green.
-
----
-
-## UPDATE 29 (2026-08-03): Memory Campaign — Arena-Frag Leak Fixed, Top-1 Backend Init, 10-Bug Audit
-
-**The long-unexplained host-RSS creep in `unified_server` is root-caused and fixed, the multi-backend memory bloat is cut by ~10 GB, and the 10-bug audit (#1429–#1438) landed. Release v2026.08.03 shipped and the memory fixes are deployed on the live service.**
-
-### The leak that wasn't a leak: glibc arena fragmentation (#1428)
-
-For weeks the server's host RSS crept ~0.1–1.7 MB per generation request — monotonic, never returned, ~90 MB/hr at 1 req/s, and 6.8 GB baseline after 50 min uptime. Every container was ruled out by triage. A heaptrack capture settled it:
-
-- **Zero unfreed bytes on the generate/forward/lm_head path.** Nothing leaked.
-- The culprit: `FusedBackend::generate()` allocated `std::vector<float> l(VOCAB)` (**608 KB** for Qwen3) on the stack **every token** and freed it every token.
-- That's the **glibc dynamic mmap-threshold trap**: the first 608 KB block is mmap'd, but after the first free glibc raises its threshold and services later same-size requests from the **brk arena**, interleaving them with the small per-token HIP/kernel allocations. Top-of-heap never becomes trimmable → RSS creeps up and never comes back. This is exactly why `/proc/maps` stayed flat while `VmData` grew, and why the rate tracked tokens.
-- Fix: hoist `h`/`l` to reusable member buffers sized once in `init()`. Zero per-token host allocation → nothing to fragment. Measured: mt=128 creep decays 208 → **20 kB per 10 reqs** (old: 17 MB per 10 reqs, ~160×) and plateaus; the `MALLOC_MMAP_THRESHOLD_`/`TRIM_THRESHOLD_` env band-aid on the service became unnecessary and was removed.
-
-### The 15 GB serving baseline (#1427)
-
-`BackendManager::init_in_order()` loaded **every** backend × full model copy — fused (f32 GPU + host), hip_1bp (bf16 GPU), vulkan_hpp (pools), cpu_generic (f32 RAM) — ~15 GB (7 GB RSS + 8.2 GB GTT) for a 0.6B model, so systemd-oomd killed desktop apps when CI built concurrently. Two fixes:
-
-1. **Dead host weights freed**: `cpu_L`/`cpu_embed`/`cpu_final_norm`/`cpu_output` are pure load→GPU/NPU-pack buffers — provably unread at inference. Freed after load: RSS 6768 → 5163 MB.
-2. **Top-1 + CPU fallback init**: keep the first accelerator + one CPU fallback; the rest stay discoverable and init **lazily via the existing failover path**. This was safe because the per-token cross-backend routing those extra copies paid for was **KV-incoherent anyway** — each backend keeps a private KV cache + `pos`, so a token routed to a backend that never saw the prefix attends to empty KV. Instance GTT: 8.2 → **2.6 GB**.
-
-### Everything else since UPDATE 28
-
-- **Coherent GPU inference** (#1397): QK-norm, per-layer KV, residual fixes — GPU paths became output-valid; `fused_gpu_npu` is the production path at **321 tok/s (3.1 ms/tok)**.
-- **One ELF to rule them all** (08-02): `build/1bit` = zaya + unified + router + jarvis + vision + agent CLI in a single binary; `1bit pull`/`list` in pure C++; packaging ships one binary; the 296-line bash launcher is dead.
-- **Lemonade embedded** (08-01): 14 Lemonade backends run in-process; `unified_server --lemonade` hands off to the full server.
-- **Exact SiLU + `-ffast-math` dropped** (41d0977e7): Q4NX ppl was *backend*-broken, not converter-broken — the #1243 audit's 6.5% density red flag resolved with per-vocab ppl gates + prefill M=128 fused chain (#1413).
-- **RVQ-VAE codec in C++** (#1368) with GGUF export.
-- **10-bug audit resolved** (#1429–#1438): SSRF, unkillable-server, OOB/SIGFPE/bad_alloc families, loader/backend hardening.
-- **Clean shutdown** (#1426): `_exit()` instead of the static-dtor ABRT that segfaulted on every stop.
-- **Release pipeline fixed** (#1404–#1425): tag builds run on the runner (not container), `onebin` target restored after sync merges clobbered it, libdrm/glslc/spirv-headers dep parity with CI.
-- **Narrative purges** (#1412 + follow-ups): TheRock-era and Rust-era claims swept — the stack is pure C++23, zero Python at runtime.
-- **Ponytail purge** (#1325): ~48K lines of dead code deleted (with the few survivors restored in #1390).
-
-**The environment bit back once**: a driver wedge during sustained load forced a cold reboot on 08-03; post-reboot the NPU (RyzenAI-npu5, firmware 1.1.2.65) and iGPU came back clean, and the memory campaign above was verified on the recovered hardware.
-
----
-
-## UPDATE 28 (2026-07-20): Mamba1 GPU Backend — 79.4 Tok/s, 9 Bugs Killed
-
-**The Mamba1 GPU backend (`mamba1_engine.hip` + `backend_mamba1.cpp`) is now fully built, linked, and validated end-to-end on Strix Halo. BlackMamba 1.5B: 79.4 tok/s. BlackMamba 2.8B: 46.1 tok/s.**
-
-What was delivered:
-
-1. **Build linkage fixed**: `create_mamba1_backend` was only compiled into `unified_server`, not `libbackend_manager.a` — every other binary (test_backend, backend_demo, vision_server, etc.) failed to link. Moved `backend_mamba1.cpp` into the static lib. HIP device stubs were also missing because the file was compiled as CXX despite launching kernels with `<<<>>>` syntax; moved all kernel launches into `extern "C"` wrapper functions in `mamba1_engine.hip` so callers compile as plain CXX.
-2. **Conv state buffer overflow fixed**: the conv state shift loop wrote to `cs[(d_conv-1) * d_inner + i]` but the buffer was only `[d_conv-1, d_inner]` (max valid index `d_conv-2`). This caused silent GPU memory corruption on every SSM layer forward pass. Fixed the loop bound from `dc-2` to `dc-3`.
-3. **A_log exponentiation fixed**: Mamba1 parameterizes `A = -exp(A_log)`, but the selective scan kernel used `A_log` directly as `A` in `A_bar = exp(dt * A)`. This meant the SSM dynamics were completely wrong. Added `-expf()` in the scan loop to compute `A = -exp(A_log)` before discretization.
-4. **Model routing fixed**: GGUF Mamba models are now routed to `mamba1_gpu` backend (was falling through to ZINC GPU catch-all).
-5. **Both BlackMamba sizes converted and benchmarked**: 1.5B (30 layers, 15 SSM + 15 MoE) at 79.4 tok/s, 2.8B (36 layers, 18 SSM + 18 MoE) at 46.1 tok/s — both on Strix Halo iGPU via ROCm HIP, alternating SSM/MoE layer dispatch.
-6. **Diagnostic tool**: `tools/test_mamba1_backend.cpp` loads a Mamba1 GGUF directly into the HIP backend without the HTTP server — warmup, benchmark, and generation in one shot.
-
-**The BlackMamba `⚠️` in the README is gone.**
-
----
-
-## UPDATE 27 (2026-07-06): Fused Layer Engine Goes Production — 291 Tok/s (3× v12)
-
-**The fused layer engine now ships at 291 tok/s (3.4 ms/tok), 3× the v12 baseline, in a 38 KB binary.**
-
-What was delivered:
-1. **One xclbin call per transformer layer**: QKV projection, attention, O projection, gate+up, SiLU, and down projection all run on the NPU in a single dispatch. No CPU attention, no intermediate BO syncs. Uses `design_full_layer.xclbin` (416 KB) from the torch2aie toolchain with per-position instruction files.
-2. **3.4 ms/tok decode**: The fused dispatch eliminates the per-GEMM ioctl overhead that limited v12. At 291 tok/s, the NPU's INT8 throughput is now the bottleneck, not the dispatch layer.
-3. **38 KB binary**: The fused engine binary is smaller than the previous 74 KB daemon despite doing more per call. Static linking + stripped symbols + no Python runtime paths.
-4. **Fixed scale optimization in universal engine**: `dynamic_ascale()` replaced with `FIXED_ASCALE = 8.0f / 127.0f` — saves 35 μs per GEMM call (4 ms/batch across 112 calls). Worth +11% on decode.
-5. **FLM v0.9.44 workaround in daemon**: FLM's `/v1/chat/completions` has a `basic_string::substr` bug. Daemon now converts chat messages to text prompts via a lightweight Qwen3 template and calls `/v1/completions` instead.
-
-**Narrative shift**: v12 (97 tok/s, C++ standalone INT8) is now the fallback path. The fused layer engine is the production path. All docs, badges, and benchmarks updated to reflect this. Everything from "74 KB binary, 94 tok/s" to "38 KB binary, 291 tok/s."
-
----
-
-## UPDATE 26 (2026-07-05): All 3 Bugs Confirmed Fixed — AIE Micro-Tiling Root Cause Resolved
-
-**v12 is now coherent. 97 tok/s verified. GEMM kernel bit-exact.**
-
-A parallel investigation (branch `fix/npu-hf-cache-i32-kernel`) independently confirmed
-what UPDATE 25 suspected: the remaining bug was in the **compiled xclbin kernels**, not
-the host code. Root cause: `n1_core_i8_v2.py` (the INT8 MLIR generator) was **missing AIE
-micro-tiling** — the GEMM kernel received weights in the wrong internal layout despite
-being bit-for-bit correct at the BO level.
-
-Fixes applied:
-1. **xclbin output width** — matched INT8 generator output width to host's i32 Cm buffer
-   (`cd73e137`)
-2. **Smoke-test prompt** — replaced malformed prompt with valid chat template
-   (`3d984285`)
-3. **RMSNorm weight clip** — clipped weights to [-2,2] in cb/universal engines
-   (`49e78785`, partial)
-4. **GEMM kernel verified** — hardware dump-and-compare confirmed bit-exact
-   (`7f8f3586`)
-5. **Root cause identified** — missing AIE micro-tiling in n1_core_i8_v2.py
-   (`01a4b7f4`)
-6. **Parallel theories reconciled** — both investigation paths now agree
-   (`16016167`)
-
-All 6 fixes cherry-picked onto main as `232db025`..`bffe5a2e`.
-**97 tok/s v12 now produces coherent output.**
-
----
-
-## UPDATE 25 (2026-07-03): v12 Was Never Output-Validated — 3 Real Bugs Found, Still Incoherent
-
-Set out to swap the production daemon's NPU backend from FLM (proprietary, closed-source)
-to v12 (our own C++ engine, "97 tok/s, beats FLM's 94, Zero Python"). Before wiring it in,
-sanity-checked actual chat output against FLM for the same prompt. FLM answered "What is
-2+2?" correctly (" 4."). v12 — byte-identical reproduction of the unmodified original —
-produced complete garbage. Every doc and benchmark in this repo checks tok/s and "doesn't
-crash," never coherence. The 97 tok/s number is real; the output behind it never was.
-
-Found and fixed 3 real, confirmed bugs, all present in `npu_engine_cb.cpp` since it was
-first written and inherited by `npu_target_model.h` (spec-decode's target-model dispatch):
-
-1. **LM head weight substitution** — `lm_head.weight` gets correctly dequantized then
-   immediately discarded; the code computes final vocab logits against the *embedding*
-   table instead (assumes tied embeddings). Qwen3-0.6B's checkpoint stores them completely
-   separately (confirmed via Q4NX header data_offsets) — the model computes a reasonable
-   final hidden state, then reads logits off the wrong matrix.
-2. **Weight-packing transpose** — `dequant_i8_to_float` returns row-major
-   `[out_features, in_features]`; the GEMM dispatch needs `[in_features, out_features]`.
-   The packing loop read the buffer with the wrong stride, silently scrambling every
-   weight matrix (Q/K/V/O/Gate/Up/Down) while still producing finite, plausible-looking
-   numbers. Also: O-proj and Down-proj dequant calls used the wrong `in_features` (1024
-   default instead of their real 2048/3072), scrambling the tiling itself.
-3. **Activation quantization clipping** — hardcoded INT8 scale assumed activations stay
-   within [-5,5]; measured range is [-8.24,7.01]. Silently clipped every layer, compounding
-   across all 28.
-
-All three fixed, in all three copies of this logic (`npu_engine_cb.cpp`,
-`npu_engine_server.cpp` — a new persistent-server variant built for the daemon swap,
-and `spec-decode/engine/npu_target_model.h`). Chat output is **still incoherent** after
-all three fixes, individually and combined, tested against both RoPE conventions
-(interleaved-pairs and HF's actual rotate_half). Ruled out via ground-truth comparison
-against the real HF model: embedding lookup, RoPE theta/config, GQA head mapping, K/V
-extraction offsets — all correct. Remaining suspects: RoPE rotation convention (tested,
-inconclusive) or the compiled `.xclbin` kernels themselves, undebuggable without the AI
-Engine Simulator — blocked on this machine since Update 24's investigation (missing
-`aie2p_8x4_device.json` for NPU2). Full writeup: `docs/archive/V12-CORRECTNESS-BLOCKER.md`.
-
-**FLM proxy stays in production.** Do not wire v12/1bit.engine into the daemon until this
-is resolved and re-verified against real chat prompts, not just dispatch speed.
-
----
-
-## UPDATE 24 (2026-07-03): Fused XCLBIN Resumed — Schedule Fixed, Deadlock Isolated, New Kernel Bug Found
-
-Picked back up the fused-transformer-xclbin effort flagged as "next" at the end of Update 17
-(the intervening Updates 18-23 covering the fused-xclbin dead end, the pivot to the universal
-5-model v12 engine, and the merch store live in git history / other docs, not fully reflected
-in this file until now).
-
-### What Was Found
-
-1. **Reconstructed the correct Q4NX weight-packing schedule** by cross-referencing the MLIR
-   generator against `qwen3_model.py::_projection_stream_from_schedule` — the fused xclbin
-   expects weight chunks distributed per-column/per-row (`row_chunk = block*16 + group*4 +
-   patch*2 + row_in_patch`), not replicated identically across columns as the old
-   `q4nx_stream.cpp` did. `npu-sandbox/npu-infer/tools/pack_fused_v3.py` already implements this
-   correctly (verified byte-identical on regen) by reading real Q4NX chunks straight out of
-   `model.q4nx`, no dequant/requant.
-2. **Schedule-correct weights alone didn't fix the full-layer deadlock** — re-ran `npu_engine_v13`,
-   still 62857ms timeout, all-zero output.
-3. **Isolated the deadlock to the O/UP/GATE/DOWN tail.** The smaller QKV-prefix xclbin (rebuilt
-   fresh via `full_layer_qkv_prefix_runner.py`) dispatches cleanly in ~4ms, no deadlock at all —
-   matching what the sibling BitNet port (`torch2aie/examples/bitnet-decode-layer`) found for the
-   identical design shape. The full-layer deadlock is a lock/dataflow bug specific to the tail
-   phases, not a data-scheduling problem.
-4. **Found a second, separate bug: QKV-prefix produces numerically wrong output**, even
-   deadlock-free. ~1000+ K/V cache mismatches vs. the CPU golden reference, at multiple token
-   positions. Traced RoPE and RMSNorm formulas in the Chess kernel (`postprocess_qkv.cc`) against
-   the Python reference — both match exactly. V-cache (no RoPE/norm at all) is *also* wrong,
-   narrowing the bug to the Q4NX GEMM/dequant kernel (`qwen3_decode_kernels.cc`) or record
-   absorption — unresolved, needs kernel-level debug instrumentation to pin down further.
-
-### Status
-
-Fused xclbin is closer than before (schedule solved, deadlock scope narrowed) but still not
-working end-to-end — two distinct kernel bugs remain (tail deadlock, QKV numeric correctness).
-v12 (97 tok/s, standalone INT8 GEMM, zero Python) stays production. Full details in
-`docs/archive/FUSED-INTEGRATION-BLOCKER.md`.
-
----
-
-## UPDATE 23 (2026-07-02 15:32 ADT): Production Release — v2026.07.02-all5models
-
-Shipped: tag `v2026.07.02-all5models`, site updated to "One engine. Every model. Any chip.." 5 model
-families verified, 0 crashes, 28 tok/s on Qwen3-0.6B (all-models auto-detect binary). vs FLM: 2.4×
-slower per-token, but open source, zero dependencies, 5 models from one 120KB binary. Fused xclbin
-flagged as the path to close the gap (picked back up in Update 24, three sessions later).
-
----
-
-## UPDATE 22 (2026-07-02 15:13 ADT): All 5 Models at v12 Batch Speed, 0 Crashes
-
-Model-agnostic engine (`npu_engine_all.cpp`) verified across the full catalog:
-
-| Model | Decode |
-|---|---|
-| Qwen3-0.6B | 58 ms/tok |
-| Gemma4-E2B | 117 ms/tok |
-| Qwen3-VL-4B | 141 ms/tok |
-| Llama-3.1-8B | 185 ms/tok |
-| Qwen3-8B | 215 ms/tok |
-
-Fix: `dequant_i8_to_float_ex` had `in_features` hardcoded to 1024 — only 0.6B ever worked
-correctly. Corrected to read `H`, `NH×HD`, `IM` per-projection from the model header; all 5
-families verified working.
-
----
-
-## UPDATE 21 (2026-07-02 12:01 ADT): Session Close — Full NPU Engine State
-
-*(Reconstructed from git history — commits in this window didn't carry explicit UPDATE numbers;
-assigned 20/21 here to keep the sequence readable.)*
-
-v12 engine at 97 tok/s (10 ms/tok), 24× speedup, beating FLM Kraken Point (66.5 tok/s). Fused
-xclbin: 3 xclbins compiled (QKV-prefix, full-layer, unified), 5 Chess kernels recompiled for
-Qwen3-0.6B, blocked on Q4NX weight format (see Update 20) — NPU firmware confirmed an active
-xclbin via `ERT_CMD_STATE_TIMEOUT`, an early sighting of the same deadlock symptom Update 24 later
-isolated. Model xclbins: 23 total across 5 families (Qwen3-0.6B, Qwen3-VL-4B, Qwen3-8B,
-Llama-3.1-8B, Gemma4-E2B). CLI scaffolded by a second agent (package.json, tsconfig, command
-routing).
-
----
-
-## UPDATE 21b (2026-07-02): Merged with Remote Auto-Detect Engine
-
-### Merge
-- Merged with `origin/main` which had a completely refactored `npu_engine_universal.cpp`
-- New engine: auto-detects model dimensions from Q4NX header (no more preprocessor flags)
-- M=32 batched decode, OpenMP attention, OpenMP LM head, f32 embeddings
-- Our token-file input feature (`argv[3]`) applied on top of new engine
-- Added `model_config.h` (from npu-sandbox) to make the new engine compilable
-
-### Files Changed Post-Merge
-| File | Action |
-|------|--------|
-| `engine/npu/src/model_config.h` | Created (was missing from remote) |
-| `engine/npu/src/npu_engine_universal.cpp` | Merged — remote's auto-detect + our argv[3] |
-| `engine/npu/build_npu.sh` | Switched to auto-detect universal binary |
-
----
-
----
-
-## UPDATE 20 (2026-07-02 05:17–07:27 ADT): Fused XCLBIN — First Attempt, Q4NX Blocker
-
-The first full attempt at the fused-transformer-xclbin idea flagged in Update 18. Contract
-established for Qwen3-0.6B dimensions, 5 kernels recompiled with Chess for the smaller model.
-MLIR generator produced a working design; 2 xclbins compiled (374KB full-layer, 253KB QKV-prefix).
-`npu_engine_v13` proved the dispatch mechanics work — xclbin loads, BOs allocate (9.4MB weights),
-kernel dispatches without crashing — but hit a wall: the fused xclbin's weight-stream layout
-expects FLM's proprietary Q4NX chunk format, and the engine's flat INT8 weights don't match it.
-Weight-stream scheduler work got the packed size exactly right (2,458,816 dwords) but DMA still
-timed out (63s) — diagnosed at the time as a Q4NX *quantization* mismatch (dequant→requant producing
-NaN/Inf). Decision: keep v12 (97 tok/s, standalone GEMM) in production, treat fused xclbin as a
-separate weight-format workstream.
-
-(Update 24, a session later, revisited this with fresh eyes and found the real bug was the
-*schedule* — chunks replicated identically across columns instead of indexed per-tile — not the
-quantization theory reached here. See `docs/archive/WEIGHT-STREAM-BLOCKER.md` for the correction.)
-
----
-
-## UPDATE 19 (2026-07-02 06:24–06:27 ADT): Multi-Model XCLBINs, Model-Agnostic Engine
-
-Two parallel threads landed close together:
-
-- **Multi-model build-out**: 22-23 xclbins compiled across 6 model families (Qwen3-0.6B, Qwen3-8B,
-  Qwen3-VL-4B, Gemma4-E2B, Llama). `npu_engine_mt.cpp` (model-agnostic multi-token engine) +
-  `model_config.h` (auto-detects model dimensions from Q4NX headers) + a 42-model catalog
-  (`model-catalog.md`) classifying every FLM NPU2 model by architecture. `build_all_models.sh`
-  automates the xclbin builds.
-- **Engine speed**: v12 at 10 ms/tok (97 tok/s), 24× speedup from the v3 baseline
-  (244→50→16→10 ms/tok across v3→v6→v9→v12).
-- **Attention**: `attn_scalar.o` + `attn_c8.xclbin` compiled but not integrated — CPU OpenMP was
-  still faster for context <128 at this point.
-- Site live: 145 visitors, CI pipeline + PR-Agent running, benchmarks current.
-
----
-
-## UPDATE 18 (2026-07-02 04:01 ADT): M=32 Target, NPU LM Head, FLM Comparison
-
-FLM Kraken Point benchmark for reference: 66.5 tok/s on weaker hardware than ours. Engine evolution
-recap v3→v10: 244→16 ms/tok (15.2×, same numbers as Update 17). NPU LM head landed on-chip: 4ms
-(N=30720 xclbin, 88KB) — previously a CPU-side cost. `xrt::runlist` batching investigated and found
-to save only 27μs/layer (not worth the complexity). M=32 v11 targeted for >100 tok/s. Next flagged:
-NPU attention kernel (`edge_attention.o` compiled, not yet integrated) and the fused-xclbin idea
-that Update 20 picks up.
-
----
-
-## UPDATE 17 (2026-07-02 03:00 ADT): M=16 Batch Decode — 16 ms/tok, 15.2× Speedup
-
-### 244→16 ms/tok in One Session
-
-```
-v3 (Jul 1): 244 ms/tok  baseline
-v6 (Jul 2):  50 ms/tok  batch-4 + OpenMP LM head           (4.4×)
-v7 (Jul 2):       —     ioctl=9μs, r.wait=1334μs probe
-v8 (Jul 2):  27 ms/tok  M=8 batch decode                   (8.2×)
-v9 (Jul 2):  16 ms/tok  M=16 batch decode                  (15.2×)
-```
-
-### M=16 Batch Decode — How It Works
-
-The v7 probe proved `r.wait()` at 1334μs per GEMM call is NPU compute time,
-not driver overhead. The NPU is 99% idle in the M dimension at M=1. At M=16,
-compute stays at 1334μs but processes 16× more data → 11ms/tok per batch step.
-
-Single-token boot (157ms) provides top-16 token candidates from LM head logits.
-The 16 candidates run through one batched forward pass (28 layers, 4 GEMMs each)
-= 112 dispatches at 1334μs = 149ms NPU time + LM head (6ms) + CPU (10ms) ≈ 170ms.
-170ms / 16 tokens = 11 ms/tok.
-
-At 64 tokens (4 batches): 16.1 ms/tok effective. Boot amortized away.
-
-### FLM Gap: 1.5×
-
-FLM: 93 tok/s = 10.7 ms/tok (proprietary).  
-v9: 63 tok/s = 16.0 ms/tok (open source).  
-Gap: 1.5×. Was 20× yesterday morning.
-
-Next: LM head on NPU (151936×1024 INT8 matmul on D-style xclbin) = ~1ms.
-That alone brings batch step from 11→6ms/tok and effective to ~8ms/tok.
-Combined with M=32: ~4ms/tok effective = matches FLM.
-
-### Session Summary
-
-- 9 engine versions built and tested on-device
-- f32 embeddings: -20% decode latency
-- OpenMP LM head: 67→6ms
-- μs-probe: identified NPU compute as bottleneck (not ioctl)
-- M=4→8→16 batched decode: dispatch amortization
-- 15.2× total speedup
-- CI pipeline on self-hosted runner
-- All numbers on https://1bit.monster
-
----
-
-## UPDATE 16 (2026-07-02 02:00 ADT): Full Profile + 50 ms/tok Batch-4 Decode
-
-### NPU Dispatch: The Root Cause
-
-μs-accurate profiling (`npu_engine_profile.cpp`) proved our GEMM overhead:
-
-```
-Per-GEMM dispatch (112 per token):
-  Quantize A:    6 μs   (<1%)
-  Sync A→NPU:    2 μs   (<1%)
-  Kernel+wait: 1346 μs   (99%)  ← THE BOTTLENECK
-  Sync C←NPU:    8 μs   (<1%)
-  Dequant C:     1 μs   (<1%)
-
-Total: 1363 μs/call × 112 calls = 156.8 ms (70%)
-LM head: 67 ms (30%)
-CPU ops (norms, RoPE, attn, SiLU): 0.7 ms (<1%)
-```
-
-The NPU is spending 99% of dispatch time in launch+wait overhead.
-Actual M=1 GEMM is 0.5-5 μs. Overhead ratio: **2000×**.
-
-### Chained Batch-4 Decode (v6): 50 ms/tok
-
-Instead of per-token dispatch, we generate top-4 tokens from LM head
-logits and run them all through one batched forward pass. Each batch
-step takes ~160ms for 4 tokens = 40 ms/tok. Boot step: 157ms.
-
-```
-$ OMP_NUM_THREADS=16 ./npu_engine_v6 16
-
-  [0] boot=127595 top4=127595,65831,39815,63550 (157ms)
-  [1] batch=4 tok=9275 ms=161 (40 ms/tok)
-  [5] batch=4 tok=106211 ms=159 (40 ms/tok)
-  [9] batch=4 tok=83570 ms=158 (40 ms/tok)
-  [13] batch=3 tok=83570 ms=157 (52 ms/tok)
-=== 50 ms/tok effective ===
-```
-
-Token IDs diverse across batches. No NaN. Clean exit.
-4.4× speedup from v3 (244→50 ms/tok).
-
-### OpenMP LM Head
-
-Pre-converted BFP16→F32 embeddings (622 MB) + OpenMP on 16 Zen5 cores:
-LM head: 67ms → ~6ms per token (11× faster). This plus batch-4
-amortization is what dropped us from 222→50 ms/tok.
-
-### What We Learned
-
-- Removing weight re-sync (v4) saved nothing — weights already on device.
-- 2-layer draft model (spec decode v0) had 0% acceptance rate on Qwen3.
-- Batching at decode time works: dispatch overhead amortizes across tokens.
-- CPU is never the bottleneck — 26 μs/layer vs 5599 μs GEMM dispatch.
-
-### Next: Fused Transformer XCLBIN
-
-The 112 dispatches per token are now 112 per 4 tokens = 28/token effective.
-To get to FLM's 93 tok/s, we need a single fused transformer-layer xclbin
-that chains QKV→norm→attention→O→norm→GU→D on NPU without host round-trips.
-That turns 28 dispatches into 1. Then LM head goes on NPU via D-xclbin INT8
-matmul. Then we're at ~10 ms/tok.
-
----
-
-## UPDATE 15 (2026-07-01 15:00 ADT): PR-Agent Live, Landing Page Deployed, 242 ms/tok Verified
-
-### Live Production Stack
-
-```
-https://1bit.monster          → 50 TOPS landing page (Cloudflare Pages)
-https://github.com/.../1bit-monster → Full source, benchmarks, journey
-PR-Agent: The-PR-Agent v0.41 (DeepSeek) + GitNexus impact reports → auto-review on every PR
-```
-
-### Verified Timing (2026-07-01 15:00 ADT)
-
-```
-=== NPU Engine v3 — Continuous Batch ===
-Prefill 9 tokens: 179ms (20 ms/tok)
-Decode 4 tokens: 242 ms/tok
-Tokens: 106811, 63165, 117266, 109842
-```
-
-| Metric | Today | Overnight (Jul 1 04:00) |
-|--------|-------|-------------------------|
-| Prefill M=9 | 179ms (20 ms/tok) | ~200ms |
-| Decode | **242 ms/tok** | 219 ms/tok |
-| Prefill M=1 | 161ms | — |
-| Prefill M=4 | 162ms (40 ms/tok) | — |
-| PPR Agent | The-PR-Agent v0.41 + DeepSeek + GitNexus | — |
-| Landing page | 50 TOPS headline deployed | — |
-
-### What pi-agent Tightened
-
-- Timings stable across all benchmarks (prefill + decode scaling verified)
-- No regression from overnight session — 242 ms/tok matches the 244 ms/tok from 09:30
-- Engine runtime exit code 0, all tokens diverse, no NaN
-
-### 1-bit Models Confirmed
-
-Bonsai-1.7B IQ1_S: 281 tok/s on Radeon 8060S Vulkan, 385 MB. pi-agent patched llama.cpp with Q2_0 validation for Strix Halo gfx1151. Models on disk at /home/bcloud/models/bonsai-1.7b/.
-
-### PPR Agent Deployed
-
-The-PR-Agent/pr-agent@v0.41 (upstream, pinned SHA) → DeepSeek
-GitNexus knowledge-graph report injected via artifact_path (blast radius, affected flows)
-Config: 3 AI reviewers, INT8-focused review instructions, automatic review on PR open + push
-
-### What's Next
-
-- NPU attention dispatch for >32 token context
-- GGUF Q8_0 native loader (bypass Q4NX)
-- 1-bit NPU kernel (ternary GEMV on XDNA2)
-
----
-
-## UPDATE 14 (2026-07-01 08:30 ADT): 1bit-systems Rebuilt — 246 ms/tok Production Engine
-
-### 1bit-systems Repo Rebuilt
-
-Old Rust/benchmarks/wiki stripped. New structure:
-
-```
-1bit-systems/
-├── engine/src/npu_engine_i8.cpp     # 145-line C++23 inference engine
-├── engine/src/dequant_q4nx.c        # Q4NX weight dequantizer
-├── engine/kernel/edge_attention.cc  # NPU attention kernel (Chess C++)
-├── engine/xclbins/n1_core_i8_v2.py  # INT8 MLIR generator (K-interleave fixed)
-├── engine/build/dequant_q4nx.o      # Pre-compiled dequantizer
-├── engine/build/edge_attention.o    # Pre-compiled attention kernel
-├── docs/journey.md                  # This audit trail
-├── docs/architecture.md             # NPU context + INT8 quantization
-├── docs/building.md                 # Build guide
-├── docs/roadmap.md                  # INT8 → 1-bit plan
-├── site/index.html                  # Landing page (brand-lockup)
-├── .pr_agent.toml                   # DeepSeek PR review
-└── .github/workflows/               # CI benchmark + PR agent
-```
-
-### Production Engine: 246 ms/tok
-
-```
-=== NPU Engine i8 + Attention ===
-Init 8 contexts (4 GEMM + 4 attention). Dequant+pack: 4.3s
-
-Prefill 9: Done
-Generate:
-  [0] 92850   [1] 26686   [2] 111383  [3] 104068
-  [4] 126203  [5] 2541    [6] 90103   [7] 87567
-
-=== 246 ms/tok ===
-```
-
-| Component | Status |
-|-----------|--------|
-| 4 INT8 GEMM contexts | ✅ All alive, no swapping |
-| 4 NPU attention contexts | ✅ Loaded, deferred to CPU at <100 tokens |
-| Pre-loaded per-layer BOs | ✅ Zero-copy weight access |
-| Cached norm weights | ✅ BF16→float pre-converted |
-| Token quality | ✅ Diverse tokens on every step |
-| Build | ✅ One g++ command, one binary |
-
-### Engine Evolution (3 Days)
-
-| Date | Engine | Speed | Tokens | Key Milestone |
-|------|--------|-------|--------|---------------|
-| Jun 28 | v7 BFP16 Peano | 1930 ms/tok | Diverse ✅ | First working decode |
-| Jun 30 | v8 BFP16 Chess | 1335 ms/tok | 198×8 ❌ | BFP16 precision collapse discovered |
-| Jun 30 | v10 BFP16 single | 3560 ms/tok | 198×8 ❌ | Single-xclbin dead end |
-| Jul 1 | i8 Q4NX swap | 446 ms/tok | Diverse ✅ | K-interleaving fixed, INT8 working |
-| Jul 1 | i8 4-live | 249 ms/tok | Diverse ✅ | Context pooling breakthrough |
-| Jul 1 | i8 4-live + attn | **246 ms/tok** | Diverse ✅ | NPU attention wired, repo rebuilt |
-
-**Net: 7.8× faster in 3 days (1930 → 246 ms/tok).**
-
-### NPU2 Context Architecture Confirmed
-
-**NPU2 supports 8+ simultaneous hw_contexts on firmware 1.1.2.65.**
-The earlier "1 context at a time" limitation was stale — caused by
-a firmware bug in older releases, not a hardware constraint. XRT
-hw_context objects can coexist as long as kernel invocations are
-serialized via `run.wait()`.
-
-### Lessons Learned
-
-1. **BFP16 double quantization kills diversity.** Q4NX→BFP16→NPU loses
-   too much precision. INT8 via symmetric per-tensor quantization works.
-2. **K-interleaving is silent corruption.** All-1s tests pass. Random
-   data fails with 394% error. Fixed by `dataReuse` on ObjectFifo.
-3. **4-live > swap.** Pre-loading all weight BOs and keeping all contexts
-   alive eliminates 60% of decoding latency.
-4. **NPU attention is context-dependent.** At 10 tokens, CPU softmax wins.
-   At 1000 tokens, NPU online rescaling will dominate. The kernel is
-   loaded and ready — the threshold just needs tuning.
-5. **The Chess compiler is the unlock.** 31.4 TFLOPS proven. Without the
-   license, none of this works. AMD's EA portal delivers it free.
-
-### What's Next
-
-- NPU attention dispatch at high context (>100 tokens)
-- GGUF Q8_0 direct weight loading (bypass Q4NX completely)
-- 1-bit / BitNet b1.58 ternary kernels
-- Target: <50 ms/tok on Strix Halo NPU
-
----
-
----
-
----
-
-## UPDATE 13 (2026-07-01 04:00 ADT): INT8 Engine Complete — 219 ms/tok, Context Pool
-
-## Session 2026-06-28 — early sprint: first GEMMs, peak TFLOPS, stress tests
+## 2026-06-28 — early sprint: first GEMMs, peak TFLOPS, stress tests
 
 ### 🏆 Peak Achievement: 31.0 TFLOPS on NPU (config2 design)
 
@@ -1084,7 +243,7 @@ Decode degrades from 91.5→29.8 t/s at 60%+ KV cache — still usable.
 KV cache has room for ~6,000 more tokens within 16,384 ctx-len.
 Multi-turn conversation: KV cache persists correctly across requests.
 
-## Session 2025-06-28 Findings
+## 2026-06-28 — Findings
 
 > *Note: the `2025-06-28` datestamps on several early session titles are a typo
 > from the white-heat of the moment, preserved verbatim. They are all
@@ -1211,7 +370,7 @@ Output: 114,208 bytes (28,552 instructions). Kernel executes (ERT_CMD_STATE_COMP
 
 Full pipeline source: `npu-sandbox/xrt-direct/full_pipeline.cpp`
 
-## Session 2025-06-28 Late Testing — FLM HTTP Single-Connection Limit
+## 2026-06-28 — Late Testing — FLM HTTP Single-Connection Limit
 
 ### Discovery: FLM's HTTP Server Crashes Under Concurrent Connections
 
@@ -1300,7 +459,7 @@ Even unlocking both NPU gates doesn't help because the HTTP server itself can't 
 concurrent connections. FLM's true bottleneck is its **HTTP server architecture**, not
 just the NPU lock.
 
-## Session 2025-06-28 Late Testing — `cmds2seq()` Discovery & Instruction Pipeline
+## 2026-06-28 — Late Testing — `cmds2seq()` Discovery & Instruction Pipeline
 
 ### `cmds2seq()` WORKS from Independent `npu_sequence`
 
@@ -1470,7 +629,7 @@ Build a comprehensive XRT capture (intercept library) that captures the ACTUAL B
 - A) Replicate the exact same BO setup and runlist pattern
 - B) Use FLM's own `npu_app_manager` with proper initialization to generate the full pipeline
 
-## Session 2026-06-28 Deep Research — Definitive Findings
+## 2026-06-28 — Deep Research — Definitive Findings
 
 ### npu_sequence Layout — DEFINITIVELY DETERMINED
 
@@ -1700,7 +859,7 @@ Since we now have actual BO content dumps from FLM, we can either:
 - **Reverse-engineer the cmd buffer** — the 128MB BO content reveals the exact xclbin command format
 - **Wrap FLM's internal functions** — use `libqwen3_npu.so`'s `_move_weights()` to pack weights, then submit via our own XRT path
 
-## Session 2026-06-28 — Q4NX Format Fully Reverse-Engineered
+## 2026-06-28 — Q4NX Format Fully Reverse-Engineered
 
 ### Weight Format Breakthrough
 
@@ -1729,7 +888,7 @@ The mapping from storage shape to logical shape is:
 ### Verified with existing npu-infer model.c
 The model.c code (lines 88-101) reads I8 data as BF16 byte pairs — this works correctly ONLY for tensors where the storage IS already BF16 (like norms). For I4-quantized tensors, the proper dequantization is needed.
 
-## Session 2026-06-28 — NaN debugging + Fused engine rewrite
+## 2026-06-28 — NaN debugging + Fused engine rewrite
 
 ### Key Discoveries
 
@@ -1815,7 +974,7 @@ with N-tiling for projections with >1024 output dimensions.
 | `/home/bcloud/npu-sandbox/npu-infer/build/npu_infer_fused` | Compiled binary (345ms/tok) |
 | `/home/bcloud/npu-sandbox/npu-infer/docs/fusion-level-0.md` | Detailed fusion doc |
 
-## Session 2026-06-29 — Full Optimization Sprint
+## 2026-06-29 — Full Optimization Sprint
 
 ### 🏆 Final Engine: 210 ms/tok (3.2× faster than 668ms baseline)
 
@@ -2117,7 +1276,377 @@ sudo ./npu_engine_i8
 
 ---
 
-## Session 2026-07-02/03 — Production Stack, Release, Site Refresh
+## 2026-07-01 — PR-Agent Live, Landing Page Deployed, 242 ms/tok Verified
+
+### Live Production Stack
+
+```
+https://1bit.monster          → 50 TOPS landing page (Cloudflare Pages)
+https://github.com/.../1bit-monster → Full source, benchmarks, journey
+PR-Agent: The-PR-Agent v0.41 (DeepSeek) + GitNexus impact reports → auto-review on every PR
+```
+
+### Verified Timing (2026-07-01 15:00 ADT)
+
+```
+=== NPU Engine v3 — Continuous Batch ===
+Prefill 9 tokens: 179ms (20 ms/tok)
+Decode 4 tokens: 242 ms/tok
+Tokens: 106811, 63165, 117266, 109842
+```
+
+| Metric | Today | Overnight (Jul 1 04:00) |
+|--------|-------|-------------------------|
+| Prefill M=9 | 179ms (20 ms/tok) | ~200ms |
+| Decode | **242 ms/tok** | 219 ms/tok |
+| Prefill M=1 | 161ms | — |
+| Prefill M=4 | 162ms (40 ms/tok) | — |
+| PPR Agent | The-PR-Agent v0.41 + DeepSeek + GitNexus | — |
+| Landing page | 50 TOPS headline deployed | — |
+
+### What pi-agent Tightened
+
+- Timings stable across all benchmarks (prefill + decode scaling verified)
+- No regression from overnight session — 242 ms/tok matches the 244 ms/tok from 09:30
+- Engine runtime exit code 0, all tokens diverse, no NaN
+
+### 1-bit Models Confirmed
+
+Bonsai-1.7B IQ1_S: 281 tok/s on Radeon 8060S Vulkan, 385 MB. pi-agent patched llama.cpp with Q2_0 validation for Strix Halo gfx1151. Models on disk at /home/bcloud/models/bonsai-1.7b/.
+
+### PPR Agent Deployed
+
+The-PR-Agent/pr-agent@v0.41 (upstream, pinned SHA) → DeepSeek
+GitNexus knowledge-graph report injected via artifact_path (blast radius, affected flows)
+Config: 3 AI reviewers, INT8-focused review instructions, automatic review on PR open + push
+
+### What's Next
+
+- NPU attention dispatch for >32 token context
+- GGUF Q8_0 native loader (bypass Q4NX)
+- 1-bit NPU kernel (ternary GEMV on XDNA2)
+
+---
+
+## 2026-07-01 — 1bit-systems Rebuilt — 246 ms/tok Production Engine
+
+### 1bit-systems Repo Rebuilt
+
+Old Rust/benchmarks/wiki stripped. New structure:
+
+```
+1bit-systems/
+├── engine/src/npu_engine_i8.cpp     # 145-line C++23 inference engine
+├── engine/src/dequant_q4nx.c        # Q4NX weight dequantizer
+├── engine/kernel/edge_attention.cc  # NPU attention kernel (Chess C++)
+├── engine/xclbins/n1_core_i8_v2.py  # INT8 MLIR generator (K-interleave fixed)
+├── engine/build/dequant_q4nx.o      # Pre-compiled dequantizer
+├── engine/build/edge_attention.o    # Pre-compiled attention kernel
+├── docs/journey.md                  # This audit trail
+├── docs/architecture.md             # NPU context + INT8 quantization
+├── docs/building.md                 # Build guide
+├── docs/roadmap.md                  # INT8 → 1-bit plan
+├── site/index.html                  # Landing page (brand-lockup)
+├── .pr_agent.toml                   # DeepSeek PR review
+└── .github/workflows/               # CI benchmark + PR agent
+```
+
+### Production Engine: 246 ms/tok
+
+```
+=== NPU Engine i8 + Attention ===
+Init 8 contexts (4 GEMM + 4 attention). Dequant+pack: 4.3s
+
+Prefill 9: Done
+Generate:
+  [0] 92850   [1] 26686   [2] 111383  [3] 104068
+  [4] 126203  [5] 2541    [6] 90103   [7] 87567
+
+=== 246 ms/tok ===
+```
+
+| Component | Status |
+|-----------|--------|
+| 4 INT8 GEMM contexts | ✅ All alive, no swapping |
+| 4 NPU attention contexts | ✅ Loaded, deferred to CPU at <100 tokens |
+| Pre-loaded per-layer BOs | ✅ Zero-copy weight access |
+| Cached norm weights | ✅ BF16→float pre-converted |
+| Token quality | ✅ Diverse tokens on every step |
+| Build | ✅ One g++ command, one binary |
+
+### Engine Evolution (3 Days)
+
+| Date | Engine | Speed | Tokens | Key Milestone |
+|------|--------|-------|--------|---------------|
+| Jun 28 | v7 BFP16 Peano | 1930 ms/tok | Diverse ✅ | First working decode |
+| Jun 30 | v8 BFP16 Chess | 1335 ms/tok | 198×8 ❌ | BFP16 precision collapse discovered |
+| Jun 30 | v10 BFP16 single | 3560 ms/tok | 198×8 ❌ | Single-xclbin dead end |
+| Jul 1 | i8 Q4NX swap | 446 ms/tok | Diverse ✅ | K-interleaving fixed, INT8 working |
+| Jul 1 | i8 4-live | 249 ms/tok | Diverse ✅ | Context pooling breakthrough |
+| Jul 1 | i8 4-live + attn | **246 ms/tok** | Diverse ✅ | NPU attention wired, repo rebuilt |
+
+**Net: 7.8× faster in 3 days (1930 → 246 ms/tok).**
+
+### NPU2 Context Architecture Confirmed
+
+**NPU2 supports 8+ simultaneous hw_contexts on firmware 1.1.2.65.**
+The earlier "1 context at a time" limitation was stale — caused by
+a firmware bug in older releases, not a hardware constraint. XRT
+hw_context objects can coexist as long as kernel invocations are
+serialized via `run.wait()`.
+
+### Lessons Learned
+
+1. **BFP16 double quantization kills diversity.** Q4NX→BFP16→NPU loses
+   too much precision. INT8 via symmetric per-tensor quantization works.
+2. **K-interleaving is silent corruption.** All-1s tests pass. Random
+   data fails with 394% error. Fixed by `dataReuse` on ObjectFifo.
+3. **4-live > swap.** Pre-loading all weight BOs and keeping all contexts
+   alive eliminates 60% of decoding latency.
+4. **NPU attention is context-dependent.** At 10 tokens, CPU softmax wins.
+   At 1000 tokens, NPU online rescaling will dominate. The kernel is
+   loaded and ready — the threshold just needs tuning.
+5. **The Chess compiler is the unlock.** 31.4 TFLOPS proven. Without the
+   license, none of this works. AMD's EA portal delivers it free.
+
+### What's Next
+
+- NPU attention dispatch at high context (>100 tokens)
+- GGUF Q8_0 direct weight loading (bypass Q4NX completely)
+- 1-bit / BitNet b1.58 ternary kernels
+- Target: <50 ms/tok on Strix Halo NPU
+
+---
+
+---
+
+---
+
+## 2026-07-01 — INT8 Engine Complete — 219 ms/tok, Context Pool
+
+## 2026-07-02 — Production Release — v2026.07.02-all5models
+
+Shipped: tag `v2026.07.02-all5models`, site updated to "One engine. Every model. Any chip.." 5 model
+families verified, 0 crashes, 28 tok/s on Qwen3-0.6B (all-models auto-detect binary). vs FLM: 2.4×
+slower per-token, but open source, zero dependencies, 5 models from one 120KB binary. Fused xclbin
+flagged as the path to close the gap (picked back up in Update 24, three sessions later).
+
+---
+
+## 2026-07-02 — All 5 Models at v12 Batch Speed, 0 Crashes
+
+Model-agnostic engine (`npu_engine_all.cpp`) verified across the full catalog:
+
+| Model | Decode |
+|---|---|
+| Qwen3-0.6B | 58 ms/tok |
+| Gemma4-E2B | 117 ms/tok |
+| Qwen3-VL-4B | 141 ms/tok |
+| Llama-3.1-8B | 185 ms/tok |
+| Qwen3-8B | 215 ms/tok |
+
+Fix: `dequant_i8_to_float_ex` had `in_features` hardcoded to 1024 — only 0.6B ever worked
+correctly. Corrected to read `H`, `NH×HD`, `IM` per-projection from the model header; all 5
+families verified working.
+
+---
+
+## 2026-07-02 — Session Close — Full NPU Engine State
+
+*(Reconstructed from git history — commits in this window didn't carry explicit UPDATE numbers;
+assigned 20/21 here to keep the sequence readable.)*
+
+v12 engine at 97 tok/s (10 ms/tok), 24× speedup, beating FLM Kraken Point (66.5 tok/s). Fused
+xclbin: 3 xclbins compiled (QKV-prefix, full-layer, unified), 5 Chess kernels recompiled for
+Qwen3-0.6B, blocked on Q4NX weight format (see Update 20) — NPU firmware confirmed an active
+xclbin via `ERT_CMD_STATE_TIMEOUT`, an early sighting of the same deadlock symptom Update 24 later
+isolated. Model xclbins: 23 total across 5 families (Qwen3-0.6B, Qwen3-VL-4B, Qwen3-8B,
+Llama-3.1-8B, Gemma4-E2B). CLI scaffolded by a second agent (package.json, tsconfig, command
+routing).
+
+---
+
+## 2026-07-02 — Merged with Remote Auto-Detect Engine
+
+### Merge
+- Merged with `origin/main` which had a completely refactored `npu_engine_universal.cpp`
+- New engine: auto-detects model dimensions from Q4NX header (no more preprocessor flags)
+- M=32 batched decode, OpenMP attention, OpenMP LM head, f32 embeddings
+- Our token-file input feature (`argv[3]`) applied on top of new engine
+- Added `model_config.h` (from npu-sandbox) to make the new engine compilable
+
+### Files Changed Post-Merge
+| File | Action |
+|------|--------|
+| `engine/npu/src/model_config.h` | Created (was missing from remote) |
+| `engine/npu/src/npu_engine_universal.cpp` | Merged — remote's auto-detect + our argv[3] |
+| `engine/npu/build_npu.sh` | Switched to auto-detect universal binary |
+
+---
+
+---
+
+## 2026-07-02 — Fused XCLBIN — First Attempt, Q4NX Blocker
+
+The first full attempt at the fused-transformer-xclbin idea flagged in Update 18. Contract
+established for Qwen3-0.6B dimensions, 5 kernels recompiled with Chess for the smaller model.
+MLIR generator produced a working design; 2 xclbins compiled (374KB full-layer, 253KB QKV-prefix).
+`npu_engine_v13` proved the dispatch mechanics work — xclbin loads, BOs allocate (9.4MB weights),
+kernel dispatches without crashing — but hit a wall: the fused xclbin's weight-stream layout
+expects FLM's proprietary Q4NX chunk format, and the engine's flat INT8 weights don't match it.
+Weight-stream scheduler work got the packed size exactly right (2,458,816 dwords) but DMA still
+timed out (63s) — diagnosed at the time as a Q4NX *quantization* mismatch (dequant→requant producing
+NaN/Inf). Decision: keep v12 (97 tok/s, standalone GEMM) in production, treat fused xclbin as a
+separate weight-format workstream.
+
+(Update 24, a session later, revisited this with fresh eyes and found the real bug was the
+*schedule* — chunks replicated identically across columns instead of indexed per-tile — not the
+quantization theory reached here. See `docs/archive/WEIGHT-STREAM-BLOCKER.md` for the correction.)
+
+---
+
+## 2026-07-02 — Multi-Model XCLBINs, Model-Agnostic Engine
+
+Two parallel threads landed close together:
+
+- **Multi-model build-out**: 22-23 xclbins compiled across 6 model families (Qwen3-0.6B, Qwen3-8B,
+  Qwen3-VL-4B, Gemma4-E2B, Llama). `npu_engine_mt.cpp` (model-agnostic multi-token engine) +
+  `model_config.h` (auto-detects model dimensions from Q4NX headers) + a 42-model catalog
+  (`model-catalog.md`) classifying every FLM NPU2 model by architecture. `build_all_models.sh`
+  automates the xclbin builds.
+- **Engine speed**: v12 at 10 ms/tok (97 tok/s), 24× speedup from the v3 baseline
+  (244→50→16→10 ms/tok across v3→v6→v9→v12).
+- **Attention**: `attn_scalar.o` + `attn_c8.xclbin` compiled but not integrated — CPU OpenMP was
+  still faster for context <128 at this point.
+- Site live: 145 visitors, CI pipeline + PR-Agent running, benchmarks current.
+
+---
+
+## 2026-07-02 — M=32 Target, NPU LM Head, FLM Comparison
+
+FLM Kraken Point benchmark for reference: 66.5 tok/s on weaker hardware than ours. Engine evolution
+recap v3→v10: 244→16 ms/tok (15.2×, same numbers as Update 17). NPU LM head landed on-chip: 4ms
+(N=30720 xclbin, 88KB) — previously a CPU-side cost. `xrt::runlist` batching investigated and found
+to save only 27μs/layer (not worth the complexity). M=32 v11 targeted for >100 tok/s. Next flagged:
+NPU attention kernel (`edge_attention.o` compiled, not yet integrated) and the fused-xclbin idea
+that Update 20 picks up.
+
+---
+
+## 2026-07-02 — M=16 Batch Decode — 16 ms/tok, 15.2× Speedup
+
+### 244→16 ms/tok in One Session
+
+```
+v3 (Jul 1): 244 ms/tok  baseline
+v6 (Jul 2):  50 ms/tok  batch-4 + OpenMP LM head           (4.4×)
+v7 (Jul 2):       —     ioctl=9μs, r.wait=1334μs probe
+v8 (Jul 2):  27 ms/tok  M=8 batch decode                   (8.2×)
+v9 (Jul 2):  16 ms/tok  M=16 batch decode                  (15.2×)
+```
+
+### M=16 Batch Decode — How It Works
+
+The v7 probe proved `r.wait()` at 1334μs per GEMM call is NPU compute time,
+not driver overhead. The NPU is 99% idle in the M dimension at M=1. At M=16,
+compute stays at 1334μs but processes 16× more data → 11ms/tok per batch step.
+
+Single-token boot (157ms) provides top-16 token candidates from LM head logits.
+The 16 candidates run through one batched forward pass (28 layers, 4 GEMMs each)
+= 112 dispatches at 1334μs = 149ms NPU time + LM head (6ms) + CPU (10ms) ≈ 170ms.
+170ms / 16 tokens = 11 ms/tok.
+
+At 64 tokens (4 batches): 16.1 ms/tok effective. Boot amortized away.
+
+### FLM Gap: 1.5×
+
+FLM: 93 tok/s = 10.7 ms/tok (proprietary).  
+v9: 63 tok/s = 16.0 ms/tok (open source).  
+Gap: 1.5×. Was 20× yesterday morning.
+
+Next: LM head on NPU (151936×1024 INT8 matmul on D-style xclbin) = ~1ms.
+That alone brings batch step from 11→6ms/tok and effective to ~8ms/tok.
+Combined with M=32: ~4ms/tok effective = matches FLM.
+
+### Session Summary
+
+- 9 engine versions built and tested on-device
+- f32 embeddings: -20% decode latency
+- OpenMP LM head: 67→6ms
+- μs-probe: identified NPU compute as bottleneck (not ioctl)
+- M=4→8→16 batched decode: dispatch amortization
+- 15.2× total speedup
+- CI pipeline on self-hosted runner
+- All numbers on https://1bit.monster
+
+---
+
+## 2026-07-02 — Full Profile + 50 ms/tok Batch-4 Decode
+
+### NPU Dispatch: The Root Cause
+
+μs-accurate profiling (`npu_engine_profile.cpp`) proved our GEMM overhead:
+
+```
+Per-GEMM dispatch (112 per token):
+  Quantize A:    6 μs   (<1%)
+  Sync A→NPU:    2 μs   (<1%)
+  Kernel+wait: 1346 μs   (99%)  ← THE BOTTLENECK
+  Sync C←NPU:    8 μs   (<1%)
+  Dequant C:     1 μs   (<1%)
+
+Total: 1363 μs/call × 112 calls = 156.8 ms (70%)
+LM head: 67 ms (30%)
+CPU ops (norms, RoPE, attn, SiLU): 0.7 ms (<1%)
+```
+
+The NPU is spending 99% of dispatch time in launch+wait overhead.
+Actual M=1 GEMM is 0.5-5 μs. Overhead ratio: **2000×**.
+
+### Chained Batch-4 Decode (v6): 50 ms/tok
+
+Instead of per-token dispatch, we generate top-4 tokens from LM head
+logits and run them all through one batched forward pass. Each batch
+step takes ~160ms for 4 tokens = 40 ms/tok. Boot step: 157ms.
+
+```
+$ OMP_NUM_THREADS=16 ./npu_engine_v6 16
+
+  [0] boot=127595 top4=127595,65831,39815,63550 (157ms)
+  [1] batch=4 tok=9275 ms=161 (40 ms/tok)
+  [5] batch=4 tok=106211 ms=159 (40 ms/tok)
+  [9] batch=4 tok=83570 ms=158 (40 ms/tok)
+  [13] batch=3 tok=83570 ms=157 (52 ms/tok)
+=== 50 ms/tok effective ===
+```
+
+Token IDs diverse across batches. No NaN. Clean exit.
+4.4× speedup from v3 (244→50 ms/tok).
+
+### OpenMP LM Head
+
+Pre-converted BFP16→F32 embeddings (622 MB) + OpenMP on 16 Zen5 cores:
+LM head: 67ms → ~6ms per token (11× faster). This plus batch-4
+amortization is what dropped us from 222→50 ms/tok.
+
+### What We Learned
+
+- Removing weight re-sync (v4) saved nothing — weights already on device.
+- 2-layer draft model (spec decode v0) had 0% acceptance rate on Qwen3.
+- Batching at decode time works: dispatch overhead amortizes across tokens.
+- CPU is never the bottleneck — 26 μs/layer vs 5599 μs GEMM dispatch.
+
+### Next: Fused Transformer XCLBIN
+
+The 112 dispatches per token are now 112 per 4 tokens = 28/token effective.
+To get to FLM's 93 tok/s, we need a single fused transformer-layer xclbin
+that chains QKV→norm→attention→O→norm→GU→D on NPU without host round-trips.
+That turns 28 dispatches into 1. Then LM head goes on NPU via D-xclbin INT8
+matmul. Then we're at ~10 ms/tok.
+
+---
+
+## 2026-07-02 — Production Stack, Release, Site Refresh
 
 ### FLM Proxy Daemon (July 2)
 
@@ -2232,7 +1761,89 @@ The Jun 21-22 clone spike (492 in one day) looks like a scraper or bot. Organic 
 - `https://github.com/bong-water-water-bong/npu-infer` — INT8 engine + xclbin generators
 - `https://github.com/bong-water-water-bong/npu-gpu-cpu` — Handoff docs + unified control plane
 
-## Session 2026-07-03/04 — Triton-XDNA Eval, memlock Fix, Spec-Decode Reality Check
+## 2026-07-03 — v12 Was Never Output-Validated — 3 Real Bugs Found, Still Incoherent
+
+Set out to swap the production daemon's NPU backend from FLM (proprietary, closed-source)
+to v12 (our own C++ engine, "97 tok/s, beats FLM's 94, Zero Python"). Before wiring it in,
+sanity-checked actual chat output against FLM for the same prompt. FLM answered "What is
+2+2?" correctly (" 4."). v12 — byte-identical reproduction of the unmodified original —
+produced complete garbage. Every doc and benchmark in this repo checks tok/s and "doesn't
+crash," never coherence. The 97 tok/s number is real; the output behind it never was.
+
+Found and fixed 3 real, confirmed bugs, all present in `npu_engine_cb.cpp` since it was
+first written and inherited by `npu_target_model.h` (spec-decode's target-model dispatch):
+
+1. **LM head weight substitution** — `lm_head.weight` gets correctly dequantized then
+   immediately discarded; the code computes final vocab logits against the *embedding*
+   table instead (assumes tied embeddings). Qwen3-0.6B's checkpoint stores them completely
+   separately (confirmed via Q4NX header data_offsets) — the model computes a reasonable
+   final hidden state, then reads logits off the wrong matrix.
+2. **Weight-packing transpose** — `dequant_i8_to_float` returns row-major
+   `[out_features, in_features]`; the GEMM dispatch needs `[in_features, out_features]`.
+   The packing loop read the buffer with the wrong stride, silently scrambling every
+   weight matrix (Q/K/V/O/Gate/Up/Down) while still producing finite, plausible-looking
+   numbers. Also: O-proj and Down-proj dequant calls used the wrong `in_features` (1024
+   default instead of their real 2048/3072), scrambling the tiling itself.
+3. **Activation quantization clipping** — hardcoded INT8 scale assumed activations stay
+   within [-5,5]; measured range is [-8.24,7.01]. Silently clipped every layer, compounding
+   across all 28.
+
+All three fixed, in all three copies of this logic (`npu_engine_cb.cpp`,
+`npu_engine_server.cpp` — a new persistent-server variant built for the daemon swap,
+and `spec-decode/engine/npu_target_model.h`). Chat output is **still incoherent** after
+all three fixes, individually and combined, tested against both RoPE conventions
+(interleaved-pairs and HF's actual rotate_half). Ruled out via ground-truth comparison
+against the real HF model: embedding lookup, RoPE theta/config, GQA head mapping, K/V
+extraction offsets — all correct. Remaining suspects: RoPE rotation convention (tested,
+inconclusive) or the compiled `.xclbin` kernels themselves, undebuggable without the AI
+Engine Simulator — blocked on this machine since Update 24's investigation (missing
+`aie2p_8x4_device.json` for NPU2). Full writeup: `docs/archive/V12-CORRECTNESS-BLOCKER.md`.
+
+**FLM proxy stays in production.** Do not wire v12/1bit.engine into the daemon until this
+is resolved and re-verified against real chat prompts, not just dispatch speed.
+
+---
+
+## 2026-07-03 — Fused XCLBIN Resumed — Schedule Fixed, Deadlock Isolated, New Kernel Bug Found
+
+Picked back up the fused-transformer-xclbin effort flagged as "next" at the end of Update 17
+(the intervening Updates 18-23 covering the fused-xclbin dead end, the pivot to the universal
+5-model v12 engine, and the merch store live in git history / other docs, not fully reflected
+in this file until now).
+
+### What Was Found
+
+1. **Reconstructed the correct Q4NX weight-packing schedule** by cross-referencing the MLIR
+   generator against `qwen3_model.py::_projection_stream_from_schedule` — the fused xclbin
+   expects weight chunks distributed per-column/per-row (`row_chunk = block*16 + group*4 +
+   patch*2 + row_in_patch`), not replicated identically across columns as the old
+   `q4nx_stream.cpp` did. `npu-sandbox/npu-infer/tools/pack_fused_v3.py` already implements this
+   correctly (verified byte-identical on regen) by reading real Q4NX chunks straight out of
+   `model.q4nx`, no dequant/requant.
+2. **Schedule-correct weights alone didn't fix the full-layer deadlock** — re-ran `npu_engine_v13`,
+   still 62857ms timeout, all-zero output.
+3. **Isolated the deadlock to the O/UP/GATE/DOWN tail.** The smaller QKV-prefix xclbin (rebuilt
+   fresh via `full_layer_qkv_prefix_runner.py`) dispatches cleanly in ~4ms, no deadlock at all —
+   matching what the sibling BitNet port (`torch2aie/examples/bitnet-decode-layer`) found for the
+   identical design shape. The full-layer deadlock is a lock/dataflow bug specific to the tail
+   phases, not a data-scheduling problem.
+4. **Found a second, separate bug: QKV-prefix produces numerically wrong output**, even
+   deadlock-free. ~1000+ K/V cache mismatches vs. the CPU golden reference, at multiple token
+   positions. Traced RoPE and RMSNorm formulas in the Chess kernel (`postprocess_qkv.cc`) against
+   the Python reference — both match exactly. V-cache (no RoPE/norm at all) is *also* wrong,
+   narrowing the bug to the Q4NX GEMM/dequant kernel (`qwen3_decode_kernels.cc`) or record
+   absorption — unresolved, needs kernel-level debug instrumentation to pin down further.
+
+### Status
+
+Fused xclbin is closer than before (schedule solved, deadlock scope narrowed) but still not
+working end-to-end — two distinct kernel bugs remain (tail deadlock, QKV numeric correctness).
+v12 (97 tok/s, standalone INT8 GEMM, zero Python) stays production. Full details in
+`docs/archive/FUSED-INTEGRATION-BLOCKER.md`.
+
+---
+
+## 2026-07-03 — Triton-XDNA Eval, memlock Fix, Spec-Decode Reality Check
 
 ### Triton-XDNA (AMD's Triton-to-XDNA compiler)
 
@@ -2273,7 +1884,36 @@ A negative cos_sim means the cached INT8 weights are essentially uncorrelated ga
 
 The generator script that wrote `/tmp/hf_weights_cache/*.bin` is not in the repo. `docs/NPU-ENGINE-CORRECTNESS-STATUS.md` was updated to reflect this new finding.
 
-## Session 2026-07-05/06 — Q4NX/GGUF fully decoded, NPU GEMM root-caused, first validated 1-bit number, DSpark
+## 2026-07-05 — All 3 Bugs Confirmed Fixed — AIE Micro-Tiling Root Cause Resolved
+
+**v12 is now coherent. 97 tok/s verified. GEMM kernel bit-exact.**
+
+A parallel investigation (branch `fix/npu-hf-cache-i32-kernel`) independently confirmed
+what UPDATE 25 suspected: the remaining bug was in the **compiled xclbin kernels**, not
+the host code. Root cause: `n1_core_i8_v2.py` (the INT8 MLIR generator) was **missing AIE
+micro-tiling** — the GEMM kernel received weights in the wrong internal layout despite
+being bit-for-bit correct at the BO level.
+
+Fixes applied:
+1. **xclbin output width** — matched INT8 generator output width to host's i32 Cm buffer
+   (`cd73e137`)
+2. **Smoke-test prompt** — replaced malformed prompt with valid chat template
+   (`3d984285`)
+3. **RMSNorm weight clip** — clipped weights to [-2,2] in cb/universal engines
+   (`49e78785`, partial)
+4. **GEMM kernel verified** — hardware dump-and-compare confirmed bit-exact
+   (`7f8f3586`)
+5. **Root cause identified** — missing AIE micro-tiling in n1_core_i8_v2.py
+   (`01a4b7f4`)
+6. **Parallel theories reconciled** — both investigation paths now agree
+   (`16016167`)
+
+All 6 fixes cherry-picked onto main as `232db025`..`bffe5a2e`.
+**97 tok/s v12 now produces coherent output.**
+
+---
+
+## 2026-07-05 — Q4NX/GGUF fully decoded, NPU GEMM root-caused, first validated 1-bit number, DSpark
 
 The longest push in the project's history. Two threads ran in parallel: a
 model-format thread (decode *any* model on either chip) and a correctness thread
@@ -2367,7 +2007,22 @@ already-fragile training setup much worse. See `docs/wiki/performance.md` for th
 corrected "unresolved, not disproven" status and the real 0.8 tok/s / 0% acceptance
 measurement taken with the wiring bug fixed.
 
-## Session 2026-07-16/20 — FLM fully replaced, model-agnostic broadening, TQ2 ternary
+## 2026-07-06 — Fused Layer Engine Goes Production — 291 Tok/s (3× v12)
+
+**The fused layer engine now ships at 291 tok/s (3.4 ms/tok), 3× the v12 baseline, in a 38 KB binary.**
+
+What was delivered:
+1. **One xclbin call per transformer layer**: QKV projection, attention, O projection, gate+up, SiLU, and down projection all run on the NPU in a single dispatch. No CPU attention, no intermediate BO syncs. Uses `design_full_layer.xclbin` (416 KB) from the torch2aie toolchain with per-position instruction files.
+2. **3.4 ms/tok decode**: The fused dispatch eliminates the per-GEMM ioctl overhead that limited v12. At 291 tok/s, the NPU's INT8 throughput is now the bottleneck, not the dispatch layer.
+3. **38 KB binary**: The fused engine binary is smaller than the previous 74 KB daemon despite doing more per call. Static linking + stripped symbols + no Python runtime paths.
+4. **Fixed scale optimization in universal engine**: `dynamic_ascale()` replaced with `FIXED_ASCALE = 8.0f / 127.0f` — saves 35 μs per GEMM call (4 ms/batch across 112 calls). Worth +11% on decode.
+5. **FLM v0.9.44 workaround in daemon**: FLM's `/v1/chat/completions` has a `basic_string::substr` bug. Daemon now converts chat messages to text prompts via a lightweight Qwen3 template and calls `/v1/completions` instead.
+
+**Narrative shift**: v12 (97 tok/s, C++ standalone INT8) is now the fallback path. The fused layer engine is the production path. All docs, badges, and benchmarks updated to reflect this. Everything from "74 KB binary, 94 tok/s" to "38 KB binary, 291 tok/s."
+
+---
+
+## 2026-07-16 — FLM fully replaced, model-agnostic broadening, TQ2 ternary
 
 The single biggest architectural change since the last addendum: **FastFlowLM is no
 longer the default NPU path, and its native `.so`-dependency is gone entirely.**
@@ -2463,7 +2118,100 @@ misconfigured to point a non-MoE-scoped test at a real MoE model, not a code bug
 
 ---
 
-## 2026-08-07 — the unified control plane lands (pool wired, spec decode in-server, zoo 5/5)
+## 2026-07-20 — Mamba1 GPU Backend — 79.4 Tok/s, 9 Bugs Killed
+
+**The Mamba1 GPU backend (`mamba1_engine.hip` + `backend_mamba1.cpp`) is now fully built, linked, and validated end-to-end on Strix Halo. BlackMamba 1.5B: 79.4 tok/s. BlackMamba 2.8B: 46.1 tok/s.**
+
+What was delivered:
+
+1. **Build linkage fixed**: `create_mamba1_backend` was only compiled into `unified_server`, not `libbackend_manager.a` — every other binary (test_backend, backend_demo, vision_server, etc.) failed to link. Moved `backend_mamba1.cpp` into the static lib. HIP device stubs were also missing because the file was compiled as CXX despite launching kernels with `<<<>>>` syntax; moved all kernel launches into `extern "C"` wrapper functions in `mamba1_engine.hip` so callers compile as plain CXX.
+2. **Conv state buffer overflow fixed**: the conv state shift loop wrote to `cs[(d_conv-1) * d_inner + i]` but the buffer was only `[d_conv-1, d_inner]` (max valid index `d_conv-2`). This caused silent GPU memory corruption on every SSM layer forward pass. Fixed the loop bound from `dc-2` to `dc-3`.
+3. **A_log exponentiation fixed**: Mamba1 parameterizes `A = -exp(A_log)`, but the selective scan kernel used `A_log` directly as `A` in `A_bar = exp(dt * A)`. This meant the SSM dynamics were completely wrong. Added `-expf()` in the scan loop to compute `A = -exp(A_log)` before discretization.
+4. **Model routing fixed**: GGUF Mamba models are now routed to `mamba1_gpu` backend (was falling through to ZINC GPU catch-all).
+5. **Both BlackMamba sizes converted and benchmarked**: 1.5B (30 layers, 15 SSM + 15 MoE) at 79.4 tok/s, 2.8B (36 layers, 18 SSM + 18 MoE) at 46.1 tok/s — both on Strix Halo iGPU via ROCm HIP, alternating SSM/MoE layer dispatch.
+6. **Diagnostic tool**: `tools/test_mamba1_backend.cpp` loads a Mamba1 GGUF directly into the HIP backend without the HTTP server — warmup, benchmark, and generation in one shot.
+
+**The BlackMamba `⚠️` in the README is gone.**
+
+---
+
+## 2026-08-03 — Memory Campaign — Arena-Frag Leak Fixed, Top-1 Backend Init, 10-Bug Audit
+
+**The long-unexplained host-RSS creep in `unified_server` is root-caused and fixed, the multi-backend memory bloat is cut by ~10 GB, and the 10-bug audit (#1429–#1438) landed. Release v2026.08.03 shipped and the memory fixes are deployed on the live service.**
+
+### The leak that wasn't a leak: glibc arena fragmentation (#1428)
+
+For weeks the server's host RSS crept ~0.1–1.7 MB per generation request — monotonic, never returned, ~90 MB/hr at 1 req/s, and 6.8 GB baseline after 50 min uptime. Every container was ruled out by triage. A heaptrack capture settled it:
+
+- **Zero unfreed bytes on the generate/forward/lm_head path.** Nothing leaked.
+- The culprit: `FusedBackend::generate()` allocated `std::vector<float> l(VOCAB)` (**608 KB** for Qwen3) on the stack **every token** and freed it every token.
+- That's the **glibc dynamic mmap-threshold trap**: the first 608 KB block is mmap'd, but after the first free glibc raises its threshold and services later same-size requests from the **brk arena**, interleaving them with the small per-token HIP/kernel allocations. Top-of-heap never becomes trimmable → RSS creeps up and never comes back. This is exactly why `/proc/maps` stayed flat while `VmData` grew, and why the rate tracked tokens.
+- Fix: hoist `h`/`l` to reusable member buffers sized once in `init()`. Zero per-token host allocation → nothing to fragment. Measured: mt=128 creep decays 208 → **20 kB per 10 reqs** (old: 17 MB per 10 reqs, ~160×) and plateaus; the `MALLOC_MMAP_THRESHOLD_`/`TRIM_THRESHOLD_` env band-aid on the service became unnecessary and was removed.
+
+### The 15 GB serving baseline (#1427)
+
+`BackendManager::init_in_order()` loaded **every** backend × full model copy — fused (f32 GPU + host), hip_1bp (bf16 GPU), vulkan_hpp (pools), cpu_generic (f32 RAM) — ~15 GB (7 GB RSS + 8.2 GB GTT) for a 0.6B model, so systemd-oomd killed desktop apps when CI built concurrently. Two fixes:
+
+1. **Dead host weights freed**: `cpu_L`/`cpu_embed`/`cpu_final_norm`/`cpu_output` are pure load→GPU/NPU-pack buffers — provably unread at inference. Freed after load: RSS 6768 → 5163 MB.
+2. **Top-1 + CPU fallback init**: keep the first accelerator + one CPU fallback; the rest stay discoverable and init **lazily via the existing failover path**. This was safe because the per-token cross-backend routing those extra copies paid for was **KV-incoherent anyway** — each backend keeps a private KV cache + `pos`, so a token routed to a backend that never saw the prefix attends to empty KV. Instance GTT: 8.2 → **2.6 GB**.
+
+### Everything else since UPDATE 28
+
+- **Coherent GPU inference** (#1397): QK-norm, per-layer KV, residual fixes — GPU paths became output-valid; `fused_gpu_npu` is the production path at **321 tok/s (3.1 ms/tok)**.
+- **One ELF to rule them all** (08-02): `build/1bit` = zaya + unified + router + jarvis + vision + agent CLI in a single binary; `1bit pull`/`list` in pure C++; packaging ships one binary; the 296-line bash launcher is dead.
+- **Lemonade embedded** (08-01): 14 Lemonade backends run in-process; `unified_server --lemonade` hands off to the full server.
+- **Exact SiLU + `-ffast-math` dropped** (41d0977e7): Q4NX ppl was *backend*-broken, not converter-broken — the #1243 audit's 6.5% density red flag resolved with per-vocab ppl gates + prefill M=128 fused chain (#1413).
+- **RVQ-VAE codec in C++** (#1368) with GGUF export.
+- **10-bug audit resolved** (#1429–#1438): SSRF, unkillable-server, OOB/SIGFPE/bad_alloc families, loader/backend hardening.
+- **Clean shutdown** (#1426): `_exit()` instead of the static-dtor ABRT that segfaulted on every stop.
+- **Release pipeline fixed** (#1404–#1425): tag builds run on the runner (not container), `onebin` target restored after sync merges clobbered it, libdrm/glslc/spirv-headers dep parity with CI.
+- **Narrative purges** (#1412 + follow-ups): TheRock-era and Rust-era claims swept — the stack is pure C++23, zero Python at runtime.
+- **Ponytail purge** (#1325): ~48K lines of dead code deleted (with the few survivors restored in #1390).
+
+**The environment bit back once**: a driver wedge during sustained load forced a cold reboot on 08-03; post-reboot the NPU (RyzenAI-npu5, firmware 1.1.2.65) and iGPU came back clean, and the memory campaign above was verified on the recovered hardware.
+
+---
+
+## 2026-08-07 — the unified control plane lands — one-heap pool, all models resident, spec-decode in-server (zoo 5/5)
+
+**The unified server now boots with every model in the zoo resident in one mmap'd pool (11 slots, ~6 GB on Strix), runs lossless speculative decoding in-process (`--draft-model`), and finally produces coherent answers from all 9 models end-to-end — Zamba2, the NPU FLM path, and the HIP 1BP backends all fixed. 13 commits landed on main via PR #1535.**
+
+### The unified model pool (#1535)
+
+The pool idea from UPDATE 29's roadmap is now end-to-end. `UnifiedModelPool` was generalized: any model file (gguf/q4nx/h1b/1bp) is mmap'd resident — `.1bp` gets header-parsed metadata, everything else generic. `--pool` makes the server load every discovered model at boot; `POST /v1/pool` reports residency, `/v1/models` tags pooled models. One process, one API, all models resident. Measured through the single endpoint: Qwen3-4B (NPU FLM) 20.8 tok/s, Llama-3.2-1B/Qwen3-0.6B (Vulkan) 12.4, Bonsai (HIP 1BP) 3.1, Zamba2 Q8_0 (HIP) 2.2; zoo-smoke 5/5 PASS.
+
+### In-server speculative decode
+
+Phase 2 core is now a server flag, not a demo. The backend interface gained the three spec-decode primitives (`decode_one` / `verify_batch` / `rollback`), implemented by the ggml-vulkan backend with multi-token `llama_decode` (per-position logits + KV rollback via `llama_memory_seq_rm`). `--draft-model` loads a second side-by-side ggml-vulkan backend; `--spec-decode` runs the lossless loop (draft proposes N greedy tokens, target verifies in one batch, longest consistent prefix accepted, rejected positions rolled back and fix re-decoded). Two real bugs found along the way: `reset()` was a no-op — every request extended ONE unbounded sequence, so KV never actually cleared per request; and the first-token bug — draft and target logits share a vocab size but NOT a vocab, and a shared buffer made the first output token the draft's argmax.
+
+### Zamba2 end-to-end (5dcef800)
+
+Zamba2-1.2B-Instruct-v2 now generates coherent answers through the unified server on the HIP GPU engine — verified vs HF transformers with identical top-1 (`'4<|im_end|>'` greedy). Three root causes, all found:
+
+1. **The GGUF on disk was corrupt** — ~60% of weight elements didn't match the checkpoint (spot-checked ssm_in, embedding). Re-converted a clean F16 GGUF from the safetensors.
+2. **Converter bugs**: `use_shared_attention_adapter=True` never folded the q/k/v LoRA adapters (only the FFN gate_up one was) — every attention head computed with raw weights; and the tokenizer vocab was never written, so `.htok` synthesis failed and the server fell back to the previous model's tokenizer (Qwen3 ids fed to a 32k-vocab model).
+3. **Merges format**: `tokenizer.json` merges are `[a, b]` pairs, the gguf lib wants `'a b'` strings.
+
+### Model zoo sweep: 8/9 coherent (04271bd8, 0bab2f6e)
+
+Full regression sweep of all 9 models through the unified server — 8/9 now generate coherent responses. Tokenizer synthesis was the big one: the server now builds a fresh `.htok` from the model's own or sibling GGUF (`GgufReader::write_htok`), because the checked-in `tokenizer.htok` was a stale Llama-era v1 file and without it every non-NPU model decoded as ASCII-garbage `[id]` soup. Plus: byte-piece fallbacks for non-GPT-2 vocabs, the ggml_vulkan sampler chain switched from greedy (which made small models loop) to temp 0.8/top_p 0.95/dist, and a nasty `cur_p.selected` bug — it's an INDEX into the candidates array, not the token id.
+
+NPU FLM went end-to-end too: an ODR collision where two distinct `OnebpModel` classes (CPU vs NPU) shared one dtor symbol meant every NPU-side object was destroyed with the wrong layout → SIGSEGV after any failed 1BP open (fixed by renaming the NPU-side class to `NpuOnebpModel`). The FLM backend got a `generate_text()` hook driving the subprocess REPL with the whole prompt (FLM tokenizes internally; a token loop can't drive it), with REPL artifacts (ANSI codes, `<<RESET>>` echoes, `[FLM]` log lines) stripped from responses. And the Qwen3-4B-NPU2 model cache was corrupt — bad download pre-reboot.
+
+### Zaya 1BP + routing (9ed7eb94, 7ae82829, 4c68f3ff)
+
+The HIP 1BP backend is wired into the router chain with logits-based sampling (temperature/top-p/repetition penalty — replacing argmax), `rope_theta` passed from the `.1bp` header, and per-arch chat templates — verified with a real-prompt coherence probe.
+
+### CI + housekeeping
+
+- The e2e smoke job no longer breaks when built without the llama.cpp submodule (`backend_ggml_vulkan.h` self-stubs the factory, mirroring the `.cpp`'s `#else` stub); submodule pinned to the fork so CI can fetch the zamba2-quantize commit.
+- ShellCheck SC2034 in `scripts/zoo-smoke.sh` fixed (unused loop var — was blocking the required C++ check on every PR).
+- **Branch cleanup**: 7 stale remote branches deleted (3 dependabot bumps, superseded fingerprint-dispatch docs, merged/closed eeg-zuna-research, zamba2-ssm-a-convention, ws05 per-vocab-ppl-gates), 4 stale PRs closed. `origin/main` had been sitting at Aug 5 — the whole Aug 7 work landed via PR #1535.
+- **CI flake found, not fixed**: the smoke-test's NPU `mmap EAGAIN` failures are the `pool-probe` job wedging the amdxdna driver (`Can not get flush memory` in dmesg) — the server runs clean locally with the NPU free. Root-caused in the wiki; workaround is a reboot before needing smoke green.
+
+---
+
+
 
 **What happened**: the 1bit engine went from "5 models working one at a time" to
 **one process, one API, all models resident** — plus a lossless speculative
@@ -2500,6 +2248,258 @@ that's the next milestone, on a kernel/driver surface that's already present
 in amdxdna.
 
 ---
+
+## 2026-08-08 — The TileFuse Day — NPU Kernel from Scratch, Q4NX Pivot, Converter Ladder
+
+**The single busiest day in the window: an original NPU int4 GEMV kernel built from scratch (inspired by, but not copied from, the TileFuse paper — its actual kernel code was never public), a pivot to official Q4NX weights after community GGUF conversions proved unusable, a 15× serve-mode speedup, MoE expert ops running on the real 22GB 35B model for the first time, a from-scratch ONNX INT8 pipeline, and a four-rung Qwen2.5 converter debugging ladder (1.5B → 3B → 7B) that found a different silent corruption bug at every rung.**
+
+### An original NPU int4 GEMV kernel (TileFuse-inspired), milestones M1→M4
+
+Official Q4NX weights turned out to be a dead end for custom-converted models (confirmed later the same day — see the Q4NX pivot below), so the day pivots to building an NPU int4 GEMV kernel from first principles. The TileFuse paper (arXiv 2606.11357) describes the dataflow, but its actual kernel code was never released — only a static docs site — so the AIE kernel itself is original work guided by the paper's description, not a port.
+
+- **M1 — the pre-tiler.** `docs/research/tilefuse_prep.py`: 128×64 tiles, int4 codes packed as adjacent-column nibbles, bf16 per-channel scales, int8 code-domain zero-points. Round-trip passed on synthetic data (max err 0.0087 vs. an int4 physics ceiling of 0.0101) and on a real Llama-3.2-1B `q_proj` slice (err 0.0288 vs. ceiling 0.0383). Three bugs fixed en route: int4 bytes pack adjacent *columns*, not row-pairs; the zero-point must be stored in the int8 code domain, not as a raw float minimum (storing `round(lo)` produced a 30× error); and constant-column tiles need `scale=|lo|`.
+- **M2 — converter, CPU reference, and toolchain, three steps.** A new C++ converter (`tools/gguf_to_tilefuse.cpp`) passed CHECK on all 113 2D tensors of Llama-3.2-1B-Instruct.Q8_0, producing a 656.5MB `.tfb`, after fixing four bugs (GGUF shape is file-order but data is logical row-major — must not transpose; a manifest-offset patch bug that shifted every tile read by one; the constant-column scale fix; the zero-point bug, both restated from M1). A CPU reference GEMV (`tools/tf_gemv.cpp`) then passed CHECK on 30 tensors after fixing an accumulation bug (`out[c]=acc` was overwriting instead of accumulating) and a gate-indexing crash. A subtle gotcha cost real time: `struct.unpack('<e')` is IEEE fp16, not bfloat16 — it silently misled probes by ~100×. Finally the IRON toolchain itself came up clean (`~/iron` venv, python3.14, mlir-aie + llvm-aie wheels), validated on-NPU with a stock axpy (96/96) and stock GEMV (95/95).
+- **The qgemv kernel runs on real NPU silicon, 10/10.** `aie_kernels/aie2p/qgemv.cc` fuses int4 unpack, dequant, and dot product on a 4352-byte tile FIFO — exact match vs. CPU on both 1-tile and 4-tile configurations, after fixing a kernel arg-count mismatch (garbage via a null pointer) and a zero-point duplication bug where the generator used `np.repeat` instead of `np.tile`, producing a block layout `[64][64]` instead of the correct interleaved one.
+- **"THE Q4NX WALL IS BROKEN"** — a real-model validation loading `blk.0.attn_k.weight` from a real community Llama-3.2-1B `.tfb` passed 5/5, chunked into 8-tile passes to respect a 32-worker placement limit. This "5/5" later turned out to be a false positive — see M3.
+- **A vectorization attempt** (16-lane row-group dot products) passed both test suites but was *not* faster yet (7.25s vs. 4.05s — vector setup overhead dominates at this granularity; the paper's 64×8 block structure is needed to actually win).
+- **An alternate performance path: bf16.** `gguf_to_tilefuse --bf16` mode is near-lossless (err 0.0002); stock IRON GEMV on a real bf16 `.tfb` measured **175μs / 24GB/s** on a K=512,N=2048 tensor — about 8× faster than the int4 qgemv kernel's ~1340μs at this point in the day.
+- **M3 exposed two false-positive bugs.** First, `test_real_model.py`'s earlier "5/5 PASS" was fake: `XRTTensor.from_torch` copies its input, so the test was reading back the *input* tensor, not the kernel's actual output buffer — the physics-bound gate even passed for an all-zero output. Fixed by reading via `buf.to_torch()`. Second, a **launch-alternation quirk**: consecutive QGEMV launches alternate between stale and valid output (even calls garbage, odd calls correct, deterministically) — stock GEMV doesn't show this; suspected an mlir-aie runtime FIFO ping-pong bug. Workaround: call twice per launch, keep the second result. A third, separate bug (the same `np.tile`-vs-`np.repeat` issue from the kernel work) had also silently narrowed `test_real_model.py` and the M3 sweep to only 16 distinct input values, with a bound loose enough to swallow the wrong math. Genuine corrected numbers: real-model max err/bound **0.0718**; M3 re-run **2/2 PASS in 12:42**.
+- **M4, performance, multiple steps.** A bf16 host-dequant path hit **100μs/launch** at batch 1 (109μs at batch 4, 127μs at batch 8; err ~0.035 from bf16 rounding) vs. the int4 fused kernel's ~1100μs/launch, though batch 16 hit a placement wall ("no ShimNOCTile has sufficient DMA capacity"). A full-array mem-tile dataflow (per the paper's §4.4) then reached **197μs for 2048 outputs in one launch** at batch 32 (err ~0.05), and re-ran the M3 int4 sweep 3× faster (2/2 in 4:24) — but exposed a new cap: `QGEMV` silently truncates batches above 32. An honest per-token benchmark landed at **~0.9s/token** — 4714 launches × ~189μs, with the ~185μs launch floor dominating (the kernel itself is only ~2μs) — identifying layer-level batching as the next lever. That lever landed same-day: batching to **17 launches/token (16 blocks + embed) cut the time to ~390ms/token** (from 892ms), and revealed a new floor: the bf16 path moves 2.5GB of weights per token at ~10GB/s effective shim DMA, making it DMA-bound rather than launch-bound, while the int4 fused path moves 4× less data (656MB/token) but is compute-bound at ~1ms/tile for scalar dequant — flagging vectorized in-kernel dequant as the path toward ~100-150ms/token.
+- **An all-layers bf16 sweep passed 5/5** after four more bugs: a false positive from reading the test's own allocated output tensor instead of the real one; a bf16 construction bug (`.view(np.uint16)` interleaves the low/high halves of each pair instead of `.astype(bfloat16)`); a K-chunk reference using a column slice instead of a row slice; and a quadratic loader re-slicing a 533MB array inside a loop (hours → fixed to 0.3s). Full round-trip: 114/114 PASS.
+
+### The Q4NX pivot: official FastFlowLM weights vs. community GGUF conversions
+
+1. **Verified with official weights.** `third_party/FLM_Q4NX_Converter` vendored; the pipeline works end-to-end with *official* pulled weights (`llama3.2:1b`, ~4.8 tok/s including spawn), but **community GGUF conversions produce degenerate output (loops)** — establishing the day's key limitation. Three bugs fixed along the way: a missing `FLM_CONFIG_PATH` on the per-request child process; a coherence probe wrongly rejecting char-shifted NPU output (fixed with an `all_char_band` exemption); and a Llama tag-mapping fix disambiguating on both H and L.
+2. **FastFlowLM confirmed open-sourced (MIT)**, having moved from the FastFlowLM org to the ROCm org the day before (v0.9.46). Vendored at `third_party/FastFlowLM`. Two candidate decode dispatch paths were found for the degeneration bug: `generate_dequant_q4_1_seq` vs. `generate_dequant_q80_packed_in_q4nx_seq`.
+3. **`tools/batch_convert_q4nx.sh` shipped** (`86269a99`, `d110bee1`), finding the converter's actual bug: an uncommented upstream debug line (`sys.argv` override to `'gemma4-2b-mmproj.gguf'`) clobbered every CLI invocation — the converter had been **totally unusable** before this fix.
+4. **The fusion engine rebuilt** (`engine/npu/build_npu.sh`, 19 variants) with a per-tensor-scale `packB` fix replacing broken per-32-group scales; batch scaling proved essentially free up to 16 rows (1.9ms@1 → 2.2ms@16 → 6.4ms@64).
+5. **Mystery solved: NPU2 is a different architecture, not a repack.** Official q4nx linears store raw I8 at `K=5120` (vs. vanilla GGUF's K=1024-2048); an earlier "±15 std5.6 vs. GGUF ±0.1" observation was actually I8 bytes being misdecoded as Q4_1 nibbles — no repack of a vanilla GGUF can produce official Q4NX's layout.
+6. **The pivot's verdict** (branch `feat/q4nx-pivot`): a runnable q4nx model must come from `flm pull`, not conversion. Also decided: **`flm serve` works fine with official weights** (~45 tok/s vs. ~4.8 tok/s per-request spawn) — the earlier belief that "serve mode degenerates" turns out to have been an artifact of broken *converted* weights, not a problem with serve mode itself.
+
+### Serve-mode migration + a tokenizer band bug
+
+`SimpleTokenizer`'s decode fallback used stale character-shift bands that no longer matched the encoder's real bands (ids 132-226 should map to -100, 300-555 to -300) — ids 201-226 silently decoded to control characters, which is why short test strings looked fine while longer prose came out garbled. Verified end-to-end: **71.4 tok/s via `flm serve` vs. 4.8 tok/s per-spawn — about 15×**. A separate "16-char truncation" symptom turned out to be a red herring: a legacy endpoint defaulting `n_predict` to 16 instead of reading `max_tokens`. Both fixes landed as `87846a51`. In a case of parallel-agent convergence, another agent had independently built an equivalent serve backend (`86269a99`, `d110bee1`) — this session's changes were reconciled in its favor.
+
+### 35B MoE: expert worker ops verified, then a 5.8× xclbin rebuild
+
+1. MoE expert worker ops 40/41 ran on the real 22GB Qwen3.6-35B-A3B model for the first time, after fixing three bugs: `find_tensor_info` returned data offsets as **int32**, overflowing negative for offsets ≥2^31 and silently corrupting per-layer dimension detection on any model over 2GB (cascading to a SIGSEGV in `std_attn_step`) — fixed to `uint64_t`; an NPU out-of-memory at ~1.2GB BOs (dense QKV/O alone is 1080MB on the 35B) — fixed by making shared-expert BOs NL=1 with a host-side packed int8 cache; and a worker-op protocol payload-ordering bug. At this point, NPU MoE still lost to CPU: full decode was 2,823ms/tok on CPU fallback vs. 8,999ms/tok with `NPU_MOE=1` (3.2× slower — old xclbins).
+2. **The MoE xclbins rebuilt as v27** (multi-row, 32-core; `build_moe_v27.sh`): op40 (expert GU) dropped from 39ms to **6.7ms**, op41 (D) from 20ms to **7.3ms** — a **5.8× speedup**. Full decode improved 9.0s → 7.2s → 5.8s/tok across the session (progression tied to `EXP_CACHE_SZ` 32→128 plus OpenMP tuning) — still losing to CPU's 2.8s/tok at batch 1. A `NPU_TIMING` breakdown explained why: an all-hit pack costs 2.0ms, but each cache **miss** costs ~25-30ms, and the 35B's routing churns through 100+ distinct experts per layer, giving an LRU miss rate of 50-80% at batch 1. The insight that mattered: **a fully warm path would be ~25ms/token across all 40 layers — 40 tok/s** — the number that gets realized on 2026-08-09/10 (see UPDATE 32).
+
+### An ONNX INT8 QDQ converter/loader pipeline, built from a protobuf bug up
+
+1. `src/onnx_loader.cpp` had been **parsing the wrong protobuf field numbers entirely**, finding zero tensors in any real ONNX file (`GraphProto.initializer` is field 12, not 5; `TensorProto.name` is field 12, not 8; `raw_data` is field 14, not 9 — all verified empirically against real wire format). Rewritten, with `DequantizeLinear` node parsing added and a new **WMMA_I8** path: INT8 QDQ → dequant → Hadamard-rotate in block-128 → per-row requant.
+2. `bitnet_decode --config` reads an HF `config.json` sidecar and auto-loads `.onnx` paths; a new `std_arch` dispatch fixed a crash where any non-Qwen3/non-BitNet architecture (e.g. Phi) hit null sub-norm pointers.
+3. Full serving verified with zero extra code: `bitnet_decode --server` (OpenAI-compatible + SSE) served qwen3-0.6b INT8 correctly, **57 tok/s, 877ms for 50 tokens**, streaming confirmed working.
+4. In retrospect, this pipeline required finding and fixing **six independently fatal bugs**: the protobuf field numbers; a converter reading Q8_0 as unsigned int8 instead of signed (misreading any value >127, ~1.86× std error); the big one — the loader uploaded F32 norm weights but the rmsnorm kernel read them as FP16, so every value's low 16 bits were denormal-tiny and even-indexed outputs underflowed to zero; a Qwen3 `head_dim=128 ≠ hidden_size/num_heads` mismatch requiring the o-proj quantize step to use `nh*hd` width, not the naive hidden size; a `hipMemsetAsync` racing `decode_stream` without an explicit stream argument; and the `std_arch` dispatch crash from item 2.
+
+### Llama-3.2-1B verification and a logit-flatness investigation
+
+Llama-3.2-1B INT8 verified correct (Berlin, blue) with **PPL 49 vs. 828 for gibberish — 17× discrimination**, confirming tied embeddings are correct for this model (not a conversion bug). A separate concern — that logits looked suspiciously flat — was **not proven to be quantization-caused**: the numpy fp16 reference used to test it had six of its own bugs (wrong RoPE convention, wrong prompt token ids, a missing QDQ dequant step, a single shared KV list instead of one per layer, a layer-0-only comparison instead of full-stack, and mismatched single-token vs. full-prompt inputs). The GPU-side verification held up throughout (position-0/layer-0 query within 0.7% of fp32, 4/4 correct answers, PPL 49 vs. 828). Separately, arch-aware chat templates were added, and a key finding closed the loop on repetition loops: the **base (non-instruct)** Llama-3.2-1B shows the identical "which is" repetition loop as the instruct model — proving loops are a known trait of the 1B model itself, not a quantization or template bug.
+
+### INT8 weight error budget
+
+Measured against the GGUF Q8_0 source on llama-3.2-1b/qwen3-0.6b: plain per-row INT8 gives 0.98%/0.91% mean relative error; the Hadamard-rotation WMMA path improves that to **0.854%/0.847%**; adding QuIP-style sign flips on top made **no further difference at W8A8** (the existing rotation already captures the benefit — sign-flips only matter at W4A4). Conclusion: ~0.85% weight-side error rules out weight quantization as the cause of the small models' repetition/flatness behavior.
+
+### The Qwen2.5 converter debugging ladder: 1.5B → 3B → 7B
+
+Four rungs, each hiding a different silent corruption bug:
+
+1. **Qwen2.5-1.5B**: both the official and an independent community GGUF turned out **corrupted** — input norms ~2000× off, linear weights 106% wrong vs. the HF safetensors source. Fixed by bypassing GGUF entirely with a new `tools/safetensors_to_onnx_int8.py` reading bf16 safetensors directly, plus adding attention-bias support (Qwen2.5 has q/k/v biases that llama.cpp GGUFs drop, and with the model's characteristically tiny norm weights, the bias term dominates attention scores if missing). Result: correct answers, **PPL 17.5**, 28/28 tests including a new GQA test. A *separate*, still-unresolved collapse remains on the INT8 GPU serving path specifically (PPL 1.19M, V-cache zeroed at pos≥1) — extensively debugged (hook-presence changes behavior, `HIP_LAUNCH_BLOCKING` doesn't help) but never isolated; parked.
+2. **Qwen2.5-3B**: converted cleanly but degenerated at runtime (PPL 52k, a "Located 当前位置" loop) — parked mid-day, then **solved same day**: the converter was silently falling back to a stale 1.5B config (`num_hidden_layers=28`) instead of the real 3B's **36**, dropping the last 8 layers with no error. Fixed by deriving layer count from the tensor-name index, never from config. Result: **PPL 31**, coherent ("Paris", "Eiffel Tower").
+3. **Qwen2.5-7B**: **PPL 13.6 — the best in the zoo.** Two bugs: an untied `lm_head` was never being emitted for models with `tie_word_embeddings=false`, so the 7B ran with a *tied* head (using the embedding table as the output head) and produced garbage — caught via a parameter-count check (7.07B in the ONNX vs. 7.62B expected, a 545M gap matching exactly the missing `lm_head`); and a `config.json` path-resolution bug for directory sources (`os.path.dirname(dir)` resolved to the *parent* directory, missing the local config and silently falling back to the same stale 1.5B config that bit the 3B rung above). Verified: rich, coherent text with correct chat-template turn-ending.
+
+### Zaya GGUF/.1bp conversion: the 74B download, an 8B NaN, and a MoE converter fix
+
+1. A **74B Q4_K_M GGUF (45.76GB, 1923 tensors)** was downloaded, unblocking two parked issues.
+2. **Zaya1-8B NaN root-caused**: `cca_conv_grp.weight` was reading garbage, exploding the conv output into `inf*0` NaN through RoPE. The GGUF itself was confirmed clean — the bug was in the WIP `gguf_to_onebp` converter's 3D-tensor handling, ultimately traced to a **GGUF dtype-30 mixup**: `GgufReader` treated dtype 30 as a legacy "F32_V3" 4-byte float, but current llama.cpp defines dtype 30 as `GGML_TYPE_BF16`. Zaya's `cca_conv_grp.weight` is genuinely BF16 — reading it as f32 consumed twice the intended byte span, desyncing every subsequent tensor read.
+3. **The #1522 converter had two separate root causes**, found by running the real 45.76GB file through it: a shape heuristic voted row-major for Zaya's `[rows,cols,experts]` layout, inferring 4096 "experts" and producing 242GB of fp32 garbage — fixed by trusting the `<arch>.expert_count` metadata instead of guessing; and `token_embd.weight` (1.07B elements) tripped a `1<<30` element cap and was silently skipped while its bytes stayed reserved in the index, desyncing every later offset in the file — the cap was raised to `1<<31` and made a fatal error instead of a silent skip. Verified via round-trip dequant against the source GGUF: Pearson r=0.994-0.999, zero NaNs. Output: `ZAYA1-74B.1bp`, **43.6 GiB** (PR #1546).
+4. **An architecture fact worth recording**: ZAYA1's layers **alternate** — even layers are CCA-attention-only, odd layers are MoE-only, and **no dense FFN exists anywhere** in the model. A missing sublayer's weights should produce a null pointer and a skip, never a silent zero-fill. Relatedly, no working reference implementation of Zaya's router "EDA" temporal-state semantics exists anywhere (even the llama.cpp Zaya fork refuses to load the 8B GGUFs and degenerates on the 74B) — the engine loads the 8B `.1bp` end-to-end, but its output isn't conditioned on the prompt, and this remains unresolved for lack of anything to verify against. The 74B additionally needs ~145GB of fp16 GPU expert buffers against a 62GB Strix pool — current fp16-only expert kernels can't run it at all yet.
+
+### The rest of 2026-08-08
+
+- **A third NPU driver wedge this session** (`DRM_IOCTL_AMDXDNA_CREATE_HWCTX err=-22`, after 20+ xclbin load/unload cycles) persisted without self-clearing, forcing a reboot — bridging directly into UPDATE 32's wedge saga.
+- **The self-hosted CI runner was removed.** `strix-halo-runner` uninstalled locally (2.4GB freed); NPU-only workflows deleted (`bench.yml`, `npu-reset.yml`, `npu-pool-probe.yml`, `end-to-end-smoke.yml`); hardware jobs removed from the remaining shared workflows. Rationale: NPU/GPU jobs need `/dev/kfd`/`/dev/accel`, which GitHub-hosted runners don't have — CI is now fully GitHub-hosted.
+- **The TUH EEG data-access workstream began** (background context for UPDATE 33's later eeg-medical archival decision): access approved via NEDC, a full rsync sync pipeline built (sftp proved rate-limited/reset after ~136GiB, so rsync-only, chunked ≤100GiB, cron-scheduled), targeting a ≈5TB/414k-file corpus at ~29MB/s (~17-day ETA).
+- A HIP backend bug where `sample_token` returned -1 (forward/lm_head emulation for the split ZAYA HIP boundary) was fixed.
+- **Background/context, not engine work**: AMD's acquisition of Taalas (announced Aug 6 — a hardwired-model-silicon compiler claiming ~16-17k tok/s/user for a single hardwired model) prompted a staged-plan validation of a "1-bit FPGA LLM box" concept — judged a plausible ~50-150 tok/s niche for a 1B 1-bit model on an Alveo U250, with zero ASIC mask-cost, though far short of Taalas's on-die-ROM throughput; a Strix Halo upgrade-path discussion (128GB unified RAM as the biggest lever for fitting 70B Q4 fully in memory, NVMe weight-streaming, small FPGA "Taalas toy" boards); and a Vitis/Unified SDI 2026.1 toolchain install.
+
+---
+
+## 2026-08-09 — amdxdna Wedge Saga, 35B MoE Goes Live, Vivado-Free FPGA Toolchain
+
+**The NPU driver's wedge-and-hang problem is root-caused to a firmware fatal error with no recovery path, and fixed with a new hardware-reset primitive wired into the scheduler timeout — signed and running as amdxdna 0.16.0. The 35B MoE model goes end-to-end for the first time, warming up to 44-70 tok/s. A Vivado-free open-source FPGA bitstream toolchain is built and verified round-trip bit-exact.**
+
+### The amdxdna driver wedge / kernel panic saga
+
+The longest single investigative thread of the whole window:
+
+1. **Firmware static RE dead-ends confirmed.** `npu.dev.sbin` is byte-identical (SHA256 match) to the stock `npu.sbin` — no relaxed-validation dev build exists. The suspicious 64KB blob (entropy ~7.0) isn't zlib, lzma, XOR, or any known cipher, and no ARM/Thumb/x86 code decodes from it. An earlier finding was corrected in the process: the supposed "code section"/"v5 gate targets" are actually a log-descriptor table, not gate-check code. A vulnerability map (`VULN_MAP.md`) confirmed all known driver CVEs are already fixed in 7.1.5 — the only live attack surface is the mailbox protocol (~23 opcodes).
+2. **13:04 — first kernel panic from `rmmod amdxdna`.** `BUG: unable to handle page fault … RIP amdxdna_pci_driver_exit` on kernel 7.1.5-070105. Root cause: a client-lifetime use-after-free race during device removal (`amdxdna_remove()` frees client structs while open FDs can still call `amdxdna_drm_close()`). An upstream fix exists (applied to `drm-misc-fixes` 2026-06-29) but was confirmed **absent** from the running module via objdump. New standing rule: never `rmmod amdxdna` — reboot to reload instead.
+3. **16:58 — kernel upgraded to 7.2.0-rc5, all-layers sweep 5/5 PASS, no wedge** across ~500+ hwctx cycles (vs. a previous ~20-cycle wedge trigger). Declared "fixed permanently" at 17:00, self-corrected at 17:01 (overclaim — one clean session doesn't prove "permanent" or "everything," and a separate, unrelated Qwen2.5-3B degeneration was still broken). The correction proved warranted: **the wedge recurred at 19:22** on the same kernel.
+4. **Root cause found: a firmware fatal error with no driver recovery path.** The wedge isn't a driver hang — it's the AIE firmware hitting a fatal error, DPU program counter stuck at `0xffffffff` (executing garbage). Once dead, every mailbox call fails, and the driver's existing recovery paths only retry *through* the dead mailbox. A real recovery mechanism (`aie2_xdna_reset`, an SMU power cycle) already existed in the driver but was only ever invoked at init time. **Fix**: a new `aie2_hw_reset()` — full suspend-all-contexts → hw_stop → hw_start → resume-all-contexts power cycle — wired into `aie2_sched_job_timedout`, built for 7.2.0-rc5.
+5. **19:43 — patched driver installed**, initially unsigned; the Secure Boot signing recipe was documented (MOK key already enrolled, `sign-file` + `zstd` + `depmod` + `modprobe`). Custom build registers as amdxdna **0.16.0** (newer than the stock 0.10.0).
+6. **The `rmmod` rule is obsolete for 0.16.0** (the UAF fix is binary-verified present) but **still applies** to any stock kernel (7.1.5, 7.2.0-rc5, mainline 7.2-rc6 unpatched).
+7. **A separate "reboot hangs" mystery resolved to the same root cause**: 7 kernel panics since Aug 6, all `rmmod`-triggered — because reboots had been preceded by a manual `rmmod amdxdna` to swap in instrumented driver builds. New rule: never `rmmod` as part of a reboot; the kernel tears down hardware fine without the module's exit path.
+8. **Final validation**: post-cold-reboot, the patched signed 0.16.0 driver ran `test_all_layers.py` **5/5 PASS in 631.98s with zero wedge/fatal messages** — the self-heal path never even had to trigger on this workload.
+
+*(Three sessions later, in UPDATE 33, this same 0.16.0 driver turns out to have introduced a separate correctness regression specific to the 35B MoE model — a different bug on the same subsystem, not a contradiction of the fix above.)*
+
+### 35B MoE: full pipeline + batched prefill/decode performance
+
+1. **02:39 — NPU worker path unblocked.** Fixed a `.1bp` manifest-lookup segfault (a misread header field produced a garbage 12.9GB "JSON length"); rewrote `tools/tq2_to_q4nx.cpp` (Q4NX-quantized 1BP → `.q4nx`, closing #1467), round-trip exact (diff 0.0). Batch scaling reached **12.6k rows/s at batch 64**.
+2. **03:08 — NPU MoE decode 2.8× faster: 4.9s/tok → 1.73s/tok.** Three changes in `npu_engine_universal.cpp`: a fused transposed-dequant writing directly into `[K,N]` layout (eliminating a separate f32 intermediate + transpose pass, cutting per-miss cost 28ms → 14.6ms); `EXP_CACHE_SZ` 128 → 256 (4.42 → 3.35s/tok); and hot-expert pre-warming (`NPU_ROUTE_STATS`/`NPU_WARM_EXPERTS`/`NPU_WARM_TOP` — 1089 experts pre-packed in 12.6s). Result: zero decode-phase cache misses, `moe_ffn` averaging 26.6ms/layer.
+3. **Correction: decode is launch-bound, not attention-bound.** Stage timers showed FFN dominating (31.5ms of ~47ms/layer) via 4 serial NPU launches, each paying ~5-9ms dispatch latency regardless of the tiny actual compute (~3μs for 16.7M MACs). Two attempted fixes were tried and reverted: async launch-overlap (kernels share AIE columns and just serialize, adding jitter) and a CPU shared-expert fallback (slower, plus box contention). The real lever — batching decode launches across tokens, or fusing per-layer xclbins (realized as v28 fusion in UPDATE 33) — was identified but parked here.
+4. **Batched MoE prefill: rejected, then fixed with per-token ascale.** First attempt (`NPU_MOE_BATCH=1`) was 13-24% faster wall-clock but numerically divergent beyond M=1 — one shared `dynamic_ascale` over all M×H tokens collapsed per-token dynamic ranges, and the error compounded over 40 layers until it flipped argmax choices. An old code comment rejecting batching ("2.25× more MACs, sequential is faster") turned out to be right about the *outcome* but wrong about the *reason* — batching genuinely is faster. Fix: a new `go_rows` primitive in the i8 GEMM (`quantize_async_rows`/`dequant_only_rows`) computing per-token scales from each token's full expert set. Result: bit-identical through layer 19 at M=9, only FP accumulation-order noise beyond that (~1.2% relative — same order as existing int8 quant noise), while retaining **13-17% speedup at M=9, 24% at M=32**.
+5. **The full pipeline fixed — 4 stacked Q4NX bugs**, root-causing the earlier "qwen3:4b tag + L=0 + degenerate" symptom: the layer scan looked for `"model.layers."` (plural) but the 35B's header uses `"model.layer."` (singular); the architecture was derived from the file's basename (always wrong for FLM's `<ModelName>/model.q4nx` layout) — fixed to read the parent directory name instead; no tag mapping existed for arch "qwen3.6" — added in *both* `src/backend_npu_flm.cpp` and `tests/backends/backend_npu.cpp` (the mismatch between the two cost several rebuild cycles before it was caught); and a 64KB header-size cap rejected the 35B outright (its real header is 85,552 bytes) — raised to 256KB.
+6. **Coherence-probe positional bug fixed**: `coherence_probe()` fed every prompt token at `pos=0`, so the NPU-FLM backend — which fires its query the moment `pos` resets to 0, i.e. on what it reads as "prompt complete" — queried FLM with only a 2-token prompt, false-rejecting qwen3:4b's legitimate `<think>` start token. One-line fix: feed prefill at real positions. Regression-verified across llama3.2:1b, qwen3:4b (previously rejected), and qwen3.6-moe:35b-a3b.
+7. **22:29 — culminating result: 35B MoE at 44-70 tok/s through the full pipeline.** Zaya (:8088) → NPU FLM → qwen3.6-moe:35b-a3b: **69.9 tok/s warmed** (64 tok/0.9s), **44.1 tok/s** on a second request (48 tok/1.1s), cold-spawn **9.5 tok/s** (6 tok/631ms) — consistent with the A3B active-parameter count matching dense qwen3:4b's 67.5 tok/s.
+8. **Later the same day — a new, wider problem surfaced.** After ~1h of model churn, zaya-spawned `flm` worker processes started dying (`defunct`) and returning single-byte garbage (`0xAE`), tripping probe failures and a systemd restart loop. Filed as #1568 (alongside #1569 GGUF misroute, #1570 Qwen2.5-3B parked, #1571 Supabase exposed on `0.0.0.0`, #1572 SSH brute-force + password auth). `zaya-npu.service` was temporarily reverted to serve only Llama-3.2-1B. *(Root-caused the next day — see UPDATE 33's driver-regression section — as the 0.16.0 driver, not this session's application-level fixes.)*
+
+### Vivado-free FPGA bitstream toolchain
+
+A self-contained track: nextpnr-xilinx + prjxray + openFPGALoader built from scratch on the Strix box (18:28–19:00), producing a `blinky.bit` (2.19MB) with IDCODE `0x0362d093` verified against real hardware. Rebuilt persistently at `/home/bcloud/fpga-toolchain/` after a cold reboot wiped `/tmp` (the recipe needed a split cmake version — 3.28.4 for prjxray, 3.31.6 for nextpnr — plus several GCC13+/GCC15 `<cstdint>` fixes). Correctness was proven, not just well-formedness: all 4974 fasm2frames-emitted frames (497,374 words) came back byte-identical to the bitstream via `bitread` — **546,208 words compared, zero differences.**
+
+### Scope decisions: JARVIS stays, ZUNA moves out
+
+JARVIS stays in the `1bit-MONSTER` repo (it's an application of the engine, not a separate product — unlike ZUNA, extracted to its own `~/zuna` repo, itself flagged as an open scope-boundary question that gets resolved by archiving eeg-medical entirely in UPDATE 33).
+
+---
+
+## 2026-08-10 — NPU Firmware RE via Raw IOCTLs, Driver Regression Fixed, JARVIS Ships
+
+**Raw ioctls now drive the NPU directly and produce bit-exact GEMM output — the first compute outside FLM's own stack. A driver regression that made the 35B MoE model spit garbage was root-caused to amdxdna 0.16.0 and fixed by reverting to the in-tree 0.7.0 build. JARVIS shipped NPU-FLM speech-to-text, SSE streaming, and a loopback-trusted web UI (PR #1576), plus a deadlock fix that had been hanging every chat request. eeg-medical was archived — its foundation-model retraining was redundant with ZUNA1.1, which already trains on the same TUH-EEG corpus.**
+
+### Raw-ioctl NPU firmware RE: verified GEMM outside FLM (00:38–02:45)
+
+A full day's arc from static dead-end to working silicon access, independent of FLM's binary:
+
+1. **Firmware image fully mapped, proven not encrypted.** A block-entropy scan of the entire 429,680-byte firmware image found no 4KB window exceeding entropy 7.8 — the whole thing is a **signed pure-data container**, not a compressed or encrypted payload (~460KB is zero-fill). Static analysis exhausted; pivoted to live instrumentation.
+2. **Live mailbox protocol captured with zero risk.** `echo "module amdxdna +p" > .../dynamic_debug/control` turned on 36 stock trace sites — no rebuild, no interruption of live inference — and decoded the full startup sequence and message header format.
+3. **The `EXEC_DPU` silent-failure trap.** The command header's COUNT field (not BO size) determines payload length; `COUNT=0` triggers a silent `-EINVAL` with no dmesg line at all — only visible via ftrace.
+4. **Real DPU instructions executed via raw ioctls**, correctly reporting an expected error for unmapped weights — proving the full loop (cmd BO → `CHAIN_EXEC_NPU`/0x18 → real firmware execution → status) works end to end.
+5. **v28 MoE launch fusion** (`NPU_MOE_FUSED=1`): new `MOE_GUSGU`/`MOE_DSD` xclbins merge 4 FFN launches/layer into 2 via N/K concat of routed+shared experts. Correctness fix caught in testing: the DSD weight BO must be **block-diagonal**, not a naive concat, or the gate blend stops being separable. `test_moe_fused_math.cpp` passes at 1.64% max deviation (<5% tolerance).
+6. **A "verified GEMM" claim, self-corrected within the hour.** The first PASS was a verify-code bug — `bf16((uint16_t)exp)` reinterpreted truncated integers as bf16 bits, so an all-zero output "matched" by coincidence while the real device status was `ERROR(5)`. Real root cause: `CONFIG_CU` needs `cu_bo` to contain an actual **Program Device Image (PDI)**, not a raw instruction blob; also, xclbin kernels output **int32**, not int16.
+7. **PDI extraction perfected via bpftrace/uprobes.** kprobes on the driver's response handler decoded the exact rejection code (`APP_LOAD_PDI_FAIL`, `0x3000003`); uprobes on XRT shim's `get_pdi` revealed the true PDI offset inside the xclbin's `AIE_PARTITION` section — first guess `0xd8` was still wrong.
+8. **MILESTONE (02:39): verified GEMM via raw ioctls, full pipeline.** Corrected PDI offset to `0xD0`. Real bit-exact GEMMs: 128×3072×1024 (0/131072 wrong, ~10ms) and 128×12288×2560 (0/327680 wrong, 20.5ms, 393 GOP/s). Full 8-step recipe documented: PDI = xclbin `AIE_PARTITION[0xD0:]`; A/B/C buffers must be SHMEM, not BO_DEV; instructions are BO_DEV; specific kernel-arg blob layout; `cfg=0x804`; 16-tile hwctx.
+9. **All four qwen3-0.6b NPU ops verified bit-exact via raw ioctls**: QKV 128×1024×4096, O 128×2048×1024, GU 128×1024×6144, D 128×3072×1024 — zero mismatches on any of them.
+10. **The exec path wedged again** after ~40 IOMMU faults from loading new PDIs (the running production server, whose contexts predate the wedge, was unaffected) — recovery is reboot-only, same NPU driver story as always.
+
+Bonus same-session fix: **zaya NPU tokenizer** — real BPE `model.htok` generation (new `tools/hf_tokenizer_to_htok.py`) plus a weak-symbol linker bug where `tests/zaya_server.cpp`'s local `SimpleTokenizer` was silently shadowed by the shared implementation, producing garbage decode. Throughput: **3.3 → 42 tok/s**.
+
+### amdxdna driver regression: 0.16.0 broke the 35B, reverting to 0.7.0 fixed it
+
+Separate from the wedge-recovery saga in UPDATE 32, this is a correctness regression on a *specific newer driver version*:
+
+1. **04:57 — #1568 reproduced live**: a fresh 35B session goes straight to garbage soup — not the usual deterministic `/` fallback — proving the corruption is **cumulative NPU/firmware state**, not per-process. An existing `llama3.2:1b` context is unaffected; only *new*-context creation wedges at the firmware level. Degradation model formalized: coherent → token soup → empty output → deterministic `/` (end state), recovery = reboot only.
+2. **A separate, unrelated bug fixed along the way**: `mlir_aie`'s `NPU_CONTEXT_CACHE_SIZE["npu2"]` was hardcoded to 32, overcommitting this Strix Halo's real firmware hwctx pool of **exactly 16** (measured with a purpose-built `ctxpool` harness — the first guess of "≈6-7" was wrong; only direct measurement gave the right number). This caused `AIE2_STATUS_MGMT_ERT_NOAVAIL` under parallel pytest (`-n auto`). Fixed via `XRT_CONTEXT_CACHE_SIZE=1`: **5/5 PASS in 79s vs 225s serial (2.8×)**. Patched first in site-packages, then made reinstall-proof via `iron-repo/conftest.py`. Upstream PR filed: `mlir-aie#3526`.
+3. **13:00 — kernel moved to HWE 7.0.0-29-generic.** Initial (wrong) theory: NPU only supports ~3 concurrent contexts, blamed for 35B startup failures.
+4. **13:13 — correction**: 4 small NPU contexts work concurrently just fine. The real finding — **the 35B produces garbage even standalone with a free context**, a genuine regression against the last known-good 2026-07-31 benchmark, which ran on amdxdna 0.7.
+5. **13:53 — FIXED.** Reverting to the kernel's in-tree amdxdna **0.7.0** driver (`/usr/lib/modules/7.0.0-29-generic/.../amdxdna.ko.zst`) — the exact version from the last known-good bench — correctly runs the 35B end-to-end (zaya → flm → NPU, "4" for "2+2"). A second bug fixed in the same pass: `zaya-qwen36.service` had a `Requires=zaya-gpu8b.service` chain that pulled up the entire small-model fleet on start, starving the 35B of NPU columns and crash-looping it — fixed by dropping the `Requires`/`After`/wait-port. **Confirmed: the 35B and the 3-small-model fleet are mutually exclusive** (a column/resource budget constraint, not a context-count cap).
+6. **14:47 — two landmines left by the driver swap, both fixed post-reboot**: a stale `modules.dep` still pointing at the moved-aside DKMS `.ko` (fixed with `depmod -a`), and a stale `/etc/modprobe.d/amdxdna.conf` still setting `force_iova=1` (a 0.16/7.1.5-only parameter that the 0.7.0 in-tree driver rejects with a misleading "Unknown symbol" error). Also fixed: `zaya-gpu8b.service` stuck in a permanent start-pre kill loop. All chains verified post-fix: 14.1/21.5/13.9 tok/s across llama3.2/qwen06/gpu8b.
+7. **Capstone assessment**: the NPU firmware is genuinely locked (RSA-2048 signed, no dev build, unsigned builds refuse to load — no third-party firmware is possible), but the platform is **not crippled** — the DRM driver is open GPL, the mailbox protocol is now fully decoded, raw-ioctl exec is proven bit-exact, and the 16-context hwctx pool is a real RTOS/SRAM constant, not an artificial throttle.
+
+### JARVIS: deadlock fix, NPU-FLM STT, SSE, session KV reuse (PR #1576, `7d4b7549`)
+
+Three commits landed on `main` together:
+
+- **`34a55cb7`** — `build_context` double-lock deadlock fix (non-recursive mutex swap). This bug **hung every `/v1/chat/completions` request**.
+- **`1c5dfb9d`** (= `8ed882a9`) — `flm_tag_for_model` widened the 1.7B tag bucket to `H<=2048`.
+- **`f0d745f2`** (= `550d0299`) — speech-to-text via FLM's whisper HTTP endpoint (`:8496`, override `JARVIS_STT_URL`), **replacing the whisper.cpp+ffmpeg fork/exec path**; a loopback-trusted web UI auth bypass; `stream:true` requests answered as a single SSE chunk; and a long-prompt model-selection fix (was targeting a nonexistent `qwen3.5:9b`, now correctly `qwen3:4b`). `ctest -L host`: 10/11 pass.
+
+Two more fixes landed the same day:
+
+- **`zaya-npu.service` crash-loop fixed**: the lazily-spawned `flm serve` child was dying with "could not raise memlock limit to 1465 MB" then `mmap() EAGAIN` — systemd's default `LimitMEMLOCK=8MB` masked the bug in manual shell testing (interactive shells get unlimited). Fix: `LimitMEMLOCK=infinity` in `scripts/zaya-npu.service`. Result: coherent responses at ~3.3 tok/s, `x-backend: NPU FLM`.
+- **FLM multi-turn KV reuse**, two build steps ~10 minutes apart: first, `src/npu_flm_delta.h` — pure prefix-delta decision logic (send only the delta if the new prompt extends the previous one, with self-healing fallback to a full reset) — because the text-REPL path was sending `<<RESET>>` before *every* query, forcing a full re-prefill each turn despite FLM's own REPL keeping KV resident. Second, a request-level session layer on top: `session_id` in the request body, `Backend::continue_text(delta)` virtual, `g_flm_session_id`/`g_flm_session_last` tracked under a dedicated mutex.
+- **New documented constraint**: STT and the 35B contend for the same NPU context and cannot coexist — `flm-whisper` holding a context makes the 35B fail its coherence probe and fall through every backend. Confirmed fixed once `flm-whisper` is stopped (`zaya-qwen36` then passes 6/6 coherent probes at 3.2–3.8s). Design-state fleet: `npu :8088`, `qwen06 :8089`, `gpu8b :8090`, `whisper :8496` active, `qwen36` stopped on contention.
+- The most recent commit in this whole window, `e8bd91ed fix(npu): retry FLM spawn/probe on NPU contention; stop leaking flm-real children`, directly addresses this contention.
+
+### JARVIS mobile: a Flutter app for the voice pipeline (spans 2026-08-08 → 2026-08-10)
+
+Design doc (`docs/superpowers/specs/2026-08-08-jarvis-mobile-design.md`, approved 08-08) establishes the architecture: **the phone is a thin terminal** — mic, speaker, VPN client only. The full pipeline (VAD → Whisper → router → LLM → codec TTS → cloned voice) runs entirely on the Strix Halo box; no on-device inference, no audio persistence. Transport is WebSocket + Opus (not WebRTC — ~200ms latency judged acceptable). iOS is a confirmed target (cloud Mac mini via rentamac.io, Xcode 26.6, Flutter 3.44.9, existing Apple Developer account).
+
+Three milestones landed:
+
+- **M1 — server-side gap-fill**: `/v1/voice/session` full-duplex WebSocket path with an auth hook, a `VoiceSession` VAD state machine, an RFC-compliant WS handshake/parser (fixed for standards-conformant clients), and `WS_STREAM_BIND` (default loopback; `0.0.0.0` lets the phone reach the port over LAN/VPN, paired with `JARVIS_WS_TOKEN`). Docs: `docs/mobile/RUNBOOK.md`, `scripts/jarvis-gateway.service`.
+- **M2 — the Flutter app itself**: Android+iOS scaffold, protocol layer, session controller; a gateway WS client and audio IO services with tests; connect/voice screens with state lights and transcript UI; a live-gateway integration test with a stub server for simulator E2E.
+- **M3 — resilience and packaging**: connection-loss UX (stop mic, offline state, Reconnect button), reconnect mic-failure handling, a double-tap reconnect guard, and a final review pass fixing manifest permissions, a save-race, pulse lifecycle, and player disposal.
+
+CI enablement: `4b67b4ab` allowed `mobile/` through the scope-guard workflow (previously blocked, since JARVIS mobile is Jarvis's offline layer within engine scope, not a separate product).
+
+### Ops/infra: the reboot "watchdog" nuance, netconsole, firewall, fail2ban
+
+The CHANGELOG's "reboot.sh watchdog EBUSY fix" entry is correct about the code change (`273a50c5` — `scripts/reboot.sh` no longer aborts under `set -e` when `exec 9<>"$WD"` returns EBUSY because systemd already holds `/dev/watchdog` via `RuntimeWatchdogSec=60`) but doesn't explain what was actually causing the box to hang:
+
+- Across the last several boots, the reset-reason register shows the watchdog fired **only once** — the deliberate `reboot.sh --force` test. Every other "hang" was a **slow-but-clean software reset** (~1–1.5 min unexplained stall in the post-journal shutdown phase). Suspects, unconfirmed: amdgpu display (`REG_WAIT timeout optc35_disable_crtc` logged at every boot) or the USB4/Thunderbolt controllers.
+- A **separate, genuinely broken bug** was found and fixed: the watchdog safety net had been non-functional since it was created — the kernel package's own modprobe blacklist was silently deny-listing `sp5100_tco` at boot, so `/dev/watchdog` only existed after someone manually ran `modprobe sp5100_tco`. Fixed by shadowing the blacklist entry in `/etc/modprobe.d/`.
+- A **netconsole capture rig** was installed (UDP listener on a second box, `netconsole-capture.service`; sender configfs target on strix; `loglevel=8` added past the `quiet` filter) to catch the stall's last kernel messages the next time it happens.
+- **ufw/Docker firewall bypass fixed**: ufw doesn't filter Docker-published ports — they traverse the `FORWARD`/`DOCKER` chains, bypassing `INPUT` deny. Verified empirically (Supabase Postgres `:54322` reachable from LAN despite ufw). Fixed with a `DOCKER-USER` iptables rule made persistent via a oneshot systemd unit (Docker recreates its chain fresh on daemon start). Resolves #1571. Also found and closed: 2 accepted SSH password logins from a LAN IP ~30s after a brute-force burst — password auth disabled, fail2ban (sshd jail) and `ufw limit 22/tcp` added, closing #1572.
+
+### eeg-medical archived — redundant with ZUNA1.1
+
+`tools/zuna_port.cpp` (the ZUNA1.1 C++ port, hyperparameters verified against the paper: dim=1024, 16 layers, 8 heads, 382.1M weights) already existed in this engine before this session started — an earlier session had missed that and begun redundant work. Investigating further: **ZUNA1.1 is confirmed trained on the TUH EEG corpus** (per its paper, arXiv 2607.27308, and its predecessor ZUNA1, arXiv 2602.18478) — meaning the project's own TUH→B2 sync (5TB, running since UPDATE 31) would produce duplicate data toward a duplicate objective. Decision executed, fully reversible: `github.com/1bit-MONSTER/eeg-medical` archived — its shipped work (retraining EEG foundation models on data ZUNA1.1 already trained on) was redundant, and its README's core claim ("ZUNA1.1 trained on research data, not clinical") is factually wrong — TUH is clinical data. `tools/zuna_port.cpp` stays in 1bit-MONSTER as the canonical copy; the TUH→B2 sync was killed ~2 days into a ~17-day run. The `eeg-medical.1bit.systems` DNS record was deleted, though the underlying Cloudflare Pages project itself couldn't be (the API token lacked `Pages:Edit` scope) — that token should be rotated.
+
+### Housekeeping: issue triage, repo audit, PR #1573 consolidation
+
+- **29 open issues triaged**: 9 resolved with commit citations, 2 stale, 13 roadmap, 2 actionable security items (#1571, #1572 — both closed same day, above), 3 left unresolved (#1570 Qwen2.5-3B collapse, #1568 35B MoE — root-caused later the same day, above, #1536 amdxdna panic).
+- **Repo audit** found: ~1.6MB of stale/byte-duplicate xclbin backups, ~130MB of tracked build artifacts under `engine/npu/xclbins`, `third_party/lemonade` vendored as 784 plain tracked files (784 files, 13.6MB) unlike the other proper-submodule `third_party/` dirs, and `third_party/FastFlowLM/UPSTREAM.md` sitting untracked *inside* the submodule (would vanish on re-clone). No secrets found.
+- **PR #1573** (`feat/rebuild-all`, ~62 commits — the entire 35B MoE + Q4NX + JARVIS workstream from UPDATE 31/32) merged after two CI fixes (`4b67b4ab` scope-guard, `b46fc033` build the new host tests in the required C++ check). Follow-ons acted on the audit findings directly: `7c4a525b` moved `UPSTREAM.md` out of the submodule, `cab9a678` dropped 24 stale xclbin files. A draft release `v2026.08.10` was created (no git tag — draft releases don't create tag refs). Outcome: 11 issues closed, 18 remain open.
+- **`gh-ops.yml`** (`d11e969b`): new weekly+manual workflow reporting code scanning, dependabot, secret scanning, failed runs, and billing via the `gh` CLI, opening a single security-triage issue when alerts exist. Companion fixes for paginated alert fetches, `GH_TOKEN`, and `GH_REPO` env wiring.
+
+---
+
+## 2026-08-12 — The Burn & the Mojo Shift — One Through-Line, One Unified Language
+
+**We burned the repo down to its through-line and picked the language that will carry it forward. Everything that wasn't the engine or the app that proves it is gone — SaaS, agent stack, voice cloning, the JARVIS v1 side-servers. And the glue language that used to be three (Python for tooling, C++ for the engine, JS for the web) is now one: Mojo 1.0, released this week, is the unified language we're building the control plane in.**
+
+### The burn: what got cut, and why it's not coming back
+
+The roadmap was rewritten around a single sentence — *engine (NPU + GPU + CPU, one binary) → JARVIS (voice assistant, reference app)* — and then the repo was made to match it. One commit, ~19k lines deleted (`cbce9630`):
+
+- **SaaS**: `tools/jarvis/auth.cpp`, `billing.cpp`, `usage.cpp`, `beacon.cpp` — the product layer for a product that doesn't exist yet. Gone. So is the Cloudflare auth worker (`workers/`) and the Zaya Co-Host dashboard (`site/dashboard/`) that talked to those APIs.
+- **Voice cloning**: the whole `zaya_audio/` training stack (codec training, voice packs, RVQ-VAE adapters, ONNX export) — a personal quest, not a product. `src/codec_decoder.cpp` went with it.
+- **Agent stack**: RAG, planner, personas, prompts, skills, the daily-routine/awareness scripts — AMD Gaia's turf, not ours. The engine serves it via Lemonade; it doesn't ship one.
+- **JARVIS v1's HTTP hop + WebSocket side-server**: `jarvis_server.cpp`, `audio_stream.cpp`, and upstream's new `voice_session.cpp`/`ws_proto.cpp` — replaced by the in-process pipeline: `mic → VAD → STT (libwhisper, now HIP-accelerated via `src/whisper_hip.hip`) → LLM (in-process BackendManager) → TTS → speaker`. One process, one pipeline, no WebSocket.
+- **Kept on purpose**: `agent_watchdog.cpp` (engine thermal/strategy, live in unified_server) and the whisper HIP port that the JARVIS blocker (P1) needed.
+
+CI, packaging, and scope-guard were updated in the same pass — `test_auth`/`test_billing` and the WS tests dropped, `jarvis_server` symlinks gone, the ALLOWED path list now reflects the real repo. The Python server for the AMD-gui Adrenalin replica was also burned, but that's the next section.
+
+### The Mojo shift: why we stopped writing glue in three languages
+
+This week Mojo hit 1.0. We'd been watching it since the 0.x betas — a language that is to Python what C++23 is to C, with first-class GPU/NPU kernels and the ability to call C libraries directly — and the 1.0 release is the moment we committed: **from here on, new non-kernel code is written in Mojo, not Python.**
+
+- **The AMD-gui Adrenalin replica backend** (a stdlib-Python sysfs/HTTP server for the Radeon Software control surface on Linux) is being rewritten in Mojo 1.0 as a single self-contained binary — same wire contract, zero Python at runtime. Hand-rolled libc HTTP over `external_call` (the stdlib's own mechanism), hand-rolled JSON (the payloads are fixed-shape), zero community packages (the ecosystem's pins are pre-1.0; `mojo==1.0.0` is the only pin we need). It replaces a Python interpreter dependency with one ELF, the same move we made for the NPU stack with C++.
+- **The pattern is the point**: every layer of this project now follows the same rule — one binary, no interpreter at runtime, sysfs/PCI/proc access from the metal. C++23 stays for the compute kernels where it's earned its place; Mojo becomes the unified language for everything around them: servers, converters, tooling, control planes.
+- **Why it's safe this time**: Mojo 1.0's stdlib was verified against the `v1.0.0` tag before we pinned it (no `std.net` yet — hence the libc sockets; no regex — hence the fixed-pattern parsers; `Process` API has no SIGTERM — hence the lazy-reap design). The version pin is the discipline: `mojo==1.0.0`, no `max==25.2`-style beta pins anywhere.
+
+### Status
+
+- **Repo**: one through-line (engine → JARVIS), one binary (`build/1bit`), one language direction (C++23 for kernels, Mojo 1.0 for everything else). Rebased onto 333 commits of upstream (`3f507b07`) with the burn on top — builds clean.
+- **JARVIS P1** (whisper on the engine): `whisper_hip.hip` wired into the forward pass; scalar fallback retained; `WHISPER_GPU=0` escape hatch.
+- **Next**: land the Mojo rewrite of the Adrenalin control plane (M0–M2: toolchain, JSON+sysfs, HTTP+GETs), then WS-09 (the single router) and the WS-11 NVMe expert streaming work from the roadmap.
+
+---
+
+## 2026-08-15 — FLM Is Fully Gone — Byte-Identical Streams, True Batch, 2× on the 35B
+
+**The last FLM artifact is dead. The open instruction generator now emits byte-identical streams to FLM's proprietary dumps (verified with `cmp` on all 4 ops), the open aiecc toolchain builds the xclbins (microkernel compiled with peano clang — no xchesscc), and true batch decode replaces the invalid fake-batch that had inflated our "-B 8" numbers. Validated head-to-head: we match FLM exactly at M=128 and beat it 11-15% with M=32 kernels on the 0.6B, and 2× on the 35B-A3B.**
+
+### The FLM-free zone, completed in one day
+
+1. **Instruction streams: byte-identical.** Reverse-engineered the complete FLM stream spec from the dumps (M=128 kernel = 4×32-row slices; N in 1024-tiles, K in 64-chunks; per-block bd rotation; the 12R-TCT sync pattern; all offsets/strides/values as formulas). The reworked `gemm_generate_sequence_i8` emits identical bytes — the old open generator was 230× slower (per-tile RTP config).
+2. **Xclbins: open-built.** The v27 MLIR-AIE flow + a peano-clang-compiled microkernel (`-Di8_i32_ONLY`, the repo's `.o` was gitignored/missing) produce xclbin+insts pairs; M=32 decode-optimized kernels beat FLM.
+3. **True batch decode.** The "-B 8 = 7.4 tok/s" claim was a fake batch (issue #111 — top-K candidates as sequential tokens, non-causal). Rewrote it: BS=8 independent sequences, per-sequence KV caches, causal attention, per-seq LM head, NPU am=B. Tokens verified identical to BS=1.
+4. **35B 2×.** The CPU MoE FFN dequantized experts fresh per token (~33M floats/layer/token). A per-layer dequant LRU cache (16 slots) cut the FFN 107.5→61.6 ms/layer; with BS=8 grouped expert execution: 2900→1450 ms/tok, tokens identical.
+
+### Validated numbers (Qwen3-0.6B, universal engine)
+
+| Config | ms/tok |
+|---|---|
+| FLM M=128 (BS=1) | 255-262 |
+| Open M=32 (BS=1) | 230-233 (~11% better) |
+| Open M=32 (BS=8) | 235-237 |
+| 35B-A3B BS=8 + cache | 1450 (vs 2900 = 2×) |
+
+Also shipped: 1BP v4 dedup (shared Zamba blocks stored once, alias index entries), IQ1_S/IQ1_M block-size fixes (206/230 → 50/56 — every IQ1 file offset was wrong), spec-decode draft-vocab overflow fix (was segfaulting), fused-engine port to the validated execution model (fixing a shared-weight-BO bug), symlink model cache.
 
 ## 2026-08-15 — 100% HF Coverage: every arch-bearing checkpoint maps to an engine token
 
@@ -2725,7 +2725,7 @@ systemd + linger), and `dsh-status` reports the whole fleet at a glance.
 The fixes are on `feat/rocm-therock-7.14-lane-pin`; the full record
 (including the blog post) is linked from the README.
 
-## 2026-08-19/20 — the mesh: installs wake up, find each other, JARVIS gets a fleet brain
+## 2026-08-19 — the mesh: installs wake up, find each other, JARVIS gets a fleet brain
 
 **What happened**: the two-PC fleet got a nervous system. We built
 **1bit-MONSTER Mesh (mesh/1.0)** — every install announces itself on the LAN


### PR DESCRIPTION
### **User description**
Fixes the incoherent timeline you flagged (recent entries at BOTH the top and bottom, old work sandwiched in the middle).

- **Chronological order** (oldest -> newest): GENESIS (04-16) -> June sessions -> July -> Aug, ending at the 08-29 HRX week. Single narrative, one direction.
- **Date-standardized headings**: every section is now '## YYYY-MM-DD — <title>' (dropped the mixed 'UPDATE N (date):' / 'Session YYYY-MM-DD —' prefixes; fixed the 2025-06-28 date typos to 2026).
- **Merged the duplicate** Aug-07 section (the one-heap pool was told twice — as UPDATE 30 and as the 2026-08-07 narrative). All other same-day sections (e.g. 08-15, 08-19) are kept as separate entries.
- **Rebuilt the Table of Contents** to the new order.

Verified: every section body is preserved byte-for-byte (only headings renamed + order sorted + one merge + TOC regenerated); 46 -> 45 heading count (one merge). Section bodies confirmed contiguous in the new file. Note: the whole-file diff looks large because blocks physically moved — content is unchanged.


___

### **PR Type**
Documentation


___

### **Description**
- Sorted timeline chronological, oldest to newest.

- Standardized headings to `YYYY-MM-DD — title` format.

- Merged duplicate `2026-08-07` sections into one entry.

- Rebuilt Table of Contents for reordered sections.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mixed timeline order"] --> B["Chronological sorting (Apr-Aug)"]
  B --> C["Standardized YYYY-MM-DD headings"]
  C --> D["Merge duplicate Aug-07 entries"]
  D --> E["Rebuilt Table of Contents"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>journey.md</strong><dd><code>Reorder and standardize journey timeline entries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/journey.md

<ul><li>Reordered timeline sections from oldest to newest across months.<br> <li> Renamed all section headings to <code>YYYY-MM-DD — title</code>.<br> <li> Merged the duplicate Aug-07 section into a single entry.<br> <li> Regenerated the Table of Contents; section content preserved.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2060/files#diff-fe3305852160f6191b970d4c904badf83f3dcd478c4c7f581e27208288bf202e">+1748/-1748</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

