### PR TITLE
fix(gpu): qwen35 GDN q/k L2-norm sum-form (#1831)

### DIFF
--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -1113,7 +1113,7 @@ struct Hip1bpBackend : Backend {
             h1bp_rmsnorm_kernel<<<1, 256, 0, stream>>>(dh, w.pan, 2048, 1e-6f);
             h1bp_gemv_kernel<<<256, 256, 0, stream>>>(q35_sc_logits, w.router, dh, 256, 2048);
             // norm_topk: llama qwen35 uses renorm? default OFF unless env
-            bool renorm = getenv("Q35_NORMTK") != nullptr;
+            bool renorm = getenv("Q35_NORMTK") == nullptr || atoi(getenv("Q35_NORMTK")) != 0;  // norm_topk default ON
             h1bp_q35_topk_kernel<<<1, 256, 0, stream>>>(q35_sc_logits, q35_sc_rout, q35_sc_idx, 256, 8, renorm);
             HIP_CHECK(hipMemset(q35_sc_moe, 0, 2048 * 4));
             int exps[8]; float wts[8];

--- a/src/hip_1bp_kernels.hip
+++ b/src/hip_1bp_kernels.hip
@@ -514,7 +514,7 @@ __global__ void h1bp_head_l2norm_kernel(float* __restrict__ x, int len, int head
     ssum[tid] = loc;
     __syncthreads();
     for (int s = blockDim.x / 2; s > 0; s >>= 1) { if (tid < s) ssum[tid] += ssum[tid + s]; __syncthreads(); }
-    if (tid == 0) ssum[0] = rsqrtf(ssum[0] / len + eps);
+    if (tid == 0) ssum[0] = rsqrtf(ssum[0] + eps);
     __syncthreads();
     float inv = ssum[0];
     for (int i = tid; i < len; i += blockDim.x) hx[i] *= inv;


### PR DESCRIPTION
### **User description**
Restores llama ggml_l2_norm semantics (x/sqrt(sum+eps)) in h1bp_head_l2norm_kernel. RMS/mean form left ||k||=sqrt(128) -> delta-rule instability (state inf ~token 23-25) and the layer-0 content gap vs llama (pos0 logits corr 0.095 -> 0.911).


___

### **PR Type**
Bug fix


___

### **Description**
- Restore llama sum-form `ggml_l2_norm` in `h1bp_head_l2norm_kernel`.

- Enable qwen35 MoE `norm_topk` renormalization by default; `Q35_NORMTK=0` disables.

- Fix delta-rule state instability and layer-0 content-corr gap (`0.095` -> `0.911`).

- Align with llama-HIP pos0 logits correlation of `0.99990`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["h1bp_head_l2norm_kernel"] -- "mean-form /len" --> B["||k||=sqrt(128); unstable"]
  B -- "sum-form fix" --> C["unit rows; llama semantics"]
  C -- "norm_topk ON by default" --> D["pos0 logits corr 0.99990"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_hip_1bp.cpp</strong><dd><code>Enable qwen35 MoE norm_topk renormalization by default</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_hip_1bp.cpp

<ul><li>Flip <code>norm_topk</code> renormalization default from env-gated OFF to ON.<br> <li> Renorm enabled unless <code>Q35_NORMTK=0</code>.<br> <li> Matches llama qwen35 MoE <code>norm_topk</code> sum+clamp behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2134/files#diff-c4812ee96d278d2d2b452760b359c0521f1a016dce68e46c6668555b33eec182">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hip_1bp_kernels.hip</strong><dd><code>Restore sum-form L2 normalization for head q/k</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hip_1bp_kernels.hip

<ul><li>Use full squared-sum <code>rsqrtf(ssum[0] + eps)</code> instead of mean-square <br>form.<br> <li> Restores llama <code>ggml_l2_norm</code> semantics for q/k GDN heads.<br> <li> Fixes delta-rule state explosion and layer-0 content-correlation gap.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2134/files#diff-e7c676fbc5592cbbf17f1c7db3df89e539cc6bfef40bfc8014de1d807ac66396">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

