### PR TITLE
fix(docs): serve docs surface from GitHub Pages (1bit.monster/docs)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,9 +60,27 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Install markdown-it-py
+        run: pip install markdown-it-py
+
+      - name: Lint docs Markdown (parse-check — issue #1963)
+        run: python3 scripts/lint_docs_markdown.py
+
+      - name: Stage site + generated docs (single surface at /docs/)
+        run: |
+          mkdir -p _deploy
+          cp -a site/. _deploy/
+          python3 scripts/gen_docs_site.py --out _deploy/docs
+
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
-          path: site
+          path: _deploy
       - id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/site/1bit-docs.html
+++ b/site/1bit-docs.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>1bit.MONSTER: Documentation</title>
+  <meta name="description" content="The 1bit.MONSTER documentation hub (redirects to /docs/)." />
+  <link rel="canonical" href="https://1bit.monster/docs/" />
+  <meta http-equiv="refresh" content="0; url=https://1bit.monster/docs/" />
+  <style>body{font-family:system-ui,sans-serif;max-width:36rem;margin:10vh auto;padding:0 1rem;text-align:center}code{background:#f2f2f2;padding:2px 6px;border-radius:6px}</style>
+</head>
+<body>
+  <p>Redirecting to the documentation hub…</p>
+  <p>If you are not redirected, go to <a href="https://1bit.monster/docs/">https://1bit.monster/docs/</a>.</p>
+  <script>window.location.replace("https://1bit.monster/docs/");</script>
+</body>
+</html>


### PR DESCRIPTION
### **User description**
Corrects the platform for the docs consolidation. `1bit.monster` is served by GitHub Pages (site/) behind Cloudflare, not the Cloudflare Pages project, so the earlier cutover only landed docs on `.pages.dev`.

- deploy.yml deploy-github-pages: build & upload the combined `_deploy/` (site + generated docs) so `https://1bit.monster/docs/` is served by GitHub Pages.
- Restore `site/1bit-docs.html` as a meta-refresh redirect to `/docs/` (GitHub Pages ignores `_redirects`, so the "Docs" nav needs a real page).
- Cloudflare `.pages.dev` keeps the `_redirects`-based version.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fix GitHub Pages deploy to publish combined `_deploy`

- Add `site/1bit-docs.html` meta-refresh redirect to `/docs/`

- Lint docs Markdown before staging generated docs

- Upload `_deploy` artifact instead of plain `site`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Start["GitHub Pages deploy"] --> Stage["Stage _deploy with site and generated docs"]
  Start --> Lint["Lint docs Markdown"]
  Lint --> Stage
  Stage --> Upload["Upload _deploy as Pages artifact"]
  Upload --> Live["https://1bit.monster/docs/"]
  Redirect["site/1bit-docs.html meta-refresh"] --> Live
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>1bit-docs.html</strong><dd><code>Restore docs hub redirect page for GitHub Pages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/1bit-docs.html

<ul><li>Adds a small HTML page redirecting to <code>https://1bit.monster/docs/</code><br> <li> Uses meta-refresh plus a JavaScript fallback redirect<br> <li> Restores a real Docs link for GitHub Pages, which does not process <br><code>_redirects</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2122/files#diff-075a7297c9f29b5bf2bef811dc9bfef8a0ff15383261551409039b8409b22f46">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy.yml</strong><dd><code>Deploy combined site and generated docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy.yml

<ul><li>Adds Python setup and installs <code>markdown-it-py</code> in the deploy job<br> <li> Runs <code>scripts/lint_docs_markdown.py</code> to parse-check docs Markdown<br> <li> Copies <code>site/</code> into <code>_deploy/</code> and generates docs to <code>_deploy/docs</code><br> <li> Uploads the combined <code>_deploy</code> instead of <code>site</code> to GitHub Pages</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2122/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3">+19/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

