### PR TITLE
feat(hrx): #1942 D2 — llama_state import shim (HRX_STATE_FILE) + hybrid evidence record

### DIFF
--- a/docs/research/hybrid-prefill-decode.md
+++ b/docs/research/hybrid-prefill-decode.md
@@ -158,3 +158,19 @@ HIP wins; short prompts amortize the handoff cost poorly).
   one process (both dlopen HIP/ROCm — the in-process HRX path already loads
   the bundle's libllama; adding the engine's own HIP-linked llama.cpp may
   conflict on ROCm symbols; the subprocess llama-server path avoids this).
+
+## §5.1 gate — RE-VERIFIED 2026-09-07 (rt_session harness)
+
+A = vendored third_party/llama.cpp @4df29be4f GGML_HIP build (session 9) · B = hrx-v2-src
+fork @0f52c297a (session 9) · Qwen3-0.6B-Q4_K_M · 5-token prompt + 8 gens → blob
+1,491,865 B (llama_state_save_file/load_file, ctx 512/512/8).
+
+- A-imported == A-native: **IDENTICAL** (13/13).
+- B-imported == B-native: **IDENTICAL** (13/13) — handoff is faithful (kv+rng fully
+  transferred; fork resumed from the vendored blob continues exactly as it natively would).
+- A-native vs B-native (no state): diverges after ~4-5 tokens = cross-build ggml-cpu
+  numeric drift (fork vs vendored kernels), reproducible under forced F16 and F32 KV
+  (rules out cache-type disagreement; §6 open question answered). Not a handoff defect.
+- Consequence for D2 hybrid correctness: per §4, continuation equality vs pure-HIP is
+  bounded by this drift ("identical up to the first diverging top-1"); the state format
+  round-trips losslessly. D1 harness remains the no-context-loss proof.

--- a/docs/research/hybrid-prefill-decode.md
+++ b/docs/research/hybrid-prefill-decode.md
@@ -238,3 +238,40 @@ question: is the decode-rate gap harness/bundle-config specific (engine path use
 dlopen+DEEPBIND + engine ctx params) or a bundle regression? Resolve via the
 engine-path integration (wire llama_state import into HrxBackend, bench through
 1bit unified) before the hybrid policy ships. The §0 HRX2 decision stands.
+
+
+## §5.2 benchmark — measured 2026-09-07 (clean run, quiet box)
+
+Qwen3-Coder-30B-A3B-Instruct-Q4_K_M · 2,962-token prompt · 500-token continuation,
+standalone harnesses: rt_A (vendored 4df29be4f GGML_HIP ngl99), rt_HRX (gfx1151
+llama-build bundle: libllama + ggml-hrx 0.9.11, HRX0, all layers offloaded).
+
+| config | wall | notes |
+|---|---|---|
+| **hybrid**: HIP prefill + HRX0 decode | **404.5 s** | prefill 4.50 s (~660 tok/s) + HRX decode 400.0 s (1.25 tok/s) |
+| **HIP-only** | **12.2 s** | prefill + 500 decode end-to-end incl. model load |
+| **HRX-only** | **596.3 s** | HRX prefill ~196 s (~15 tok/s) + decode ~400 s |
+
+Token comparisons: hybrid-vs-hip-only and hybrid-vs-hrx-only diverge at token 0
+(cross-backend prefill/decode kernel numerics — HIP == fork-CPU decode agreed
+48/48 on identical kv earlier; HRX0-device decode drifts from token 0 vs both).
+Continuations are fluent/coherent on all three paths (no context loss).
+
+**Verdict:** D2 handoff is functionally proven (lossless state transfer; decode on
+HIP, fork-CPU and HRX0 all work from the shared blob), but the §5.2 perf criterion
+(hybrid total beats either backend alone) is **NOT met** with this bundle: HRX0
+decode measured 1.25 tok/s in the standalone harness vs the 80-87 tok/s documented
+for the engine's in-process path (hrx_inprocess) and HIP decode ~70 tok/s. Open
+question: is the decode-rate gap harness/bundle-config specific (engine path uses
+dlopen+DEEPBIND + engine ctx params) or a bundle regression? Resolve via the
+engine-path integration (wire llama_state import into HrxBackend, bench through
+1bit unified) before the hybrid policy ships. The §0 HRX2 decision stands.
+
+## 2026-09-07 follow-up — HRX0 import-decode blocker filed (#2145)
+
+b66 release bundle and the amd-hrx-graph fork both FAIL llama_decode at token 2 on
+HRX0 after llama_state_load_file of the 292 MB HIP-prefill blob (graph compute -1);
+the local llama-build (GET_ROWS-capable) decodes from the imported state (500 tokens,
+coherent) but at 1.25 tok/s. Handoff losslessness stands (fork-CPU + HIP 48/48).
+Filed as 1bit-MONSTER/1bit-MONSTER#2145 — blocks the D2 shipped fast path; D1
+tokens-only re-prefix remains the correctness fallback; §0 HRX2 decision untouched.

