### PR TITLE
fix: #2140 1BP v4 discovery + OnebpArch remap; #2141 census tokens jugnuvr/m2r; #2143 overflow/format fixes

### DIFF
--- a/engine/npu/src/npu_engine_universal.cpp
+++ b/engine/npu/src/npu_engine_universal.cpp
@@ -3402,7 +3402,7 @@ struct Bf16Ctx {
                                 fprintf(stderr, "\n[C1DUMP l=%d] C1h[0..15]=", l);
                                 for (int k = 0; k < 16; k++) fprintf(stderr, "%d ", C1h[k]);
                                 int h0 = -1, h1 = -1;
-                                for (size_t k = 0; k < (uint32_t)cg_fused_i4->MD * (uint32_t)cg_fused_i4->bC_nd; k++) {
+                                for (size_t k = 0; k < (size_t)cg_fused_i4->MD * (size_t)cg_fused_i4->bC_nd; k++) {
                                     if ((int64_t)c1m[k] == (int64_t)C1h[0]) { if (h0<0) h0 = (int)k; }
                                     if ((int64_t)c1m[k] == (int64_t)C1h[1]) { if (h1<0) h1 = (int)k; }
                                 }
@@ -3412,7 +3412,7 @@ struct Bf16Ctx {
                             }
                             // Also report whether bC(bo2/C1) got any nonzero write.
                             bool bczero = true;
-                            for (size_t k = 0; k < (uint32_t)cg_fused_i4->MD * (uint32_t)cg_fused_i4->bC_nd; k++)
+                            for (size_t k = 0; k < (size_t)cg_fused_i4->MD * (size_t)cg_fused_i4->bC_nd; k++)
                                 if (c1m[k] != 0) { bczero = false; break; }
                             fprintf(stderr, "[FUSED_H2] l=%d h2corrGt=%.6f h2maeGt=%.3f h2peakGt=%.0f h2badGt=%d/%d bC_zero=%d h2[0..7]=%d %d %d %d %d %d %d %d h2gt[0..3]=%d %d %d %d\n",
                                     l, gcorr, hgmae / IM, hgpeak, hgbad, IM, (int)bczero,

--- a/engine/npu/tests/diag_fused_weight_accuracy.cpp
+++ b/engine/npu/tests/diag_fused_weight_accuracy.cpp
@@ -115,7 +115,7 @@ int main(int argc, char** argv) {
     double mT=sT/n, mF=sF/n, cxx=sT2/n-mT*mT, cyy=sF2/n-mF*mF, cxy=sTF/n-mT*mF;
     double corr = (cxx>0&&cyy>0)?cxy/std::sqrt(cxx*cyy):(cxx==0&&cyy==0)?1.0:0.0;
     fprintf(stderr, "\n=== qwen3-0.6b L%d dense GU: fused int4 reconstruction vs TRUE 4-bit Q4NX ===\n", L);
-    fprintf(stderr, "  N=%ld samples, W_true rms=%.5f, W_fused rms=%.5f\n", cnt, std::sqrt(cxx), std::sqrt(cyy));
+    fprintf(stderr, "  N=%lld samples, W_true rms=%.5f, W_fused rms=%.5f\n", cnt, std::sqrt(cxx), std::sqrt(cyy));
     fprintf(stderr, "  GLOBAL corr(W_fused, W_true)=%.6f   MAE=%.6g  max|e|=%.6g\n", corr, mae/n, maxe);
     fprintf(stderr, "  per-col corr (first %d cols): min=%.6f avg=%.6f\n", ccnt, cmin, csum/ccnt);
     // sample a few
@@ -147,7 +147,7 @@ int main(int argc, char** argv) {
         double m1=gT/gc, m2=gF/gc, cx=gT2/gc-m1*m1, cy=gF2/gc-m2*m2, cxy=gTF/gc-m1*m2;
         double cor = (cx>0&&cy>0)?cxy/std::sqrt(cx*cy):0.0;
         fprintf(stderr, "  [%s] corr=%.5f mae=%.6f rms_true=%.5f rms_fused=%.5f satB=%lld/%lld\n",
-                which?"UP ":"GATE", cor, gmae/gc, std::sqrt(cx), std::sqrt(cy), sat, gc);
+                which?"UP ":"GATE", cor, gmae/gc, std::sqrt(cx), std::sqrt(cy), (long long)sat, gc);
     }
     munmap(md, st.st_size);
     return 0;

--- a/include/rocm_cpp/bitnet_model.h
+++ b/include/rocm_cpp/bitnet_model.h
@@ -601,6 +601,8 @@ typedef enum {
     RCPP_ARCH_TINYTRANSFORMER = 1001, // tinytransformer — TinyTransformerForCausalLM minimal custom-code transformer (Mayuresh231/tiny-transformer-29m; registry token, engine support XL, generic loader refuses)
     RCPP_ARCH_IKNN = 1002,            // iknn-rl1-a1 — IKNN-Rl1-A1ForCausalLM (deeprcurs/IKNN-Rl1-A1; MLX-era file_* config, RoPE 1e4 + RMSNorm, gpt2-shaped; registry token, engine support XL, generic loader refuses)
     RCPP_ARCH_K2HORIZON = 1003,       // k2horizon — K2-Horizon-MoVA (Moonshot K2-Horizon MoE: 100E/8, layernorm_num_groups, query_key_norm, rope_head_dim, attention_gate_func, decoder_sparse_step; registry token, engine support XL, generic loader refuses)
+    RCPP_ARCH_JUGNUVR = 1004,         // jugnuvr — JugnuVRForCausalLM (altslate/JugnuLM-110M-R1; custom-code dense transformer, per-layer layer_types plan, silu, head_dim 64; registry token, engine support XL, generic loader refuses)
+    RCPP_ARCH_M2R = 1005,             // m2r — gdiamos/amx-reasoning-v1-instruct (hybrid lin/SSM + sliding-window-attn layer types, d_state 32, d_ff 640, route_block 1024; registry token, engine support XL, generic loader refuses)
     // Sentinel for unmapped architecture strings. Unmapped archs used to
     // silently become RCPP_ARCH_BITNET (wrong activation / attention for
     // most families) — now they fail loudly at discovery/load (decision
@@ -2533,6 +2535,10 @@ static inline rcpp_arch_t rcpp_arch_from_string(const char* s) {
     if (strcmp(s, "k2horizon") == 0) return RCPP_ARCH_K2HORIZON;      // census stripped arch name (registry token)
     if (strcmp(s, "k2_horizon_mova") == 0) return RCPP_ARCH_K2HORIZON; // HF model_type
     if (strcmp(s, "k2horizonforcausallm") == 0) return RCPP_ARCH_K2HORIZON;  // raw HF architecture string (regression guard)
+    if (strcmp(s, "jugnuvr") == 0) return RCPP_ARCH_JUGNUVR;              // census stripped arch name (registry token)
+    if (strcmp(s, "jugnuvrforcausallm") == 0) return RCPP_ARCH_JUGNUVR;   // raw HF architecture string (regression guard)
+    if (strcmp(s, "m2r") == 0) return RCPP_ARCH_M2R;                      // census stripped arch name (registry token)
+    if (strcmp(s, "m2rforcausallm") == 0) return RCPP_ARCH_M2R;           // raw HF architecture string (regression guard)
     // ── 2026-09-02 census watcher (PR #2046 CI gate) ──
     // Both classes are GENUINELY NEW architectures, verified against live HF
     // configs, so they get a real registry token (own identity) rather than an

--- a/src/baretorch_engine.cpp
+++ b/src/baretorch_engine.cpp
@@ -301,7 +301,7 @@ private:
     // ── cs_lrad layer: exact chunked math, incremental ──
     void cs_lrad_step(BrLayer& ly, const float* xn, float* out) {
         // project this token
-        std::vector<float> q(D), k(D), v(D), U(H * r_), R(H * r_), gate(H), beta(H), lg(H), sw(D);
+        std::vector<float> q(D), k(D), v(D), U((size_t)H * r_), R((size_t)H * r_), gate(H), beta(H), lg(H), sw(D);
         mm(ly.W_q, xn, D, D, q.data());
         mm(ly.W_k, xn, D, D, k.data());
         mm(ly.W_v, xn, D, D, v.data());
@@ -345,7 +345,7 @@ private:
 
         // Y_local: chunked decay-link causal attention over current chunk
         //   out[h,d] = sum_{j<=pos} exp(min(lam_pos(h)-lam_j(h),0)) * (q_pos . k_j) * v_j / sqrt(dh)
-        std::vector<float> yloc(H * dh, 0.0f);
+        std::vector<float> yloc((size_t)H * dh, 0.0f);
         const float* qp = ly.cq[pos].data();
         for (int j = 0; j <= pos; j++) {
             const float* kj = ly.ck[j].data();

--- a/src/model_discovery.cpp
+++ b/src/model_discovery.cpp
@@ -4,6 +4,7 @@
 #include "model_discovery.h"
 #include "gguf_reader.h"
 #include "q4nx_reader.h"
+#include "onebp_format.h"
 #include "safetensors_reader.h"
 #include <cstdio>
 #include <cstring>
@@ -300,6 +301,38 @@ static bool read_gguf_metadata(const std::string& path, ModelConfig& cfg) {
 }
 
 // ── Read .1bp (oneBP) metadata header ────────────────────────────────────
+// 1BP tensor-index probe: the index follows the 256-byte header with
+// tensor_count entries of
+//   [name_len:u32][name bytes][ndim:u32][dims:u32 × ndim][offset:u64][bytes:u64]
+// (v4 alias entries have bytes==0 and offset=index — names/dims still written).
+// Reads names only (no tensor data); bails on truncated/corrupt files.
+static bool onebp_index_has(const std::string& path, const char* want) {
+    FILE* f = fopen(path.c_str(), "rb");
+    if (!f) return false;
+    uint8_t hdr[256];
+    if (fread(hdr, 1, 256, f) != 256) { fclose(f); return false; }
+    uint32_t magic, tensor_count;
+    memcpy(&magic, hdr, 4);
+    memcpy(&tensor_count, hdr + 88, 4);
+    if (magic != 0x00504231 || tensor_count > 100000) { fclose(f); return false; }
+    const size_t wl = strlen(want);
+    bool found = false;
+    for (uint32_t i = 0; i < tensor_count && !found; i++) {
+        uint32_t name_len = 0, ndim = 0;
+        if (fread(&name_len, 4, 1, f) != 1 || name_len > 4096) break;
+        std::vector<char> nb(name_len);
+        if (fread(nb.data(), 1, name_len, f) != name_len) break;
+        if (fread(&ndim, 4, 1, f) != 1 || ndim > 8) break;
+        if (ndim > 0 && fseek(f, (long)ndim * 4, SEEK_CUR) != 0) break;
+        uint64_t off = 0, bytes = 0;
+        if (fread(&off, 8, 1, f) != 1 || fread(&bytes, 8, 1, f) != 1) break;
+        (void)off; (void)bytes;
+        if (name_len == wl && memcmp(nb.data(), want, wl) == 0) found = true;
+    }
+    fclose(f);
+    return found;
+}
+
 static bool read_onebp_metadata(const std::string& path, ModelConfig& cfg) {
     FILE* f = fopen(path.c_str(), "rb");
     if (!f) return false;
@@ -317,7 +350,9 @@ static bool read_onebp_metadata(const std::string& path, ModelConfig& cfg) {
     // Read version
     uint32_t version;
     memcpy(&version, hdr_buf + 4, 4);
-    if (version < 1 || version > 3) return false;
+    // Accept through ONEBP_VERSION (v4 = dedup-alias index entries). The old
+    // `> 3` cap made every current conversion (v4) undiscoverable — #2140.
+    if (version < 1 || version > ONEBP_VERSION) return false;
 
     // Extract fields from header at known offsets (OnebpHeader layout)
     // WARNING: offsets must match OnebpHeader struct — scale_type at 16 means
@@ -384,11 +419,13 @@ static bool read_onebp_metadata(const std::string& path, ModelConfig& cfg) {
         cfg.model_name = path.substr(slash + 1, dot - slash - 1);
     }
 
-    // Architecture string from enum
+    // Architecture string from the OnebpArch enum (include/onebp_format.h).
     // Note: ONEBP_DENSE (arch=0) is shared by all dense transformers.
     // We infer the specific architecture from model dimensions and name.
+    // #2140: the pre-2026-08 switch used a stale enum table (1→"llama") that
+    // misrouted every ONEBP_MOE file to the llama backend.
     switch (arch_raw) {
-        case 0: {
+        case ONEBP_DENSE: {
             // Dense transformer (ONEBP_DENSE) — disambiguate by model name or dims.
             // Since arch=0 covers Qwen3, Qwen2, Llama, Mistral, Gemma, Phi, etc.,
             // the model_name (from filename) is the most reliable signal.
@@ -439,25 +476,58 @@ static bool read_onebp_metadata(const std::string& path, ModelConfig& cfg) {
             }
             break;
         }
-        case 1:  cfg.architecture = "llama"; break;
-        case 2:  cfg.architecture = "mistral"; break;
-        case 3:  cfg.architecture = "phi3"; break;
-        case 4:  cfg.architecture = "gemma"; break;
-        case 5:  cfg.architecture = "falcon"; break;
-        case 6:  cfg.architecture = "starcoder"; break;
-        case 7:  cfg.architecture = "deepseek2"; break;
-        case 8:  cfg.architecture = "qwen2moe"; break;
-        case 9:  cfg.architecture = "qwen3moe"; break;
-        case 10: cfg.architecture = "qwen35"; break;
-        case 11: cfg.architecture = "qwen35moe"; break;
-        case 12: cfg.architecture = "zamba"; break;
-        case 13: cfg.architecture = "zamba2"; break;
-        case 14: cfg.architecture = "mamba"; break;
-        case 15: cfg.architecture = "gemma3"; break;
-        case 16: cfg.architecture = "gemma4"; break;
-        case 17: cfg.architecture = "olmo"; break;
-        case 18: cfg.architecture = "laguna"; break;
-        case 19: cfg.architecture = "zaya1"; break;
+        case ONEBP_MOE: {
+            // Generic MoE — probe the tensor index for the qwen35 GDN
+            // signature (fused attn_qkv + ssm_a; same probe as
+            // backend_hip_1bp), then fall back to name/dims inference.
+            const bool gdn = onebp_index_has(path, "blk.0.attn_qkv.weight") &&
+                             onebp_index_has(path, "blk.0.ssm_a");
+            const std::string nm = cfg.model_name;
+            if (gdn)
+                cfg.architecture = "qwen35";
+            else if (nm.find("zaya") != std::string::npos || nm.find("Zaya") != std::string::npos)
+                cfg.architecture = "zaya";
+            else if (nm.find("cohere2") != std::string::npos || nm.find("Cohere2") != std::string::npos)
+                cfg.architecture = "cohere2moe";
+            else if (nm.find("Qwen3") != std::string::npos || nm.find("qwen3") != std::string::npos)
+                cfg.architecture = "qwen3moe";
+            else if (nm.find("Phi") != std::string::npos || nm.find("phi") != std::string::npos)
+                cfg.architecture = "phi_moe";
+            else if (hidden_size == 2048 && intermediate_size == 2048 &&
+                     num_layers == 40 && num_experts == 16)
+                cfg.architecture = "zaya";  // zaya1 dims (matches raw-bin discovery)
+            else
+                cfg.architecture = "unknown(" + std::to_string(arch_raw) + ")";  // refuse loudly
+            break;
+        }
+        case ONEBP_VISION: {
+            const std::string nm = cfg.model_name;
+            if (nm.find("Ovis") != std::string::npos || nm.find("ovis") != std::string::npos ||
+                nm.find("PaliGemma") != std::string::npos || nm.find("paligemma") != std::string::npos)
+                cfg.architecture = "paligemma";
+            else
+                cfg.architecture = "llava";  // generic VL → QWEN2VL-family loader
+            break;
+        }
+        case ONEBP_AUDIO:     cfg.architecture = "whisper"; break;
+        case ONEBP_TERNARY:   cfg.architecture = "bitnet"; break;
+        case ONEBP_MAMBA:     cfg.architecture = "mamba"; break;
+        case ONEBP_LAGUNA:    cfg.architecture = "laguna"; break;
+        case ONEBP_SMOLVLM:   cfg.architecture = "smolvlm"; break;
+        case ONEBP_LLAVA:     cfg.architecture = "llava"; break;
+        case ONEBP_MOLMO:     cfg.architecture = "molmo"; break;
+        case ONEBP_OVIS:      cfg.architecture = "ovis"; break;
+        case ONEBP_PALIGEMMA: cfg.architecture = "paligemma"; break;
+        case ONEBP_FLORENCE:  cfg.architecture = "florence"; break;
+        case ONEBP_DEEPSEEK2:   cfg.architecture = "deepseek2"; break;
+        case ONEBP_PHI_MOE:     cfg.architecture = "phi_moe"; break;
+        case ONEBP_DEEPSEEK_V4: cfg.architecture = "deepseek4"; break;
+        case ONEBP_WHISPER:   cfg.architecture = "whisper"; break;
+        case ONEBP_KIMI_K3:   cfg.architecture = "kimi_k3"; break;
+        case ONEBP_MOONLIGHT: cfg.architecture = "moonlight"; break;
+        case ONEBP_KIMI_VL:   cfg.architecture = "kimi_vl"; break;
+        // Diffusion (ONEBP_SD..LTX) and ONEBP_AUDIO_CPP: no text-LM engine
+        // mapping yet — refuse loudly rather than silently misroute.
         default: cfg.architecture = "unknown(" + std::to_string(arch_raw) + ")"; break;
     }
     // 1BP has no self-describing arch field (ONEBP_DENSE is shared by all


### PR DESCRIPTION
### **User description**
## Summary

Splits three already-verified fixes off `feat/zc-mem-handoff` so they can merge to `main` independently of the owner's D2 zero-copy WIP (draft #2161).

- **#2140** — 1BP v4 discovery + `OnebpArch` remap
- **#2141** — census registry tokens `jugnuvr` / `m2r`
- **#2143** — overflow-prone int mults + printf format fixes

## Commits

1. `e2746bc3` — fix(engine): #2140 1BP v4 discovery + OnebpArch remap; #2141 census tokens jugnuvr/m2r
2. `da3220d8` — fix(sec): #2143 triage — widen overflow-prone int mults, printf format fixes

## What changed

### #2140 — model discovery accepts v4 files and remaps the arch enum
- `src/model_discovery.cpp`: version cap raised `>3` → `>ONEBP_VERSION` (v4 dedup-alias-index files were previously undiscoverable); stale `1→"llama"` enum table replaced with the current `OnebpArch` enum; `ONEBP_MOE` now probes the tensor index (GDN signature `blk.0.attn_qkv.weight` + `blk.0.ssm_a` → `qwen35`, same probe as `backend_hip_1bp`) then name/dims inference, and **refuses loudly** (`unknown(N)`) instead of silently misrouting to llama.

### #2141 — census registry tokens
- `include/rocm_cpp/bitnet_model.h`: `RCPP_ARCH_JUGNUVR = 1004`, `RCPP_ARCH_M2R = 1005` with stripped-name + raw-class regression-guard mappings.

### #2143 — overflow/format hygiene
- `src/baretorch_engine.cpp`: `U`/`R`/`yloc` sized by `H*r_`/`H*dh` widened to `size_t` before multiply.
- `engine/npu/src/npu_engine_universal.cpp`: two scan-loop bounds widened to `size_t`.
- `engine/npu/tests/diag_fused_weight_accuracy.cpp`: `%lld`/`%ld` format-string mismatches corrected.

## Verification (run on this branch)

- `Testing/arch_mapping_selfcheck` — **all 1122 checks passed**
- `Testing/discovery_selfcheck` — **all 5 checks passed**
- 1BP v4/v5 matrix (synthesized + real files):
  - v1 dense `Qwen3-0.6B.1bp` → `qwen3` ✓ (regression)
  - v4 GDN → `qwen35` ✓
  - v4 zaya1-dims → `zaya` ✓
  - v4 unclassifiable → `unknown(1)` + loud refusal ✓
  - v5 → rejected ✓

Closes #2140, closes #2141, closes #2143.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix #2140: v4 1BP discovery and current OnebpArch remap

- Refuse unknown ONEBP_MOE routes instead of misrouting to llama

- Add census registry tokens jugnuvr/m2r for #2141

- Harden overflow-prone int multiplications and printf formats


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["1BP v4 file"] --> B["model_discovery accepts v4 and remaps arch"]
  B --> C["correct engine routing"]
  D["census tokens jugnuvr/m2r"] --> E["bitnet_model registry tokens"]
  F["int mults / printf mismatches"] --> G["size_t casts / correct formats"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model_discovery.cpp</strong><dd><code>Remap 1BP discovery to v4 and OnebpArch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/model_discovery.cpp

<ul><li>Add <code>onebp_index_has()</code> tensor-index name probe for 1BP files<br> <li> Raise version cap from 3 to <code>ONEBP_VERSION</code> so v4 alias files are <br>discovered<br> <li> Replace stale enum mapping with current <code>OnebpArch</code> switch<br> <li> Probe GDN signature for <code>qwen35</code>, infer MoE families, refuse unknown <br>arches</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2162/files#diff-8e5a86a100d1f204ba46c30c372580243c8f23095dd10e80a94f7110a39cd378">+92/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>baretorch_engine.cpp</strong><dd><code>Widen overflow-prone vector size computations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/baretorch_engine.cpp

<ul><li>Cast <code>H * r_</code> to <code>size_t</code> when sizing <code>U</code> and <code>R</code> vectors<br> <li> Cast <code>H * dh</code> to <code>size_t</code> when sizing the <code>yloc</code> vector<br> <li> Prevents integer overflow before implicit <code>size_type</code> conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2162/files#diff-2fe42e3677c1fd8b4ce56e3abe55b99b719c5a510c4cf78d483ed4d2fff87484">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>npu_engine_universal.cpp</strong><dd><code>Widen NPU debug scan loop bounds to size_t</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/npu_engine_universal.cpp

<ul><li>Change <code>(uint32_t)MD * (uint32_t)bC_nd</code> bounds to <code>size_t</code> math<br> <li> Applies to two scan loops in the <code>Bf16Ctx</code> <code>NPU_C1_DUMP</code> debug path</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2162/files#diff-63677a636d5ff19712cf034cc1e2c15a96b194137caee54d8bd6883b0b76a10b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bitnet_model.h</strong><dd><code>Add census registry tokens jugnuvr and m2r</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/rocm_cpp/bitnet_model.h

<ul><li>Add <code>RCPP_ARCH_JUGNUVR = 1004</code> and <code>RCPP_ARCH_M2R = 1005</code><br> <li> Map <code>jugnuvr</code> and <code>jugnuvrforcausallm</code> to the JUGNUVR token<br> <li> Map <code>m2r</code> and <code>m2rforcausallm</code> to the M2R token<br> <li> Closes census coverage gap for newly discovered HF model classes</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2162/files#diff-12d8fec0ba47f1c901fbf55f16f798edaba0a693e7c892bfd9302e0b1a87318a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>diag_fused_weight_accuracy.cpp</strong><dd><code>Fix printf format specifiers in accuracy diagnostic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tests/diag_fused_weight_accuracy.cpp

<ul><li>Change <code>N=%ld</code> to <code>N=%lld</code> for the long long <code>cnt</code> value<br> <li> Cast int <code>sat</code> to <code>long long</code> before <code>%lld</code> output<br> <li> Avoids wrong-type-format undefined behavior in diagnostic output</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2162/files#diff-9eeaa1486ee6cafde3ec9145efe9983bae89e7135ca9bf3fd9aff3cc70bcee8c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

