### PR TITLE
fix(docs): retire workflow deploy step

### DIFF
--- a/.github/workflows/retire-docs-subdomain.yml
+++ b/.github/workflows/retire-docs-subdomain.yml
@@ -22,24 +22,24 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Stage catch-all redirect
+        run: |
+          mkdir -p _retiredocs
+          printf '%s\n' \
+            '# Retired docs.1bit.monster -> 1bit.monster/docs' \
+            '/            https://1bit.monster/docs/   302' \
+            '/*           https://1bit.monster/docs/   302' \
+            > _retiredocs/_redirects
+          printf '%s\n' \
+            '<!doctype html><html><head><meta charset="utf-8">' \
+            '<meta http-equiv="refresh" content="0; url=https://1bit.monster/docs/">' \
+            '<link rel="canonical" href="https://1bit.monster/docs/"></head>' \
+            '<body><p>Docs moved to <a href="https://1bit.monster/docs/">https://1bit.monster/docs/</a></p>' \
+            '<script>window.location.replace("https://1bit.monster/docs/")</script></body></html>' \
+            > _retiredocs/index.html
       - name: Deploy catch-all redirect to 1bit-monster-docs
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0  # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: |
-            tmp=$(mktemp -d)
-            printf '%s\n' \
-              '# Retired docs.1bit.monster -> 1bit.monster/docs' \
-              '/            https://1bit.monster/docs/   302' \
-              '/*           https://1bit.monster/docs/   302' \
-              > "$tmp/_redirects"
-            printf '%s\n' \
-              '<!doctype html><html><head><meta charset="utf-8">' \
-              '<meta http-equiv="refresh" content="0; url=https://1bit.monster/docs/">' \
-              '<link rel="canonical" href="https://1bit.monster/docs/"></head>' \
-              '<body><p>Docs moved to <a href="https://1bit.monster/docs/">https://1bit.monster/docs/</a></p>' \
-              '<script>window.location.replace("https://1bit.monster/docs/")</script></body></html>' \
-              > "$tmp/index.html"
-            printf '%s\n' "$tmp/_redirects" "$tmp/index.html"
-            npx wrangler pages deploy "$tmp" --project-name=1bit-monster-docs
+          command: pages deploy _retiredocs --project-name=1bit-monster-docs


### PR DESCRIPTION
### **User description**
Fix the retire-docs workflow: use wrangler-action's command (`pages deploy _retiredocs`) instead of `npx wrangler`.


___

### **PR Type**
Bug fix


___

### **Description**
- Use wrangler-action command instead of npx wrangler.

- Stage `_retiredocs` redirect files before deployment.

- Fix broken docs retirement workflow step.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["checkout repo"] --> B["stage _retiredocs"]
  B --> C["wrangler-action pages deploy"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>retire-docs-subdomain.yml</strong><dd><code>Fix docs retirement deploy command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/retire-docs-subdomain.yml

<ul><li>Replaced <code>npx wrangler pages deploy</code> with wrangler-action <code>pages deploy </code><br><code>_retiredocs</code>.<br> <li> Added a <code>Stage catch-all redirect</code> step that creates <code>_redirects</code> and <br><code>index.html</code> in <code>_retiredocs</code>.<br> <li> Removed <code>mktemp</code> temp-directory handling from the workflow command.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2125/files#diff-cb9ea1f9ff27e34bbddaff9ab0a68cd8ed6c6c48aa8c7eaabaebbff5fbb73b9b">+16/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