--- a/docs/research/hybrid-prefill-decode.md
+++ b/docs/research/hybrid-prefill-decode.md
@@ -174,3 +174,17 @@ fork @0f52c297a (session 9) · Qwen3-0.6B-Q4_K_M · 5-token prompt + 8 gens → 
 - Consequence for D2 hybrid correctness: per §4, continuation equality vs pure-HIP is
   bounded by this drift ("identical up to the first diverging top-1"); the state format
   round-trips losslessly. D1 harness remains the no-context-loss proof.
+
+## §5.2 D2 handoff — correctness PROVEN on the 30B (2026-09-07)
+
+Qwen3-Coder-30B-A3B-Instruct-Q4_K_M (the HRX-bundle model), 2,962-token prompt:
+- A (vendored 4df29be4f GGML_HIP, ngl99) prefills on HIP (~620 tok/s incl. save),
+  292,011,596 B session blob via llama_state_save_file.
+- B (hrx2 fork @0f52c297a, session 9) imports the blob (llama_state_load_file) and
+  decodes. **A-run (HIP decode of own kv) vs B-run (fork decode of imported kv):
+  48/48 continuation tokens IDENTICAL** — the handoff is lossless; no context loss.
+- B-imported vs B-native (fork re-prefill from scratch) diverges from token 0 =
+  A-HIP-prefill vs B-CPU-prefill kernel drift (anticipated by §4: equality is bounded
+  by the first diverging top-1; decode-on-identical-kv agrees 100%).
+- Remaining for full §5.2 acceptance: decode leg on the real HRX device (bundle),
+  ≥500-token continuation, and the hybrid-vs-single-backend timing table.

--- a/docs/research/hybrid-prefill-decode.md
+++ b/docs/research/hybrid-prefill-decode.md
@@ -188,3 +188,53 @@ Qwen3-Coder-30B-A3B-Instruct-Q4_K_M (the HRX-bundle model), 2,962-token prompt:
   by the first diverging top-1; decode-on-identical-kv agrees 100%).
 - Remaining for full §5.2 acceptance: decode leg on the real HRX device (bundle),
   ≥500-token continuation, and the hybrid-vs-single-backend timing table.
