### PR TITLE
fix(hrx): #2147 follow-up — restore GGML_HRX_CPU_OPS on HrxBackend teardown

### DIFF
--- a/src/backend_hrx.cpp
+++ b/src/backend_hrx.cpp
@@ -113,6 +113,7 @@ bool HrxBackend::init(const ModelConfig& cfg, const std::string& weights_dir) {
     // explicitly configured it.
     if (cfg.architecture == "qwen3moe" && std::getenv("GGML_HRX_CPU_OPS") == nullptr) {
         setenv("GGML_HRX_CPU_OPS", "RMS_NORM", 1);
+        cpu_ops_set_by_us_ = true;
         fprintf(stderr, "HRX: qwen3moe decode needs CPU RMSNorm (#2147) - set GGML_HRX_CPU_OPS=RMS_NORM\n");
     }
 
@@ -324,6 +325,14 @@ void HrxBackend::destroy() {
     inprocess_mode_ = false;
     kill_server();
     initialized_ = false;
+    // #2147 follow-up: init() sets GGML_HRX_CPU_OPS process-global for
+    // qwen3moe (single-model constraint). Restore the environment on teardown
+    // so a later backend/model served in this process doesn't inherit the
+    // RMS_NORM CPU split (and a later qwen3moe init re-applies it cleanly).
+    if (cpu_ops_set_by_us_) {
+        unsetenv("GGML_HRX_CPU_OPS");
+        cpu_ops_set_by_us_ = false;
+    }
 }
 
 bool HrxBackend::reset() {

--- a/src/backend_hrx.h
+++ b/src/backend_hrx.h
@@ -53,6 +53,7 @@ private:
     pid_t pid_ = -1;
     bool initialized_ = false;
     bool inprocess_mode_ = false;
+    bool cpu_ops_set_by_us_ = false;  // #2147 follow-up: we set GGML_HRX_CPU_OPS in init() — restore it on destroy()
     std::unique_ptr<hrx::Inprocess> inprocess_;
     std::string server_bin_;
     std::string model_path_;


### PR DESCRIPTION
### **User description**
Follow-up to PR #2156 (merged, e10490af). The process-global `setenv(GGML_HRX_CPU_OPS=RMS_NORM)` in `HrxBackend::init` for qwen3moe now:

- is tracked via `cpu_ops_set_by_us_`
- is undone (`unsetenv`) in `HrxBackend::destroy()`

So teardown restores the operator's environment and a later model/backend in the same process doesn't inherit the RMS_NORM CPU split. A later qwen3moe init re-applies it cleanly.

Addresses the non-blocking note from the #2156 review (process-global setenv lifecycle).


___

### **PR Type**
Bug fix


___

### **Description**
- Track GGML_HRX_CPU_OPS when HrxBackend::init sets it for qwen3moe

- Unset the process-global env var in HrxBackend::destroy

- Prevent later models/backends from inheriting RMS_NORM CPU split

- Allow a later qwen3moe init to re-apply the setting cleanly


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["HrxBackend::init for qwen3moe"] --> B["setenv GGML_HRX_CPU_OPS=RMS_NORM"]
  B --> C["cpu_ops_set_by_us_ = true"]
  C --> D["HrxBackend::destroy"]
  D --> E["unsetenv GGML_HRX_CPU_OPS"]
  E --> F["Later backend ignores RMS_NORM split"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_hrx.cpp</strong><dd><code>Track and restore GGML_HRX_CPU_OPS on backend teardown</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_hrx.cpp

<ul><li>Set <code>cpu_ops_set_by_us_ = true</code> when auto-configuring <br><code>GGML_HRX_CPU_OPS=RMS_NORM</code> for qwen3moe<br> <li> In <code>HrxBackend::destroy()</code>, unset <code>GGML_HRX_CPU_OPS</code> when the flag <br>indicates this backend set it<br> <li> Reset the tracking flag after cleanup so a later qwen3moe init can <br>re-apply it<br> <li> Added comments explaining the process-global env lifecycle and <br>teardown restore</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2158/files#diff-711ccf478ce94d93f0833c2e69042e84105a1a74c6a52680e6177be019ece9e5">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backend_hrx.h</strong><dd><code>Add cpu_ops_set_by_us_ lifecycle flag to HrxBackend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_hrx.h

<ul><li>Added <code>cpu_ops_set_by_us_</code> boolean member to <code>HrxBackend</code><br> <li> Records whether this backend set the process-global <code>GGML_HRX_CPU_OPS</code> <br>env var<br> <li> Supports environment restoration in teardown and avoids stale <br>inheritance by later backends</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2158/files#diff-dd69a74b1b996379a69d77e3e4386afe29f437c64f8a29e137b597d1c859acac">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

