### PR TITLE
ci(autopr): create PRs with GitHub App token — GITHUB_TOKEN PR creation org-denied

### DIFF
--- a/.github/workflows/census-autopr.yml
+++ b/.github/workflows/census-autopr.yml
@@ -38,9 +38,33 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Mint GitHub App installation token
+        id: app-token
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          { [ -n "$APP_ID" ] && [ -n "$APP_PRIVATE_KEY" ]; } || { echo "::error::APP_ID / APP_PRIVATE_KEY secrets not set — autopr cannot create PRs"; exit 1; }
+          B64() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+          NOW=$(date +%s)
+          HEADER=$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | B64)
+          PAYLOAD=$(printf '{"iat":%s,"exp":%s,"iss":%s}' "$((NOW-60))" "$((NOW+540))" "$APP_ID" | B64)
+          SIG=$(printf '%s.%s' "$HEADER" "$PAYLOAD" | openssl dgst -sha256 -sign <(printf '%s' "$APP_PRIVATE_KEY") -binary | B64)
+          JWT="$HEADER.$PAYLOAD.$SIG"
+          AUTH="Authorization: Bearer $JWT"
+          INSTALL_ID=$(curl -s -H "$AUTH" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations" | \
+            jq -r --arg o "$GITHUB_REPOSITORY_OWNER" '.[] | select(.account.login == $o) | .id' | head -1)
+          { [ -n "$INSTALL_ID" ]; } || { echo "::error::GitHub App not installed on $GITHUB_REPOSITORY_OWNER"; exit 1; }
+          TOKEN=$(curl -s -X POST -H "$AUTH" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations/$INSTALL_ID/access_tokens" | jq -r '.token // empty')
+          { [ -n "$TOKEN" ]; } || { echo "::error::Could not mint installation token — check app permissions (Contents + Pull requests R/W)"; exit 1; }
+          echo "TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+
       - name: Run the watcher with alias-autopr enabled
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.TOKEN }}
         run: |
           # CENSUS_SKIP_PR stays UNSET so census_autopr may file draft PRs.
           python3 Testing/hf_new_models.py --limit 120 2>&1 | tee /tmp/census-autopr.log
@@ -88,7 +112,7 @@ jobs:
       - name: Open draft PR for significant posts
         if: steps.sigpost.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.TOKEN }}
         run: |
           set -euo pipefail
           DATE="$(date -u +%Y%m%d)"

--- a/.github/workflows/post-seo.yml
+++ b/.github/workflows/post-seo.yml
@@ -61,10 +61,35 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Mint GitHub App installation token
+        if: steps.gen.outputs.changed == 'true'
+        id: app-token
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          { [ -n "$APP_ID" ] && [ -n "$APP_PRIVATE_KEY" ]; } || { echo "::error::APP_ID / APP_PRIVATE_KEY secrets not set — autopr cannot create PRs"; exit 1; }
+          B64() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+          NOW=$(date +%s)
+          HEADER=$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | B64)
+          PAYLOAD=$(printf '{"iat":%s,"exp":%s,"iss":%s}' "$((NOW-60))" "$((NOW+540))" "$APP_ID" | B64)
+          SIG=$(printf '%s.%s' "$HEADER" "$PAYLOAD" | openssl dgst -sha256 -sign <(printf '%s' "$APP_PRIVATE_KEY") -binary | B64)
+          JWT="$HEADER.$PAYLOAD.$SIG"
+          AUTH="Authorization: Bearer $JWT"
+          INSTALL_ID=$(curl -s -H "$AUTH" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations" | \
+            jq -r --arg o "$GITHUB_REPOSITORY_OWNER" '.[] | select(.account.login == $o) | .id' | head -1)
+          { [ -n "$INSTALL_ID" ]; } || { echo "::error::GitHub App not installed on $GITHUB_REPOSITORY_OWNER"; exit 1; }
+          TOKEN=$(curl -s -X POST -H "$AUTH" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations/$INSTALL_ID/access_tokens" | jq -r '.token // empty')
+          { [ -n "$TOKEN" ]; } || { echo "::error::Could not mint installation token — check app permissions (Contents + Pull requests R/W)"; exit 1; }
+          echo "TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+
       - name: Open PR when post tags changed
         if: steps.gen.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.TOKEN }}
         run: |
           set -euo pipefail
           DATE="$(date -u +%Y%m%d)"

