### PR TITLE
toolchain(1956): reflection-verified enum→name tables (BackendType & co)

### DIFF
--- a/Testing/cpp26_name_maps_selfcheck.cpp
+++ b/Testing/cpp26_name_maps_selfcheck.cpp
@@ -1,0 +1,164 @@
+// cpp26_name_maps_selfcheck.cpp — issue #1956 verification harness.
+//
+// Proves the enum↔name tables (common.h BackendType, pilot.h SubLayer +
+// PilotBackend, backend_manager.h BackendTier) are exhaustive and unchanged
+// in output, and exercises the toolchain-shipped C++26 features the issue
+// tracked:
+//   - P2996 reflection (std::meta): with -freflection the *headers themselves*
+//     static_assert table completeness (compile error if an enumerator lacks a
+//     row); this TU additionally prints the mapping auto-derived from the enum
+//     via enumerators_of (the "generate from enum" direction).
+//   - std::inplace_vector (P0843): decode-path style fixed-capacity buffers,
+//     no heap.
+//
+// Build (ryzen/strixhalo, g++-16/libstdc++16 installed 2026-09-06):
+//   g++-16 -std=c++26 -freflection -O2 -Iinclude -Isrc \
+//       Testing/cpp26_name_maps_selfcheck.cpp -o /tmp/cpp26_check
+//   /tmp/cpp26_check
+//
+// A plain compiler (g++-15, clang/amdclang) also builds and runs this — the
+// reflection/inplace_vector sections are macro-gated off, runtime name checks
+// still run. That keeps CI runners (no g++-16 yet) green.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string_view>
+
+#include "common.h"          // BackendType / kBackendTypeNames / backend_name
+#include "pilot.h"           // SubLayer + PilotBackend tables
+#include "backend_manager.h" // BackendTier / kBackendTierNames / tier_name
+
+// ---------------------------------------------------------------------------
+// 1. Runtime checks: every table row still yields the exact legacy strings.
+// ---------------------------------------------------------------------------
+static int g_fail = 0;
+#define CHECK(cond, label)                                                     \
+    do {                                                                       \
+        if (cond) std::printf("ok   %s\n", label);                             \
+        else { std::printf("FAIL %s\n", label); ++g_fail; }                    \
+    } while (0)
+
+static void check_backend_names() {
+    struct { BackendType type; const char* name; } expect[] = {
+        {BackendType::NONE,        "none"},
+        {BackendType::HIP_GPU,     "HIP GPU (ROCm)"},
+        {BackendType::VULKAN,      "Vulkan GPU (portable)"},
+        {BackendType::NPU_XRT,     "NPU XDNA (XRT)"},
+        {BackendType::CPU_AVX512,  "CPU AVX-512"},
+        {BackendType::CPU_SCALAR,  "CPU (scalar)"},
+        {BackendType::GENERIC,     "Generic CPU (GGUF)"},
+        {BackendType::ZAMBA2,      "Zamba2 (Mamba2 CPU)"},
+        {BackendType::ZAMBA2_GPU,  "Zamba2 (Mamba2 GPU)"},
+        {BackendType::ZINC_GPU,    "ZINC GPU (Vulkan, multi-arch)"},
+        {BackendType::Q4NX_FUSION, "Q4NX Fusion (CPU)"},
+        {BackendType::CUDA_GPU,    "CUDA GPU (NVIDIA)"},
+        {BackendType::METAL_GPU,   "Metal GPU (Apple)"},
+        {BackendType::VART,        "VART (Versal/Zynq DPU)"},
+        {BackendType::ONNX_NPU,    "ONNX NPU (VitisAI EP)"},
+        {BackendType::LSE_GPU,     "LSE GPU (MLX via lse-server)"},
+        {BackendType::HRX_GPU,     "HRX GPU (fused GGUF via hrx llama-server)"},
+    };
+    bool all = true;
+    for (auto& e : expect)
+        if (std::strcmp(backend_name(e.type), e.name) != 0) all = false;
+    CHECK(all, "backend_name matches legacy strings for every enumerator");
+    CHECK(std::strcmp(backend_name(static_cast<BackendType>(250)), "none") == 0,
+          "backend_name out-of-range falls back to \"none\"");
+}
+
+static void check_pilot_names() {
+    CHECK(std::strcmp(sublayer_name(SubLayer::ATTENTION_Q), "attn_q") == 0 &&
+              std::strcmp(sublayer_name(SubLayer::ROUTER), "router") == 0 &&
+              std::strcmp(sublayer_name(SubLayer::FFN_DOWN), "ffn_down") == 0,
+          "sublayer_name matches legacy strings");
+    CHECK(std::strcmp(pilot_backend_name(PilotBackend::UNKNOWN), "?") == 0 &&
+              std::strcmp(pilot_backend_name(PilotBackend::NPU), "NPU") == 0 &&
+              std::strcmp(pilot_backend_name(PilotBackend::CPU), "CPU") == 0,
+          "pilot_backend_name matches legacy strings");
+}
+
+static void check_tier_names() {
+    CHECK(std::strcmp(tier_name(BackendTier::T1_ACCELERATOR), "NPU/Accelerator") == 0 &&
+              std::strcmp(tier_name(BackendTier::T2_GPU), "GPU") == 0 &&
+              std::strcmp(tier_name(BackendTier::T3_CPU), "CPU") == 0,
+          "tier_name matches legacy strings");
+    CHECK(std::strcmp(tier_name(static_cast<BackendTier>(99)), "unknown") == 0,
+          "tier_name out-of-range falls back to \"unknown\"");
+}
+
+// ---------------------------------------------------------------------------
+// 2. P2996: print the BackendType mapping derived straight from the enum.
+//    Compiles only under g++-16 -freflection (RCPP26_HAS_REFLECTION).
+// ---------------------------------------------------------------------------
+#if RCPP26_HAS_REFLECTION
+static void print_reflected_backend_names() {
+    std::printf("-- BackendType mapping via std::meta::enumerators_of --\n");
+    constexpr static auto kEnums =
+        std::define_static_array(std::meta::enumerators_of(^^BackendType));
+    template for (constexpr auto e : kEnums) {
+        constexpr BackendType v = [:e:];
+        std::printf("  %2d  %-16s -> %s\n", (int)v,
+                    std::meta::identifier_of(e).data(), backend_name(v));
+    }
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// 3. std::inplace_vector (P0843, libstdc++ 16): fixed-capacity decode buffers
+//    (token batch + per-layer KV header) — the issue's hot-path example.
+//    Note: __cpp_lib_inplace_vector materializes when <inplace_vector> (or
+//    <version>) is included — test __has_include first, then include, then the
+//    macro is defined (libstdc++ per-header want-flag mechanism).
+// ---------------------------------------------------------------------------
+#if __has_include(<inplace_vector>)
+#include <inplace_vector>
+#define RCPP26_HAS_INPLACE_VECTOR 1
+#else
+#define RCPP26_HAS_INPLACE_VECTOR 0
+#endif
+
+static constexpr long kLibInplaceVector =
+#if RCPP26_HAS_INPLACE_VECTOR
+    (long)__cpp_lib_inplace_vector;
+#else
+    0;
+#endif
+
+#if RCPP26_HAS_INPLACE_VECTOR
+static void check_inplace_vector() {
+    // Token batch for one decode step (bounded by n_batch; fixed 8 here).
+    std::inplace_vector<uint32_t, 8> batch;
+    for (uint32_t i = 0; i < 6; ++i) batch.push_back(1000 + i);
+    // KV cache header: per-layer scratch [n_layers ≤ 64]; emulate layer 0..3.
+    std::inplace_vector<std::pair<uint32_t, uint32_t>, 64> kv_headers;
+    for (uint32_t l = 0; l < 4; ++l) kv_headers.emplace_back(l, 128 * (l + 1));
+
+    bool ok = batch.size() == 6 && kv_headers.size() == 4 &&
+              batch[5] == 1005 && kv_headers[3].second == 512;
+    CHECK(ok, "std::inplace_vector decode buffers (no heap alloc)");
+    std::printf("   batch.size=%zu cap=%zu kv_headers.size=%zu cap=%zu\n",
+                (size_t)batch.size(), (size_t)batch.capacity(),
+                (size_t)kv_headers.size(), (size_t)kv_headers.capacity());
+}
+#endif
+
+int main() {
+    std::printf("== cpp26 name-maps selfcheck (compiler: %s) ==\n", __VERSION__);
+    std::printf("RCPP26_HAS_REFLECTION=%d __cpp_lib_inplace_vector=%ld\n",
+                (int)RCPP26_HAS_REFLECTION, kLibInplaceVector);
+    check_backend_names();
+    check_pilot_names();
+    check_tier_names();
+#if RCPP26_HAS_REFLECTION
+    print_reflected_backend_names();
+#endif
+#if RCPP26_HAS_INPLACE_VECTOR
+    check_inplace_vector();
+#else
+    std::printf("skip std::inplace_vector (libstdc++ < 16 / no <inplace_vector>)\n");
+#endif
+    if (g_fail == 0) std::printf("CPP26-NAME-MAPS: ALL PASSED\n");
+    else            std::printf("CPP26-NAME-MAPS: %d FAILED\n", g_fail);
+    return g_fail ? 1 : 0;
+}

--- a/include/backend_manager.h
+++ b/include/backend_manager.h
@@ -26,14 +26,22 @@ enum class BackendTier : uint8_t {
     T3_CPU         = 2,  // CPU (always available fallback)
 };
 
+inline constexpr rcpp26::EnumName<BackendTier> kBackendTierNames[] = {
+    {BackendTier::T1_ACCELERATOR, "NPU/Accelerator"},
+    {BackendTier::T2_GPU,         "GPU"},
+    {BackendTier::T3_CPU,         "CPU"},
+};
+
 inline const char* tier_name(BackendTier t) {
-    switch(t) {
-        case BackendTier::T1_ACCELERATOR: return "NPU/Accelerator";
-        case BackendTier::T2_GPU:         return "GPU";
-        case BackendTier::T3_CPU:         return "CPU";
-        default: return "unknown";
-    }
+    if (const char* n = rcpp26::lookup_enum_name(kBackendTierNames, t)) return n;
+    return "unknown";
 }
+
+// g++-16 -freflection builds: prove kBackendTierNames covers every enumerator.
+RCPP26_REQUIRE_ENUM_TABLE(rcpp26_verify_backend_tier_names, BackendTier,
+                          kBackendTierNames,
+                          "BackendTier: new enumerator missing a row in "
+                          "kBackendTierNames (include/backend_manager.h)")
 
 // ── Backend info (like an ORT EP descriptor) ──
 struct BackendInfo {

--- a/include/common.h
+++ b/include/common.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include "rocm_cpp/bitnet_model.h"
+#include "cpp26_reflect.h"
 
 enum class BackendType : uint8_t {
     NONE = 0,
@@ -24,27 +25,40 @@ enum class BackendType : uint8_t {
     HRX_GPU = 17,     // HRX (Hip Runtime Extended) via bundled llama-server subprocess — fused GGUF lane on AMD GPU
 };
 
+// Display names live in one table beside the enum (issue #1956): a backend
+// added to the enum without a row here is a compile error under a
+// g++-16 -std=c++26 -freflection build (RCPP26_REQUIRE_ENUM_TABLE below),
+// instead of silently degrading to "none" at runtime.
+inline constexpr rcpp26::EnumName<BackendType> kBackendTypeNames[] = {
+    {BackendType::NONE,         "none"},
+    {BackendType::HIP_GPU,      "HIP GPU (ROCm)"},
+    {BackendType::VULKAN,       "Vulkan GPU (portable)"},
+    {BackendType::NPU_XRT,      "NPU XDNA (XRT)"},
+    {BackendType::CPU_AVX512,   "CPU AVX-512"},
+    {BackendType::CPU_SCALAR,   "CPU (scalar)"},
+    {BackendType::GENERIC,      "Generic CPU (GGUF)"},
+    {BackendType::ZAMBA2,       "Zamba2 (Mamba2 CPU)"},
+    {BackendType::ZAMBA2_GPU,   "Zamba2 (Mamba2 GPU)"},
+    {BackendType::ZINC_GPU,     "ZINC GPU (Vulkan, multi-arch)"},
+    {BackendType::Q4NX_FUSION,  "Q4NX Fusion (CPU)"},
+    {BackendType::CUDA_GPU,     "CUDA GPU (NVIDIA)"},
+    {BackendType::METAL_GPU,    "Metal GPU (Apple)"},
+    {BackendType::VART,         "VART (Versal/Zynq DPU)"},
+    {BackendType::ONNX_NPU,     "ONNX NPU (VitisAI EP)"},
+    {BackendType::LSE_GPU,      "LSE GPU (MLX via lse-server)"},
+    {BackendType::HRX_GPU,      "HRX GPU (fused GGUF via hrx llama-server)"},
+};
+
 inline const char* backend_name(BackendType t) {
-    switch(t) {
-        case BackendType::HIP_GPU: return "HIP GPU (ROCm)";
-        case BackendType::VULKAN: return "Vulkan GPU (portable)";
-        case BackendType::NPU_XRT: return "NPU XDNA (XRT)";
-        case BackendType::CPU_AVX512: return "CPU AVX-512";
-        case BackendType::CPU_SCALAR: return "CPU (scalar)";
-        case BackendType::GENERIC: return "Generic CPU (GGUF)";
-        case BackendType::ZAMBA2: return "Zamba2 (Mamba2 CPU)";
-        case BackendType::ZAMBA2_GPU: return "Zamba2 (Mamba2 GPU)";
-        case BackendType::ZINC_GPU: return "ZINC GPU (Vulkan, multi-arch)";
-        case BackendType::Q4NX_FUSION: return "Q4NX Fusion (CPU)";
-        case BackendType::CUDA_GPU: return "CUDA GPU (NVIDIA)";
-        case BackendType::METAL_GPU: return "Metal GPU (Apple)";
-        case BackendType::VART: return "VART (Versal/Zynq DPU)";
-        case BackendType::ONNX_NPU: return "ONNX NPU (VitisAI EP)";
-        case BackendType::LSE_GPU: return "LSE GPU (MLX via lse-server)";
-        case BackendType::HRX_GPU: return "HRX GPU (fused GGUF via hrx llama-server)";
-        default: return "none";
-    }
+    if (const char* n = rcpp26::lookup_enum_name(kBackendTypeNames, t)) return n;
+    return "none";
 }
+
+// g++-16 -freflection builds: prove kBackendTypeNames covers every enumerator.
+RCPP26_REQUIRE_ENUM_TABLE(rcpp26_verify_backend_type_names, BackendType,
+                          kBackendTypeNames,
+                          "BackendType: new enumerator missing a row in "
+                          "kBackendTypeNames (include/common.h)")
 
 enum class ModelFormat : uint8_t {
     UNKNOWN = 0,

--- a/include/cpp26_reflect.h
+++ b/include/cpp26_reflect.h
@@ -1,0 +1,97 @@
+// cpp26_reflect.h — P2996 (C++26 reflection) helpers for enum↔name tables.
+//
+// Issue #1956: adopt the toolchain-shipped C++26 subset incrementally,
+// starting with the BackendType ↔ backend_name() duplication class. This
+// header lets an enum's display-name table live right next to the enum
+// (single source of truth), while any g++-16 -std=c++26 -freflection TU that
+// includes the table gets a *compile-time proof* that the table covers every
+// enumerator. Adding an enumerator without a table row is now a compile error
+// instead of a silent "none"/"?"/fallback string.
+//
+// Compiler surface:
+//   - g++-16+ with -std=c++26 -freflection  → RCPP26_HAS_REFLECTION 1, checks
+//     active (requires libstdc++ 16 for <meta>, guarded below).
+//   - everything else (clang/amdclang, libstdc++ 15, g++ without
+//     -freflection) → RCPP26_HAS_REFLECTION 0; macros expand to nothing, no
+//     new includes, no runtime cost, behavior identical to before.
+//
+// Usage, next to the enum it describes:
+//
+//   inline constexpr rcpp26::EnumName<BackendType> kBackendTypeNames[] = {
+//       {BackendType::NONE, "none"},
+//       {BackendType::HIP_GPU, "HIP GPU (ROCm)"},
+//       ...
+//   };
+//   inline const char* backend_name(BackendType t) {
+//       if (const char* n = rcpp26::lookup_enum_name(kBackendTypeNames, t))
+//           return n;
+//       return "none";
+//   }
+//   RCPP26_REQUIRE_ENUM_TABLE(rcpp26_verify_backend_type_names, BackendType,
+//       kBackendTypeNames, "BackendType: new enumerator missing a row in "
+//       "kBackendTypeNames (include/common.h)");
+//
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+namespace rcpp26 {
+
+// Table row type. Every enum→name table in the tree is an array of these so
+// the reflection checks below stay generic.
+template <typename E>
+struct EnumName {
+    E        type;
+    const char* name;
+};
+
+// O(rows) lookup — tables are tiny (≤ 18 rows) and the *_name() helpers are
+// not hot; this replaces hand-maintained switch statements with a table that
+// reflection can inspect.
+template <typename E, std::size_t N>
+constexpr const char* lookup_enum_name(const EnumName<E> (&table)[N], E v) {
+    for (std::size_t i = 0; i < N; ++i)
+        if (table[i].type == v) return table[i].name;
+    return nullptr;
+}
+
+}  // namespace rcpp26
+
+#if defined(__cpp_impl_reflection) && __cpp_impl_reflection >= 202506L && \
+    __has_include(<meta>)
+#include <meta>
+#define RCPP26_HAS_REFLECTION 1
+
+namespace rcpp26_detail {
+
+template <typename E, std::size_t N>
+consteval bool has_name(const rcpp26::EnumName<E> (&table)[N], E v) {
+    for (std::size_t i = 0; i < N; ++i)
+        if (table[i].type == v) return true;
+    return false;
+}
+
+}  // namespace rcpp26_detail
+
+// Expands to a consteval verifier + static_assert: every enumerator of E must
+// have a row in TABLE. MSG is the literal shown on failure — name the enum and
+// the table so the next editor knows what to update. Compile-time only.
+#define RCPP26_REQUIRE_ENUM_TABLE(FN, E, TABLE, MSG)                              \
+    namespace rcpp26_detail {                                                     \
+        consteval bool FN() {                                                     \
+            constexpr static auto kEnums_ =                                       \
+                std::define_static_array(std::meta::enumerators_of(^^E));         \
+            template for (constexpr auto e : kEnums_) {                           \
+                constexpr E v = [:e:];                                            \
+                static_assert(rcpp26_detail::has_name(TABLE, v), MSG);            \
+            }                                                                     \
+            return true;                                                          \
+        }                                                                         \
+    }                                                                             \
+    static_assert(rcpp26_detail::FN(), MSG);
+
+#else  // no P2996-capable compiler in this TU
+#define RCPP26_HAS_REFLECTION 0
+#define RCPP26_REQUIRE_ENUM_TABLE(FN, E, TABLE, MSG) /* check inactive */ ;
+#endif

--- a/include/pilot.h
+++ b/include/pilot.h
@@ -70,19 +70,30 @@ enum class SubLayer : uint8_t {
     ROUTER        = 7,
 };
 
+// Display-name tables beside their enums (issue #1956) — see common.h
+// kBackendTypeNames for the rationale; RCPP26_REQUIRE_ENUM_TABLE below makes
+// a missing row a compile error under g++-16 -freflection builds.
+inline constexpr rcpp26::EnumName<SubLayer> kSubLayerNames[] = {
+    {SubLayer::ATTENTION_Q, "attn_q"},
+    {SubLayer::ATTENTION_K, "attn_k"},
+    {SubLayer::ATTENTION_V, "attn_v"},
+    {SubLayer::ATTENTION_O, "attn_o"},
+    {SubLayer::FFN_GATE,    "ffn_gate"},
+    {SubLayer::FFN_UP,      "ffn_up"},
+    {SubLayer::FFN_DOWN,    "ffn_down"},
+    {SubLayer::ROUTER,      "router"},
+};
+
 inline const char* sublayer_name(SubLayer sl) {
-    switch (sl) {
-        case SubLayer::ATTENTION_Q: return "attn_q";
-        case SubLayer::ATTENTION_K: return "attn_k";
-        case SubLayer::ATTENTION_V: return "attn_v";
-        case SubLayer::ATTENTION_O: return "attn_o";
-        case SubLayer::FFN_GATE:    return "ffn_gate";
-        case SubLayer::FFN_UP:      return "ffn_up";
-        case SubLayer::FFN_DOWN:    return "ffn_down";
-        case SubLayer::ROUTER:      return "router";
-        default: return "?";
-    }
+    if (const char* n = rcpp26::lookup_enum_name(kSubLayerNames, sl)) return n;
+    return "?";
 }
+
+// g++-16 -freflection builds: prove kSubLayerNames covers every enumerator.
+RCPP26_REQUIRE_ENUM_TABLE(rcpp26_verify_sub_layer_names, SubLayer,
+                          kSubLayerNames,
+                          "SubLayer: new enumerator missing a row in "
+                          "kSubLayerNames (include/pilot.h)")
 
 // ── Backend preference for a sub-layer ──
 // The pilot predicts which backend each sub-layer will use.
@@ -96,14 +107,23 @@ enum class PilotBackend : uint8_t {
     CPU     = 3,
 };
 
+inline constexpr rcpp26::EnumName<PilotBackend> kPilotBackendNames[] = {
+    {PilotBackend::UNKNOWN, "?"},
+    {PilotBackend::NPU,     "NPU"},
+    {PilotBackend::GPU,     "GPU"},
+    {PilotBackend::CPU,     "CPU"},
+};
+
 inline const char* pilot_backend_name(PilotBackend pb) {
-    switch (pb) {
-        case PilotBackend::NPU: return "NPU";
-        case PilotBackend::GPU: return "GPU";
-        case PilotBackend::CPU: return "CPU";
-        default: return "?";
-    }
+    if (const char* n = rcpp26::lookup_enum_name(kPilotBackendNames, pb)) return n;
+    return "?";
 }
+
+// g++-16 -freflection builds: prove kPilotBackendNames covers every enumerator.
+RCPP26_REQUIRE_ENUM_TABLE(rcpp26_verify_pilot_backend_names, PilotBackend,
+                          kPilotBackendNames,
+                          "PilotBackend: new enumerator missing a row in "
+                          "kPilotBackendNames (include/pilot.h)")
 
 static inline PilotBackend backend_type_to_pilot(BackendType bt) {
     switch (bt) {


### PR DESCRIPTION
### **User description**
Closes #1956 (the actionable core — see remainder note below).

## What
Adopts the g++-16/libstdc++-16 subset incrementally, starting with the
`BackendType ↔ backend_name()` duplication class the issue calls out:

- **`include/cpp26_reflect.h`** (new) — `EnumName<E>` table type + lookup
  helper + `RCPP26_REQUIRE_ENUM_TABLE`: a P2996 (`std::meta`) compile-time
  proof that an enum's name table covers **every** enumerator. Active only
  under `g++-16 -std=c++26 -freflection` (`__cpp_impl_reflection ≥ 202506L`
  + `<meta>` present); clang/amdclang, libstdc++ 15 and plain g++ builds
  expand it to a no-op — no behavior change, no cost.
- Name switches → tables beside their enums: `backend_name` (BackendType),
  `sublayer_name` (SubLayer), `pilot_backend_name` (PilotBackend),
  `tier_name` (BackendTier). Output byte-identical to the legacy switches
  (out-of-range fallbacks preserved). Adding an enumerator without a row is
  now a **compile error** under a `-freflection` build instead of a silent
  default string.
- **`Testing/cpp26_name_maps_selfcheck.cpp`** (new) — host-only harness:
  legacy-string parity checks, a P2996 section printing the BackendType
  mapping derived straight from the enum (`enumerators_of`/`identifier_of`),
  and a `std::inplace_vector` (P0843) decode-buffer exercise.

## Verified (ryzen, 2026-09-06)
| Build | Result |
|---|---|
| `g++-16 -std=c++26 -freflection` | clean, ALL PASSED (reflection + inplace_vector active) |
| enforcement negative test (row omitted) | `static assertion failed: …missing a row in kBackendTypeNames…` ✓ |
| `g++-16` / `g++-15 -std=c++26` (no reflection) | clean, ALL PASSED (checks inactive) |
| `amdclang++` (TheRock) `-fsyntax-only` | clean on `tests/test_backend.cpp` + full include chain (`model_discovery.h`) |

Note: with libstdc++-16 now installed, amdclang host compiles auto-resolve
`c++/16` headers, so `inplace_vector` is reachable in HIP-toolchain host
code too.

## Remainder (upstream-gated, not shippable yet)
`rcpp_arch_from_string` (bitnet_model.h) is an **alias** map of arbitrary
HF `model_type` strings — not derivable from the enum, left as-is.
P2300 senders/receivers, `std::text`, `std::hive` are not in libstdc++ 16
(20260322 snapshot) — keep watching upstream.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add reflection-gated EnumName tables in cpp26_reflect.h

- Replace enum name switches with table lookups

- Enforce table completeness compile-time under g++-16 -freflection

- Add selfcheck harness for legacy parity and inplace_vector


___

### Diagram Walkthrough


```mermaid
flowchart LR
  E["Enums: BackendType, SubLayer, PilotBackend, BackendTier"] --> T["EnumName tables beside each enum"]
  T --> L["rcpp26::lookup_enum_name helper"]
  L --> N["*_name() byte-identical strings"]
  E --> R["P2996 (g++-16 -freflection)"]
  T --> R
  R --> C["RCPP26_REQUIRE_ENUM_TABLE static_assert: every enumerator covered"]
  H["cpp26_name_maps_selfcheck.cpp"] --> N
  H --> C
  H --> V["std::inplace_vector decode-buffer exercise"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cpp26_reflect.h</strong><dd><code>New reflection helper header for verified enum name tables</code></dd></summary>
<hr>

include/cpp26_reflect.h

<ul><li>New header with <code>rcpp26::EnumName<E></code> row type and <code>lookup_enum_name</code> helper<br> <li> Adds <code>RCPP26_REQUIRE_ENUM_TABLE</code> macro proving enum tables cover every <br>enumerator<br> <li> Macro active only under P2996 (<code>g++-16 -std=c++26 -freflection</code>), no-op <br>elsewhere</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2133/files#diff-9c3d736db7186f42c94128c5d10045e4d3b70768fd576cc5ef6b50bd52941bb7">+97/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>common.h</strong><dd><code>Convert BackendType name switch to checked table lookup</code>&nbsp; &nbsp; </dd></summary>
<hr>

include/common.h

<ul><li>Added <code>kBackendTypeNames</code> table beside <code>BackendType</code><br> <li> Replaced <code>backend_name</code> switch with <code>rcpp26::lookup_enum_name</code><br> <li> Added <code>RCPP26_REQUIRE_ENUM_TABLE</code> compile-time coverage assertion<br> <li> Preserved "none" out-of-range fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2133/files#diff-bc020f3ca1b410d9c45f1a3e744c2b506de509f4c7063cf7755272d69283cdb4">+33/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backend_manager.h</strong><dd><code>Convert BackendTier name switch to verified table lookup</code>&nbsp; </dd></summary>
<hr>

include/backend_manager.h

<ul><li>Added <code>kBackendTierNames</code> table for <code>BackendTier</code><br> <li> Replaced <code>tier_name</code> switch with table lookup<br> <li> Added reflection verification for complete enumerator coverage<br> <li> Preserved "unknown" out-of-range fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2133/files#diff-59ff365586c7cb33235cd3786a5f0cc2fa9a0add61d7aa2d109b335b98cc7266">+14/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pilot.h</strong><dd><code>Add verified name tables for SubLayer and PilotBackend</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/pilot.h

<ul><li>Added <code>kSubLayerNames</code> and <code>kPilotBackendNames</code> tables<br> <li> Replaced <code>sublayer_name</code> and <code>pilot_backend_name</code> switches with lookups<br> <li> Added <code>RCPP26_REQUIRE_ENUM_TABLE</code> checks for both enums<br> <li> Preserved legacy "?" fallback behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2133/files#diff-9fc152f7ee91eb03ca2ff2af008a6e12978d878f4a6761bac95727cf41fac3c9">+37/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cpp26_name_maps_selfcheck.cpp</strong><dd><code>Add selfcheck test for enum name maps and C++26 features</code>&nbsp; </dd></summary>
<hr>

Testing/cpp26_name_maps_selfcheck.cpp

<ul><li>New host-only verification harness for all enum→name tables<br> <li> Runtime checks compare table output against legacy strings, including <br>fallbacks<br> <li> P2996 section prints BackendType mapping derived from enum via <br><code>std::meta</code><br> <li> Exercises <code>std::inplace_vector</code> decode-buffer pattern<br> <li> Macro-gated sections keep plain g++-15/clang builds green</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2133/files#diff-eb75d43115f65a8eea442db1f731052d295dbbefc6674d9dbf97c9eeb1aa4227">+164/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

