### PR TITLE
npu-infer(tools): gen_mm_insts alignment guard + build-deps self-doc

### DIFF
--- a/npu-infer/tools/gen_mm_insts.cpp
+++ b/npu-infer/tools/gen_mm_insts.cpp
@@ -19,6 +19,18 @@ int main(int argc, char** argv) {
     uint32_t woff = (uint32_t)strtoul(argv[6], nullptr, 10);
     bool add_bias = (argc > 7) && (strtoul(argv[7], nullptr, 10) != 0);
 
+    // Issue #2103: reject unsupported M geometries up front. FastFlowLM's
+    // generate_seq rejects M < 256 ("GEMM M size not aligned with total npu
+    // rows") deep inside the library; without this guard the tool used to
+    // exit 0 with no .bin written, which looks like success.
+    if (M < 256 || (M % 256) != 0) {
+        fprintf(stderr,
+            "gen_mm_insts: unsupported GEMM M=%u - M must be >= 256 and a "
+            "multiple of 256 (256, 512, 1024, 2048, ...); no %s written\n",
+            M, argv[2]);
+        return 1;
+    }
+
     LM_Config config;
     std::ifstream f(argv[1]);
     if (!f.is_open()) { fprintf(stderr, "cannot open %s\n", argv[1]); return 1; }
@@ -29,11 +41,37 @@ int main(int argc, char** argv) {
     gemm.generate_seq(&seq, M, K, N, woff, add_bias, Gemm::NO_Activation, 0);
     seq.cmds2seq();
     seq.write_out_sequence(argv[2]);
+
+    // Issue #2103: never exit 0 without a usable .bin. generate_seq failures
+    // surface inside the prebuilt lib (error text only, no return code), so
+    // confirm the instruction stream actually landed on disk.
+    {
+        std::ifstream chk(argv[2], std::ios::binary | std::ios::ate);
+        if (!chk.is_open() || chk.tellg() <= 0) {
+            fprintf(stderr,
+                "gen_mm_insts: %s was not written (generate_seq failed?) - "
+                "exiting non-zero\n", argv[2]);
+            return 1;
+        }
+    }
     fprintf(stderr, "wrote %s for GEMM %ux%ux%u woff=%u bias=%d\n",
             argv[2], M, K, N, woff, (int)add_bias);
     return 0;
 }
 
+// Build prerequisites (issue #2107):
+//   * -include climits is required: npu_utils/npu_cmd.hpp uses UCHAR_MAX
+//     without including <climits> itself, so g++ rejects the include chain
+//     unless climits is force-included (-include).
+//   * -lq4_npu_eXpress is required in the link: libqwen3_npu.so leaves
+//     SafeTensors::~SafeTensors() and load_weights undefined, and only
+//     libq4_npu_eXpress.so resolves them.
+//   * The include tree must match the FastFlowLM build that produced the
+//     prebuilt libs. In this repo that is the third_party/FastFlowLM
+//     submodule (src/include + src/include/npu_utils); the dev boxes also
+//     carry a separate amd-oss fastflowlm checkout or a /opt/fastflowlm
+//     install that works the same way. Adjust -I/-L to the tree actually
+//     installed on the machine you build on.
 // Build:
 //   g++ -O2 -std=c++17 -include climits -mavx2 gen_mm_insts.cpp -o gen_mm_insts \
 //     -I/home/bcloud/amd-oss/fastflowlm/src/include \


### PR DESCRIPTION
### **User description**
**Closes #2103** — `gen_mm_insts` used to exit 0 with no `.bin` written when M was unsupported (FastFlowLM's `generate_seq` fails text-only, deep inside the prebuilt lib). Now:
- M is pre-validated (`>= 256` and a multiple of 256) with a clear stderr message and **exit 1**.
- After `write_out_sequence`, the tool verifies the output `.bin` is non-empty on disk before returning 0 — the "looks successful but produced nothing" trap is gone.

**Addresses #2107** — the header comment now self-documents the two non-obvious build prerequisites: `-include climits` (npu_cmd.hpp uses `UCHAR_MAX` without including `<climits>`) and `-lq4_npu_eXpress` (resolves `SafeTensors::~SafeTensors()`/`load_weights` undefined in libqwen3_npu.so), and notes that `-I/-L` must match the FastFlowLM tree that built the prebuilt libs (third_party/FastFlowLM submodule vs a dev-box amd-oss checkout).

Deliberately **not** auto-rounding M: silently changing GEMM geometry would be worse than failing loudly.

Verification note: `gen_mm_insts` is an offline code generator — nothing calls it at runtime (the engine loads pre-generated `<xclbin>.bin` files). Change is confined to the tool's `main()` and comments. Full build/run verification needs the NPU toolchain (FastFlowLM prebuilt libs) on the dev box.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Reject non-256-aligned M, exit 1 before generate_seq

- Verify output `.bin` non-empty after generation

- Document `-include climits` and `libq4_npu_eXpress` build deps

- Fail loudly instead of silently auto-rounding M


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gen_mm_insts invocation"]
  B{"M >= 256 and multiple of 256?"}
  C["stderr message + exit 1"]
  D["generate_seq + write_out_sequence"]
  E{"out.bin non-empty?"}
  F["exit 0 + success message"]
  A --> B
  B -- "no" --> C
  B -- "yes" --> D
  D --> E
  E -- "no" --> C
  E -- "yes" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gen_mm_insts.cpp</strong><dd><code>Add M alignment guard, output check, and build docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

npu-infer/tools/gen_mm_insts.cpp

<ul><li>Add early guard rejecting M below 256 or not a multiple of 256 with a <br>clear stderr message and exit 1<br> <li> Verify generated <code>.bin</code> is non-empty on disk before returning 0, <br>avoiding silent no-output success<br> <li> Add header comment documenting <code>-include climits</code> and <code>libq4_npu_eXpress</code> <br>link requirements and matching FastFlowLM include tree<br> <li> Improve error messaging so unsupported M says no <code>.bin</code> was written</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2118/files#diff-ed6f6eedadaa2204601089380526efe33f7227d96c7f882193c2f93feec854ac">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