+
+## §5.2 benchmark — measured 2026-09-07 (clean run, quiet box)
+
+Qwen3-Coder-30B-A3B-Instruct-Q4_K_M · 2,962-token prompt · 500-token continuation,
+standalone harnesses: rt_A (vendored 4df29be4f GGML_HIP ngl99), rt_HRX (gfx1151
+llama-build bundle: libllama + ggml-hrx 0.9.11, HRX0, all layers offloaded).
+
+| config | wall | notes |
+|---|---|---|
+| **hybrid**: HIP prefill + HRX0 decode | **404.5 s** | prefill 4.50 s (~660 tok/s) + HRX decode 400.0 s (1.25 tok/s) |
+| **HIP-only** | **12.2 s** | prefill + 500 decode (~41+ tok/s end-to-end incl. load) |
+| **HRX-only** | **596.3 s** | HRX prefill ~196 s (~15 tok/s) + decode ~400 s |
+
+Token comparisons: hybrid-vs-hip-only and hybrid-vs-hrx-only diverge at token 0
+(cross-backend prefill/decode kernel numerics — HIP == fork-CPU decode agreed
+48/48 on identical kv earlier; HRX0-device decode drifts from token 0 vs both).
+Continuations are fluent/coherent on all three paths (no context loss).
+
+**Verdict:** D2 handoff is functionally proven (lossless state transfer, decode on
+HIP/fork-CPU/HRX0 all work from the shared blob), but the §5.2 perf criterion
+(hybrid total beats either backend alone) is **NOT met**: HRX0 decode measured
+1.25 tok/s in this harness vs the 80-87 tok/s documented for the engines
+
+
+## §5.2 benchmark — measured 2026-09-07 (clean run, quiet box)
+
+Qwen3-Coder-30B-A3B-Instruct-Q4_K_M · 2,962-token prompt · 500-token continuation,
+standalone harnesses: rt_A (vendored 4df29be4f GGML_HIP ngl99), rt_HRX (gfx1151
+llama-build bundle: libllama + ggml-hrx 0.9.11, HRX0, all layers offloaded).
+
+| config | wall | notes |
+|---|---|---|
+| **hybrid**: HIP prefill + HRX0 decode | **404.5 s** | prefill 4.50 s (~660 tok/s) + HRX decode 400.0 s (1.25 tok/s) |
+| **HIP-only** | **12.2 s** | prefill + 500 decode end-to-end incl. model load |
+| **HRX-only** | **596.3 s** | HRX prefill ~196 s (~15 tok/s) + decode ~400 s |
+
+Token comparisons: hybrid-vs-hip-only and hybrid-vs-hrx-only diverge at token 0
+(cross-backend prefill/decode kernel numerics — HIP == fork-CPU decode agreed
+48/48 on identical kv earlier; HRX0-device decode drifts from token 0 vs both).
+Continuations are fluent/coherent on all three paths (no context loss).
+
+**Verdict:** D2 handoff is functionally proven (lossless state transfer; decode on
+HIP, fork-CPU and HRX0 all work from the shared blob), but the §5.2 perf criterion
+(hybrid total beats either backend alone) is **NOT met** with this bundle: HRX0
+decode measured 1.25 tok/s in the standalone harness vs the 80-87 tok/s documented
+for the engine's in-process path (hrx_inprocess) and HIP decode ~70 tok/s. Open
+question: is the decode-rate gap harness/bundle-config specific (engine path uses
+dlopen+DEEPBIND + engine ctx params) or a bundle regression? Resolve via the
+engine-path integration (wire llama_state import into HrxBackend, bench through
+1bit unified) before the hybrid policy ships. The §0 HRX2 decision stands.

