### PR TITLE
fix(lemonade): APU GTT pool counted in model size filter (#3377)

### DIFF
--- a/third_party/lemonade/src/cpp/server/model_manager.cpp
+++ b/third_party/lemonade/src/cpp/server/model_manager.cpp
@@ -3603,14 +3603,21 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
         // Because we have mixed types this just makes every device_type an array.
         nlohmann::json dev_list = devices.is_array() ? devices : nlohmann::json{devices};
 
-        // Expand this later to accommodate mixed pools
-        MemoryAllocBehavior dev_mem_alloc_behavior = MemoryAllocBehavior::Hardware;
-        if (dev_type == "amd_igpu")
-            dev_mem_alloc_behavior = MemoryAllocBehavior::Largest;
-        if (enable_dgpu_gtt)
-            dev_mem_alloc_behavior = MemoryAllocBehavior::Unified;
-
         for (const auto& dev : dev_list) {
+            // Expand this later to accommodate mixed pools.  Behavior must be
+            // chosen per device, not per device-type: system_info never emits
+            // an "amd_igpu" container key -- AMD APUs are reported under
+            // "amd_gpu" with an "integrated": true flag and the large
+            // host-visible GTT pool in virtual_mem_gb, while the VRAM
+            // carve-out can be only ~1-4 GB.  Keying Largest on the old
+            // dev_type == "amd_igpu" check made that branch dead, so every
+            // device fell back to Hardware (vram_gb only) and streaming
+            // models that fit in GTT were falsely rejected on APUs.
+            MemoryAllocBehavior dev_mem_alloc_behavior = MemoryAllocBehavior::Hardware;
+            if (dev.value("integrated", false))
+                dev_mem_alloc_behavior = MemoryAllocBehavior::Largest;
+            if (enable_dgpu_gtt)
+                dev_mem_alloc_behavior = MemoryAllocBehavior::Unified;
             curr_mem_pool_gb = get_max_memory_of_device(dev, dev_mem_alloc_behavior);
             largest_mem_pool_gb = largest_mem_pool_gb < curr_mem_pool_gb ? curr_mem_pool_gb : largest_mem_pool_gb;
         }


### PR DESCRIPTION
### **User description**
Ports the lemonade #3377 GTT-pool fix onto the vendored **11.9.0** tree in `main`.

## What was wrong
`ModelManager::filter_models_by_backend` sized streaming models against the VRAM carve-out only on AMD APUs. `system_info` reports integrated GPUs under `"amd_gpu"` with `"integrated": true` and the large host-visible GTT pool in `virtual_mem_gb` — but behavior keyed on `dev_type == "amd_igpu"`, a container key that is never emitted. The branch was dead, every device fell through to `Hardware`, and on Strix Halo (`gfx1151`) models needing >~1 GB resident GPU memory were falsely rejected:

```
Model 'DeepSeek-V4-Flash-IQ2XXS-DS4' ... largest memory pool is only 1.0 GB
```

## The fix (14+/7−, one file)
Move alloc-behavior selection inside the device loop, keyed on the device's own `integrated` flag:

- `integrated` → `Largest` = max(vram_gb, virtual_mem_gb)
- `enable_dgpu_gtt` still forces `Unified` (unchanged)

## Verified (gfx1151, from the original report + issue thread)
- Largest pool logged: **1.0 → 120.0 GB** (default config)
- `DeepSeek-V4-Flash-IQ2XXS-DS4` (`min_resident_gb: 16.0`) loads with no `enable_dgpu_gtt` workaround; 32 GB resident in GTT

## Provenance
- Upstream issue: lemonade-sdk/lemonade#3377 (filed 2026-08-26, 3 independent repros)
- Upstream fix (same change, different base): lemonade-sdk/lemonade#3502 — still under review there; this lands it in our vendored LOCAL-ONLY tree now
- Previously cherry-picked onto the 11.8.1-era branches (`chore/lemonade-v11.7.0`, `fix/npu-1934-model-tag`, `rebuild/iso-appliance`); this PR is the 11.9.0 `main` application


___

### **PR Type**
Bug fix


___

### **Description**
- Fix dead APU memory-alloc check in model filter.

- Move behavior selection inside per-device loop.

- Key `Largest` on per-device `integrated` flag.

- Keep `enable_dgpu_gtt` forcing `Unified` behavior.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["filter_models_by_backend"] --> B["Device loop"]
  B --> C{"device integrated flag"}
  C -- "true" --> D["Largest: max(vram_gb, virtual_mem_gb)"]
  C -- "false/absent" --> E["Hardware: vram_gb only"]
  B --> F{"enable_dgpu_gtt"}
  F -- "true" --> G["Unified"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model_manager.cpp</strong><dd><code>Per-device integrated flag fixes APU GTT sizing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

third_party/lemonade/src/cpp/server/model_manager.cpp

<ul><li>Replaces dead <code>dev_type == "amd_igpu"</code> check with per-device <code>integrated</code> <br>flag detection.<br> <li> Moves memory-alloc behavior selection inside the device iteration <br>loop.<br> <li> Integrated AMD APUs now use <code>Largest</code> pool (max VRAM and GTT <br><code>virtual_mem_gb</code>).<br> <li> <code>enable_dgpu_gtt</code> still overrides to <code>Unified</code> for every device.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2085/files#diff-5e42fac1c2b5ca78ecfcaa4f65c788e8deb5eb6d27bf9f409193ffb801dd634b">+14/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

