### PR TITLE
feat(gpu): qwen35moe on HIP — port map + captured schema + structural loader (#1831)

### DIFF
--- a/docs/research/hip-qwen35-gdn-port.md
+++ b/docs/research/hip-qwen35-gdn-port.md
@@ -105,7 +105,9 @@ Expected output drives M2's exact name table + fused-QKV slice geometry.
 
 Captured from the header of the real target file (`unsloth/Qwen3.6-35B-A3B-GGUF`
 `Qwen3.6-35B-A3B-Q8_0.gguf`, arch token **`qwen35moe`**, GGUF v3, 733 tensors,
-40 layers × 19 tensors). This is the M2 loader table.
+40 layers). Two layer kinds — validated on real hardware (strixhalo gfx1151,
+2026-09-05): **full-attention** layers `(l+1)%4==0` (3,7,…,39; 10 of 40) carry
+16 tensors; **GDN** layers carry 19. MoE set is identical on both.
 
 KV (arch `qwen35moe.*`):
 
@@ -126,7 +128,7 @@ KV (arch `qwen35moe.*`):
 | full_attention_interval | 4 (every 4th layer full MHA) |
 | context_length | 262144 |
 
-Per-layer tensors (GGUF-native shape, shape[0] fastest; row-major = reversed):
+Per-layer tensors — GDN kind (19/layer; GGUF-native shape):
 
 | blk.N. name | gguf shape | row-major | dtype |
 |-------------|-----------|----------|-------|
@@ -146,6 +148,16 @@ Per-layer tensors (GGUF-native shape, shape[0] fastest; row-major = reversed):
 | ffn_gate_shexp / ffn_up_shexp | (2048, 512) | (512, 2048) | Q8_K |
 | ffn_down_shexp | (512, 2048) | (2048, 512) | Q8_K |
 | ffn_gate_inp_shexp.weight | (2048,) | — | F32 |
+
+Full-attention kind (16/layer — replaces attn_qkv/attn_gate/ssm_* with split MHA):
+
+| blk.N. name | gguf shape | row-major | dtype |
+|-------------|-----------|----------|-------|
+| attn_q.weight | (2048, 8192) | (8192, 2048) | Q8_K |  ← NH·HD·2 (q + gate halves), 16 heads × 256
+| attn_k.weight / attn_v.weight | (2048, 512) | (512, 2048) | Q8_K |  ← NKV·HD, 2 × 256
+| attn_q_norm.weight / attn_k_norm.weight | (256,) | — | F32 |
+| attn_output.weight | (4096, 2048) | (2048, 4096) | Q8_K |  ← NH·HD = 4096
+| (shared: attn_norm, post_attention_norm, ffn_* × 8 as above) |
 
 Globals: `token_embd.weight` + `output.weight` both (248320, 2048) Q8_K
 (probably tied — compare data offsets at load); `output_norm.weight` (2048) F32.

