### PR TITLE
docs(research): FastFlowLM upstream-report package (#2083)

### DIFF
--- a/docs/research/fastflowlm-analysis/upstream-reports/01-batched-prefill-rope-divergence.md
+++ b/docs/research/fastflowlm-analysis/upstream-reports/01-batched-prefill-rope-divergence.md
@@ -1,0 +1,52 @@
+# Upstream report 01 — Batched prefill(ids) RoPE divergence vs N×forward(tok)
+
+**Target:** ROCm/FastFlowLM (upstream of `third_party/FastFlowLM` @ `17a35cb7`)
+**Source:** 1bit-MONSTER/1bit-MONSTER issues #2052 (closed), #2083; tracking doc `npu-infer/docs/txn-decode-findings.md` (rounds R39/R67)
+**Severity:** correctness — internal inconsistency of the runtime's own decode path
+
+## Summary
+
+`model.prefill(ids)` with a batched token list produces **different KV/rope
+state** than N × `model.forward(tok)` over the same prompt. This is an
+internal inconsistency of the runtime's own decode path, not a caller bug:
+both paths are expected to produce identical state for the same prompt.
+
+## Observed mechanism (captured via interposer)
+
+- Batched prefill **never advances the host-side RoPE (i6) table** — the
+  table is the identity table across all dumps.
+- `forward()` updates the RoPE table per position as expected.
+- The batched kernels then apply RoPE **internally** from an exact-math
+  `inv_freq` table that disagrees with the runtime's hardcoded `.rodata`
+  `inv_freq` at exactly the **j=25 / j=57** rope classes → bf16 flips →
+  argmax flips on near-ties.
+
+## Numbers (Qwen3-0.6B)
+
+- 4-token probe: keys corr **0.9999** — only rope elements 50/51 + 114/115
+  differ (growing head set); logits corr **0.9777** with an argmax flip.
+- 162-token prompt: corr(mm, seq) = **0.926976**, maxdiff **6.91**.
+- Deterministic and bit-reproducible within a boot; stable property of a
+  **healthy** runtime (R67).
+
+## Repro
+
+- Harness: `npu-infer/tools/capture/run_qwen3_npu`-style driver, tokens
+  `1000`+`1001`.
+- Compare (a) `model.prefill(ids)` for the prompt vs (b) N×
+  `model.forward(tok)`; dump per-position KV + logits via the rtcap
+  interposer (`/home/bcloud/.cache/rtcap/`).
+- Byte-parity comparison scripts used in R39.
+
+## Impact / note for us
+
+Per-ctx comparisons must use the `forward()` path (already the documented
+methodology in our tracking doc). The upstream question is which of the two
+RoPE applications is authoritative and why they disagree.
+
+## Environment
+
+- xclbins: Qwen3-0.6B FLM xclbin set (mm/attn/layer/dequant)
+- XRT runlist stack, amdxdna driver (kernel/driver IDs per capture log;
+  kernel `7.2.0-next-20260821-unstable` generation)
+- FastFlowLM runtime libs (libqwen3_npu.so family), XRT 2.26.0 runlist stack

--- a/docs/research/fastflowlm-analysis/upstream-reports/02-reboot-drift.md
+++ b/docs/research/fastflowlm-analysis/upstream-reports/02-reboot-drift.md
@@ -1,0 +1,45 @@
+# Upstream report 02 — Reboot-drift phenomenon (deterministic per boot)
+
+**Target:** ROCm/FastFlowLM (upstream of `third_party/FastFlowLM` @ `17a35cb7`)
+**Source:** 1bit-MONSTER/1bit-MONSTER issues #2065 (closed), #2083; tracking doc `npu-infer/docs/txn-decode-findings.md` (rounds R40/R41/R66)
+**Severity:** correctness / determinism — outputs move across a reboot with byte-identical inputs
+
+## Summary
+
+Byte-identical runtime outputs — identical binary, libs, xclbins, model, and
+inputs — **moved across one reboot**:
+
+- Reboot @ 2026-09-02 23:19 (kernel `7.2.0-next-20260821-unstable`):
+  logits corr **0.99803** vs the pre-reboot state, argmax **397 → 144370**.
+- The **next fresh boot (R41) reverted**: round-37 signature byte-identical
+  again.
+- Deterministic within each boot. Engine-side piecewise replay (byte-identical
+  TXNs) did **not** move.
+
+## What this rules out / suggests
+
+The engine and runtime submit byte-identical TXNs/ELFs on the same device;
+only the runtime's output moved. This points at a runtime-flow component
+sensitive to kernel/driver state:
+
+- SVA vs identity-IOMMU DMA,
+- load-time staging,
+- the documented round-27 x0.5 runner-quirk state,
+
+or a genuine arithmetic difference in kernel/firmware execution across the
+reboot.
+
+## Repro
+
+- Harness: `npu-infer/tools/capture/run_qwen3_npu`-style driver, tokens
+  `1000`+`1001`.
+- Procedure: capture on boot A → reboot → same binary/libs/xclbins/model/input
+  → capture on boot B → compare (corr / argmax / byte-parity).
+- Byte-parity comparison scripts used in R40/R41.
+
+## Environment
+
+- xclbins: Qwen3-0.6B FLM xclbin set
+- Kernel `7.2.0-next-20260821-unstable` (and the pre/post-reboot pair it was
+  observed on), XRT 2.26.0 runlist stack, amdxdna driver
+- rtcap captures: `/home/bcloud/.cache/rtcap/` on the dev box

--- a/docs/research/fastflowlm-analysis/upstream-reports/README.md
+++ b/docs/research/fastflowlm-analysis/upstream-reports/README.md
@@ -1,0 +1,29 @@
+# FastFlowLM Upstream Report Package
+
+Packaged upstream-report candidates for [ROCm/FastFlowLM](https://github.com/ROCm/FastFlowLM)
+(upstream of the vendored `third_party/FastFlowLM` submodule @ `17a35cb7`).
+
+Two runtime anomalies were closed on our side as intrinsic/one-off but are
+genuine upstream behavioral questions with minimal repros. Both are fully
+documented with captures in `npu-infer/docs/txn-decode-findings.md` and were
+tracked here as issues #2052 / #2065 (closed) and #2083 (packaging).
+
+| Report | Anomaly | Repo issue | Status |
+|--------|---------|------------|--------|
+| [`01-batched-prefill-rope-divergence.md`](01-batched-prefill-rope-divergence.md) | Batched `prefill(ids)` produces different KV/rope state than N×`forward(tok)` on the same prompt — an internal inconsistency of the runtime's own decode path | #2052 (closed), R39/R67 | Ready to file |
+| [`02-reboot-drift.md`](02-reboot-drift.md) | Byte-identical runtime outputs move across one reboot (deterministic per boot, reverts on next fresh boot) | #2065 (closed), R40/R41/R66 | Ready to file |
+
+## Packaging decision (issue #2083)
+
+File **two separate upstream issues** — the mechanisms are unrelated
+(runtime-internal prefill/rope inconsistency vs. cross-reboot kernel/driver
+state sensitivity). Each report is self-contained for an external maintainer.
+
+Filing checklist per report:
+
+- [ ] Repo + issue title from the report header
+- [ ] Environment list included (xclbins, XRT runlist stack, kernel/driver IDs)
+- [ ] Repro harness: `npu-infer/tools/capture/run_qwen3_npu`-style, tokens `1000`+`1001`
+- [ ] Capture artifacts from `/home/bcloud/.cache/rtcap/` on the dev box attached
+      or referenced (rtcap captures + byte-parity comparison scripts from R39/R41)
+- [ ] Reference the detailed tracking doc `npu-infer/docs/txn-decode-findings.md`


### PR DESCRIPTION
### **User description**
**Closes #2083** — packages the two upstream-report candidates for ROCm/FastFlowLM (upstream of the vendored `third_party/FastFlowLM` submodule @ 17a35cb7):

- `docs/research/fastflowlm-analysis/upstream-reports/README.md` — index + packaging decision (file as **two separate upstream issues**: mechanisms are unrelated)
- `01-batched-prefill-rope-divergence.md` — batched `prefill(ids)` vs N×`forward(tok)` KV/rope divergence (from closed #2052, R39/R67)
- `02-reboot-drift.md` — byte-identical outputs move across a reboot, deterministic per boot (from closed #2065, R40/R41/R66)

Each report is self-contained for an external maintainer: anomaly, observed mechanism, numbers, repro harness pointer (`npu-infer/tools/capture/run_qwen3_npu`, tokens 1000+1001), capture artifact location (`/home/bcloud/.cache/rtcap/` on the dev box), and environment list (XRT 2.26.0 runlist stack, kernel/driver IDs).

Docs-only change — no code. The README carries the filing checklist; actual upstream issue filing against ROCm/FastFlowLM is a separate, explicit step.


___

### **PR Type**
Documentation


___

### **Description**
- Adds upstream-report package for ROCm/FastFlowLM

- Documents batched-prefill rope divergence anomaly

- Documents reboot-drift deterministic-per-boot anomaly

- Recommends filing two separate upstream issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FastFlowLM upstream anomalies"] --> B["Docs package"]
  B --> C["Report 01: batched-prefill rope divergence"]
  B --> D["Report 02: reboot-drift phenomenon"]
  C --> E["File two separate upstream issues"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>01-batched-prefill-rope-divergence.md</strong><dd><code>Documents batched-prefill RoPE divergence upstream report</code></dd></summary>
<hr>

docs/research/fastflowlm-analysis/upstream-reports/01-batched-prefill-rope-divergence.md

<ul><li>Adds self-contained upstream report on batched prefill rope divergence<br> <li> Explains host-side i6 RoPE table never advances on prefill<br> <li> Details j=25/j=57 inv_freq mismatch causing bf16 argmax flips<br> <li> Includes repro harness, environment list, and impact notes</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2119/files#diff-d5349f2f7b82c4c0320fc1e65a825dc791da9a05fe7d9c9f5ec1647b805588dc">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>02-reboot-drift.md</strong><dd><code>Documents reboot-drift phenomenon upstream report</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/research/fastflowlm-analysis/upstream-reports/02-reboot-drift.md

<ul><li>Adds upstream report on reboot drift, deterministic within each boot<br> <li> Captures evidence: logits corr 0.99803, argmax 397 -> 144370, reverted <br>on next boot<br> <li> Suggests kernel/driver-state sensitivity as likely cause area<br> <li> Provides repro procedure, environment list, and capture refs</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2119/files#diff-582ec7d3527ceb8b5083be8b1c15dc65ae3f02d5dc8018bd24083842c162aa2b">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Adds upstream report package index and filing checklist</code>&nbsp; &nbsp; </dd></summary>
<hr>

docs/research/fastflowlm-analysis/upstream-reports/README.md

<ul><li>Adds index and packaging decision for the upstream-report candidates<br> <li> Recommends filing two separate upstream issues with rationale<br> <li> Maps reports to source issues and tracking rounds<br> <li> Includes per-report filing checklist (env, repro, artifacts)</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2119/files#diff-fb14aa9473fc8af9638c9a7900c4857e3087168046d2dfd03f785b14edbd1bc8">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