--- a/.github/workflows/seo-sync.yml
+++ b/.github/workflows/seo-sync.yml
@@ -38,10 +38,35 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Mint GitHub App installation token
+        if: steps.sync.outputs.changed == 'true'
+        id: app-token
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          { [ -n "$APP_ID" ] && [ -n "$APP_PRIVATE_KEY" ]; } || { echo "::error::APP_ID / APP_PRIVATE_KEY secrets not set — autopr cannot create PRs"; exit 1; }
+          B64() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+          NOW=$(date +%s)
+          HEADER=$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | B64)
+          PAYLOAD=$(printf '{"iat":%s,"exp":%s,"iss":%s}' "$((NOW-60))" "$((NOW+540))" "$APP_ID" | B64)
+          SIG=$(printf '%s.%s' "$HEADER" "$PAYLOAD" | openssl dgst -sha256 -sign <(printf '%s' "$APP_PRIVATE_KEY") -binary | B64)
+          JWT="$HEADER.$PAYLOAD.$SIG"
+          AUTH="Authorization: Bearer $JWT"
+          INSTALL_ID=$(curl -s -H "$AUTH" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations" | \
+            jq -r --arg o "$GITHUB_REPOSITORY_OWNER" '.[] | select(.account.login == $o) | .id' | head -1)
+          { [ -n "$INSTALL_ID" ]; } || { echo "::error::GitHub App not installed on $GITHUB_REPOSITORY_OWNER"; exit 1; }
+          TOKEN=$(curl -s -X POST -H "$AUTH" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations/$INSTALL_ID/access_tokens" | jq -r '.token // empty')
+          { [ -n "$TOKEN" ]; } || { echo "::error::Could not mint installation token — check app permissions (Contents + Pull requests R/W)"; exit 1; }
+          echo "TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+
       - name: Open PR when drift found
         if: steps.sync.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.TOKEN }}
         run: |
           set -euo pipefail
           DATE="$(date -u +%Y%m%d)"

