### PR TITLE
fix(ci): onebin undefined create_ggml_vulkan_backend when llama.cpp not pre-built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1521,6 +1521,11 @@ if(TARGET ggml_vulkan)
         "${GGML_BUILD_DIR}/common/libllama-common.a"
         "${GGML_BUILD_DIR}/common/libllama-common-base.a"
         -lvulkan -ldl -lpthread -lm)
+    # backend_ggml_vulkan.h declares the real factory only under this define;
+    # without it the header self-stubs to nullptr so onebin still links when
+    # llama.cpp's static libs weren't pre-built (its headers may still be
+    # present via recursive submodules — header presence != backend linked).
+    target_compile_definitions(onebin PRIVATE GGML_VULKAN_LINKED=1)
 endif()
 if(EMBED_LEMONADE)
     target_link_libraries(onebin PRIVATE lemonade-server-core)
@@ -1830,6 +1835,9 @@ endif()
 # -- bench_ggml_vk: GGML-Vulkan backend benchmark (llama.cpp MIT License) ---
 if(TARGET ggml_vulkan)
     add_executable(bench_ggml_vk tools/bench_ggml_vk.cpp src/backend_ggml_vulkan.cpp)
+    # Same contract as onebin: bench_ggml_vk.cpp calls create_ggml_vulkan_backend()
+    # directly, so the real factory declaration must be visible in this target.
+    target_compile_definitions(bench_ggml_vk PRIVATE GGML_VULKAN_LINKED=1)
     target_include_directories(bench_ggml_vk PRIVATE
         include
         src

--- a/src/backend_ggml_vulkan.h
+++ b/src/backend_ggml_vulkan.h
@@ -1,17 +1,23 @@
 #pragma once
 // backend_ggml_vulkan.h — llama.cpp Vulkan backend wrapper.
 // Uses ggml-vulkan (MIT License) via llama.cpp API for high-performance inference.
-// The factory self-stubs when llama.h is unreachable (CI builds without the
-// submodule), so unified_server links unconditionally.
+//
+// The factory self-stubs to nullptr unless the including target was built with
+// GGML_VULKAN_LINKED (defined by CMakeLists.txt only inside if(TARGET
+// ggml_vulkan), i.e. when third_party/llama.cpp was pre-built with
+// GGML_VULKAN=ON). An absent backend must be a runtime "unavailable" (the
+// dlsym/fallback design in backend_manager.cpp), never a link error.
+//
+// Do NOT key the stub off __has_include("llama.h"): recursive-submodule CI
+// clones llama.cpp's headers without ever building its static libs, so header
+// presence says nothing about whether the backend was compiled in — that
+// mismatch produced `undefined symbol: create_ggml_vulkan_backend` when
+// linking onebin.
 
 #include "backend.h"
 
-#ifdef __has_include
-#  if __has_include("llama.h")
+#ifdef GGML_VULKAN_LINKED
 extern "C" Backend* create_ggml_vulkan_backend();
-#  else
-static inline Backend* create_ggml_vulkan_backend() { return nullptr; }
-#  endif
 #else
-extern "C" Backend* create_ggml_vulkan_backend();
+static inline Backend* create_ggml_vulkan_backend() { return nullptr; }
 #endif


### PR DESCRIPTION
### **User description**
## What / why

Every Release run on main since `3d9f5984` (Sep 2) fails in **Build all C++ targets** at the final link:

```
FAILED: [code=1] 1bit
ld.lld: error: undefined symbol: create_ggml_vulkan_backend
```

Root cause chain:

1. The only definition lives in `src/backend_ggml_vulkan.cpp`, which CMake compiles **only when** `TARGET ggml_vulkan` exists — i.e. only when `third_party/llama.cpp` was pre-built with `GGML_VULKAN=ON` (`CMakeLists.txt:1200-1201`, gate at `:584-585`). CI never pre-builds llama.cpp (CMake even prints the warning telling you to).
2. `tools/unified_server.cpp:1707` calls `create_ggml_vulkan_backend()` directly (optional speculative-decode draft model) and is folded into the onebin/`1bit` ELF unconditionally.
3. `src/backend_ggml_vulkan.h` was supposed to stub that call to `nullptr` — but its condition was `__has_include("llama.h")`. The new Release workflow checks out submodules **recursively**, so `llama.h` *is* reachable while the static libs were never built. Headers present ≠ backend linked → extern declared, nothing defines it → link error.

## Fix

Drive the stub decision off CMake instead of header presence:

- `CMakeLists.txt` defines `GGML_VULKAN_LINKED=1` only inside `if(TARGET ggml_vulkan)` for the targets that compile files including the header (`onebin`, `bench_ggml_vk`).
- `backend_ggml_vulkan.h` declares the real factory only under that define; otherwise it self-stubs to `nullptr`, so the backend degrades to runtime-unavailable per the documented dlsym/fallback design (an absent backend must never be a link error).

## Verified

- llama.cpp pre-built (dev box): `ninja -C build onebin` and `bench_ggml_vk` link clean; real symbol exported.
- CI configuration (llama.h reachable, define absent): compiling `unified_server.cpp` produces **no** reference to `create_ggml_vulkan_backend`.

Fixes the red streak on the Release workflow (run 33734689852 and all predecessors back to Sep 2).


___

### **PR Type**
Bug fix


___

### **Description**
- Headers present via recursive submodules, static libs absent

- Replace `__has_include("llama.h")` gating with `GGML_VULKAN_LINKED`

- Define `GGML_VULKAN_LINKED` only when `ggml_vulkan` target exists

- Enable it for `onebin` and `bench_ggml_vk`

- Unlinked builds self-stub factory to `nullptr` instead of failing link


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CMake: if(TARGET ggml_vulkan)"] -- "GGML_VULKAN_LINKED defined" --> B["onebin + bench_ggml_vk compile"]
  B -- "real factory declared" --> C["create_ggml_vulkan_backend linked"]
  A -- "no pre-built llama.cpp" --> D["macro not defined"]
  D -- "header self-stubs nullptr" --> E["runtime unavailable, no link error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_ggml_vulkan.h</strong><dd><code>Gate Vulkan factory declaration behind GGML_VULKAN_LINKED</code></dd></summary>
<hr>

src/backend_ggml_vulkan.h

<ul><li>Replaced <code>__has_include("llama.h")</code> guard with <code>GGML_VULKAN_LINKED</code><br> <li> Real factory is declared only when the define is present<br> <li> Header now self-stubs to <code>nullptr</code> when the backend was not compiled in<br> <li> Comments clarify why header presence cannot indicate backend <br>availability</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2062/files#diff-1e4cd78412f7b955fffa04a7fe5c957bb56413b8e8316bd67d3551a718a30936">+14/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Define GGML_VULKAN_LINKED only when ggml_vulkan target exists</code></dd></summary>
<hr>

CMakeLists.txt

<ul><li>Added <code>GGML_VULKAN_LINKED=1</code> compile definition for <code>onebin</code><br> <li> Added the same compile definition for <code>bench_ggml_vk</code><br> <li> Both definitions live inside the existing <code>if(TARGET ggml_vulkan)</code> block<br> <li> Comments document the recursive-submodule header/lib mismatch root <br>cause</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2062/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

