### PR TITLE
chore(docs): retire docs subdomain (docs.1bit.monster -> 1bit.monster/docs)

### DIFF
--- a/.github/workflows/retire-docs-subdomain.yml
+++ b/.github/workflows/retire-docs-subdomain.yml
@@ -1,0 +1,45 @@
+name: Retire docs subdomain
+
+# One-time (re-runnable) step in the docs consolidation: the single docs
+# surface now lives at https://1bit.monster/docs/ (GitHub Pages). Point the
+# retired docs.1bit.monster Cloudflare Pages project at it so the old
+# subdomain redirects instead of serving a stale second surface.
+
+# NOTE: this only deploys a static `_redirects` to the `1bit-monster-docs`
+# Cloudflare Pages project (which `docs.1bit.monster` resolves to). It does
+# NOT delete the project or touch DNS. Removing the project / the `docs` CNAME
+# is a dashboard/DNS action (the repo token is Account/Pages-only).
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  retire:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Deploy catch-all redirect to 1bit-monster-docs
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0  # v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: |
+            tmp=$(mktemp -d)
+            printf '%s\n' \
+              '# Retired docs.1bit.monster -> 1bit.monster/docs' \
+              '/            https://1bit.monster/docs/   302' \
+              '/*           https://1bit.monster/docs/   302' \
+              > "$tmp/_redirects"
+            printf '%s\n' \
+              '<!doctype html><html><head><meta charset="utf-8">' \
+              '<meta http-equiv="refresh" content="0; url=https://1bit.monster/docs/">' \
+              '<link rel="canonical" href="https://1bit.monster/docs/"></head>' \
+              '<body><p>Docs moved to <a href="https://1bit.monster/docs/">https://1bit.monster/docs/</a></p>' \
+              '<script>window.location.replace("https://1bit.monster/docs/")</script></body></html>' \
+              > "$tmp/index.html"
+            printf '%s\n' "$tmp/_redirects" "$tmp/index.html"
+            npx wrangler pages deploy "$tmp" --project-name=1bit-monster-docs


### PR DESCRIPTION
### **User description**
Deploys a catch-all redirect to the retired `1bit-monster-docs` Pages project so `docs.1bit.monster` redirects to the single surface `https://1bit.monster/docs/`. One-time; leaves the project/DNS for a dashboard action.


___

### **PR Type**
Other


___

### **Description**
- Adds manually-triggered workflow to retire docs subdomain

- Deploys catch-all 302 redirect to consolidated docs surface

- Includes HTML meta-refresh fallback for the retired project

- Leaves Cloudflare project and DNS for manual cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Dispatch["Manual workflow_dispatch"] --> Deploy["wrangler pages deploy temp dir"]
  Deploy --> Redirect["_redirects: catch-all 302 -> 1bit.monster/docs"]
  Deploy --> Meta["index.html meta-refresh fallback"]
  Redirect --> Surface["https://1bit.monster/docs/"]
  Meta --> Surface
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>retire-docs-subdomain.yml</strong><dd><code>Add one-time workflow redirecting retired docs subdomain</code>&nbsp; </dd></summary>
<hr>

.github/workflows/retire-docs-subdomain.yml

<ul><li>Adds a <code>workflow_dispatch</code> workflow under <code>.github/workflows</code><br> <li> Deploys a static <code>_redirects</code> catch-all with HTTP 302 to Pages project<br> <li> Adds <code>index.html</code> meta refresh, canonical link, and JS fallback<br> <li> Explicitly leaves Cloudflare project and DNS for manual cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2124/files#diff-cb9ea1f9ff27e34bbddaff9ab0a68cd8ed6c6c48aa8c7eaabaebbff5fbb73b9b">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

