### PR TITLE
feat(gpu): #1831 M3 — Q8_0 kernels + qwen35 loader self-check (task 2 infra)

### DIFF
--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -1020,6 +1020,14 @@ struct Hip1bpBackend : Backend {
         HIP_CHECK(hipMemcpy(d_token, &token_id, sizeof(int), hipMemcpyHostToDevice));
         h1bp_q8embed_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dh, q35_emb, d_token, 2048);
         int n_full_layers = 0;
+        auto q35_wb = [&](const char* nm, const float* buf, int n) {
+            if (pos != 0 || !getenv("H1BP_Q35_STAGE")) return;
+            std::vector<float> tmp(n);
+            HIP_CHECK(hipMemcpy(tmp.data(), buf, n * 4, hipMemcpyDeviceToHost));
+            char fn[1024]; snprintf(fn, sizeof fn, "%s/%s.f32", getenv("H1BP_Q35_STAGE"), nm);
+            FILE* f = fopen(fn, "wb"); if (f) { fwrite(tmp.data(), 4, n, f); fclose(f); }
+        };
+        if (pos == 0) q35_wb("emb", dh, 2048);
         for (int l = 0; l < NC; l++) {
             Q35L& w = q35L[l];
             bool full = ((l + 1) % 4 == 0);
@@ -1058,6 +1066,7 @@ struct Hip1bpBackend : Backend {
                 h1bp_q35_conv_kernel<<<(8192 + 255) / 256, 256, 0, stream>>>(
                     q35_sc_qc, q35_sc_qkv, w.conv1d,
                     q35_conv_state + (size_t)l * 8192 * 3, 8192, 4, pos);
+                if (l == 0) { q35_wb("qkv", q35_sc_qkv, 8192); q35_wb("qc", q35_sc_qc, 8192); }
                 // q/k l2-norm per 16 heads then expand to 32 (tiled)
                 h1bp_head_l2norm_kernel<<<16, 256, 0, stream>>>(q35_sc_qc, 128, 16, 1e-6f);
                 h1bp_head_l2norm_kernel<<<16, 256, 0, stream>>>(q35_sc_qc + 2048, 128, 16, 1e-6f);
@@ -1080,6 +1089,7 @@ struct Hip1bpBackend : Backend {
                 h1bp_head_rmsnorm_kernel<<<32, 256, 0, stream>>>(q35_sc_z, w.snorm, 128, 1e-6f);
                 h1bp_silu_inplace_kernel<<<(4096 + 255) / 256, 256, 0, stream>>>(q35_sc_att, 4096);
                 h1bp_elmul_kernel<<<(4096 + 255) / 256, 256, 0, stream>>>(q35_sc_z, q35_sc_att, 4096);
+                if (l == 0) { q35_wb("g", q35_sc_g, 32); q35_wb("beta", q35_sc_b, 32); q35_wb("zattn", q35_sc_z, 4096); }
                 // ssm_out gemv [2048 x 4096] -> H
                 h1bp_q8gemv_kernel<<<2048, 256, 0, stream>>>(q35_sc_aout, w.ssm_out, q35_sc_z, 2048, 4096);
             }
@@ -1119,6 +1129,7 @@ struct Hip1bpBackend : Backend {
             h1bp_acc_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(q35_sc_moe, q35_sc_expd, 2048);
             h1bp_copy_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dh, dsilu, 2048);
             h1bp_add_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dh, q35_sc_moe, 2048);
+            if (l == 0) q35_wb("l0out", dh, 2048);
         }
         // output norm + lm head + argmax
         h1bp_rmsnorm_kernel<<<1, 256, 0, stream>>>(dh, q35_onorm, 2048, 1e-6f);

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -1036,14 +1036,22 @@ struct Hip1bpBackend : Backend {
             h1bp_copy_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dsilu, dh, 2048);
             h1bp_rmsnorm_kernel<<<1, 256, 0, stream>>>(dh, w.an, 2048, 1e-6f);
             if (full) {
-                // q/k/v gemvs
+                // q/k/v gemvs (attn_q rows = per-head [q 256 | gate 256] pairs at 512-stride)
                 h1bp_q8gemv_kernel<<<8192, 256, 0, stream>>>(q35_sc_qk, w.q, dh, 8192, 2048);
                 h1bp_q8gemv_kernel<<<512, 256, 0, stream>>>(q35_sc_v2, w.k, dh, 512, 2048);
-                // q per-head rmsnorm (16 x 256, weight qn); k norm on v2 (2 x 256)
-                h1bp_head_rmsnorm_kernel<<<16, 256, 0, stream>>>(q35_sc_qk, w.qn, 256, 1e-6f);
+                // de-interleave q/gate halves into contiguous per-head buffers:
+                // q35_sc_att = q (16x256), q35_sc_qc = gate (16x256)
+                for (int h = 0; h < 16; h++) {
+                    HIP_CHECK(hipMemcpyAsync(q35_sc_att + (size_t)h * 256, q35_sc_qk + (size_t)h * 512,
+                                             256 * 4, hipMemcpyDeviceToDevice, stream));
+                    HIP_CHECK(hipMemcpyAsync(q35_sc_qc + (size_t)h * 256, q35_sc_qk + (size_t)h * 512 + 256,
+                                             256 * 4, hipMemcpyDeviceToDevice, stream));
+                }
+                // q per-head rmsnorm on contiguous q halves; k norm on v2 (2 x 256)
+                h1bp_head_rmsnorm_kernel<<<16, 256, 0, stream>>>(q35_sc_att, w.qn, 256, 1e-6f);
                 h1bp_head_rmsnorm_kernel<<<2, 256, 0, stream>>>(q35_sc_v2, w.kn, 256, 1e-6f);
-                // rope nrot64: q stored as per-head [q 256 | gate 256] pairs (hd=512 layout)
-                h1bp_rope_nrot_kernel<<<16, 256, 0, stream>>>(q35_sc_qk, 512, 64, d_pos, rope_theta, 16);
+                // rope nrot64 on contiguous q (16 heads x 256) and k (2 heads x 256)
+                h1bp_rope_nrot_kernel<<<16, 256, 0, stream>>>(q35_sc_att, 256, 64, d_pos, rope_theta, 16);
                 h1bp_rope_nrot_kernel<<<2, 256, 0, stream>>>(q35_sc_v2, 256, 64, d_pos, rope_theta, 2);
                 // store k (v2) and v into the per-layer kv cache [seq][k0 k1 v0 v1]
                 int f = n_full_layers;
@@ -1052,10 +1060,10 @@ struct Hip1bpBackend : Backend {
                 h1bp_q8gemv_kernel<<<512, 256, 0, stream>>>(q35_sc_v, w.v, dh, 512, 2048);
                 HIP_CHECK(hipMemcpyAsync(kvbase + (size_t)pos * 1024 + 512, q35_sc_v, 512 * 4, hipMemcpyDeviceToDevice, stream));
                 // attention over the cache, then sigmoid-gate multiply, then o_proj
-                h1bp_q35_fattn_kernel<<<16, 256, 0, stream>>>(q35_sc_qk, kvbase, q35_sc_att,
+                h1bp_q35_fattn_kernel<<<16, 256, 0, stream>>>(q35_sc_att, kvbase, q35_sc_att,
                     q35_kv_scores, 16, 2, 256, max_seq, d_pos);
                 for (int h = 0; h < 16; h++) {
-                    float* g = q35_sc_qk + (size_t)h * 512 + 256;
+                    float* g = q35_sc_qc + (size_t)h * 256;
                     float* a = q35_sc_att + (size_t)h * 256;
                     h1bp_sigmoid_mul_kernel<<<(256 + 255) / 256, 256, 0, stream>>>(a, g, 256);
                 }

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -1084,12 +1084,16 @@ struct Hip1bpBackend : Backend {
                 // recurrence
                 h1bp_q35_delta_kernel<<<32, 128, 0, stream>>>(q35_sc_q, q35_sc_k, q35_sc_v,
                     q35_rec_state + (size_t)l * 128 * 128 * 32, q35_sc_z, q35_sc_g, q35_sc_b, 128, 128, 32);
+                if (l == 0) { q35_wb("qexp", q35_sc_q, 4096); q35_wb("kexp", q35_sc_k, 4096);
+                              q35_wb("v", q35_sc_v, 4096); q35_wb("deltaraw", q35_sc_z, 4096); }
                 // z gemv (attn_gate 4096x2048) -> silu -> group norm out * silu(z)
                 h1bp_q8gemv_kernel<<<4096, 256, 0, stream>>>(q35_sc_att, w.gate, dh, 4096, 2048);
                 h1bp_head_rmsnorm_kernel<<<32, 256, 0, stream>>>(q35_sc_z, w.snorm, 128, 1e-6f);
                 h1bp_silu_inplace_kernel<<<(4096 + 255) / 256, 256, 0, stream>>>(q35_sc_att, 4096);
                 h1bp_elmul_kernel<<<(4096 + 255) / 256, 256, 0, stream>>>(q35_sc_z, q35_sc_att, 4096);
-                if (l == 0) { q35_wb("g", q35_sc_g, 32); q35_wb("beta", q35_sc_b, 32); q35_wb("zattn", q35_sc_z, 4096); }
+                if (l == 0) { q35_wb("g", q35_sc_g, 32); q35_wb("beta", q35_sc_b, 32); q35_wb("zattn", q35_sc_z, 4096);
+                              q35_wb("q16n", q35_sc_qc, 2048); q35_wb("k16n", q35_sc_qc + 2048, 2048);
+                              q35_wb("zraw", q35_sc_att, 4096); }
                 // ssm_out gemv [2048 x 4096] -> H
                 h1bp_q8gemv_kernel<<<2048, 256, 0, stream>>>(q35_sc_aout, w.ssm_out, q35_sc_z, 2048, 4096);
             }

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -56,6 +56,28 @@ struct Hip1bpBackend : Backend {
     std::unique_ptr<NpuOnebpModel> model_;
     std::unique_ptr<GgufReader> gguf_;  // GGUF-direct mode (lossless f32, no 1BP conversion)
 
+    // qwen35moe (Qwen3.6-35B-A3B) device weights — GGUF-direct, Q8_0 raw tiles
+    // (34 B/block) + f32 small tensors. M3 (#1831). Rows = out dim, K = ne0.
+    struct Q35L {
+        float* an = nullptr, *pan = nullptr;            // attn_norm / post_attention_norm (H f32)
+        uint8_t* qkv = nullptr, *gate = nullptr;        // GDN: 8192xH / 4096xH Q8_0
+        uint8_t* ssm_out = nullptr;                     // GDN out proj: 2048 x 4096 (M=2048,K=4096)
+        uint8_t* alpha = nullptr, *beta = nullptr;      // GDN: 32 x H Q8_0
+        float* ssa = nullptr, *dt = nullptr;            // ssm_a / ssm_dt.bias (32 f32)
+        float* snorm = nullptr;                         // ssm_norm (128 f32)
+        float* conv1d = nullptr;                        // ssm_conv1d (8192 x 4 f32, K=4)
+        uint8_t* q = nullptr, *k = nullptr, *v = nullptr, *o = nullptr;  // full-attn Q8_0
+        float* qn = nullptr, *kn = nullptr;             // q/k_norm (256 f32)
+        uint8_t* ex_g = nullptr, *ex_u = nullptr, *ex_d = nullptr;      // fused experts Q8_0
+        uint8_t* sh_g = nullptr, *sh_u = nullptr, *sh_d = nullptr;      // shared expert Q8_0
+        float* router = nullptr;                        // ffn_gate_inp (256 x H f32)
+        float* sh_gatew = nullptr;                      // ffn_gate_inp_shexp (H f32)
+    };
+    bool q35_loaded = false;
+    uint8_t* q35_emb = nullptr, *q35_out = nullptr;     // token_embd / output (V x H Q8_0)
+    float* q35_onorm = nullptr;                         // output_norm (H f32)
+    std::vector<Q35L> q35L;
+
     // GPU scratch (persistent, device-only)
     float *dh=nullptr,*datt=nullptr,*dgate=nullptr,*dup=nullptr;
     float *dsilu=nullptr,*doproj=nullptr,*dffn=nullptr,*datt2=nullptr;
@@ -338,6 +360,104 @@ struct Hip1bpBackend : Backend {
                 } else {
                     fprintf(stderr, "[hip1bp] qwen35 selfcheck: attn_qkv raw read failed "
                                     "(want %zu B)\n", (size_t)M0 * rowb);
+                }
+            }
+            // Full device load (env H1BP_Q35_LOAD): every qwen35moe tensor to
+            // device with the captured slicing — Q8_0 raw for the big weights,
+            // f32 for norms/router/ssm params. Consumed by the M3 decode path
+            // (tasks 3-5, not yet wired — decode still refused below).
+            if (ok && getenv("H1BP_Q35_LOAD")) {
+                size_t tot = 0;
+                q35L.assign(NC, Q35L());
+                auto q8 = [&](const char* nm, int l, uint8_t*& dst, int M, int K,
+                              bool optional = false) -> bool {
+                    char bn[180];
+                    if (l < 0) snprintf(bn, sizeof bn, "%s", nm);
+                    else       snprintf(bn, sizeof bn, "blk.%d.%s", l, nm);
+                    std::vector<uint8_t> raw;
+                    if (!gguf_->get_tensor_raw(bn, 32, 34, raw)) {
+                        if (optional) return true;
+                        fprintf(stderr, "[hip1bp] q35 load: MISSING %s\n", bn); return false;
+                    }
+                    size_t want = (size_t)M * ((size_t)(K >> 5) * 34);
+                    if (raw.size() != want) {
+                        fprintf(stderr, "[hip1bp] q35 load: %s size %zu != want %zu "
+                                        "(M=%d K=%d)\n", bn, raw.size(), want, M, K);
+                        return false;
+                    }
+                    if (hipMalloc((void**)&dst, want) != hipSuccess ||
+                        hipMemcpy(dst, raw.data(), want, hipMemcpyHostToDevice) != hipSuccess) {
+                        fprintf(stderr, "[hip1bp] q35 load: hip alloc/copy failed %s\n", bn);
+                        return false;
+                    }
+                    tot += want;
+                    return true;
+                };
+                auto f32t = [&](const char* nm, int l, float*& dst, int n) -> bool {
+                    char bn[180];
+                    if (l < 0) snprintf(bn, sizeof bn, "%s", nm);
+                    else       snprintf(bn, sizeof bn, "blk.%d.%s", l, nm);
+                    std::vector<float> v;
+                    if (!gguf_->get_tensor_f32(bn, v)) {
+                        fprintf(stderr, "[hip1bp] q35 load: MISSING %s\n", bn); return false;
+                    }
+                    if ((int)v.size() != n) {
+                        fprintf(stderr, "[hip1bp] q35 load: %s n=%zu != %d\n", bn, v.size(), n);
+                        return false;
+                    }
+                    if (hipMalloc((void**)&dst, (size_t)n * 4) != hipSuccess ||
+                        hipMemcpy(dst, v.data(), (size_t)n * 4, hipMemcpyHostToDevice) != hipSuccess) {
+                        fprintf(stderr, "[hip1bp] q35 load: hip alloc/copy failed %s\n", bn);
+                        return false;
+                    }
+                    tot += (size_t)n * 4;
+                    return true;
+                };
+                bool lok = true;
+                // globals
+                lok &= q8("token_embd.weight", -1, q35_emb, 248320, 2048);
+                lok &= q8("output.weight", -1, q35_out, 248320, 2048);
+                lok &= f32t("output_norm.weight", -1, q35_onorm, 2048);
+                for (int l = 0; lok && l < NC; l++) {
+                    Q35L& w = q35L[l];
+                    bool full = ((l + 1) % 4 == 0);
+                    lok &= f32t("attn_norm.weight", l, w.an, 2048);
+                    lok &= f32t("post_attention_norm.weight", l, w.pan, 2048);
+                    if (full) {
+                        lok &= q8("attn_q.weight", l, w.q, 8192, 2048);
+                        lok &= q8("attn_k.weight", l, w.k, 512, 2048);
+                        lok &= q8("attn_v.weight", l, w.v, 512, 2048);
+                        lok &= q8("attn_output.weight", l, w.o, 2048, 4096);
+                        lok &= f32t("attn_q_norm.weight", l, w.qn, 256);
+                        lok &= f32t("attn_k_norm.weight", l, w.kn, 256);
+                    } else {
+                        lok &= q8("attn_qkv.weight", l, w.qkv, 8192, 2048);
+                        lok &= q8("attn_gate.weight", l, w.gate, 4096, 2048);
+                        lok &= q8("ssm_alpha.weight", l, w.alpha, 32, 2048);
+                        lok &= q8("ssm_beta.weight", l, w.beta, 32, 2048);
+                        lok &= f32t("ssm_a", l, w.ssa, 32);
+                        lok &= f32t("ssm_dt.bias", l, w.dt, 32);
+                        lok &= f32t("ssm_norm.weight", l, w.snorm, 128);
+                        lok &= f32t("ssm_conv1d.weight", l, w.conv1d, 8192 * 4);
+                        lok &= q8("ssm_out.weight", l, w.ssm_out, 2048, 4096);
+                    }
+                    // MoE — every layer (fused experts are expert-major stacked)
+                    lok &= q8("ffn_gate_exps.weight", l, w.ex_g, 256 * 512, 2048);
+                    lok &= q8("ffn_up_exps.weight", l, w.ex_u, 256 * 512, 2048);
+                    lok &= q8("ffn_down_exps.weight", l, w.ex_d, 256 * 2048, 512);
+                    lok &= q8("ffn_gate_shexp.weight", l, w.sh_g, 512, 2048);
+                    lok &= q8("ffn_up_shexp.weight", l, w.sh_u, 512, 2048);
+                    lok &= q8("ffn_down_shexp.weight", l, w.sh_d, 2048, 512);
+                    lok &= f32t("ffn_gate_inp.weight", l, w.router, 256 * 2048);
+                    lok &= f32t("ffn_gate_inp_shexp.weight", l, w.sh_gatew, 2048);
+                }
+                if (lok) {
+                    q35_loaded = true;
+                    fprintf(stderr, "[hip1bp] qwen35 device load OK: %zu B (%.1f MB) "
+                                    "across %d layers + globals\n",
+                            tot, tot / 1048576.0, NC);
+                } else {
+                    fprintf(stderr, "[hip1bp] qwen35 device load FAILED — falling back\n");
                 }
             }
             return false;   // decode kernels are M3/M4; fall through to CPU/NPU
@@ -829,6 +949,15 @@ struct Hip1bpBackend : Backend {
         for(auto&ll:L){hf(ll.wq);hf(ll.wk);hf(ll.wv);hf(ll.wo);hf(ll.w1);hf(ll.w2);hf(ll.w3);hf(ll.pn);hf(ll.pon);hf(ll.q_norm);hf(ll.k_norm);hf(ll.bq);hf(ll.bk);hf(ll.bv);}
         for (auto& pd : PD) { hf(pd.pq); hf(pd.pk); hf(pd.pv); hf(pd.po); hf(pd.p1); hf(pd.p2); hf(pd.p3); }
         PD.clear(); hf(d_output_packed);
+        for (auto& w : q35L) {
+            hf(w.an); hf(w.pan); hf(w.qkv); hf(w.gate); hf(w.ssm_out); hf(w.alpha); hf(w.beta);
+            hf(w.ssa); hf(w.dt); hf(w.snorm); hf(w.conv1d); hf(w.q); hf(w.k); hf(w.v); hf(w.o);
+            hf(w.qn); hf(w.kn); hf(w.ex_g); hf(w.ex_u); hf(w.ex_d); hf(w.sh_g); hf(w.sh_u);
+            hf(w.sh_d); hf(w.router); hf(w.sh_gatew);
+        }
+        q35L.clear();
+        hf(q35_emb); hf(q35_out); hf(q35_onorm);
+        q35_loaded = false;
         L.clear();P.clear();model_.reset();
         hf(dh);hf(datt);hf(dgate);hf(dup);hf(dsilu);hf(doproj);hf(dffn);hf(dlogits);hf(dpart);
         hf(datt2);hf(dK);hf(dV);hf(dQ);hf(dAttn);

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -482,7 +482,7 @@ struct Hip1bpBackend : Backend {
             // Full device load (env H1BP_Q35_LOAD)... runs when set; decode path
             // below enabled by H1BP_Q35_TRY (eager decode; no hipGraph for q35).
             if (ok && getenv("H1BP_Q35_LOAD") && getenv("H1BP_Q35_TRY")) {
-                if (!q35_alloc_state()) {
+                if (!qwen35_alloc_state()) {
                     fprintf(stderr, "[hip1bp] qwen35 scratch alloc failed\n");
                 } else {
                     qwen35_zero_state();
@@ -977,7 +977,7 @@ struct Hip1bpBackend : Backend {
 
     // ── qwen35moe decode (M3, #1831) — eager per-token, no hipGraph ──
     bool qwen35_alloc_state() {
-        auto zz = [&](float*& p, size_t n) {
+        auto zz = [&](auto*& p, size_t n) {
             if (!n) { p = nullptr; return true; }
             if (hipMalloc((void**)&p, n * 4) != hipSuccess) { fprintf(stderr, "[hip1bp] q35 state alloc fail\n"); return false; }
             HIP_CHECK(hipMemset(p, 0, n * 4)); return true;

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -77,6 +77,25 @@ struct Hip1bpBackend : Backend {
     uint8_t* q35_emb = nullptr, *q35_out = nullptr;     // token_embd / output (V x H Q8_0)
     float* q35_onorm = nullptr;                         // output_norm (H f32)
     std::vector<Q35L> q35L;
+    // qwen35 decode scratch (per token, eager) + recurrent/conv/kv state
+    float* q35_sc_qkv = nullptr, *q35_sc_qc = nullptr;  // [8192] fused gemv / conv-out
+    float* q35_sc_q = nullptr, *q35_sc_k = nullptr, *q35_sc_v = nullptr;   // [4096] expanded q/k [2048->4096], v [4096]
+    float* q35_sc_z = nullptr;                          // [4096]
+    float* q35_sc_g = nullptr, *q35_sc_b = nullptr;     // [32] gate/beta
+    float* q35_sc_qk = nullptr, *q35_sc_v2 = nullptr;   // full-attn: q[8192] flat, k/v [512]
+    float* q35_sc_att = nullptr, *q35_sc_aout = nullptr;  // [4096] attn out / [2048] post
+    float* q35_sc_act = nullptr;                        // [2048]
+    float* q35_sc_moe = nullptr;                        // [2048]
+    float* q35_sc_exp = nullptr, *q35_sc_expw = nullptr;  // [512] expert act / [512] gate
+    float* q35_sc_expd = nullptr;                       // [2048] expert down out
+    float* q35_sc_logits = nullptr;                     // [256] router logits / topk w/idx
+    int* q35_sc_idx = nullptr;                          // [8]
+    float* q35_sc_rout = nullptr;                       // [256] router weights
+    float* q35_conv_state = nullptr;                    // [30*8192*3]
+    float* q35_rec_state = nullptr;                     // [30*128*128*32]
+    float* q35_kvc = nullptr;                           // [10][seq][2][256] (f32), seq = max_seq
+    float* q35_kv_scores = nullptr;                     // [16*max_seq]
+    float* q35_gate_flat = nullptr;                     // [16*256] sigmoid'd gates for o proj
 
     // GPU scratch (persistent, device-only)
     float *dh=nullptr,*datt=nullptr,*dgate=nullptr,*dup=nullptr;
@@ -460,6 +479,22 @@ struct Hip1bpBackend : Backend {
                     fprintf(stderr, "[hip1bp] qwen35 device load FAILED — falling back\n");
                 }
             }
+            // Full device load (env H1BP_Q35_LOAD)... runs when set; decode path
+            // below enabled by H1BP_Q35_TRY (eager decode; no hipGraph for q35).
+            if (ok && getenv("H1BP_Q35_LOAD") && getenv("H1BP_Q35_TRY")) {
+                if (!q35_alloc_state()) {
+                    fprintf(stderr, "[hip1bp] qwen35 scratch alloc failed\n");
+                } else {
+                    qwen35_zero_state();
+                    gpu_ok = true; pos = 0;
+                    *h_token = 0; *h_pos = 0;
+                    HIP_CHECK(hipMemcpy(d_token, h_token, sizeof(int), hipMemcpyHostToDevice));
+                    HIP_CHECK(hipMemcpy(d_pos, h_pos, sizeof(int), hipMemcpyHostToDevice));
+                    initialized = true;
+                    printf("[hip1bp] ✅ qwen35moe GPU decode ready (eager)\n");
+                    return true;
+                }
+            }
             return false;   // decode kernels are M3/M4; fall through to CPU/NPU
         }
 
@@ -641,7 +676,11 @@ struct Hip1bpBackend : Backend {
         return true;
     }
 
-    bool reset()override{pos=0;HIP_CHECK(hipMemset(dK,0,kvb));HIP_CHECK(hipMemset(dV,0,kvb));return true;}
+    bool reset()override{
+        pos=0;
+        if (q35_loaded) { qwen35_zero_state(); return true; }
+        HIP_CHECK(hipMemset(dK,0,kvb));HIP_CHECK(hipMemset(dV,0,kvb));return true;
+    }
 
     void launch_tq2nz(const uint8_t* w, const float* x, float* out, int N, int K) {
         int ntc = (K + 255) / 256;                    // 256-col tiles per row
@@ -880,6 +919,7 @@ struct Hip1bpBackend : Backend {
     // generate() == forward() + lm_head() — argmax semantics unchanged.
     // Phase 2: when graph_ok, the whole step replays from the captured graph.
     int generate_fast(int token_id){
+        if (q35_loaded) return qwen35_step(token_id);
         if (graph_ok) {
             *h_token = token_id; *h_pos = pos;
             HIP_CHECK(hipGraphLaunch(graphExec, stream));
@@ -935,6 +975,163 @@ struct Hip1bpBackend : Backend {
         return generate_fast(token_id);
     }
 
+    // ── qwen35moe decode (M3, #1831) — eager per-token, no hipGraph ──
+    bool qwen35_alloc_state() {
+        auto zz = [&](float*& p, size_t n) {
+            if (!n) { p = nullptr; return true; }
+            if (hipMalloc((void**)&p, n * 4) != hipSuccess) { fprintf(stderr, "[hip1bp] q35 state alloc fail\n"); return false; }
+            HIP_CHECK(hipMemset(p, 0, n * 4)); return true;
+        };
+        bool ok = zz(q35_sc_qkv, 8192) && zz(q35_sc_qc, 8192) && zz(q35_sc_q, 4096) &&
+                  zz(q35_sc_k, 4096) && zz(q35_sc_v, 4096) && zz(q35_sc_z, 4096) &&
+                  zz(q35_sc_g, 32) && zz(q35_sc_b, 32) && zz(q35_sc_qk, 8192) &&
+                  zz(q35_sc_v2, 512) && zz(q35_sc_att, 4096) && zz(q35_sc_aout, 2048) &&
+                  zz(q35_sc_act, 2048) && zz(q35_sc_moe, 2048) && zz(q35_sc_exp, 512) &&
+                  zz(q35_sc_expw, 512) && zz(q35_sc_expd, 2048) && zz(q35_sc_logits, 256) &&
+                  zz(q35_sc_rout, 256) && zz(q35_sc_idx, 8) &&
+                  zz(q35_conv_state, (size_t)NC * 8192 * 3) &&
+                  zz(q35_rec_state, (size_t)NC * 128 * 128 * 32) &&
+                  zz(q35_kvc, (size_t)10 * max_seq * 1024) &&
+                  zz(q35_kv_scores, (size_t)16 * max_seq) &&
+                  zz(q35_gate_flat, 16 * 256);
+        if (hipMalloc((void**)&q35_sc_idx, 8 * 4) != hipSuccess) ok = false;
+        return ok;
+    }
+    void qwen35_zero_state() {
+        if (q35_conv_state) HIP_CHECK(hipMemset(q35_conv_state, 0, (size_t)NC * 8192 * 3 * 4));
+        if (q35_rec_state)  HIP_CHECK(hipMemset(q35_rec_state, 0, (size_t)NC * 128 * 128 * 32 * 4));
+        if (q35_kvc)        HIP_CHECK(hipMemset(q35_kvc, 0, (size_t)10 * max_seq * 1024 * 4));
+    }
+    // expand q/k heads 16 -> 32 by tiling (h -> h%16) via copy kernel pair
+    void q35_expand16(float* dst, const float* src) {  // src [16*128], dst [32*128]
+        for (int h = 0; h < 32; h++) {
+            float* d = dst + (size_t)h * 128;
+            const float* s = src + (size_t)(h & 15) * 128;
+            HIP_CHECK(hipMemcpy(d, s, 128 * 4, hipMemcpyDeviceToDevice));
+        }
+    }
+    int qwen35_step(int token_id) {
+        if (!q35_loaded) return -1;
+        if (pos >= max_seq - 1) { fprintf(stderr, "[hip1bp] q35 KV overflow pos=%d\n", pos); return -1; }
+        *h_token = token_id; *h_pos = pos;
+        HIP_CHECK(hipMemcpyAsync(d_token, h_token, sizeof(int), hipMemcpyHostToDevice, stream));
+        HIP_CHECK(hipMemcpyAsync(d_pos, h_pos, sizeof(int), hipMemcpyHostToDevice, stream));
+        // embed (Q8_0 row dequant) into dh
+        HIP_CHECK(hipMemcpy(d_token, &token_id, sizeof(int), hipMemcpyHostToDevice));
+        h1bp_q8embed_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dh, q35_emb, d_token, 2048);
+        int n_full_layers = 0;
+        for (int l = 0; l < NC; l++) {
+            Q35L& w = q35L[l];
+            bool full = ((l + 1) % 4 == 0);
+            // residual pre-save + attn_norm (in-place dh)
+            h1bp_copy_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dsilu, dh, 2048);
+            h1bp_rmsnorm_kernel<<<1, 256, 0, stream>>>(dh, w.an, 2048, 1e-6f);
+            if (full) {
+                // q/k/v gemvs
+                h1bp_q8gemv_kernel<<<8192, 256, 0, stream>>>(q35_sc_qk, w.q, dh, 8192, 2048);
+                h1bp_q8gemv_kernel<<<512, 256, 0, stream>>>(q35_sc_v2, w.k, dh, 512, 2048);
+                // q per-head rmsnorm (16 x 256, weight qn); k norm on v2 (2 x 256)
+                h1bp_head_rmsnorm_kernel<<<16, 256, 0, stream>>>(q35_sc_qk, w.qn, 256, 1e-6f);
+                h1bp_head_rmsnorm_kernel<<<2, 256, 0, stream>>>(q35_sc_v2, w.kn, 256, 1e-6f);
+                // rope nrot64: q stored as per-head [q 256 | gate 256] pairs (hd=512 layout)
+                h1bp_rope_nrot_kernel<<<16, 256, 0, stream>>>(q35_sc_qk, 512, 64, d_pos, rope_theta, 16);
+                h1bp_rope_nrot_kernel<<<2, 256, 0, stream>>>(q35_sc_v2, 256, 64, d_pos, rope_theta, 2);
+                // store k (v2) and v into the per-layer kv cache [seq][k0 k1 v0 v1]
+                int f = n_full_layers;
+                float* kvbase = q35_kvc + (size_t)f * (max_seq * 1024);
+                HIP_CHECK(hipMemcpy(kvbase + (size_t)pos * 1024, q35_sc_v2, 512 * 4, hipMemcpyDeviceToDevice));
+                h1bp_q8gemv_kernel<<<512, 256, 0, stream>>>(q35_sc_v, w.v, dh, 512, 2048);
+                HIP_CHECK(hipMemcpy(kvbase + (size_t)pos * 1024 + 512, q35_sc_v, 512 * 4, hipMemcpyDeviceToDevice));
+                // attention over the cache, then sigmoid-gate multiply, then o_proj
+                h1bp_q35_fattn_kernel<<<16, 256, 0, stream>>>(q35_sc_qk, kvbase, q35_sc_att,
+                    q35_kv_scores, 16, 2, 256, max_seq, d_pos);
+                for (int h = 0; h < 16; h++) {
+                    float* g = q35_sc_qk + (size_t)h * 512 + 256;
+                    float* a = q35_sc_att + (size_t)h * 256;
+                    h1bp_sigmoid_mul_kernel<<<(256 + 255) / 256, 256, 0, stream>>>(a, g, 256);
+                }
+                h1bp_q8gemv_kernel<<<2048, 256, 0, stream>>>(q35_sc_aout, w.o, q35_sc_att, 2048, 4096);
+                n_full_layers++;
+            } else {
+                // GDN: fused qkv gemv + conv + silu (into qc), then slice
+                h1bp_q8gemv_kernel<<<8192, 256, 0, stream>>>(q35_sc_qkv, w.qkv, dh, 8192, 2048);
+                h1bp_q35_conv_kernel<<<(8192 + 255) / 256, 256, 0, stream>>>(
+                    q35_sc_qc, q35_sc_qkv, w.conv1d,
+                    q35_conv_state + (size_t)l * 8192 * 3, 8192, 4, pos);
+                // q/k l2-norm per 16 heads then expand to 32 (tiled)
+                h1bp_head_l2norm_kernel<<<16, 256, 0, stream>>>(q35_sc_qc, 128, 16, 1e-6f);
+                h1bp_head_l2norm_kernel<<<16, 256, 0, stream>>>(q35_sc_qc + 2048, 128, 16, 1e-6f);
+                h1bp_mul_scalar_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(q35_sc_qc, 1.0f / sqrtf(128.0f), 2048);
+                q35_expand16(q35_sc_q, q35_sc_qc);
+                q35_expand16(q35_sc_k, q35_sc_qc + 2048);
+                HIP_CHECK(hipMemcpy(q35_sc_v, q35_sc_qc + 4096, 4096 * 4, hipMemcpyDeviceToDevice));
+                // alpha/beta/gate: gemv 32x2048 then dt, softplus, ssa mul, sigmoid
+                h1bp_q8gemv_kernel<<<32, 256, 0, stream>>>(q35_sc_g, w.alpha, dh, 32, 2048);
+                h1bp_add_kernel<<<(32 + 255) / 256, 256, 0, stream>>>(q35_sc_g, w.dt, 32);
+                h1bp_softplus_kernel<<<(32 + 255) / 256, 256, 0, stream>>>(q35_sc_g, 32);
+                h1bp_elmul_kernel<<<(32 + 255) / 256, 256, 0, stream>>>(q35_sc_g, w.ssa, 32);
+                h1bp_q8gemv_kernel<<<32, 256, 0, stream>>>(q35_sc_b, w.beta, dh, 32, 2048);
+                h1bp_sigmoid_inplace_kernel<<<(32 + 255) / 256, 256, 0, stream>>>(q35_sc_b, 32);
+                // recurrence
+                h1bp_q35_delta_kernel<<<32, 128, 0, stream>>>(q35_sc_q, q35_sc_k, q35_sc_v,
+                    q35_rec_state + (size_t)l * 128 * 128 * 32, q35_sc_z, q35_sc_g, q35_sc_b, 128, 128, 32);
+                // z gemv (attn_gate 4096x2048) -> silu -> group norm out * silu(z)
+                h1bp_q8gemv_kernel<<<4096, 256, 0, stream>>>(q35_sc_att, w.gate, dh, 4096, 2048);
+                h1bp_head_rmsnorm_kernel<<<32, 256, 0, stream>>>(q35_sc_z, w.snorm, 128, 1e-6f);
+                h1bp_silu_inplace_kernel<<<(4096 + 255) / 256, 256, 0, stream>>>(q35_sc_att, 4096);
+                h1bp_elmul_kernel<<<(4096 + 255) / 256, 256, 0, stream>>>(q35_sc_z, q35_sc_att, 4096);
+                // ssm_out gemv [2048 x 4096] -> H
+                h1bp_q8gemv_kernel<<<2048, 256, 0, stream>>>(q35_sc_aout, w.ssm_out, q35_sc_z, 2048, 4096);
+            }
+            // residual: dh = preatt + attn out
+            h1bp_copy_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dh, dsilu, 2048);
+            h1bp_add_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dh, q35_sc_aout, 2048);
+            // post norm + MoE (every layer)
+            h1bp_copy_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dsilu, dh, 2048);
+            h1bp_rmsnorm_kernel<<<1, 256, 0, stream>>>(dh, w.pan, 2048, 1e-6f);
+            h1bp_gemv_kernel<<<256, 256, 0, stream>>>(q35_sc_logits, w.router, dh, 256, 2048);
+            // norm_topk: llama qwen35 uses renorm? default OFF unless env
+            bool renorm = getenv("Q35_NORMTK") != nullptr;
+            h1bp_q35_topk_kernel<<<1, 256, 0, stream>>>(q35_sc_logits, q35_sc_rout, q35_sc_idx, 256, 8, renorm);
+            HIP_CHECK(hipMemset(q35_sc_moe, 0, 2048 * 4));
+            int exps[8]; float wts[8];
+            HIP_CHECK(hipMemcpy(exps, q35_sc_idx, 8 * 4, hipMemcpyDeviceToHost));
+            HIP_CHECK(hipMemcpy(wts, q35_sc_rout, 8 * 4, hipMemcpyDeviceToHost));
+            for (int r = 0; r < 8; r++) {
+                int e = exps[r];
+                h1bp_q8gemv_slice_kernel<<<512, 256, 0, stream>>>(q35_sc_exp, w.ex_u, dh, e, 512, 2048, 1);
+                h1bp_q8gemv_slice_kernel<<<512, 256, 0, stream>>>(q35_sc_expw, w.ex_g, dh, e, 512, 2048, 1);
+                h1bp_silu_gate_mul_kernel<<<(512 + 255) / 256, 256, 0, stream>>>(q35_sc_exp, q35_sc_expw, 512);
+                h1bp_q8gemv_slice_kernel<<<2048, 256, 0, stream>>>(q35_sc_expd, w.ex_d, q35_sc_exp, e, 2048, 512, 1);
+                h1bp_mul_scalar_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(q35_sc_expd, wts[r], 2048);
+                h1bp_acc_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(q35_sc_moe, q35_sc_expd, 2048);
+            }
+            // shared expert + sigmoid gate
+            h1bp_q8gemv_kernel<<<512, 256, 0, stream>>>(q35_sc_exp, w.sh_u, dh, 512, 2048);
+            h1bp_q8gemv_kernel<<<512, 256, 0, stream>>>(q35_sc_expw, w.sh_g, dh, 512, 2048);
+            h1bp_silu_gate_mul_kernel<<<(512 + 255) / 256, 256, 0, stream>>>(q35_sc_exp, q35_sc_expw, 512);
+            h1bp_q8gemv_kernel<<<2048, 256, 0, stream>>>(q35_sc_expd, w.sh_d, q35_sc_exp, 2048, 512);
+            { float sgate;
+              h1bp_gemv_kernel<<<1, 256, 0, stream>>>(q35_sc_logits, w.sh_gatew, dh, 1, 2048);
+              HIP_CHECK(hipMemcpy(&sgate, q35_sc_logits, 4, hipMemcpyDeviceToHost));
+              sgate = 1.0f / (1.0f + expf(-sgate));
+              h1bp_mul_scalar_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(q35_sc_expd, sgate, 2048); }
+            h1bp_acc_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(q35_sc_moe, q35_sc_expd, 2048);
+            h1bp_copy_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dh, dsilu, 2048);
+            h1bp_add_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dh, q35_sc_moe, 2048);
+        }
+        // output norm + lm head + argmax
+        h1bp_rmsnorm_kernel<<<1, 256, 0, stream>>>(dh, q35_onorm, 2048, 1e-6f);
+        h1bp_q8gemv_kernel<<<248320, 256, 0, stream>>>(dlogits, q35_out, dh, 248320, 2048);
+        int nblk = std::min(AMX_MAXB, (248320 + 255) / 256);
+        h1bp_argmax_pass1_kernel<<<nblk, 256, 0, stream>>>(dlogits, 248320, d_amx, d_ami);
+        h1bp_argmax_pass2_kernel<<<1, 256, 0, stream>>>(d_amx, d_ami, nblk, d_argmax);
+        int out_tok = -1;
+        HIP_CHECK(hipMemcpy(&out_tok, d_argmax, sizeof(int), hipMemcpyDeviceToHost));
+        pos++;
+        return out_tok;
+    }
+
     float benchmark(int tokens)override{
         if(!initialized)return-1;reset();
         auto t0=std::chrono::steady_clock::now();int tok=1;
@@ -957,6 +1154,11 @@ struct Hip1bpBackend : Backend {
         }
         q35L.clear();
         hf(q35_emb); hf(q35_out); hf(q35_onorm);
+        hf(q35_sc_qkv); hf(q35_sc_qc); hf(q35_sc_q); hf(q35_sc_k); hf(q35_sc_v); hf(q35_sc_z);
+        hf(q35_sc_g); hf(q35_sc_b); hf(q35_sc_qk); hf(q35_sc_v2); hf(q35_sc_att); hf(q35_sc_aout);
+        hf(q35_sc_act); hf(q35_sc_moe); hf(q35_sc_exp); hf(q35_sc_expw); hf(q35_sc_expd);
+        hf(q35_sc_logits); hf(q35_sc_rout); hf(q35_sc_idx);
+        hf(q35_conv_state); hf(q35_rec_state); hf(q35_kvc); hf(q35_kv_scores); hf(q35_gate_flat);
         q35_loaded = false;
         L.clear();P.clear();model_.reset();
         hf(dh);hf(datt);hf(dgate);hf(dup);hf(dsilu);hf(doproj);hf(dffn);hf(dlogits);hf(dpart);

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -57,7 +57,7 @@ struct Hip1bpBackend : Backend {
     std::unique_ptr<GgufReader> gguf_;  // GGUF-direct mode (lossless f32, no 1BP conversion)
 
     // qwen35moe (Qwen3.6-35B-A3B) device weights — GGUF-direct, Q8_0 raw tiles
-    // (36 B/block; GGUF dtype 8 Q8_1 layout: fp16 d | fp16 s | 32 int8, val = qs*d)
+    // (34 B/block Q8_0) + f32 small tensors. Rows = out dim, K = ne0.
     struct Q35L {
         float* an = nullptr, *pan = nullptr;            // attn_norm / post_attention_norm (H f32)
         uint8_t* qkv = nullptr, *gate = nullptr;        // GDN: 8192xH / 4096xH Q8_0
@@ -332,15 +332,15 @@ struct Hip1bpBackend : Backend {
                         H, NC, n_full);
             }
             // M3 loader/kernel self-check (env H1BP_Q35_SELFCHECK): pull
-            // blk.0.attn_qkv (dtype-8 raw, 36 B/block) and run the device Q8 gemv
+            // blk.0.attn_qkv (Q8_0 raw, 34 B/block) and run the device Q8 gemv
             // against a host dequant of the same rows. Exercises the raw-GGUF
             // loader + h1bp_q8gemv_kernel on real hardware without a decode
             // path. Dense models never reach here (arch gate above).
             if (ok && getenv("H1BP_Q35_SELFCHECK")) {
                 std::vector<uint8_t> raw;
                 const int K0 = 2048, M0 = 8192;
-                const size_t rowb = (size_t)(K0 / 32) * 36;
-                if (gguf_->get_tensor_raw("blk.0.attn_qkv.weight", 32, 36, raw) &&
+                const size_t rowb = (size_t)(K0 / 32) * 34;
+                if (gguf_->get_tensor_raw("blk.0.attn_qkv.weight", 32, 34, raw) &&
                     raw.size() == (size_t)M0 * rowb) {
                     auto host_h2f = [](unsigned short h) -> float {
                         unsigned s = (h & 0x8000u) ? -1 : 1;
@@ -353,7 +353,7 @@ struct Hip1bpBackend : Backend {
                     for (int j = 0; j < K0; j++) x[j] = ((j % 13) - 6) * 0.25f;  // deterministic ramp
                     double ref0 = 0;
                     for (int j = 0; j < K0; j++) {
-                        const uint8_t* bp = raw.data() + (j >> 5) * 36;
+                        const uint8_t* bp = raw.data() + (j >> 5) * 34;
                         float d = host_h2f(*(const unsigned short*)bp);
                         float v = d * (float)((signed char)bp[2 + (j & 31)]);
                         ref0 += (double)v * x[j];
@@ -394,11 +394,11 @@ struct Hip1bpBackend : Backend {
                     if (l < 0) snprintf(bn, sizeof bn, "%s", nm);
                     else       snprintf(bn, sizeof bn, "blk.%d.%s", l, nm);
                     std::vector<uint8_t> raw;
-                    if (!gguf_->get_tensor_raw(bn, 32, 36, raw)) {
+                    if (!gguf_->get_tensor_raw(bn, 32, 34, raw)) {
                         if (optional) return true;
                         fprintf(stderr, "[hip1bp] q35 load: MISSING %s\n", bn); return false;
                     }
-                    size_t want = (size_t)M * ((size_t)(K >> 5) * 36);
+                    size_t want = (size_t)M * ((size_t)(K >> 5) * 34);
                     if (raw.size() != want) {
                         fprintf(stderr, "[hip1bp] q35 load: %s size %zu != want %zu "
                                         "(M=%d K=%d)\n", bn, raw.size(), want, M, K);

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -290,6 +290,56 @@ struct Hip1bpBackend : Backend {
                                 "(#1831 M3/M4) — use the CPU (qwen3next) or NPU path.\n",
                         H, NC, n_full);
             }
+            // M3 loader/kernel self-check (env H1BP_Q35_SELFCHECK): pull
+            // blk.0.attn_qkv (Q8_0 raw, 34 B/block) and run the device Q8 gemv
+            // against a host dequant of the same rows. Exercises the raw-GGUF
+            // loader + h1bp_q8gemv_kernel on real hardware without a decode
+            // path. Dense models never reach here (arch gate above).
+            if (ok && getenv("H1BP_Q35_SELFCHECK")) {
+                std::vector<uint8_t> raw;
+                const int K0 = 2048, M0 = 8192;
+                if (gguf_->get_tensor_raw("blk.0.attn_qkv.weight", 32, 34, raw) &&
+                    raw.size() == (size_t)M0 * ((size_t)(K0 / 32) * 34)) {
+                    auto host_h2f = [](unsigned short h) -> float {
+                        unsigned s = (h & 0x8000u) ? -1 : 1;
+                        unsigned e = (h >> 10) & 0x1f, m = h & 0x3ff;
+                        if (e == 0) return m == 0 ? 0.0f : s * ((float)m / 16384.0f / 1024.0f);
+                        if (e == 31) return s * (m ? NAN : INFINITY);
+                        return s * (1.0f + (float)m / 1024.0f) * powf(2.0f, (int)e - 15);
+                    };
+                    const size_t rowb = (size_t)(K0 / 32) * 34;
+                    std::vector<float> x(K0);
+                    for (int j = 0; j < K0; j++) x[j] = ((j % 13) - 6) * 0.25f;  // deterministic ramp
+                    double ref0 = 0;
+                    for (int j = 0; j < K0; j++) {
+                        const uint8_t* bp = raw.data() + (j >> 5) * 34;
+                        float d = host_h2f(*(const unsigned short*)bp);
+                        float v = d * (float)((signed char)bp[2 + (j & 31)]);
+                        ref0 += (double)v * x[j];
+                    }
+                    uint8_t* dq = nullptr; float* dx = nullptr; float* dy = nullptr;
+                    if (hipMalloc((void**)&dq, raw.size()) == hipSuccess &&
+                        hipMalloc((void**)&dx, K0 * 4) == hipSuccess &&
+                        hipMalloc((void**)&dy, (size_t)M0 * 4) == hipSuccess) {
+                        HIP_CHECK(hipMemcpy(dq, raw.data(), raw.size(), hipMemcpyHostToDevice));
+                        HIP_CHECK(hipMemcpy(dx, x.data(), K0 * 4, hipMemcpyHostToDevice));
+                        h1bp_q8gemv_kernel<<<M0, 256, 0, stream>>>(dy, dq, dx, M0, K0);
+                        HIP_CHECK(hipStreamSynchronize(stream));
+                        float dev0 = 0;
+                        HIP_CHECK(hipMemcpy(&dev0, dy, 4, hipMemcpyDeviceToHost));
+                        bool pass = fabsf((float)ref0 - dev0) <= 2e-3f * (1.0f + fabsf((float)ref0));
+                        fprintf(stderr, "[hip1bp] qwen35 selfcheck blk.0.attn_qkv: "
+                                        "M=%d K=%d raw=%zu B; row0 ref=%.6f dev=%.6f → %s\n",
+                                M0, K0, raw.size(), (float)ref0, dev0, pass ? "PASS" : "FAIL");
+                        HIP_CHECK_D(hipFree(dy)); HIP_CHECK_D(hipFree(dx)); HIP_CHECK_D(hipFree(dq));
+                    } else {
+                        fprintf(stderr, "[hip1bp] qwen35 selfcheck: hipMalloc failed\n");
+                    }
+                } else {
+                    fprintf(stderr, "[hip1bp] qwen35 selfcheck: attn_qkv raw read failed "
+                                    "(want %zu B)\n", (size_t)M0 * rowb);
+                }
+            }
             return false;   // decode kernels are M3/M4; fall through to CPU/NPU
         }
 

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -1007,7 +1007,7 @@ struct Hip1bpBackend : Backend {
         for (int h = 0; h < 32; h++) {
             float* d = dst + (size_t)h * 128;
             const float* s = src + (size_t)(h & 15) * 128;
-            HIP_CHECK(hipMemcpy(d, s, 128 * 4, hipMemcpyDeviceToDevice));
+            HIP_CHECK(hipMemcpyAsync(d, s, 128 * 4, hipMemcpyDeviceToDevice, stream));
         }
     }
     int qwen35_step(int token_id) {
@@ -1047,9 +1047,9 @@ struct Hip1bpBackend : Backend {
                 // store k (v2) and v into the per-layer kv cache [seq][k0 k1 v0 v1]
                 int f = n_full_layers;
                 float* kvbase = q35_kvc + (size_t)f * (max_seq * 1024);
-                HIP_CHECK(hipMemcpy(kvbase + (size_t)pos * 1024, q35_sc_v2, 512 * 4, hipMemcpyDeviceToDevice));
+                HIP_CHECK(hipMemcpyAsync(kvbase + (size_t)pos * 1024, q35_sc_v2, 512 * 4, hipMemcpyDeviceToDevice, stream));
                 h1bp_q8gemv_kernel<<<512, 256, 0, stream>>>(q35_sc_v, w.v, dh, 512, 2048);
-                HIP_CHECK(hipMemcpy(kvbase + (size_t)pos * 1024 + 512, q35_sc_v, 512 * 4, hipMemcpyDeviceToDevice));
+                HIP_CHECK(hipMemcpyAsync(kvbase + (size_t)pos * 1024 + 512, q35_sc_v, 512 * 4, hipMemcpyDeviceToDevice, stream));
                 // attention over the cache, then sigmoid-gate multiply, then o_proj
                 h1bp_q35_fattn_kernel<<<16, 256, 0, stream>>>(q35_sc_qk, kvbase, q35_sc_att,
                     q35_kv_scores, 16, 2, 256, max_seq, d_pos);
@@ -1073,7 +1073,7 @@ struct Hip1bpBackend : Backend {
                 h1bp_mul_scalar_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(q35_sc_qc, 1.0f / sqrtf(128.0f), 2048);
                 q35_expand16(q35_sc_q, q35_sc_qc);
                 q35_expand16(q35_sc_k, q35_sc_qc + 2048);
-                HIP_CHECK(hipMemcpy(q35_sc_v, q35_sc_qc + 4096, 4096 * 4, hipMemcpyDeviceToDevice));
+                HIP_CHECK(hipMemcpyAsync(q35_sc_v, q35_sc_qc + 4096, 4096 * 4, hipMemcpyDeviceToDevice, stream));
                 // alpha/beta/gate: gemv 32x2048 then dt, softplus, ssa mul, sigmoid
                 h1bp_q8gemv_kernel<<<32, 256, 0, stream>>>(q35_sc_g, w.alpha, dh, 32, 2048);
                 h1bp_add_kernel<<<(32 + 255) / 256, 256, 0, stream>>>(q35_sc_g, w.dt, 32);
@@ -1109,6 +1109,7 @@ struct Hip1bpBackend : Backend {
             h1bp_q35_topk_kernel<<<1, 256, 0, stream>>>(q35_sc_logits, q35_sc_rout, q35_sc_idx, 256, 8, renorm);
             HIP_CHECK(hipMemset(q35_sc_moe, 0, 2048 * 4));
             int exps[8]; float wts[8];
+            HIP_CHECK(hipStreamSynchronize(stream));
             HIP_CHECK(hipMemcpy(exps, q35_sc_idx, 8 * 4, hipMemcpyDeviceToHost));
             HIP_CHECK(hipMemcpy(wts, q35_sc_rout, 8 * 4, hipMemcpyDeviceToHost));
             for (int r = 0; r < 8; r++) {

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -1020,14 +1020,15 @@ struct Hip1bpBackend : Backend {
         HIP_CHECK(hipMemcpy(d_token, &token_id, sizeof(int), hipMemcpyHostToDevice));
         h1bp_q8embed_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dh, q35_emb, d_token, 2048);
         int n_full_layers = 0;
-        auto q35_wb = [&](const char* nm, const float* buf, int n) {
-            if (pos != 0 || !getenv("H1BP_Q35_STAGE")) return;
+        auto q35_wb = [&](const char* nm, const float* buf, int n, int layer) {
+            if (!getenv("H1BP_Q35_STAGE")) return;
+            if (pos != 0 && !getenv("H1BP_Q35_ALLSTAGE")) return;
+            char fn[1024]; snprintf(fn, sizeof fn, "%s/l%02d_%s.f32", getenv("H1BP_Q35_STAGE"), layer, nm);
             std::vector<float> tmp(n);
             HIP_CHECK(hipMemcpy(tmp.data(), buf, n * 4, hipMemcpyDeviceToHost));
-            char fn[1024]; snprintf(fn, sizeof fn, "%s/%s.f32", getenv("H1BP_Q35_STAGE"), nm);
             FILE* f = fopen(fn, "wb"); if (f) { fwrite(tmp.data(), 4, n, f); fclose(f); }
         };
-        if (pos == 0) q35_wb("emb", dh, 2048);
+        if (pos == 0) q35_wb("emb", dh, 2048, -1);
         for (int l = 0; l < NC; l++) {
             Q35L& w = q35L[l];
             bool full = ((l + 1) % 4 == 0);
@@ -1066,7 +1067,7 @@ struct Hip1bpBackend : Backend {
                 h1bp_q35_conv_kernel<<<(8192 + 255) / 256, 256, 0, stream>>>(
                     q35_sc_qc, q35_sc_qkv, w.conv1d,
                     q35_conv_state + (size_t)l * 8192 * 3, 8192, 4, pos);
-                if (l == 0) { q35_wb("qkv", q35_sc_qkv, 8192); q35_wb("qc", q35_sc_qc, 8192); }
+                q35_wb("qkv", q35_sc_qkv, 8192, l); q35_wb("qc", q35_sc_qc, 8192, l);
                 // q/k l2-norm per 16 heads then expand to 32 (tiled)
                 h1bp_head_l2norm_kernel<<<16, 256, 0, stream>>>(q35_sc_qc, 128, 16, 1e-6f);
                 h1bp_head_l2norm_kernel<<<16, 256, 0, stream>>>(q35_sc_qc + 2048, 128, 16, 1e-6f);
@@ -1084,16 +1085,15 @@ struct Hip1bpBackend : Backend {
                 // recurrence
                 h1bp_q35_delta_kernel<<<32, 128, 0, stream>>>(q35_sc_q, q35_sc_k, q35_sc_v,
                     q35_rec_state + (size_t)l * 128 * 128 * 32, q35_sc_z, q35_sc_g, q35_sc_b, 128, 128, 32);
-                if (l == 0) { q35_wb("qexp", q35_sc_q, 4096); q35_wb("kexp", q35_sc_k, 4096);
-                              q35_wb("v", q35_sc_v, 4096); q35_wb("deltaraw", q35_sc_z, 4096); }
+                q35_wb("qexp", q35_sc_q, 4096, l); q35_wb("kexp", q35_sc_k, 4096, l);
+                q35_wb("v", q35_sc_v, 4096, l); q35_wb("deltaraw", q35_sc_z, 4096, l);
                 // z gemv (attn_gate 4096x2048) -> silu -> group norm out * silu(z)
                 h1bp_q8gemv_kernel<<<4096, 256, 0, stream>>>(q35_sc_att, w.gate, dh, 4096, 2048);
                 h1bp_head_rmsnorm_kernel<<<32, 256, 0, stream>>>(q35_sc_z, w.snorm, 128, 1e-6f);
                 h1bp_silu_inplace_kernel<<<(4096 + 255) / 256, 256, 0, stream>>>(q35_sc_att, 4096);
                 h1bp_elmul_kernel<<<(4096 + 255) / 256, 256, 0, stream>>>(q35_sc_z, q35_sc_att, 4096);
-                if (l == 0) { q35_wb("g", q35_sc_g, 32); q35_wb("beta", q35_sc_b, 32); q35_wb("zattn", q35_sc_z, 4096);
-                              q35_wb("q16n", q35_sc_qc, 2048); q35_wb("k16n", q35_sc_qc + 2048, 2048);
-                              q35_wb("zraw", q35_sc_att, 4096); }
+                q35_wb("g", q35_sc_g, 32, l); q35_wb("beta", q35_sc_b, 32, l);
+                q35_wb("zattn", q35_sc_z, 4096, l);
                 // ssm_out gemv [2048 x 4096] -> H
                 h1bp_q8gemv_kernel<<<2048, 256, 0, stream>>>(q35_sc_aout, w.ssm_out, q35_sc_z, 2048, 4096);
             }
@@ -1134,7 +1134,7 @@ struct Hip1bpBackend : Backend {
             h1bp_acc_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(q35_sc_moe, q35_sc_expd, 2048);
             h1bp_copy_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dh, dsilu, 2048);
             h1bp_add_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dh, q35_sc_moe, 2048);
-            if (l == 0) q35_wb("l0out", dh, 2048);
+            q35_wb("hidden", dh, 2048, l);
         }
         // output norm + lm head + argmax
         h1bp_rmsnorm_kernel<<<1, 256, 0, stream>>>(dh, q35_onorm, 2048, 1e-6f);

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -1123,6 +1123,12 @@ struct Hip1bpBackend : Backend {
         // output norm + lm head + argmax
         h1bp_rmsnorm_kernel<<<1, 256, 0, stream>>>(dh, q35_onorm, 2048, 1e-6f);
         h1bp_q8gemv_kernel<<<248320, 256, 0, stream>>>(dlogits, q35_out, dh, 248320, 2048);
+        if (const char* ld = getenv("H1BP_Q35_LOGDIR")) {
+            std::vector<float> lg(248320);
+            HIP_CHECK(hipMemcpy(lg.data(), dlogits, 248320 * 4, hipMemcpyDeviceToHost));
+            char fn[1024]; snprintf(fn, sizeof fn, "%s/p%04d.f32", ld, pos);
+            FILE* f = fopen(fn, "wb"); if (f) { fwrite(lg.data(), 4, 248320, f); fclose(f); }
+        }
         int nblk = std::min(AMX_MAXB, (248320 + 255) / 256);
         h1bp_argmax_pass1_kernel<<<nblk, 256, 0, stream>>>(dlogits, 248320, d_amx, d_ami);
         h1bp_argmax_pass2_kernel<<<1, 256, 0, stream>>>(d_amx, d_ami, nblk, d_argmax);

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -57,7 +57,7 @@ struct Hip1bpBackend : Backend {
     std::unique_ptr<GgufReader> gguf_;  // GGUF-direct mode (lossless f32, no 1BP conversion)
 
     // qwen35moe (Qwen3.6-35B-A3B) device weights — GGUF-direct, Q8_0 raw tiles
-    // (34 B/block) + f32 small tensors. M3 (#1831). Rows = out dim, K = ne0.
+    // (36 B/block; GGUF dtype 8 Q8_1 layout: fp16 d | fp16 s | 32 int8, val = qs*d)
     struct Q35L {
         float* an = nullptr, *pan = nullptr;            // attn_norm / post_attention_norm (H f32)
         uint8_t* qkv = nullptr, *gate = nullptr;        // GDN: 8192xH / 4096xH Q8_0
@@ -332,15 +332,15 @@ struct Hip1bpBackend : Backend {
                         H, NC, n_full);
             }
             // M3 loader/kernel self-check (env H1BP_Q35_SELFCHECK): pull
-            // blk.0.attn_qkv (Q8_0 raw, 34 B/block) and run the device Q8 gemv
+            // blk.0.attn_qkv (dtype-8 raw, 36 B/block) and run the device Q8 gemv
             // against a host dequant of the same rows. Exercises the raw-GGUF
             // loader + h1bp_q8gemv_kernel on real hardware without a decode
             // path. Dense models never reach here (arch gate above).
             if (ok && getenv("H1BP_Q35_SELFCHECK")) {
                 std::vector<uint8_t> raw;
                 const int K0 = 2048, M0 = 8192;
-                const size_t rowb = (size_t)(K0 / 32) * 34;
-                if (gguf_->get_tensor_raw("blk.0.attn_qkv.weight", 32, 34, raw) &&
+                const size_t rowb = (size_t)(K0 / 32) * 36;
+                if (gguf_->get_tensor_raw("blk.0.attn_qkv.weight", 32, 36, raw) &&
                     raw.size() == (size_t)M0 * rowb) {
                     auto host_h2f = [](unsigned short h) -> float {
                         unsigned s = (h & 0x8000u) ? -1 : 1;
@@ -353,7 +353,7 @@ struct Hip1bpBackend : Backend {
                     for (int j = 0; j < K0; j++) x[j] = ((j % 13) - 6) * 0.25f;  // deterministic ramp
                     double ref0 = 0;
                     for (int j = 0; j < K0; j++) {
-                        const uint8_t* bp = raw.data() + (j >> 5) * 34;
+                        const uint8_t* bp = raw.data() + (j >> 5) * 36;
                         float d = host_h2f(*(const unsigned short*)bp);
                         float v = d * (float)((signed char)bp[2 + (j & 31)]);
                         ref0 += (double)v * x[j];
@@ -394,11 +394,11 @@ struct Hip1bpBackend : Backend {
                     if (l < 0) snprintf(bn, sizeof bn, "%s", nm);
                     else       snprintf(bn, sizeof bn, "blk.%d.%s", l, nm);
                     std::vector<uint8_t> raw;
-                    if (!gguf_->get_tensor_raw(bn, 32, 34, raw)) {
+                    if (!gguf_->get_tensor_raw(bn, 32, 36, raw)) {
                         if (optional) return true;
                         fprintf(stderr, "[hip1bp] q35 load: MISSING %s\n", bn); return false;
                     }
-                    size_t want = (size_t)M * ((size_t)(K >> 5) * 34);
+                    size_t want = (size_t)M * ((size_t)(K >> 5) * 36);
                     if (raw.size() != want) {
                         fprintf(stderr, "[hip1bp] q35 load: %s size %zu != want %zu "
                                         "(M=%d K=%d)\n", bn, raw.size(), want, M, K);

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -298,8 +298,9 @@ struct Hip1bpBackend : Backend {
             if (ok && getenv("H1BP_Q35_SELFCHECK")) {
                 std::vector<uint8_t> raw;
                 const int K0 = 2048, M0 = 8192;
+                const size_t rowb = (size_t)(K0 / 32) * 34;
                 if (gguf_->get_tensor_raw("blk.0.attn_qkv.weight", 32, 34, raw) &&
-                    raw.size() == (size_t)M0 * ((size_t)(K0 / 32) * 34)) {
+                    raw.size() == (size_t)M0 * rowb) {
                     auto host_h2f = [](unsigned short h) -> float {
                         unsigned s = (h & 0x8000u) ? -1 : 1;
                         unsigned e = (h >> 10) & 0x1f, m = h & 0x3ff;
@@ -307,7 +308,6 @@ struct Hip1bpBackend : Backend {
                         if (e == 31) return s * (m ? NAN : INFINITY);
                         return s * (1.0f + (float)m / 1024.0f) * powf(2.0f, (int)e - 15);
                     };
-                    const size_t rowb = (size_t)(K0 / 32) * 34;
                     std::vector<float> x(K0);
                     for (int j = 0; j < K0; j++) x[j] = ((j % 13) - 6) * 0.25f;  // deterministic ramp
                     double ref0 = 0;

--- a/src/hip_1bp_kernels.hip
+++ b/src/hip_1bp_kernels.hip
@@ -388,19 +388,20 @@ __global__ void h1bp_rocmfp4_part_kernel(const uint8_t* __restrict__ w,
     part[(size_t)row * 32 * wpr + (warp % wpr) * 32 + lane] = acc;
 }
 
-// ── Q8_0 (GGUF dtype 8, block 32: fp16 scale + 32 int8, 34 B/block) GEMV ──
+// ── GGUF dtype 8 (Q8_1 layout: fp16 d | fp16 s | 32 int8, 36 B/block;
+// value = qs*d, s = block-sum sidecar) GEMV ──
 // W row r = K/32 blocks contiguous: [fp16 d][qs0..31][fp16 d][qs0..31]...
 // y[M] = W[M,K] @ x[K]; K % 32 == 0. Mirrors h1bp_gemv_kernel structure.
 __global__ void h1bp_q8gemv_kernel(float* y, const uint8_t* W, const float* x, int M, int K) {
     int row = blockIdx.x;
     if (row >= M) return;
-    const uint8_t* wr = W + (size_t)row * ((size_t)(K >> 5) * 34);
+    const uint8_t* wr = W + (size_t)row * ((size_t)(K >> 5) * 36);
     double sum = 0;
     for (int j = threadIdx.x; j < K; j += blockDim.x) {
         int blk = j >> 5, lane = j & 31;
-        const uint8_t* bp = wr + (size_t)blk * 34;
+        const uint8_t* bp = wr + (size_t)blk * 36;
         float d = __half2float(__ushort_as_half(*(const unsigned short*)bp));
-        sum += (double)x[j] * (d * (float)((signed char)bp[2 + lane]));
+        sum += (double)x[j] * (d * (float)((signed char)bp[4 + lane]));
     }
     __shared__ double sdata[256];
     sdata[threadIdx.x] = sum;
@@ -412,14 +413,14 @@ __global__ void h1bp_q8gemv_kernel(float* y, const uint8_t* W, const float* x, i
     if (threadIdx.x == 0) y[row] = (float)sdata[0];
 }
 
-// Q8_0 embedding row fetch: y[K] = dequant(embed[tok]) — one block per row.
+// dtype-8 embedding row fetch: y[K] = dequant(embed[tok]) — one block per row.
 __global__ void h1bp_q8embed_kernel(float* y, const uint8_t* E, const int* d_tok, int K) {
     int tok = *d_tok;
     int j = threadIdx.x + blockIdx.x * blockDim.x;
     if (j >= K) return;
-    const uint8_t* bp = E + (size_t)tok * ((size_t)(K >> 5) * 34) + (size_t)(j >> 5) * 34;
+    const uint8_t* bp = E + (size_t)tok * ((size_t)(K >> 5) * 36) + (size_t)(j >> 5) * 36;
     float d = __half2float(__ushort_as_half(*(const unsigned short*)bp));
-    y[j] = d * (float)((signed char)bp[2 + (j & 31)]);
+    y[j] = d * (float)((signed char)bp[4 + (j & 31)]);
 }
 
 // Q8_0 fused-expert gemv for one expert block: experts are stored
@@ -429,14 +430,14 @@ __global__ void h1bp_q8gemv_slice_kernel(float* y, const uint8_t* W, const float
                                          int exp_idx, int out_per_exp, int K, int out_stride_floats) {
     int row = blockIdx.x;               // 0..out_per_exp-1
     if (row >= out_per_exp) return;
-    const uint8_t* wr = W + (size_t)exp_idx * ((size_t)out_per_exp * (K >> 5) * 34)
-                          + (size_t)row * ((size_t)(K >> 5) * 34);
+    const uint8_t* wr = W + (size_t)exp_idx * ((size_t)out_per_exp * (K >> 5) * 36)
+                          + (size_t)row * ((size_t)(K >> 5) * 36);
     double sum = 0;
     for (int j = threadIdx.x; j < K; j += blockDim.x) {
         int blk = j >> 5, lane = j & 31;
-        const uint8_t* bp = wr + (size_t)blk * 34;
+        const uint8_t* bp = wr + (size_t)blk * 36;
         float d = __half2float(__ushort_as_half(*(const unsigned short*)bp));
-        sum += (double)x[j] * (d * (float)((signed char)bp[2 + lane]));
+        sum += (double)x[j] * (d * (float)((signed char)bp[4 + lane]));
     }
     __shared__ double sdata[256];
     sdata[threadIdx.x] = sum;

--- a/src/hip_1bp_kernels.hip
+++ b/src/hip_1bp_kernels.hip
@@ -388,20 +388,19 @@ __global__ void h1bp_rocmfp4_part_kernel(const uint8_t* __restrict__ w,
     part[(size_t)row * 32 * wpr + (warp % wpr) * 32 + lane] = acc;
 }
 
-// ── GGUF dtype 8 (Q8_1 layout: fp16 d | fp16 s | 32 int8, 36 B/block;
-// value = qs*d, s = block-sum sidecar) GEMV ──
+// ── Q8_0 (GGUF dtype 8, block 32: fp16 scale + 32 int8, 34 B/block) GEMV ──
 // W row r = K/32 blocks contiguous: [fp16 d][qs0..31][fp16 d][qs0..31]...
 // y[M] = W[M,K] @ x[K]; K % 32 == 0. Mirrors h1bp_gemv_kernel structure.
 __global__ void h1bp_q8gemv_kernel(float* y, const uint8_t* W, const float* x, int M, int K) {
     int row = blockIdx.x;
     if (row >= M) return;
-    const uint8_t* wr = W + (size_t)row * ((size_t)(K >> 5) * 36);
+    const uint8_t* wr = W + (size_t)row * ((size_t)(K >> 5) * 34);
     double sum = 0;
     for (int j = threadIdx.x; j < K; j += blockDim.x) {
         int blk = j >> 5, lane = j & 31;
-        const uint8_t* bp = wr + (size_t)blk * 36;
+        const uint8_t* bp = wr + (size_t)blk * 34;
         float d = __half2float(__ushort_as_half(*(const unsigned short*)bp));
-        sum += (double)x[j] * (d * (float)((signed char)bp[4 + lane]));
+        sum += (double)x[j] * (d * (float)((signed char)bp[2 + lane]));
     }
     __shared__ double sdata[256];
     sdata[threadIdx.x] = sum;
@@ -418,9 +417,9 @@ __global__ void h1bp_q8embed_kernel(float* y, const uint8_t* E, const int* d_tok
     int tok = *d_tok;
     int j = threadIdx.x + blockIdx.x * blockDim.x;
     if (j >= K) return;
-    const uint8_t* bp = E + (size_t)tok * ((size_t)(K >> 5) * 36) + (size_t)(j >> 5) * 36;
+    const uint8_t* bp = E + (size_t)tok * ((size_t)(K >> 5) * 34) + (size_t)(j >> 5) * 34;
     float d = __half2float(__ushort_as_half(*(const unsigned short*)bp));
-    y[j] = d * (float)((signed char)bp[4 + (j & 31)]);
+    y[j] = d * (float)((signed char)bp[2 + (j & 31)]);
 }
 
 // Q8_0 fused-expert gemv for one expert block: experts are stored
@@ -430,14 +429,14 @@ __global__ void h1bp_q8gemv_slice_kernel(float* y, const uint8_t* W, const float
                                          int exp_idx, int out_per_exp, int K, int out_stride_floats) {
     int row = blockIdx.x;               // 0..out_per_exp-1
     if (row >= out_per_exp) return;
-    const uint8_t* wr = W + (size_t)exp_idx * ((size_t)out_per_exp * (K >> 5) * 36)
-                          + (size_t)row * ((size_t)(K >> 5) * 36);
+    const uint8_t* wr = W + (size_t)exp_idx * ((size_t)out_per_exp * (K >> 5) * 34)
+                          + (size_t)row * ((size_t)(K >> 5) * 34);
     double sum = 0;
     for (int j = threadIdx.x; j < K; j += blockDim.x) {
         int blk = j >> 5, lane = j & 31;
-        const uint8_t* bp = wr + (size_t)blk * 36;
+        const uint8_t* bp = wr + (size_t)blk * 34;
         float d = __half2float(__ushort_as_half(*(const unsigned short*)bp));
-        sum += (double)x[j] * (d * (float)((signed char)bp[4 + lane]));
+        sum += (double)x[j] * (d * (float)((signed char)bp[2 + lane]));
     }
     __shared__ double sdata[256];
     sdata[threadIdx.x] = sum;

--- a/src/hip_1bp_kernels.hip
+++ b/src/hip_1bp_kernels.hip
@@ -532,7 +532,7 @@ __global__ void h1bp_q35_delta_kernel(const float* __restrict__ q, const float* 
     int col = threadIdx.x; if (col >= S_v) return;
     const float* kh = k + (size_t)h * S_k;
     const float* qh = q + (size_t)h * S_k;
-    float* Scol = state + ((size_t)h * S_v + col);       // S[i][col]: stride S_v per i
+    float* Scol = state + ((size_t)h * S_v * S_v + col);  // S[i][col]: stride S_v per i
     float gv = __expf(g[h]);                             // decay for this head
     float kv = 0.0f;
     for (int i = 0; i < S_k; i++) kv += Scol[(size_t)i * S_v] * kh[i];

--- a/src/hip_1bp_kernels.hip
+++ b/src/hip_1bp_kernels.hip
@@ -387,3 +387,63 @@ __global__ void h1bp_rocmfp4_part_kernel(const uint8_t* __restrict__ w,
     }
     part[(size_t)row * 32 * wpr + (warp % wpr) * 32 + lane] = acc;
 }
+
+// ── Q8_0 (GGUF dtype 8, block 32: fp16 scale + 32 int8, 34 B/block) GEMV ──
+// W row r = K/32 blocks contiguous: [fp16 d][qs0..31][fp16 d][qs0..31]...
+// y[M] = W[M,K] @ x[K]; K % 32 == 0. Mirrors h1bp_gemv_kernel structure.
+__global__ void h1bp_q8gemv_kernel(float* y, const uint8_t* W, const float* x, int M, int K) {
+    int row = blockIdx.x;
+    if (row >= M) return;
+    const uint8_t* wr = W + (size_t)row * ((size_t)(K >> 5) * 34);
+    double sum = 0;
+    for (int j = threadIdx.x; j < K; j += blockDim.x) {
+        int blk = j >> 5, lane = j & 31;
+        const uint8_t* bp = wr + (size_t)blk * 34;
+        float d = __half2float(__ushort_as_half(*(const unsigned short*)bp));
+        sum += (double)x[j] * (d * (float)((signed char)bp[2 + lane]));
+    }
+    __shared__ double sdata[256];
+    sdata[threadIdx.x] = sum;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s) sdata[threadIdx.x] += sdata[threadIdx.x + s];
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) y[row] = (float)sdata[0];
+}
+
+// Q8_0 embedding row fetch: y[K] = dequant(embed[tok]) — one block per row.
+__global__ void h1bp_q8embed_kernel(float* y, const uint8_t* E, const int* d_tok, int K) {
+    int tok = *d_tok;
+    int j = threadIdx.x + blockIdx.x * blockDim.x;
+    if (j >= K) return;
+    const uint8_t* bp = E + (size_t)tok * ((size_t)(K >> 5) * 34) + (size_t)(j >> 5) * 34;
+    float d = __half2float(__ushort_as_half(*(const unsigned short*)bp));
+    y[j] = d * (float)((signed char)bp[2 + (j & 31)]);
+}
+
+// Q8_0 fused-expert gemv for one expert block: experts are stored
+// expert-major contiguous (gate/up: [256 exp][512 out][2048 in]); this kernel
+// computes out[e*R ..] for the expert whose slice starts at base + e*R*Kbytes.
+__global__ void h1bp_q8gemv_slice_kernel(float* y, const uint8_t* W, const float* x,
+                                         int exp_idx, int out_per_exp, int K, int out_stride_floats) {
+    int row = blockIdx.x;               // 0..out_per_exp-1
+    if (row >= out_per_exp) return;
+    const uint8_t* wr = W + (size_t)exp_idx * ((size_t)out_per_exp * (K >> 5) * 34)
+                          + (size_t)row * ((size_t)(K >> 5) * 34);
+    double sum = 0;
+    for (int j = threadIdx.x; j < K; j += blockDim.x) {
+        int blk = j >> 5, lane = j & 31;
+        const uint8_t* bp = wr + (size_t)blk * 34;
+        float d = __half2float(__ushort_as_half(*(const unsigned short*)bp));
+        sum += (double)x[j] * (d * (float)((signed char)bp[2 + lane]));
+    }
+    __shared__ double sdata[256];
+    sdata[threadIdx.x] = sum;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s) sdata[threadIdx.x] += sdata[threadIdx.x + s];
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) y[(size_t)row * out_stride_floats] = (float)sdata[0];
+}

--- a/src/hip_1bp_kernels.hip
+++ b/src/hip_1bp_kernels.hip
@@ -447,3 +447,201 @@ __global__ void h1bp_q8gemv_slice_kernel(float* y, const uint8_t* W, const float
     }
     if (threadIdx.x == 0) y[(size_t)row * out_stride_floats] = (float)sdata[0];
 }
+
+// ── qwen35moe (M3) kernels ────────────────────────────────────────────────
+// RoPE over the first n_rot dims of a head_dim head (qwen35: 64 of 256),
+// head h owns contiguous [head_dim] floats; pairs (d, d+n_rot/2), d<n_rot/2.
+__global__ void h1bp_rope_nrot_kernel(float* __restrict__ x, int head_dim, int n_rot,
+                                  const int* __restrict__ d_pos, float theta_base, int num_heads) {
+    const int pos = *d_pos;
+    int h = blockIdx.x, d = threadIdx.x;
+    if (h >= num_heads || d >= n_rot / 2) return;
+    float freq = 1.0f / powf(theta_base, (float)(2 * d) / (float)n_rot);
+    float t = (float)pos * freq, c = cosf(t), s = sinf(t);
+    int idx = h * head_dim + d;
+    float a = x[idx], b = x[idx + n_rot / 2];
+    x[idx] = a * c - b * s;
+    x[idx + n_rot / 2] = a * s + b * c;
+}
+__global__ void h1bp_softplus_kernel(float* __restrict__ x, int n) {
+    int i = threadIdx.x + blockIdx.x * blockDim.x;
+    if (i < n) x[i] = log1pf(__expf(x[i]));
+}
+__global__ void h1bp_sigmoid_mul_kernel(float* __restrict__ x, const float* __restrict__ g, int n) {
+    int i = threadIdx.x + blockIdx.x * blockDim.x;
+    if (i < n) x[i] = x[i] * (1.0f / (1.0f + __expf(-g[i])));
+}
+// in-place a[i] *= b[i]
+__global__ void h1bp_elmul_kernel(float* __restrict__ a, const float* __restrict__ b, int n) {
+    int i = threadIdx.x + blockIdx.x * blockDim.x;
+    if (i < n) a[i] *= b[i];
+}
+// causal depthwise conv1d (d_conv taps over time) + silu on the 8192 fused
+// channels; state: per channel last d_conv-1 inputs, prepended at token t.
+// weights layout: tap-major rows? llama conv1d ne=[d_conv, channels]:
+// kernel[k][c] at flat c*d_conv + k (channels row-major over taps).
+__global__ void h1bp_q35_conv_kernel(float* __restrict__ out, const float* __restrict__ qkv,
+                                  const float* __restrict__ w, float* __restrict__ state,
+                                  int channels, int d_conv, int tok) {
+    int c = blockIdx.x * blockDim.x + threadIdx.x;
+    if (c >= channels) return;
+    float* st = state + (size_t)c * (d_conv - 1);
+    const float* wr = w + (size_t)c * d_conv;
+    // causal: out = sum_{k=0..d_conv-1} wr[k] * inp[t - (d_conv-1) + k]
+    // inp history: st[0]=x_{t-2}, st[1]=x_{t-1} for d_conv=4 (tok 0..). We keep
+    // st[j] = x_{t - (d_conv-1) + j} for j<d_conv-1 (oldest first).
+    float acc = 0.0f;
+    float xcur = qkv[c];
+    // taps k=0..d_conv-1: input index = tok - (d_conv-1) + k
+    //   index < 0 -> history st[tok + k]... maintain state as x_{t-3},x_{t-2},x_{t-1}
+    // (llama decode: conv_state holds last d_conv-1 inputs; output[t] =
+    //  sum_k w[k] * (k < d_conv-1 ? state[k] : x[t]) with state advancing)
+    for (int k = 0; k < d_conv - 1; k++) acc += wr[k] * st[k];
+    acc += wr[d_conv - 1] * xcur;
+    // advance state: shift left, push xcur
+    for (int k = 0; k < d_conv - 2; k++) st[k] = st[k + 1];
+    st[d_conv - 2] = xcur;
+    out[c] = acc * (1.0f / (1.0f + __expf(-acc)));   // silu
+}
+// per-head L2-norm over len with scale 1/sqrt(len) applied AFTER (llama scales
+// q by 1/sqrt(S_k) separately); here: normalize rows of x, heads contiguous.
+__global__ void h1bp_head_l2norm_kernel(float* __restrict__ x, int len, int heads, float eps) {
+    __shared__ float ssum[256];
+    int h = blockIdx.x, tid = threadIdx.x;
+    float* hx = x + (size_t)h * len;
+    float loc = 0.0f;
+    for (int i = tid; i < len; i += blockDim.x) loc += hx[i] * hx[i];
+    ssum[tid] = loc;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) { if (tid < s) ssum[tid] += ssum[tid + s]; __syncthreads(); }
+    if (tid == 0) ssum[0] = rsqrtf(ssum[0] / len + eps);
+    __syncthreads();
+    float inv = ssum[0];
+    for (int i = tid; i < len; i += blockDim.x) hx[i] *= inv;
+}
+// GDN delta rule, one token, per head h of H_v (heads pre-expanded to H_v):
+// q/k per head length S_k, v per head S_v, state S[i][col] natural
+// (i = k/q dim, col = v dim), stored h*S_v*S_v + i*S_v + col. g_h = decay
+// (exp of gate), beta_h scalar. out[col] = sum_i S[i][col] q[i] (q pre-scaled
+// by 1/sqrt(S_k) by the caller, matching llama's scale-then-recurrence).
+__global__ void h1bp_q35_delta_kernel(const float* __restrict__ q, const float* __restrict__ k,
+                                   const float* __restrict__ v, float* __restrict__ state,
+                                   float* __restrict__ out, const float* __restrict__ g,
+                                   const float* __restrict__ beta, int S_k, int S_v, int H_v) {
+    int h = blockIdx.x; if (h >= H_v) return;
+    int col = threadIdx.x; if (col >= S_v) return;
+    const float* kh = k + (size_t)h * S_k;
+    const float* qh = q + (size_t)h * S_k;
+    float* Scol = state + ((size_t)h * S_v + col);       // S[i][col]: stride S_v per i
+    float gv = __expf(g[h]);                             // decay for this head
+    float kv = 0.0f;
+    for (int i = 0; i < S_k; i++) kv += Scol[(size_t)i * S_v] * kh[i];
+    float delta = (v[h * S_v + col] - gv * kv) * beta[h];
+    float outv = 0.0f;
+    for (int i = 0; i < S_k; i++) {
+        float s = gv * Scol[(size_t)i * S_v] + kh[i] * delta;
+        Scol[(size_t)i * S_v] = s;
+        outv += s * qh[i];
+    }
+    out[h * S_v + col] = outv;
+}
+
+// full-attention decode over the f32 per-layer KV cache (10 full layers).
+// Cache layout per (layer, seq): [k kvh0 hd | k kvh1 hd | v kvh0 hd | v kvh1 hd]
+// = 4*hd floats/seq. q: [n_qh x hd] rope'd/qk-normed (contiguous heads);
+// probs computed into global scratch (per-head region) then v-weighted sum.
+__global__ void h1bp_q35_fattn_kernel(const float* __restrict__ q, const float* __restrict__ kv,
+                                   float* __restrict__ out, float* __restrict__ probs,
+                                   int n_qh, int n_kvh, int hd, int seq, int* d_pos) {
+    int h = blockIdx.x, tid = threadIdx.x;
+    if (h >= n_qh) return;
+    int pos = *d_pos;
+    if (pos >= seq) return;
+    int kvh = h / (n_qh / n_kvh);
+    const float* qh = q + (size_t)h * hd;
+    float* ph = probs + (size_t)h * seq;
+    const int row = 2 * n_kvh * hd;
+    const float inv = 1.0f / sqrtf((float)hd);
+    // pass 1: scores -> probs
+    for (int s = 0; s <= pos; s++) {
+        const float* kh = kv + (size_t)s * row + (size_t)kvh * hd;
+        float sc = 0;
+        for (int d = tid; d < hd; d += blockDim.x) sc += qh[d] * kh[d];
+        __shared__ float red[256];
+        red[tid] = sc; __syncthreads();
+        for (int x = blockDim.x / 2; x > 0; x >>= 1) { if (tid < x) red[tid] += red[tid + x]; __syncthreads(); }
+        if (tid == 0) ph[s] = red[0] * inv;
+        __syncthreads();
+    }
+    if (tid == 0) {
+        float mx = -1e30f;
+        for (int s = 0; s <= pos; s++) mx = fmaxf(mx, ph[s]);
+        float su = 0;
+        for (int s = 0; s <= pos; s++) { ph[s] = __expf(ph[s] - mx); su += ph[s]; }
+        for (int s = 0; s <= pos; s++) ph[s] /= su;
+    }
+    __syncthreads();
+    for (int d = tid; d < hd; d += blockDim.x) {
+        float a = 0;
+        for (int s = 0; s <= pos; s++) {
+            const float* vh = kv + (size_t)s * row + (size_t)n_kvh * hd + (size_t)kvh * hd;
+            a += ph[s] * vh[d];
+        }
+        out[(size_t)h * hd + d] = a;
+    }
+}
+__global__ void h1bp_sigmoid_inplace_kernel(float* __restrict__ x, int n) {
+    int i = threadIdx.x + blockIdx.x * blockDim.x;
+    if (i < n) x[i] = 1.0f / (1.0f + __expf(-x[i]));
+}
+__global__ void h1bp_silu_inplace_kernel(float* __restrict__ x, int n) {
+    int i = threadIdx.x + blockIdx.x * blockDim.x;
+    if (i < n) x[i] = x[i] / (1.0f + __expf(-x[i]));
+}
+// MoE router: softmax 256 -> top-8 (serial argmax w/ masking) -> weights.
+// renorm=true divides by the selected sum (llama norm_topk_prob semantics).
+__global__ void h1bp_q35_topk_kernel(const float* __restrict__ logits, float* __restrict__ w,
+                                  int* __restrict__ idx, int n_exp, int topk, bool renorm) {
+    __shared__ float p[512];
+    int t = threadIdx.x;
+    // softmax
+    if (t < n_exp) p[t] = logits[t];
+    __syncthreads();
+    float mx = -1e30f;
+    for (int i = t; i < n_exp; i += blockDim.x) mx = fmaxf(mx, p[i]);
+    __shared__ float smx, ssum;
+    if (t == 0) {
+        float m2 = -1e30f;
+        for (int i = 0; i < n_exp; i++) m2 = fmaxf(m2, p[i]);
+        float su = 0;
+        for (int i = 0; i < n_exp; i++) { p[i] = __expf(p[i] - m2); su += p[i]; }
+        smx = m2; ssum = su;
+    }
+    __syncthreads();
+    for (int i = t; i < n_exp; i += blockDim.x) p[i] /= ssum;
+    __syncthreads();
+    if (t == 0) {
+        float sel[16];
+        for (int r = 0; r < topk; r++) {
+            float best = -1e30f; int bi = -1;
+            for (int i = 0; i < n_exp; i++) if (p[i] > best) { best = p[i]; bi = i; }
+            sel[r] = best; idx[r] = bi; p[bi] = -1e30f;
+        }
+        float sel_sum = 0;
+        for (int r = 0; r < topk; r++) sel_sum += sel[r];
+        for (int r = 0; r < topk; r++) w[r] = renorm ? sel[r] / sel_sum : sel[r];
+    }
+}
+// combine: y = silu(gate) * up (in-place on up), 512 floats
+__global__ void h1bp_silu_gate_mul_kernel(float* __restrict__ up, const float* __restrict__ gate, int n) {
+    int i = threadIdx.x + blockIdx.x * blockDim.x;
+    if (i < n) up[i] = up[i] * (gate[i] / (1.0f + __expf(-gate[i])));
+}
+__global__ void h1bp_mul_scalar_kernel(float* __restrict__ x, float s, int n) {
+    int i = threadIdx.x + blockIdx.x * blockDim.x;
+    if (i < n) x[i] *= s;
+}
+__global__ void h1bp_acc_kernel(float* __restrict__ acc, const float* __restrict__ src, int n) {
+    int i = threadIdx.x + blockIdx.x * blockDim.x;
+    if (i < n) acc[i] += src[i];
+}

--- a/tools/bench_hip_1bp.cpp
+++ b/tools/bench_hip_1bp.cpp
@@ -65,9 +65,8 @@ int main(int argc, char** argv) {
     for (int i = 0; i < warmup; i++) { tok = b->generate(tok); if (tok < 0) break; }
     printf("  Warmup: %d tokens (last token id: %d)\n", warmup, tok);
 
-    // Benchmark
-    b->reset();
-    tok = 1;
+    bool prompt_mode = getenv("H1BP_Q35_PROMPT") != nullptr;
+    if (!prompt_mode) { b->reset(); tok = 1; }
     t0 = std::chrono::steady_clock::now();
     int generated = 0;
     fprintf(stderr, "[bench_hip_1bp] tokens:");
@@ -87,6 +86,7 @@ int main(int argc, char** argv) {
     printf("  Time:       %.0f ms\n", ms);
     printf("  Per token:  %.1f ms\n", ms / generated);
     printf("  Throughput: %.0f tok/s\n", generated / (ms/1000.0));
+    if (prompt_mode) { b->destroy(); delete b; return 0; }
     printf("  Tokens:    ");
     b->reset();
     tok = 1;

--- a/tools/bench_hip_1bp.cpp
+++ b/tools/bench_hip_1bp.cpp
@@ -48,9 +48,20 @@ int main(int argc, char** argv) {
     auto t1 = std::chrono::steady_clock::now();
     printf("  Init: %.0f ms\n", std::chrono::duration<double,std::milli>(t1-t0).count());
 
-    // Warmup
+    // Warmup / prompt (qwen35 validation): H1BP_Q35_PROMPT="id,id,..." feeds the
+    // prompt tokens through generate() (positions advance), loop starts at the last id.
     b->reset();
     int tok = 1;
+    if (const char* pr = getenv("H1BP_Q35_PROMPT")) {
+        std::vector<int> ids;
+        const char* p = pr;
+        while (*p) { while (*p == ',' || *p == ' ') p++; if (!*p) break; ids.push_back(atoi(p)); while (*p && *p != ',') p++; }
+        if (ids.size() >= 1) {
+            for (size_t i = 0; i + 1 < ids.size(); i++) { if (b->generate(ids[i]) < 0) break; }
+            tok = ids.back();
+            printf("  Prompt: %zu tokens, decode continues from token %d\n", ids.size(), tok);
+        }
+    }
     for (int i = 0; i < warmup; i++) { tok = b->generate(tok); if (tok < 0) break; }
     printf("  Warmup: %d tokens (last token id: %d)\n", warmup, tok);
 


### PR DESCRIPTION
### **User description**
**Part of #1831** (open). M3 task-2 infrastructure: the raw-Q8_0 device path + kernels the qwen35moe decode needs, plus a hardware self-check.

**Kernels** (`src/hip_1bp_kernels.hip`):
- `h1bp_q8gemv_kernel` — Q8_0 (GGUF dtype 8: fp16 scale + 32 int8 per block, 34 B/block) row gemv, mirroring `h1bp_gemv_kernel`.
- `h1bp_q8embed_kernel` — Q8_0 embedding row dequant.
- `h1bp_q8gemv_slice_kernel` — fused-expert per-expert gemv over expert-major contiguous tensors (the MUL_MAT_ID equivalent confirmed in the M3 capture).

**Model format note:** the staged `Qwen3.6-35B-A3B-Q8_0.gguf` is **Q8_0** (llama ftype + GGUF dtype 8), not Q8_K — block-32 geometry per the #2104 dtype table. Dequant-to-f32 of the whole 35B is infeasible on-device, so decode will run on raw Q8_0 tiles.

**Self-check** (`H1BP_Q35_SELFCHECK=1`, runs only after the M2 structural gate, dense path untouched): pulls `blk.0.attn_qkv` raw (34 B/block), runs the device Q8 gemv (8192×2048) and compares row 0 vs a host dequant+dot — verifies loader + kernel on real hardware before any decode wiring. qwen35 decode still refused (tasks 3-5).

Run on strixhalo: `H1BP_Q35_SELFCHECK=1 ./build/bench_hip_1bp ~/models/Qwen3.6-35B-A3B-Q8_0.gguf` → expect `selfcheck ... row0 ref=… dev=… → PASS` then the structure-verified message.


___

### **PR Type**
Enhancement


___

### **Description**
- Adds full qwen35moe eager decode to HIP backend.
  - GatedDeltaNet linear attention, fused QKV, conv1d.
  - Full-attn layers with RoPE and KV cache.
  - MoE top-8 router, gated/shared experts.

- Introduces Q8_0 gemv/embed/slice kernels and qwen35 decode kernels.

- Loader/self-check behind H1BP_Q35_LOAD and H1BP_Q35_SELFCHECK.

- Bench tool feeds prompts with H1BP_Q35_PROMPT.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  GGUF["Qwen3.6-35B-A3B Q8_0 GGUF"] --> Loader["H1BP_Q35_LOAD device loader"]
  Loader --> Decode["qwen35_step eager decode"]
  Decode --> GDN["GDN: conv1d + delta rule"]
  Decode --> FA["Full-attn: RoPE + KV cache"]
  Decode --> MoE["MoE top-8 + shared expert"]
  GDN --> Head["output norm + lm_head argmax"]
  FA --> Head
  MoE --> Head
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_hip_1bp.cpp</strong><dd><code>qwen35moe loader, scratch, and eager decode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_hip_1bp.cpp

<ul><li>Adds qwen35moe device-weight structs (<code>Q35L</code>) and scratch buffers for <br>conv, recurrent delta, KV cache, and MoE state.<br> <li> Adds env-gated raw-Q8_0 loader (<code>H1BP_Q35_LOAD</code>) and device gemv <br>self-check (<code>H1BP_Q35_SELFCHECK</code>).<br> <li> Implements <code>qwen35_step()</code> eager decode covering GDN, full-attention, <br>and MoE paths; dispatches from <code>generate_fast()</code>.<br> <li> Extends <code>reset()</code>/<code>destroy()</code> to manage q35 state and device buffers.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2127/files#diff-c4812ee96d278d2d2b452760b359c0521f1a016dce68e46c6668555b33eec182">+412/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hip_1bp_kernels.hip</strong><dd><code>Q8_0 gemv and qwen35 decode kernels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hip_1bp_kernels.hip

<ul><li>Adds Q8_0 row gemv, embedding dequant, and expert-slice gemv kernels.<br> <li> Implements GDN kernels: causal conv1d+silu, head L2-norm, and <br>delta-rule recurrence.<br> <li> Adds full-attention kernel over the per-layer KV cache plus RoPE.<br> <li> Adds MoE router/top-k, sigmoid/silu gating, scale, accumulate, and <br>elementwise kernels.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2127/files#diff-e7c676fbc5592cbbf17f1c7db3df89e539cc6bfef40bfc8014de1d807ac66396">+258/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bench_hip_1bp.cpp</strong><dd><code>bench prompt-mode support for qwen35 validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/bench_hip_1bp.cpp

<ul><li>Adds <code>H1BP_Q35_PROMPT</code> support to feed prompt tokens through <code>generate()</code> <br>before decode benchmarking.<br> <li> Skips reset/token restart and returns early in prompt mode for <br>accurate decode measurement.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2127/files#diff-ba7085f2c60678386a91382bf78ea72395c9d7dc1345f2dbb5dc698687d91522">+15/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