--- a/.github/workflows/significant-post.yml
+++ b/.github/workflows/significant-post.yml
@@ -57,10 +57,35 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Mint GitHub App installation token
+        if: steps.gen.outputs.changed == 'true'
+        id: app-token
+        env:
+          APP_ID: ${{ secrets.APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          { [ -n "$APP_ID" ] && [ -n "$APP_PRIVATE_KEY" ]; } || { echo "::error::APP_ID / APP_PRIVATE_KEY secrets not set — autopr cannot create PRs"; exit 1; }
+          B64() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+          NOW=$(date +%s)
+          HEADER=$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | B64)
+          PAYLOAD=$(printf '{"iat":%s,"exp":%s,"iss":%s}' "$((NOW-60))" "$((NOW+540))" "$APP_ID" | B64)
+          SIG=$(printf '%s.%s' "$HEADER" "$PAYLOAD" | openssl dgst -sha256 -sign <(printf '%s' "$APP_PRIVATE_KEY") -binary | B64)
+          JWT="$HEADER.$PAYLOAD.$SIG"
+          AUTH="Authorization: Bearer $JWT"
+          INSTALL_ID=$(curl -s -H "$AUTH" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations" | \
+            jq -r --arg o "$GITHUB_REPOSITORY_OWNER" '.[] | select(.account.login == $o) | .id' | head -1)
+          { [ -n "$INSTALL_ID" ]; } || { echo "::error::GitHub App not installed on $GITHUB_REPOSITORY_OWNER"; exit 1; }
+          TOKEN=$(curl -s -X POST -H "$AUTH" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/app/installations/$INSTALL_ID/access_tokens" | jq -r '.token // empty')
+          { [ -n "$TOKEN" ]; } || { echo "::error::Could not mint installation token — check app permissions (Contents + Pull requests R/W)"; exit 1; }
+          echo "TOKEN=$TOKEN" >> "$GITHUB_OUTPUT"
+
       - name: Open draft PR
         if: steps.gen.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.TOKEN }}
         run: |
           set -euo pipefail
           DATE="$(date -u +%Y%m%d)"


### PR DESCRIPTION
### **User description**
## Problem

All four autopr workflows (`census-autopr.yml`, `significant-post.yml`, `seo-sync.yml`, `post-seo.yml`) file PRs using the built-in `GITHUB_TOKEN`. The org denies Actions PR creation (`createPullRequest`) regardless of the `pull-requests: write` declared in each workflow — so **every autopr run since ~Sep 2 23:50 UTC fails at `gh pr create`**, after already pushing its branch:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

That's why `seo/post-*` / `post/significant-*` branches were accumulating unmerged on the branches page.

## Fix

Create PRs with a **short-lived GitHub App installation token** instead (app tokens are not subject to the GITHUB_TOKEN PR-creation restriction). Reuses the exact mint pattern already proven in `traffic-alert.yml` (`APP_ID` + `APP_PRIVATE_KEY` secrets → RS256 JWT → installation token):

- `post-seo.yml`, `significant-post.yml`, `seo-sync.yml`: mint step added (same `if` as the PR step, so it only runs when there's something to PR); the PR step's `GH_TOKEN` now points at the app token
- `census-autopr.yml`: mint step up front; both the alias-autopr watcher step (files draft PRs) and the significant-post PR step use the app token
- git pushes inside those steps are unchanged (built-in token, `contents: write`)

**App requirement:** the GitHub App behind `APP_ID` needs **Contents: Read and write** + **Pull requests: Read and write**, installed on the org. Mint fails loudly (step error) if secrets/install/perms are wrong.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix autopr PR creation denied by the org for Actions-created PRs.

- Use short-lived GitHub App installation tokens instead of `GITHUB_TOKEN` for `gh pr create`.

- Mint tokens from `APP_ID` + `APP_PRIVATE_KEY` via RS256 JWT and installations API.

- Apply to census-autopr, significant-post, seo-sync, and post-seo workflows; pushes stay unchanged.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Autopr workflows (census, significant, seo)"] --> B["gh pr create with GITHUB_TOKEN"]
  B --> C["Denied: org forbids Actions PR creation"]
  D["APP_ID + APP_PRIVATE_KEY"] --> E["Mint step: RS256 JWT to installation token"]
  E --> F["gh pr create with GH_TOKEN=app token"]
  F --> G["PRs created successfully"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>census-autopr.yml</strong><dd><code>Add app token minting for census autopr</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/census-autopr.yml

<ul><li>Adds an unconditional GitHub App installation-token mint step after <br>Python setup.<br> <li> Uses the minted token for the alias-autopr watcher step that files <br>draft PRs.<br> <li> Switches the significant-posts draft PR step to the same app token.<br> <li> Leaves <code>git push</code> on the built-in token unchanged.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2087/files#diff-0f84ff0173547f1ac1e7e8aad568b593cee71209bc3dd72fb384507984b9efe0">+26/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>post-seo.yml</strong><dd><code>Use app token for post-seo PR creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/post-seo.yml

<ul><li>Adds a conditional app-token mint step that runs only when post tags <br>changed.<br> <li> Builds RS256 JWT and fetches installation token using <br>APP_ID/APP_PRIVATE_KEY.<br> <li> Moves PR creation <code>GH_TOKEN</code> from <code>github.token</code> to the minted app token.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2087/files#diff-b766a1380327589536026944196fe3bbadcd1d8eb775f27f9785f9efc4e4a014">+26/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>seo-sync.yml</strong><dd><code>Use app token for SEO sync PRs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/seo-sync.yml

<ul><li>Adds a conditional app-token mint step gated on detected SEO drift.<br> <li> Switches the drift PR step to use the minted token instead of <br><code>GITHUB_TOKEN</code>.<br> <li> Preserves existing push behavior with the built-in token.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2087/files#diff-66c40869f524c6864276cb1e5de5acc7b0166fbc4a10bfdcd3b81ffcfc364275">+26/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>significant-post.yml</strong><dd><code>Use app token for significant posts PRs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/significant-post.yml

<ul><li>Adds a conditional app-token mint step before opening the <br>significant-posts draft PR.<br> <li> Updates the draft PR step to use the minted GitHub App installation <br>token.<br> <li> Fails loudly when secrets are missing or the app is not installed.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2087/files#diff-c50885d40221740808f022b9603ea1d1dd42f3bdf05cbc1b22a258f4482e47b3">+26/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