--- a/src/backend_hrx.cpp
+++ b/src/backend_hrx.cpp
@@ -123,6 +123,14 @@ bool HrxBackend::init(const ModelConfig& cfg, const std::string& weights_dir) {
         uint32_t ctx = (uint32_t)std::atoi(ctx_size_.c_str());
         if (ctx == 0) ctx = 4096;
         if (inprocess_->init() && inprocess_->load_model(model_path_, n_gpu_layers, ctx)) {
+            // #1942 D2 hybrid: HRX_STATE_FILE=<session.bin> imports a llama_state
+            // blob (HIP-prefill lane output) so decode continues from its KV.
+            if (const char* sf = std::getenv("HRX_STATE_FILE")) {
+                long n = inprocess_->load_session_file(sf);
+                if (n < 0) {
+                    fprintf(stderr, "HRX: state import failed (%s) — continuing with empty KV\n", sf);
+                }
+            }
             inprocess_mode_ = true;
             initialized_ = true;
             fprintf(stderr, "HRX: in-process engine active (token-level, %s)\n",

--- a/src/hrx_inprocess.cpp
+++ b/src/hrx_inprocess.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -129,6 +130,7 @@ using fn_llama_model_get_vocab = llama_vocab* (*)(const llama_model*);
 using fn_llama_vocab_n_tokens = int32_t (*)(const llama_vocab*);
 using fn_llama_model_n_embd = int32_t (*)(const llama_model*);
 using fn_llama_model_desc = int32_t (*)(const llama_model*, char*, size_t);
+using fn_llama_state_load_file = bool (*)(llama_context*, const char*, llama_token*, size_t, size_t*);
 using fn_ggml_backend_dev_by_name = ggml_backend_dev_t (*)(const char*);
 using fn_ggml_backend_dev_name = const char* (*)(ggml_backend_dev_t);
 using fn_ggml_backend_hrx_get_device_count = int32_t (*)(void);
@@ -151,6 +153,8 @@ struct Inprocess::Impl {
     fn_llama_vocab_n_tokens llama_vocab_n_tokens = nullptr;
     fn_llama_model_n_embd llama_model_n_embd = nullptr;
     fn_llama_model_desc llama_model_desc = nullptr;
+    fn_llama_state_load_file llama_state_load_file = nullptr;
+    size_t n_session = 0;
     fn_ggml_backend_dev_by_name ggml_backend_dev_by_name = nullptr;
     fn_ggml_backend_dev_name ggml_backend_dev_name = nullptr;
     fn_ggml_backend_hrx_get_device_count ggml_backend_hrx_get_device_count = nullptr;
@@ -268,6 +272,7 @@ bool Inprocess::init() {
     impl_->llama_vocab_n_tokens = (fn_llama_vocab_n_tokens)sym(impl_->handle, "llama_vocab_n_tokens");
     impl_->llama_model_n_embd = (fn_llama_model_n_embd)sym(impl_->handle, "llama_model_n_embd");
     impl_->llama_model_desc = (fn_llama_model_desc)sym(impl_->handle, "llama_model_desc");
+    impl_->llama_state_load_file = (fn_llama_state_load_file)sym(impl_->handle, "llama_state_load_file");  // optional (D2 hybrid)
     impl_->ggml_backend_dev_by_name = (fn_ggml_backend_dev_by_name)sym(impl_->handle, "ggml_backend_dev_by_name");
     impl_->ggml_backend_dev_name = (fn_ggml_backend_dev_name)sym(impl_->handle, "ggml_backend_dev_name");
     impl_->ggml_backend_hrx_get_device_count = (fn_ggml_backend_hrx_get_device_count)sym(impl_->handle, "ggml_backend_hrx_get_device_count");
@@ -352,6 +357,24 @@ bool Inprocess::load_model(const std::string& model_path, int n_gpu_layers, uint
             impl_->llama_n_ctx ? impl_->llama_n_ctx(impl_->ctx) : 0u,
             impl_->vocab, impl_->n_embd);
     return true;
+}
+
+long Inprocess::load_session_file(const std::string& path) {
+    if (!impl_->ctx || !impl_->llama_state_load_file) {
+        fprintf(stderr, "[hrx] load_session_file: no context, or bundle lacks llama_state_load_file\n");
+        return -1;
+    }
+    std::vector<llama_token> toks(65536);
+    size_t n = 0;
+    if (!impl_->llama_state_load_file(impl_->ctx, path.c_str(), toks.data(), toks.size(), &n)) {
+        fprintf(stderr, "[hrx] load_session_file: import failed for %s\n", path.c_str());
+        return -1;
+    }
+    impl_->n_session = n;
+    impl_->pos = (llama_pos)n;  // continue after the imported tokens
+    fprintf(stderr, "[hrx] session imported: %zu tokens from %s (pos=%lld)\n",
+            n, path.c_str(), (long long)impl_->pos);
+    return (long)n;
 }
 
 int Inprocess::generate(int token_id) {

--- a/src/hrx_inprocess.h
+++ b/src/hrx_inprocess.h
@@ -38,6 +38,12 @@ public:
     // model_path: path to a .gguf; n_gpu_layers: <0 = all; ctx_size: 0 = model default.
     bool load_model(const std::string& model_path, int n_gpu_layers, uint32_t ctx_size);
 
+    // #1942 D2 hybrid: import a llama_state session blob (saved by a compatible
+    // llama.cpp build, e.g. the GGML_HIP prefill lane) into the current context
+    // so generate() continues from the imported KV. Call AFTER load_model(),
+    // BEFORE generate(). Returns the number of imported tokens, or -1.
+    long load_session_file(const std::string& session_path);
+
     // One decode step: feed token_id, return argmax next token, or -1 on failure.
     int generate(int token_id);
 


### PR DESCRIPTION
### **User description**
## D2 hybrid prefill/decode — state-handoff shim + measured evidence (#1942, #2082)

Engine-side piece of the hybrid-prefill-decode D2 lane, plus the full measured
record from the end-to-end investigation (2026-09-06/07, strixhalo).

### Code (env-gated, additive)
- `src/hrx_inprocess.{h,cpp}`: `Inprocess::load_session_file()` — dlsym'd
  `llama_state_load_file` (optional symbol; bundle ABI unchanged), imports a
  LLAMA_SESSION_VERSION-9 session blob after `load_model()` and sets `pos` to
  the imported token count so `generate()` continues from the transferred KV.
- `src/backend_hrx.cpp`: `HRX_STATE_FILE=<session.bin>` env hook in the
  in-process path (import after load; failure degrades to empty KV + clear log).

### Evidence recorded in docs/research/hybrid-prefill-decode.md
- **§5.1 round-trip gate re-verified**: vendored llama.cpp @4df29be4f (session 9)
  ↔ hrx2 fork @0f52c297a (session 9): 5-token prompt + 8 gens, 1,491,865 B blob;
  A-imported == A-native and B-imported == B-native, 13/13 identical both sides.
- **§5.2 handoff correctness on the 30B** (Qwen3-Coder-30B-A3B Q4_K_M, 2,962-token
  HIP prefill → 292,011,596 B blob): decode of the imported state 48/48
  token-identical between vendored-HIP and fork-CPU; coherent 500-token decode
  on the working bundle; cross-backend prefill-kernel drift documented per §4.
- **§5.2 benchmark**: hybrid 404.5 s vs HIP-only 12.2 s vs HRX-only 596.3 s —
  criterion unmet because HRX0-device decode measures 1.25 tok/s in the
  standalone/engine harness on current bundles (80-87 tok/s engine-path claim
  not reproducible on today's artifacts).
- **Blocker filed: #2145** — llama_state-imported context fails HRX0-device
  decode at token 2 (graph compute -1) on the b66 release bundle and the
  amd-hrx-graph fork; only the local GET_ROWS-capable llama-build decodes
  (at the 1.25 tok/s rate). The shim here is the landing point for that fix.

### Validation
- Shim exercised through the engine code path (llama-build bundle, HRX0):
  import 2,971 tokens at pos=2971, 50/50 decodes clean.
- Full engine target builds with the change (onebit_engine 100%).

### Status
Handoff machinery proven; shipped fast path gated on #2145 (HRX-stack bug,
fleet lanes aware). D1 tokens-only re-prefix remains the correctness fallback;
the §0 HRX2 decision (zaya pp32) is untouched and owned elsewhere.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add `Inprocess::load_session_file()` for importing `llama_state` blobs
  - optional `llama_state_load_file` dlsym; bundle ABI unchanged
  - resumes `generate()` from the imported token count

- Wire `HRX_STATE_FILE` hook into in-process `HrxBackend`
  - import failures degrade to empty KV with a clear log line

- Record round-trip gate and 30B handoff correctness in docs

- Document measured decode gap and #2145 import-decode blocker


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["llama_state blob (session 9)"] -- "HRX_STATE_FILE" --> B["HrxBackend in-process"]
  B -- "load_session_file()" --> C["llama_state_load_file import"]
  C -- "pos = imported tokens" --> D["generate() continues decode"]
  D -. "1.25 tok/s blocker #2145" .-> E["Hybrid perf criterion unmet"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_hrx.cpp</strong><dd><code>Add HRX_STATE_FILE env-gated state import hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_hrx.cpp

<ul><li>Adds <code>HRX_STATE_FILE</code> env-gated session import in the in-process path<br> <li> Calls <code>Inprocess::load_session_file()</code> after <code>load_model()</code><br> <li> Logs import failure and continues with empty KV</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2146/files#diff-711ccf478ce94d93f0833c2e69042e84105a1a74c6a52680e6177be019ece9e5">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hrx_inprocess.cpp</strong><dd><code>Implement Inprocess::load_session_file llama_state importer</code></dd></summary>
<hr>

src/hrx_inprocess.cpp

<ul><li>Adds <code>fn_llama_state_load_file</code> typedef and optional dlsym resolution<br> <li> Implements <code>Inprocess::load_session_file()</code> with token-vector buffer<br> <li> Stores imported token count and resumes <code>generate()</code> from that <code>pos</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2146/files#diff-1be430bc0e9cd754dec5c1dde369292f05c4124f871df9d34b6c36538c693649">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hrx_inprocess.h</strong><dd><code>Declare load_session_file in HRX in-process API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hrx_inprocess.h

<ul><li>Declares public <code>load_session_file()</code> to be used after <code>load_model()</code><br> <li> Documents return value as imported token count or -1</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2146/files#diff-2004a93bae0a6ab910d1e3c59b144b48ecbacf316081aba9dcdf4e7f0dd884f1">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hybrid-prefill-decode.md</strong><dd><code>Document D2 handoff evidence, benchmark, and blocker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/research/hybrid-prefill-decode.md

<ul><li>Re-verifies §5.1 state round-trip gate (vendored vs hrx2 fork)<br> <li> Proves §5.2 30B handoff correctness with 48/48 identical continuations<br> <li> Records hybrid benchmark (404.5 s) missing the performance criterion<br> <li> Files #2145 import-decode blocker; benchmark section appears <br>duplicated</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2146/files#diff-1ab8203d2db454ac8c9d6623d9a508fd459fc49b1fe46ca61932064c293eb983">+117/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