--- a/docs/research/hip-qwen35-gdn-port.md
+++ b/docs/research/hip-qwen35-gdn-port.md
@@ -101,6 +101,61 @@ capture is in hand.
 ```
 Expected output drives M2's exact name table + fused-QKV slice geometry.
 
+## Captured schema (authoritative — 2026-09-05)
+
+Captured from the header of the real target file (`unsloth/Qwen3.6-35B-A3B-GGUF`
+`Qwen3.6-35B-A3B-Q8_0.gguf`, arch token **`qwen35moe`**, GGUF v3, 733 tensors,
+40 layers × 19 tensors). This is the M2 loader table.
+
+KV (arch `qwen35moe.*`):
+
+| Key | Value |
+|-----|-------|
+| embedding_length | 2048 (H) |
+| block_count | 40 |
+| attention.head_count / head_count_kv | 16 / 2 |
+| attention.key_length / value_length | 256 / 256 |
+| attention.layer_norm_rms_epsilon | 1e-6 |
+| rope.dimension_count / dimension_sections | 64 / [11, 11, 10, 0] |
+| rope.freq_base | 1e7 |
+| ssm.conv_kernel / group_count | 4 / 16 |
+| ssm.inner_size / state_size | 4096 / 128 |
+| ssm.time_step_rank | 32 |
+| expert_count / expert_used_count | 256 / 8 |
+| expert_feed_forward_length / expert_shared_… | 512 / 512 |
+| full_attention_interval | 4 (every 4th layer full MHA) |
+| context_length | 262144 |
+
+Per-layer tensors (GGUF-native shape, shape[0] fastest; row-major = reversed):
+
+| blk.N. name | gguf shape | row-major | dtype |
+|-------------|-----------|----------|-------|
+| attn_norm.weight | (2048,) | (2048,) | F32 |
+| attn_qkv.weight | (2048, 8192) | (8192, 2048) | Q8_K |
+| attn_gate.weight | (2048, 4096) | (4096, 2048) | Q8_K |
+| post_attention_norm.weight | (2048,) | — | F32 |
+| ssm_a | (32,) | — | F32 |
+| ssm_alpha.weight / ssm_beta.weight | (2048, 32) | (32, 2048) | Q8_K |
+| ssm_conv1d.weight | (4, 8192) | (8192, 4) | F32 |
+| ssm_dt.bias | (32,) | — | F32 |
+| ssm_norm.weight | (128,) | — | F32 |
+| ssm_out.weight | (4096, 2048) | (2048, 4096) | Q8_K |
+| ffn_gate_inp.weight | (2048, 256) | (256, 2048) | F32 |
+| ffn_gate_exps / ffn_up_exps | (2048, 512, 256) | (256, 512, 2048) | Q8_K |
+| ffn_down_exps | (512, 2048, 256) | (256, 2048, 512) | Q8_K |
+| ffn_gate_shexp / ffn_up_shexp | (2048, 512) | (512, 2048) | Q8_K |
+| ffn_down_shexp | (512, 2048) | (2048, 512) | Q8_K |
+| ffn_gate_inp_shexp.weight | (2048,) | — | F32 |
+
+Globals: `token_embd.weight` + `output.weight` both (248320, 2048) Q8_K
+(probably tied — compare data offsets at load); `output_norm.weight` (2048) F32.
+Vocab 248320.
+
+Open questions for M3 (kernel math, NOT M2): attn_qkv 8192-row slice semantics
+(full-attn q/k/v vs GDN q/q-halves), attn_gate 4096-row role, conv1d over which
+8192 slice, ssm group/head mapping (32 vs group_count 16 × state 128), and the
+fused-expert tensor row indexing (256×512×2048).
+
 ## References
 
 - Issue #1831 (parent), #1830 (NPU-universal 35B decode bug), #1624/#1627

--- a/docs/research/hip-qwen35-gdn-port.md
+++ b/docs/research/hip-qwen35-gdn-port.md
@@ -1,0 +1,108 @@
+# feat(gpu): qwen3_5_moe (35B-A3B) on the HIP backend — port map (#1831)
+
+**Status:** scoped / M1 plan. Issue #1831. Branch `feat/hip-qwen35-gdn`.
+
+## Goal
+
+`backend_hip_1bp` currently hard-rejects every `qwen3_5_moe` model at init
+(missing `attn_v/ffn_gate/ffn_up/ffn_down` dense tensors, arch check #1624).
+Goal: run the 35B-A3B (GatedDeltaNet + gated GQA + gated MoE) on the HIP GPU
+path behind the `RCPP_ARCH_QWEN35` gate (= 21, `include/rocm_cpp/bitnet_model.h`;
+GGUF arch strings that map to it: `interns2preview`/`kimik2`/`quark`/
+`qwen3_5dllm`).
+
+## Ground truth collected (2026-09-05)
+
+- **Arch gate exists:** `cfg.arch == RCPP_ARCH_QWEN35`; `model_router` already
+  routes the family (CPU + NPU lanes exist); the HIP lane is the gap.
+- **CPU reference (math, exact):** `src/qwen3next_engine.cpp` — per-layer
+  `linear_attention | full_attention` dispatch, GatedDeltaNet delta rule
+  (conv1d → silu → q/k l2norm → `state *= exp(g)` with `g = -exp(A)·softplus(a+dt)`,
+  `beta = sigmoid(b)`, group RMSNorm (direct weight, norm-before-gate) × silu(z),
+  out_proj), full-attention `q_proj [2*hd]` q+gate split + q/k RMSNorm + partial
+  rope × sigmoid(gate), MoE (softmax router top-k + norm_topk, gated experts,
+  shared expert + shared_expert_gate sigmoid). Validated corr 0.9997 vs numpy.
+  **Caveat:** consumes HF safetensors naming (`model.layers.N.linear_attn.*`,
+  `mlp.experts.N.*`, `lm_head.weight`) + `config.json` `layer_types`.
+- **NPU reference (schema family):** `engine/npu/src/npu_engine_universal.cpp`
+  consumes 1BP-side names `model.layer.N.linear_attn.ssm_a` /
+  `.ssm_alpha_proj.weight` / `.ssm_beta_proj.weight` / `.ssm_conv1d.weight` /
+  `.ssm_dt.bias` / `.ssm_norm.weight` / `.ssm_out_proj.weight`, MoE
+  `model.layer.N.mlp.gate_exps_proj.weight` + `share_*_exps_proj` +
+  `shared_expert_gate.weight` (+ JSON sidecar manifest). GDN `ssm_a`/`dt_bias`
+  are `[32]` (linear value heads), `ssm_norm [128]` (value head dim).
+- **Issue #1831's GGUF tensor list (community GGUF):** fused
+  `attn_qkv.weight`; `ssm_a, ssm_alpha, ssm_beta, ssm_conv1d, ssm_dt.bias,
+  ssm_norm, ssm_out, attn_gate`; MoE `ffn_gate_exps / ffn_up_exps /
+  ffn_down_exps.weight`, `ffn_gate_inp`, shared `ffn_gate_shexp/up_shexp/
+  down_shexp`; `attn_output_gate: true`.
+
+## Schema hazard (why M1 is plan-first, not blind code)
+
+Three naming dialects exist for the SAME arch family and the hip backend's
+GGUF-direct mode must match the writer that produced the target file:
+llama.cpp-style GGUF (`blk.N.*`), HF safetensors (`model.layers.N.*`), 1BP/NPU
+(`model.layer.N.*`, no `.weight` on `ssm_a`). The community 35B GGUF's exact
+kv-key names (head counts, head_dim, linear heads, `layer_types` encoding,
+expert counts) are NOT confirmed in any checked-out source; the producing
+converter lives in the ROCmFP4/llama.cpp fork. Guessing keys would produce a
+loader that silently finds nothing — the failure mode #1627/#1624 exist to stop.
+M1 therefore = this plan + a schema-capture procedure; M2 = code once the
+capture is in hand.
+
+## Milestones
+
+- **M1 (this PR):** port map + capture procedure. No engine behavior change.
+- **M2 — load path** (`backend_hip_1bp.cpp` init, GGUF-direct only):
+  1. Gate on `cfg.arch == RCPP_ARCH_QWEN35` before the dense #1624 check.
+  2. Probe actual tensors via `GgufReader::tensor_names()` / `tensor_info()`
+     (shape[0] fastest-varying) and metadata via `kv_keys()` suffix matching —
+     classify subfamily by presence rules (fused `attn_qkv` vs split q/k/v;
+     `ssm_*` vs `linear_attn.*`; `ffn_*_exps` vs `mlp.experts.N.*`).
+  3. Parse dims from shapes + metadata (no guessing): H, full-attn NH/NKV/HD,
+     linear NK/NV/KHD/VHD, conv kernel, `decoder_sparse_step`, expert NE/topk/
+     MIE/SIE, `norm_topk_prob`, eps, rope_theta, partial_rotary.
+  4. Fused `attn_qkv` → split q/k/v rows per the row layout the converter used
+     (recorded from capture); validate each slice size before accept.
+  5. Refuse decode loudly until M3/M4 kernels land (no silent garbage).
+- **M3 — GDN layer decode:** conv1d + delta-rule recurrent kernels with
+  per-layer recurrent state (port the math from `qwen3next_engine.cpp`
+  `linear_attn()`; device state layout mirrors the CPU engine).
+- **M4 — full-attn + MoE decode:** `q_proj[2*hd]` gate split + partial rope +
+  qk-norm path; MoE router softmax top-k + experts (grouped or top-k gemv loop
+  over existing h1bp kernels) + shared expert + output gates.
+- **M5 — validation on strixhalo:** decode-vs-CPU corr gate (run the 35B on
+  `qwen3next`-class CPU reference vs the HIP path over the same prompts;
+  tokens 1000/1001 methodology; H1BP_DUMP bisection per layer).
+
+## Acceptance gate (M5)
+
+- Logits corr ≥ 0.99 vs CPU reference over ≥ 100 tokens (multi-prompt), on
+  strixhalo TheRock (gfx1151); byte-parity for the deterministic layers.
+- Dense models: zero behavior change (existing CI + regression).
+
+## Blockers to lift before M2
+
+1. **Schema capture** of the actual target file (35B-A3B community GGUF and/or
+   official `model.q4nx`) — kv keys + tensor list + the fused-QKV row layout.
+   Procedure below.
+2. **Router wiring:** confirm `model_router` offers a HIP candidate for the
+   qwen35moe arch once the backend can load (CPU/NPU lanes exist; HIP lane add).
+3. **Model on strixhalo:** a 35B GGUF/q4nx staged at `~/models/` for the M2/M5
+   loops (visible set today is GLM-4.7/MiniCPM/Qwen3-0.6B/zaya + qwen3next-80b).
+
+## Schema-capture procedure (run on strixhalo against the target file)
+
+```
+# kv keys + tensor table via the GGUF reader this backend uses:
+# add a debug env (H1BP_SCHEMA_DUMP=<path>) that prints, for the opened GGUF:
+#   kv_keys() sorted; per tensor: name, shape (GGUF order), dtype, numel
+# then: grep -nE "attn_qkv|ssm_|linear_attn|ffn_gate|ffn_up|ffn_down|exps|gate_inp|shared|output_norm|token_embd|output\b|layer_types|full_attention" 
+```
+Expected output drives M2's exact name table + fused-QKV slice geometry.
+
+## References
+
+- Issue #1831 (parent), #1830 (NPU-universal 35B decode bug), #1624/#1627
+  (loud-rejection precedent), #2104 (dtype-dispatch rule), #1942/#2080
+  (cascade program), #2115-2117 (llama.cpp fork hrx/qwen35 lane).

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -200,23 +200,17 @@ struct Hip1bpBackend : Backend {
                                 "q4nx conversion for GDN/MoE not wired yet — #1831 M2)\n");
                 return false;
             }
-            // Per-layer tensor family (19/layer; every layer carries the fused
-            // attn_qkv + ssm_* family + MoE; every 4th layer executes full
-            // attention per qwen35moe.full_attention_interval=4). GGUF-native
-            // shapes (shape[0] fastest-varying) from the Q8_0 capture.
+            // Per-layer tensor families. Every layer shares the norm + MoE set
+            // (10); the attention block differs by kind: GDN layers (l+1 % 4 != 0,
+            // e.g. 0,1,2,4…) carry the fused attn_qkv + attn_gate + ssm_* family
+            // (19 total), full-attention layers (l+1 % 4 == 0 → 3,7,…,39 — 10 of
+            // 40, matching qwen35moe.full_attention_interval=4) carry the split
+            // attn_q/k/v + q/k_norm + attn_output instead (16 total). Captured
+            // from the Q8_0 header (GGUF-native shapes, shape[0] fastest).
             struct E { const char* n; std::vector<uint64_t> sh; };
-            const E LAYER0[] = {
+            const E SHARED[] = {
                 {"attn_norm.weight",            {2048}},
-                {"attn_qkv.weight",             {2048, 8192}},   // fused q/k/v (+GDN q halves)
-                {"attn_gate.weight",            {2048, 4096}},   // output/gate proj
                 {"post_attention_norm.weight",  {2048}},
-                {"ssm_a",                       {32}},           // decay (already -A conv.)
-                {"ssm_alpha.weight",            {2048, 32}},
-                {"ssm_beta.weight",             {2048, 32}},
-                {"ssm_conv1d.weight",           {4, 8192}},      // conv kernel 4 over fused 8192
-                {"ssm_dt.bias",                 {32}},
-                {"ssm_norm.weight",             {128}},
-                {"ssm_out.weight",              {4096, 2048}},
                 {"ffn_gate_inp.weight",         {2048, 256}},    // MoE router (256 experts)
                 {"ffn_gate_exps.weight",        {2048, 512, 256}},
                 {"ffn_up_exps.weight",          {2048, 512, 256}},
@@ -225,6 +219,25 @@ struct Hip1bpBackend : Backend {
                 {"ffn_up_shexp.weight",         {2048, 512}},
                 {"ffn_down_shexp.weight",       {512, 2048}},
                 {"ffn_gate_inp_shexp.weight",   {2048}},         // shared-expert scalar gate
+            };
+            const E GDN[] = {   // fused QKV + GDN linear attention (19/layer incl. SHARED)
+                {"attn_qkv.weight",             {2048, 8192}},   // fused q/k/v (+GDN q halves)
+                {"attn_gate.weight",            {2048, 4096}},   // GDN output gate
+                {"ssm_a",                       {32}},           // decay (already -A conv.)
+                {"ssm_alpha.weight",            {2048, 32}},
+                {"ssm_beta.weight",             {2048, 32}},
+                {"ssm_conv1d.weight",           {4, 8192}},      // conv kernel 4 over fused 8192
+                {"ssm_dt.bias",                 {32}},
+                {"ssm_norm.weight",             {128}},
+                {"ssm_out.weight",              {4096, 2048}},
+            };
+            const E FULL[] = {  // split MHA (16/layer incl. SHARED)
+                {"attn_q.weight",               {2048, 8192}},   // NH*HD*2 = q + gate halves
+                {"attn_k.weight",               {2048, 512}},    // NKV*HD
+                {"attn_v.weight",               {2048, 512}},
+                {"attn_q_norm.weight",          {256}},
+                {"attn_k_norm.weight",          {256}},
+                {"attn_output.weight",          {4096, 2048}},
             };
             auto chk = [&](const char* nm, const std::vector<uint64_t>& want,
                            int l) -> bool {
@@ -248,9 +261,15 @@ struct Hip1bpBackend : Backend {
             bool ok = chk("token_embd.weight", {2048, 248320}, -1) &&
                       chk("output_norm.weight", {2048}, -1) &&
                       chk("output.weight", {2048, 248320}, -1);
-            for (int l = 0; ok && l < NC; l++)
-                for (const E& e : LAYER0)
+            int n_full = 0;
+            for (int l = 0; ok && l < NC; l++) {
+                bool is_full = ((l + 1) % 4 == 0);   // layers 3,7,…,39 (10 of 40)
+                if (is_full) n_full++;
+                for (const E& e : SHARED)
                     if (!(ok = chk(e.n, e.sh, l))) break;
+                for (const E& e : (is_full ? FULL : GDN))
+                    if (!(ok = chk(e.n, e.sh, l))) break;
+            }
             // Cross-check the cfg dims the router/discovery computed vs the file.
             if (ok && (cfg.hidden_size != 2048 || cfg.num_layers != 40 ||
                        cfg.num_experts != 256 || cfg.vocab_size != 248320))
@@ -260,10 +279,12 @@ struct Hip1bpBackend : Backend {
                         cfg.hidden_size, cfg.num_layers, cfg.num_experts, cfg.vocab_size);
             if (ok) {
                 fprintf(stderr, "[hip1bp] qwen35moe structure verified (H=%d L=%d, "
-                                "19 tensors/layer, fused attn_qkv 8192 rows, MoE 256x8 + "
+                                "10 shared + kind-specific per layer; %d full-attn MHA "
+                                "layers 3,7,…,39 with split attn_q/k/v + q/k-norm, "
+                                "rest GDN fused attn_qkv 8192 rows + ssm; MoE 256x8 + "
                                 "shared): GDN/MoE decode kernels not implemented yet "
                                 "(#1831 M3/M4) — use the CPU (qwen3next) or NPU path.\n",
-                        H, NC);
+                        H, NC, n_full);
             }
             return false;   // decode kernels are M3/M4; fall through to CPU/NPU
         }

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -267,8 +267,12 @@ struct Hip1bpBackend : Backend {
                 if (is_full) n_full++;
                 for (const E& e : SHARED)
                     if (!(ok = chk(e.n, e.sh, l))) break;
-                for (const E& e : (is_full ? FULL : GDN))
-                    if (!(ok = chk(e.n, e.sh, l))) break;
+                const E* fam = is_full ? FULL : GDN;      // array → ptr + count (no
+                size_t nfam = is_full ?                  // ternary range-for, which
+                    sizeof(FULL)/sizeof(FULL[0]) :       // would decay to a pointer)
+                    sizeof(GDN)/sizeof(GDN[0]);
+                for (size_t i = 0; i < nfam; i++)
+                    if (!(ok = chk(fam[i].n, fam[i].sh, l))) break;
             }
             // Cross-check the cfg dims the router/discovery computed vs the file.
             if (ok && (cfg.hidden_size != 2048 || cfg.num_layers != 40 ||

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <chrono>
 #include <memory>
+#include <algorithm>
 
 #include "hip_1bp_kernels.hip"
 
@@ -180,6 +181,92 @@ struct Hip1bpBackend : Backend {
         // F16/F32 stay on the f32 path (quant2 = 0): the packed GEMV kernels
         // are 4-bit-only, and lossless weights must not be re-quantized.
         if (getenv("H1BP_F32")) quant2 = 0;   // debug: force f32 path
+
+        // #1831 M2: qwen3_5_moe (Qwen3.6-35B-A3B — GatedDeltaNet linear attention
+        // + gated GQA + gated MoE) on the HIP backend. GGUF-direct only for now.
+        // The dense #1624 check below would reject this family with a misleading
+        // "missing attn_v/ffn_gate/ffn_up/ffn_down" error, so detect it FIRST and
+        // validate its real structure (names+dims from the schema captured on the
+        // actual unsloth/Qwen3.6-35B-A3B-GGUF file, arch token "qwen35moe" — see
+        // docs/research/hip-qwen35-gdn-port.md §captured-schema). tensor_info()
+        // lookups read the GGUF header table only (no tensor data), so this costs
+        // nothing on the failure path and stays out of the way of the multi-GB
+        // embed dequant below.
+        bool qwen35 = (cfg.arch == RCPP_ARCH_QWEN35) ||
+                      (gguf_ && gguf_->architecture() == "qwen35moe");
+        if (qwen35) {
+            if (!gguf_) {
+                fprintf(stderr, "[hip1bp] qwen35moe requires GGUF-direct mode (1BP "
+                                "q4nx conversion for GDN/MoE not wired yet — #1831 M2)\n");
+                return false;
+            }
+            // Per-layer tensor family (19/layer; every layer carries the fused
+            // attn_qkv + ssm_* family + MoE; every 4th layer executes full
+            // attention per qwen35moe.full_attention_interval=4). GGUF-native
+            // shapes (shape[0] fastest-varying) from the Q8_0 capture.
+            struct E { const char* n; std::vector<uint64_t> sh; };
+            const E LAYER0[] = {
+                {"attn_norm.weight",            {2048}},
+                {"attn_qkv.weight",             {2048, 8192}},   // fused q/k/v (+GDN q halves)
+                {"attn_gate.weight",            {2048, 4096}},   // output/gate proj
+                {"post_attention_norm.weight",  {2048}},
+                {"ssm_a",                       {32}},           // decay (already -A conv.)
+                {"ssm_alpha.weight",            {2048, 32}},
+                {"ssm_beta.weight",             {2048, 32}},
+                {"ssm_conv1d.weight",           {4, 8192}},      // conv kernel 4 over fused 8192
+                {"ssm_dt.bias",                 {32}},
+                {"ssm_norm.weight",             {128}},
+                {"ssm_out.weight",              {4096, 2048}},
+                {"ffn_gate_inp.weight",         {2048, 256}},    // MoE router (256 experts)
+                {"ffn_gate_exps.weight",        {2048, 512, 256}},
+                {"ffn_up_exps.weight",          {2048, 512, 256}},
+                {"ffn_down_exps.weight",        {512, 2048, 256}},
+                {"ffn_gate_shexp.weight",       {2048, 512}},    // shared expert (A3B: 1 shared)
+                {"ffn_up_shexp.weight",         {2048, 512}},
+                {"ffn_down_shexp.weight",       {512, 2048}},
+                {"ffn_gate_inp_shexp.weight",   {2048}},         // shared-expert scalar gate
+            };
+            auto chk = [&](const char* nm, const std::vector<uint64_t>& want,
+                           int l) -> bool {
+                char bn[160];
+                if (l < 0) snprintf(bn, sizeof bn, "%s", nm);
+                else       snprintf(bn, sizeof bn, "blk.%d.%s", l, nm);
+                const GgufTensorInfo* ti = gguf_->tensor_info(bn);
+                if (!ti) {
+                    fprintf(stderr, "[hip1bp] qwen35moe: MISSING %s\n", bn); return false;
+                }
+                if (ti->shape.size() != want.size() ||
+                    !std::equal(want.begin(), want.end(), ti->shape.begin())) {
+                    fprintf(stderr, "[hip1bp] qwen35moe: %s shape mismatch (want", bn);
+                    for (uint64_t w : want) fprintf(stderr, " %llu", (unsigned long long)w);
+                    fprintf(stderr, " got");
+                    for (uint64_t w : ti->shape) fprintf(stderr, " %llu", (unsigned long long)w);
+                    fprintf(stderr, ")\n"); return false;
+                }
+                return true;
+            };
+            bool ok = chk("token_embd.weight", {2048, 248320}, -1) &&
+                      chk("output_norm.weight", {2048}, -1) &&
+                      chk("output.weight", {2048, 248320}, -1);
+            for (int l = 0; ok && l < NC; l++)
+                for (const E& e : LAYER0)
+                    if (!(ok = chk(e.n, e.sh, l))) break;
+            // Cross-check the cfg dims the router/discovery computed vs the file.
+            if (ok && (cfg.hidden_size != 2048 || cfg.num_layers != 40 ||
+                       cfg.num_experts != 256 || cfg.vocab_size != 248320))
+                fprintf(stderr, "[hip1bp] qwen35moe: cfg dims differ from file "
+                                "(H=%d L=%d NE=%d V=%d) — schema check still passed on "
+                                "tensor shapes; verify discovery (#1831)\n",
+                        cfg.hidden_size, cfg.num_layers, cfg.num_experts, cfg.vocab_size);
+            if (ok) {
+                fprintf(stderr, "[hip1bp] qwen35moe structure verified (H=%d L=%d, "
+                                "19 tensors/layer, fused attn_qkv 8192 rows, MoE 256x8 + "
+                                "shared): GDN/MoE decode kernels not implemented yet "
+                                "(#1831 M3/M4) — use the CPU (qwen3next) or NPU path.\n",
+                        H, NC);
+            }
+            return false;   // decode kernels are M3/M4; fall through to CPU/NPU
+        }
 
         std::vector<float> emb,fn,out;
         auto ld=[&](const char* n,std::vector<float>& v){return get_w(n,v);};

--- a/tools/bench_hip_1bp.cpp
+++ b/tools/bench_hip_1bp.cpp
@@ -2,6 +2,7 @@
 #include <cstdio>
 #include <chrono>
 #include <string>
+#include <cstring>
 
 extern "C" Backend* create_hip_1bp_backend();
 
@@ -23,15 +24,22 @@ int main(int argc, char** argv) {
     uint8_t hdr[256];
     FILE* f = fopen(path, "rb"); if (!f) { fprintf(stderr, "Cannot open %s\n", path); return 1; }
     fread(hdr, 1, 256, f); fclose(f);
-    memcpy(&cfg.hidden_size, hdr+20, 4); memcpy(&cfg.num_layers, hdr+24, 4);
-    memcpy(&cfg.num_heads, hdr+28, 4); memcpy(&cfg.num_kv_heads, hdr+32, 4);
-    memcpy(&cfg.head_dim, hdr+36, 4); memcpy(&cfg.intermediate_size, hdr+40, 4);
-    memcpy(&cfg.vocab_size, hdr+44, 4);
+    // GGUF-direct models: the header is NOT a 1BP header — skip the parse and
+    // let backend_hip_1bp's GGUF path drive (dims stay at ModelConfig defaults,
+    // which match the qwen35moe family this driver validates).
+    bool is_gguf = strlen(path) > 5 && strcmp(path + strlen(path) - 5, ".gguf") == 0;
+    if (!is_gguf) {
+        memcpy(&cfg.hidden_size, hdr+20, 4); memcpy(&cfg.num_layers, hdr+24, 4);
+        memcpy(&cfg.num_heads, hdr+28, 4); memcpy(&cfg.num_kv_heads, hdr+32, 4);
+        memcpy(&cfg.head_dim, hdr+36, 4); memcpy(&cfg.intermediate_size, hdr+40, 4);
+        memcpy(&cfg.vocab_size, hdr+44, 4);
+    }
 
     printf("  Model: %s\n", path);
-    printf("  Dims:  H=%d NC=%d NH=%d NKV=%d HD=%d IM=%d V=%d\n",
+    printf("  Dims:  H=%d NC=%d NH=%d NKV=%d HD=%d IM=%d V=%d %s\n",
            cfg.hidden_size, cfg.num_layers, cfg.num_heads, cfg.num_kv_heads,
-           cfg.head_dim, cfg.intermediate_size, cfg.vocab_size);
+           cfg.head_dim, cfg.intermediate_size, cfg.vocab_size,
+           is_gguf ? "(GGUF-direct)" : "");
     printf("  Tokens: %d (%d warmup + %d measured)\n\n", tokens + warmup, warmup, tokens);
 
     // Init


### PR DESCRIPTION
### **User description**
**Part of #1831** (open). M1+M2 of the HIP-lane port for `qwen3_5_moe` (Qwen3.6-35B-A3B GatedDeltaNet + gated GQA + gated MoE).

**M1 — port map** (`docs/research/hip-qwen35-gdn-port.md`): arch-gate ground truth (RCPP_ARCH_QWEN35=21; GGUF token `qwen35moe`), the validated CPU math reference (`qwen3next_engine.cpp`), the NPU schema family, the 3-dialect naming hazard, M1–M5 milestones + acceptance gate (decode-vs-CPU corr ≥ 0.99 on strixhalo TheRock; dense models zero-change).

**Schema capture (the #1831 blocker-1 data):** header of the actual target file (`unsloth/Qwen3.6-35B-A3B-GGUF` Q8_0, arch token `qwen35moe`, GGUF v3, 733 tensors, 40×19) — full KV table (H=2048, 16h/2kv, ssm group 16/state 128/dt 32/inner 4096/conv 4, rope 64 dims sections [11,11,10,0] @1e7, 256 experts top-8 IM 512, `full_attention_interval` 4, vocab 248320) + per-layer shape table, now in-repo.

**M2 — structural loader** (`src/backend_hip_1bp.cpp`): arch-gated detection before the dense #1624 rejection (which previously misled: "missing attn_v/ffn_gate/ffn_up/ffn_down" for an arch that has none of those separate). New path validates the real 40×19-tensor structure + globals via `GgufReader::tensor_info()` header-only lookups (no tensor data → free failure path), cross-checks cfg dims, then returns false with the precise "GDN/MoE decode kernels not implemented (M3/M4)" diagnostic so the manager falls through to CPU/NPU. Dense models: zero behavior change.

CI compiles the HIP target. Next: M3 GDN kernel math (open questions recorded: attn_qkv 8192-row slice semantics, attn_gate 4096-row role, ssm group mapping, fused-expert indexing) — validated on strixhalo against the staged Q8_0 file (36.9GB download in progress there).


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Adds arch-gated structural loader for qwen35moe GGUF

- Validates GDN/full-attention 40-layer schema via header metadata

- Port map documents ground truth, naming hazard, and M1–M5 steps

- Bench driver skips 1BP header parse for GGUF-direct models


___

### Diagram Walkthrough


```mermaid
flowchart TD
    A["qwen35moe GGUF model"] --> B["Hip1bpBackend init"]
    B --> C{"qwen35 arch or token detected?"}
    C -- "yes" --> D["GGUF tensor_info structure check"]
    C -- "no" --> E["Dense model load path unchanged"]
    D --> F["GDN + full-attention + MoE schema verified"]
    F --> G["Return false with M3/M4 diagnostic"]
    G --> H["Fallback to CPU qwen3next or NPU"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_hip_1bp.cpp</strong><dd><code>Add qwen35moe structural schema gate to HIP loader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_hip_1bp.cpp

<ul><li>Detect qwen3_5_moe arch/GGUF token before the dense-tensor rejection <br>path<br> <li> Validate globals and all 40 layers against captured GDN/full-attention <br>schemas via <code>tensor_info()</code><br> <li> Cross-check cfg dims and return a precise “GDN/MoE kernels not <br>implemented” diagnostic<br> <li> Keep dense-model load path unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2121/files#diff-c4812ee96d278d2d2b452760b359c0521f1a016dce68e46c6668555b33eec182">+112/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bench_hip_1bp.cpp</strong><dd><code>Support GGUF-direct models in bench driver</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/bench_hip_1bp.cpp

<ul><li>Recognize <code>.gguf</code> paths and skip the 1BP header field parsing<br> <li> Print GGUF-direct status in the model dims line<br> <li> Let <code>backend_hip_1bp</code> drive dims for GGUF-direct models</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2121/files#diff-ba7085f2c60678386a91382bf78ea72395c9d7dc1345f2dbb5dc698687d91522">+14/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hip-qwen35-gdn-port.md</strong><dd><code>Add qwen35 HIP port map and captured schema doc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/research/hip-qwen35-gdn-port.md

<ul><li>Record arch gate, CPU math reference, NPU schema family, and GGUF <br>tensor lists<br> <li> Document the three naming dialects and the resulting M2 dependency on <br>schema capture<br> <li> Add authoritative Q8_0 KV table and per-layer shape tables for <br>GDN/full-attention kinds<br> <li> Define M1–M5 milestones, acceptance gate, and schema-capture procedure</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2121/files#diff-f0fee3fff9aa45835f0cdaae8063061b7133a03b428860d7cdf067ee3acc7562">+175/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

