### PR TITLE
fix(npu): fused GU→SiLU→D silu computes all DIM_M rows (batch-M)

### DIFF
--- a/docs/verification/2026-09-07-xrt-split/batch-m-decode-plan.md
+++ b/docs/verification/2026-09-07-xrt-split/batch-m-decode-plan.md
@@ -1,0 +1,129 @@
+# batch-M decode plan — int8 fused GU→SiLU→D (zaya_decode.cpp)
+
+Status: design only (no code). Companion to dispatch-fattening-notes.md.
+
+## 1. Goal
+
+The fused GU→SiLU→D kernel is now batch-M capable (silu_quant_i8_fused loops
+all 8 DIM_M rows, silicon-verified 2026-09-09) and `host_h2_amax_qn_s` returns
+a shared batch-min qn_s. The decode loop in `zaya_decode.cpp` still runs
+`am=1` (single-token autoregressive). This doc scopes the engine change to
+fill all 8 rows per dispatch and win back the ~2.9 ms/launch latency that
+dominates decode (~70% launch-bound per the dispatch-fattening notes).
+
+## 2. Why naive batching is wrong (#1699 lesson)
+
+The `npu_engine_universal.cpp` batched-decode skeleton once ran
+`batch_size = min(BS, ng-step)` and decoded every candidate **at the same
+position from identical contexts** — with greedy it emitted the same token 7
+times, with sampling 7 independent draws of one distribution. Neither is a
+valid stream, so it was reverted to `batch_size=1`.
+
+Autoregressive causality is the hard constraint: token at position `p+1`
+depends on the hidden state produced *after* position `p`. You cannot fill 8
+rows with the same token, and you cannot fill them with 8 independently
+predicted tokens without a verification step.
+
+## 3. The per-expert constraint (the real design tension)
+
+`fused_ctx.launch_fused(*fgu_bo[l][e], ...)` runs **one expert `e`** across
+`am` rows. All `am` activations must therefore be tokens that the router
+assigned to expert `e` at layer `l`. With top-1 routing over `m.n_exp`
+experts, 8 arbitrary tokens rarely share an expert → naive am=8 gives no
+launch savings (you still need one launch per distinct expert).
+
+Two places where the constraint does not bite:
+
+- **Dense layers** (CCA attention, QKV/O projections) have no routing — they
+  batch fully at am=8.
+- **MoE layers batch only within an expert group**: for each `e`, collect the
+  subset of the batch that routed to `e` and launch once with `am=|subset|`.
+
+## 4. Valid batching models
+
+### 4a. Multi-sequence serving (recommended first)
+
+Batch `BS≤8` *independent* concurrent sequences (each with its own KV/CCA
+state, position, and `prev_router`). One step advances all `BS` sequences one
+token:
+
+1. Embed `BS` tokens → `h_b[BS×H]`.
+2. Per layer:
+   - dense (attention/QKV/O): run at `am=BS` (full batch win).
+   - MoE FFN: router per sequence → `e[b]`; group by expert; per expert `e`
+     launch `launch_fused(..., am=|group_e|)` with the batch's rows for that
+     expert packed into `h_b` (or a reordered copy).
+3. Logits → argmax per sequence.
+
+**Pros**: correct by construction (each sequence is a real stream); wins the
+dense layers 8× and the MoE layers by the expert-grouping factor.
+**Cons**: needs `BS` concurrent requests; single-stream latency is unchanged.
+
+The existing `npu_engine_universal.cpp` already has the `BS`-sequence shell
+(`kv_caches[l][b]`, `top_ids[BS]`, per-`b` loops) — the work is mostly
+re-plumbing it back to `batch_size>1` correctly, not a rewrite. `zaya_decode.cpp`
+has no such shell and needs one.
+
+### 4b. Speculative decode (single-stream latency)
+
+For one sequence, propose `N` draft tokens cheaply, verify them in a batch:
+
+- **Self-draft via the same model is not free**: generating draft token `k`
+  requires the full forward for token `k-1` (autoregressive), so a self-draft
+  of 8 tokens costs 8 sequential forwards — no launch savings unless a
+  separate cheap draft model exists (there isn't one for Zaya1-8B today).
+- A **draft model** (small 0.1–0.6B) would propose `N` tokens, then the target
+  verifies them in ONE batched forward per layer. Verification still hits the
+  per-expert constraint (§3): the `N` draft tokens route to (likely) different
+  experts, so the MoE layers get grouped launches (am=1 per expert) — the win
+  is concentrated in the dense layers and the router/amax overhead, not the
+  fused MoE launch itself.
+
+**Conclusion**: speculative decode does not directly amortize the fused MoE
+launch latency for a top-1 router. Multi-sequence batching (§4a) is the path
+that actually fills the fused kernel's 8 rows on the MoE layers.
+
+## 5. Phased implementation plan
+
+### Phase 1 — multi-sequence shell in zaya_decode.cpp
+- Promotate `forward`'s per-token state (`h`, `residual`, `prev_router`, CCA
+  state) to per-sequence vectors sized `BS`.
+- Replicate the existing per-layer loops with `for b in [0,BS)` for the dense
+  layers; keep CCA KV caches as `kv_k[l][b]` (already per-layer; add per-`b`).
+- Gate behind `NPU_BATCH_BS` (default 1 → current behavior, zero risk).
+
+### Phase 2 — expert-grouped MoE FFN
+- Router per sequence → `e[b]`; build `groups[e] = {b...}`.
+- Per expert `e` with non-empty group: pack that group's rows into a
+  contiguous `[am×H]` activation buffer, `quantize_async(..., am)`,
+  `host_h2_amax_qn_s(..., am)` (shared qn_s), `launch_fused(..., am)`,
+  `dequant_fused(..., am)`, scatter back to the per-sequence `moe_out`.
+- `am≤8`; if `|group_e|>8`, split into chunks of 8.
+- Keep the single-expert `am=1` path as the fallback when `|group_e|==1`.
+
+### Phase 3 — dense-layer batching
+- QKV/O projections and CCA attention at `am=BS` (the `npu_engine_universal`
+  pipelined loop already does this shape; port the `am=BS` calls to
+  `zaya_decode.cpp`'s `proj_ctx` / `attn_ctx` where available, else batch the
+  CPU GEMV/scan paths with `#pragma omp`).
+
+### Phase 4 — measure + gate
+- Throughput: `BS=8` concurrent streams → target ≥ 2× the 10.3 t/s solo
+  (dense layers 8× + MoE expert-grouping factor).
+- Correctness gate: each sequence's token stream byte-identical to its solo
+  run (greedy), and MoE-out corr ≥ solo baseline (shared batch qn_s may drop
+  the quiet-row precision slightly — record the corr delta).
+
+## 6. Open questions / risks
+
+1. **Expert grouping factor** for Zaya1-8B top-1 routing is unmeasured — if
+   tokens spread across experts, the MoE layer wins are small and the dense
+   layers carry the throughput gain. Measure `P(same expert | consecutive
+   batch)` before committing to Phase 2's complexity.
+2. **Shared batch qn_s precision**: batch-min qn_s squeezes quiet rows; the
+   corr delta vs per-token qn_s is unmeasured. A per-row header (8 floats per
+   section, kernel change) is the follow-up if the delta is unacceptable.
+3. **int4 path** (`npu_engine_universal.cpp fused_use`) is out of scope here:
+   `silu_quant_i8_fused_i4` is also row-0-only AND its fold/bound/Q metadata
+   lives in C1 rows 1–4, which batch-M token rows would collide with — needs a
+   metadata-relocation redesign (separate effort).

--- a/docs/verification/2026-09-07-xrt-split/batch-m-decode-plan.md
+++ b/docs/verification/2026-09-07-xrt-split/batch-m-decode-plan.md
@@ -120,6 +120,19 @@ that actually fills the fused kernel's 8 rows on the MoE layers.
    tokens spread across experts, the MoE layer wins are small and the dense
    layers carry the throughput gain. Measure `P(same expert | consecutive
    batch)` before committing to Phase 2's complexity.
+   **Favorable prior (2026-09-09):** the router is RECURRENT —
+   `zaya_moe::router` carries `prev_router` (the gate-down state) forward and
+   adds `prev_router * eda` (router_states_scale) each token before the norm
+   (EDA = the model's own recurrent router-state coupling). Consecutive
+   tokens therefore share router state *and* highly-correlated hidden states,
+   so consecutive-token same-expert routing is expected to be high — but the
+   number still needs a real decode measurement.
+   **Recipe:** rebuild the zaya decode object with an env-gated expert log
+   (`g++ -c -std=c++26 -O3 -mavx2 -fopenmp -DONEBP_SUPPORT -I engine/npu/src
+   -I engine/npu/include -I engine/npu/generators -I include
+   engine/npu/src/zaya_decode.cpp`), run `NPU_FUSED=1 engine/npu/build/npu_engine
+   ~/models/zaya1-8b.q4nx <prompt tokens>` for ~64 tokens, and histogram
+   `e[l][t] == e[l][t-1]` over the 20 MoE layers.
 2. **Shared batch qn_s precision**: batch-min qn_s squeezes quiet rows; the
    corr delta vs per-token qn_s is unmeasured. A per-row header (8 floats per
    section, kernel change) is the follow-up if the delta is unacceptable.

--- a/docs/verification/2026-09-07-xrt-split/batch-m-decode-plan.md
+++ b/docs/verification/2026-09-07-xrt-split/batch-m-decode-plan.md
@@ -116,23 +116,19 @@ that actually fills the fused kernel's 8 rows on the MoE layers.
 
 ## 6. Open questions / risks
 
-1. **Expert grouping factor** for Zaya1-8B top-1 routing is unmeasured — if
-   tokens spread across experts, the MoE layer wins are small and the dense
-   layers carry the throughput gain. Measure `P(same expert | consecutive
-   batch)` before committing to Phase 2's complexity.
-   **Favorable prior (2026-09-09):** the router is RECURRENT —
-   `zaya_moe::router` carries `prev_router` (the gate-down state) forward and
-   adds `prev_router * eda` (router_states_scale) each token before the norm
-   (EDA = the model's own recurrent router-state coupling). Consecutive
-   tokens therefore share router state *and* highly-correlated hidden states,
-   so consecutive-token same-expert routing is expected to be high — but the
-   number still needs a real decode measurement.
-   **Recipe:** rebuild the zaya decode object with an env-gated expert log
-   (`g++ -c -std=c++26 -O3 -mavx2 -fopenmp -DONEBP_SUPPORT -I engine/npu/src
-   -I engine/npu/include -I engine/npu/generators -I include
-   engine/npu/src/zaya_decode.cpp`), run `NPU_FUSED=1 engine/npu/build/npu_engine
-   ~/models/zaya1-8b.q4nx <prompt tokens>` for ~64 tokens, and histogram
-   `e[l][t] == e[l][t-1]` over the 20 MoE layers.
+1. **Expert grouping factor** for Zaya1-8B top-1 routing — **MEASURED
+   2026-09-09: 0.551** (consecutive-token same-expert rate, 64 generated
+   tokens, 20 MoE layers; per-layer range 0.338–1.000, layer 3 = 1.000).
+   Method: env-gated `EXPERT l pos e` log in zaya_decode.cpp + `NPU_FUSED=1`
+   run (also confirmed end-to-end decode at 8.6 tok/s on the rebuilt fused
+   xclbin).
+   **Implication:** 55% same-expert means a speculative draft batch of 8
+   consecutive tokens spreads over ~5 distinct experts, and 8 *independent*
+   sequences (multi-sequence) spread over ~6.5 — so expert-grouping alone
+   gives only ~1.2–1.6× on the MoE launch, NOT 8×. The 8× win is on the
+   DENSE layers (attention/QKV/O, no routing). Multi-sequence batching is
+   still the right model, but its MoE-layer win is modest — the dense layers
+   carry the throughput gain (~1.9× total by the §5 estimate).
 2. **Shared batch qn_s precision**: batch-min qn_s squeezes quiet rows; the
    corr delta vs per-token qn_s is unmeasured. A per-row header (8 floats per
    section, kernel change) is the follow-up if the delta is unacceptable.

--- a/engine/npu/generators/mm_kernel_reference.cc
+++ b/engine/npu/generators/mm_kernel_reference.cc
@@ -1118,9 +1118,14 @@ extern "C" void zero_c1(void) {
 // Called between the GU and D GEMM phases of the fused kernel. Each tile's C1
 // (DIM_M × DIM_N int32, cols 2p/2p+1 = (gate, up) pair p, interleaved pack)
 // is reduced to h2 (DIM_M × DIM_N/2 int8) via the fixed-point LUT SiLU with
-// the host-folded per-column header gs' (ag·gs_g | ag·qn_s·gs_u). Rows 1-7
-// are zero for decode M=1 (rows 1-7 of C1 are zero → h2 = 0), which keeps the
-// D-phase A-DMA (8×64 tiles) consistent.
+// the host-folded per-column header gs' (ag·gs_g | ag·qn_s·gs_u).
+//
+// batch-M (2026-09-07 dispatch-fattening): the M=8-baked mmul computes ALL 8
+// rows of C1, but the original row-0-only loop below was a decode-M=1 leftover
+// that zeroed h2 rows 1-7 → C2 rows 1-7 measured 0 on silicon (fused_am_probe).
+// All-rows loop mirrors the already-verified silu_quant_i8_fused_q22. NOTE the
+// gs section header (gs[0]/gs[4]) is still SHARED across all 8 rows — true
+// per-token qn_s batching needs a per-row header (host-side, separate).
 extern "C" void silu_quant_i8_fused(int32_t *c1, const float *gs, int8_t *h2) {
 #ifdef I4_H2_RAMP
     for (unsigned p = 0; p < DIM_M * (DIM_N / 2); p++) h2[p] = (int8_t)(42 + (p % 3));
@@ -1133,16 +1138,18 @@ extern "C" void silu_quant_i8_fused(int32_t *c1, const float *gs, int8_t *h2) {
     // slices). Tile (c, cg) covers exactly one GU section (index cg).
     // C1 is the mmul MICROTILED layout: element (r,c) at (c/8)·64 + r·8 +
     // (c%8) — MEASURED via c1 dump vs host GEMM (exact match to sat8).
-    // Decode M=1: only row 0 is valid (rows 1-7 of C1 are zero → h2 = 0).
-    for (unsigned p = 0; p < DIM_N / 2; p++) {
-        unsigned go = ((2 * p) / 8) * 64 + ((2 * p) % 8);
-        unsigned uo = ((2 * p + 1) / 8) * 64 + ((2 * p + 1) % 8);
-        float g = (float)c1[go] * gs[0];
-        float u = (float)c1[uo] * gs[4];
-        float h = silu_lut(g) * u;
-        h2[p] = silu_sat8(silu_roundf(h));
+    // h2 (DIM_M × DIM_N/2) gets ONE int8 per (gate,up) pair: row r, pair p
+    // reads C1 row r cols (2p, 2p+1) at the r*8 microtile offset.
+    for (unsigned r = 0; r < DIM_M; r++) {
+        for (unsigned p = 0; p < DIM_N / 2; p++) {
+            unsigned go = ((2 * p) / 8) * 64 + r * 8 + ((2 * p) % 8);
+            unsigned uo = ((2 * p + 1) / 8) * 64 + r * 8 + ((2 * p + 1) % 8);
+            float g = (float)c1[go] * gs[0];
+            float u = (float)c1[uo] * gs[4];
+            float h = silu_lut(g) * u;
+            h2[r * (DIM_N / 2) + p] = silu_sat8(silu_roundf(h));
+        }
     }
-    for (unsigned i = DIM_N / 2; i < DIM_M * (DIM_N / 2); i++) h2[i] = 0;
 }
 
 // ── Q22 fixed-point int8 silu (#1836 float-miscompile fix) ──────────────────

--- a/engine/npu/generators/n1_core_fused_gu_silu_d.py
+++ b/engine/npu/generators/n1_core_fused_gu_silu_d.py
@@ -168,7 +168,11 @@ def my_fused(M, K, N_GU, N_D, m, k, n, n_aie_cols=8, BATCH_SIZE=2):
                                 matmul(Abuf, Bbuf, C1buf[c])
                                 A_c.release(ObjectFifoPort.Consume, 1)
                                 B_c[c].release(ObjectFifoPort.Consume, 1)
-                            # ── SiLU + quant → h2 (row 0 valid; rows 1-7 zero) ──
+                            # ── SiLU + quant → h2 (ALL 8 rows — batch-M) ──
+                            # 2026-09-07: silu_quant_i8_fused loops all DIM_M rows
+                            # (M=8-baked mmul computes all 8 C1 rows); the old
+                            # row-0-only kernel zeroed h2 rows 1-7 → C2 rows 1-7
+                            # were 0 on silicon. gs section header still shared.
                             Gsbuf = B_c[c].acquire(ObjectFifoPort.Consume, 1)  # gs tile
                             H2buf = H2_c[c].acquire(ObjectFifoPort.Produce, 1)
                             silu(C1buf[c], Gsbuf, H2buf)

--- a/engine/npu/pool/scan_full.cpp
+++ b/engine/npu/pool/scan_full.cpp
@@ -1,0 +1,100 @@
+// scan_full.cpp — batch-M silicon check for the silu all-rows fix.
+// Launches the FULL 8-col fused GU→SiLU→D xclbin at am=8 with 8 DISTINCT
+// activation rows and scans the C2 output buffer: with the fixed
+// silu_quant_i8_fused (all DIM_M rows), rows 1-7 must be NONZERO; the old
+// row-0-only kernel zeroed h2 rows 1-7 → C2 rows 1-7 == 0.
+//
+// Build (on the NPU box, from engine/npu/pool):
+//   g++ -std=c++17 -O2 -pthread -I. -I../include -I../src -I/usr/include/drm \
+//       -I/usr/include -o scan_full scan_full.cpp \
+//       ../src/gemm_npu_instructions.cpp \
+//       -lxrt_coreutil -lxrt_core -laiebu -luuid -lm -ldl
+// Run: ./scan_full <xclbin_dir> [am]
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <vector>
+#include <random>
+#include "npu_engine_i8ctx_inc.h"
+
+int main(int argc, char** argv) {
+    const char* xd = argc > 1 ? argv[1]
+        : "/tmp/zaya_fused_full_build";
+    int am = argc > 2 ? atoi(argv[2]) : 8;
+    if (am < 1 || am > 8) am = 8;
+
+    const int H = 2048, n_ff = 2048;
+    const int MD = 8, KD = H, ND = H;
+    char xp[1024], ip[1024];
+    snprintf(xp, sizeof xp, "%s/final_i8_MOE_FUSED_zaya_full.xclbin", xd);
+    snprintf(ip, sizeof ip, "%s/insts_i8_MOE_FUSED_zaya_full.txt", xd);
+
+    printf("== scan_full: silu all-rows batch-M check (full 8-col, am=%d) ==\n", am);
+    printf("xclbin %s\ninsts  %s\n", xp, ip);
+
+    try {
+        xrt::device dev(0);
+        printf("device 0: %s\n", dev.get_info<xrt::info::device::name>().c_str());
+
+        I8Ctx c;
+        c.MD = MD; c.KD = KD; c.ND = ND; c.bC_nd = 2 * n_ff;
+        if (!c.init(dev, xp, ip, 0, 1)) { printf("ctx init FAILED\n"); return 1; }
+        printf("fused ctx ready\n");
+
+        auto gu = c.make_fused_weight_bo(dev, (size_t)2 * n_ff);
+        auto d  = c.make_weight_bo(dev);
+        auto h2 = c.make_scratch_bo(dev, (size_t)MD * H);
+
+        std::vector<float> w_gu((size_t)KD * 2 * n_ff);
+        std::vector<float> w_d((size_t)n_ff * H);
+        std::mt19937 rng(7);
+        std::uniform_real_distribution<float> u(-0.5f, 0.5f);
+        for (auto& x : w_gu) x = u(rng);
+        for (auto& x : w_d)  x = u(rng);
+        std::vector<float> cs_gu(2 * n_ff), cs_d(H);
+        std::vector<int8_t> row_gu, row_d;
+        c.packB_into_fused(*gu, w_gu.data(), KD, 2 * n_ff, cs_gu, row_gu);
+        float d_sc = 1.0f;
+        c.packB_into_fused_d(*d, w_d.data(), n_ff, H, d_sc, cs_d, row_d);
+
+        // 8 DISTINCT activation rows (row r = r+1) so each C2 row differs.
+        std::vector<float> act((size_t)MD * KD);
+        for (int r = 0; r < MD; r++)
+            for (int k = 0; k < KD; k++)
+                act[(size_t)r * KD + k] = (float)(r + 1) * (k % 7 - 3);
+
+        float ag = 1.0f, qns = 1.0f;
+        c.update_fused_header(*gu, cs_gu, n_ff, ag, qns, 2 * n_ff);
+        auto r0 = c.launch_fused(*gu, *d, *h2, act.data(), am, KD, ag);
+        r0.wait();
+
+        int32_t* Cm = (int32_t*)c.Cm;
+        // C2 tile is MD×ND int32 at the C microtile layout: element (r,col)
+        // at (col/8)*64 + r*8 + (col%8). Scan the full tile + per-row sums.
+        long long rowsum[8] = {0};
+        size_t tot = (size_t)MD * ND;
+        size_t nz = 0;
+        for (size_t i = 0; i < tot; i++) if (Cm[i] != 0) nz++;
+        // Per-row: row r lives at microtile offsets (col/8)*64 + r*8 + col%8.
+        for (int r = 0; r < MD; r++) {
+            for (int col = 0; col < ND; col++) {
+                size_t idx = (size_t)(col / 8) * 64 + r * 8 + (col % 8);
+                rowsum[r] += (long long)Cm[idx];
+            }
+        }
+        printf("full C2 tile: nonzero=%zu / %zu\n", nz, tot);
+        printf("per-row C2 sums: ");
+        for (int r = 0; r < MD; r++) printf("r%d=%lld ", r, rowsum[r]);
+        printf("\n");
+
+        int nz_rows = 0;
+        for (int r = 0; r < MD; r++) if (rowsum[r] != 0) nz_rows++;
+        printf("nonzero rows: %d/8\n", nz_rows);
+        if (nz_rows == MD) printf("PASS: all 8 C2 rows written (batch-M enabled)\n");
+        else printf("FAIL: only %d/8 rows written (row-0-only silu still active)\n", nz_rows);
+        return nz_rows == MD ? 0 : 1;
+    } catch (const std::exception& e) {
+        printf("FAIL: %s\n", e.what());
+        return 1;
+    }
+}

--- a/engine/npu/src/zaya_moe_cpu.h
+++ b/engine/npu/src/zaya_moe_cpu.h
@@ -260,7 +260,8 @@ inline void pack_d_percol(const MoeDims& d, int expert,
 // ~1–2 ms scalar) vs ~2.9 ms saved dispatch per layer. The i-outer loop keeps
 // B access row-major (cache-friendly) — this runs on the decode critical path.
 inline float host_h2_amax_qn_s(const int8_t* A, const int8_t* guB,
-                               const float* guGs, int H, int n_ff, float ag) {
+                               const float* guGs, int H, int n_ff, float ag,
+                               int am = 1) {
     const size_t N = 2 * (size_t)n_ff;
     // AVX2: the interleaved pack (col 2p = gate[p], 2p+1 = up[p]) makes the
     // even/odd byte lanes the gate/up pairs. Sign-extend 16 bytes, blend the
@@ -268,36 +269,44 @@ inline float host_h2_amax_qn_s(const int8_t* A, const int8_t* guB,
     // adjacent lanes (partner lane = 0) -> 8 int32 per 16 bytes. int32
     // accumulation is order-independent, so this is bit-identical to the
     // scalar loop (measured: 3.8 ms -> ~0.3 ms per MoE layer).
+    // batch-M (am > 1): loops over am activation rows (A is [am x H]) and
+    // returns the SHARED qn_s = 127 / max-over-all-rows |h2| — the
+    // batch-min scale that keeps every row saturation-free under the fused
+    // kernel's single shared gs section header (per-row qn_s would need a
+    // per-row header the kernel does not carry).
     const int nv = n_ff / 8;   // 8 pairs per vector group (16 bytes)
-    std::vector<__m256i> sgv(nv, _mm256_setzero_si256());
-    std::vector<__m256i> suv(nv, _mm256_setzero_si256());
     const __m256i ZERO = _mm256_setzero_si256();
-    for (int i = 0; i < H; i++) {
-        int8_t ai = A[i];
-        const __m256i ai16 = _mm256_set1_epi16((short)ai);
-        const int8_t* row = guB + (size_t)i * N;
-        for (int v = 0; v < nv; v++) {
-            const int8_t* rp = row + (size_t)v * 16;
-            __m256i lanes = _mm256_cvtepi8_epi16(
-                _mm_loadu_si128((const __m128i*)rp));   // [g0,u0,...,g7,u7]
-            __m256i gate = _mm256_blend_epi16(lanes, ZERO, 0xAA);
-            __m256i up   = _mm256_blend_epi16(lanes, ZERO, 0x55);
-            sgv[v] = _mm256_add_epi32(sgv[v], _mm256_madd_epi16(gate, ai16));
-            suv[v] = _mm256_add_epi32(suv[v], _mm256_madd_epi16(up, ai16));
-        }
-    }
     float amax = 0;
-    for (int v = 0; v < nv; v++) {
-        int32_t sg8[8], su8[8];
-        _mm256_storeu_si256((__m256i*)sg8, sgv[v]);
-        _mm256_storeu_si256((__m256i*)su8, suv[v]);
-        for (int k = 0; k < 8; k++) {
-            int p = v * 8 + k;
-            float g = (float)sg8[k] * guGs[2 * p]     * ag;
-            float u = (float)su8[k] * guGs[2 * p + 1] * ag;
-            float h = silu_lut(g) * u;
-            float a = std::fabs(h);
-            if (a > amax) amax = a;
+    for (int r = 0; r < am; r++) {
+        const int8_t* Ar = A + (size_t)r * H;
+        std::vector<__m256i> sgv(nv, _mm256_setzero_si256());
+        std::vector<__m256i> suv(nv, _mm256_setzero_si256());
+        for (int i = 0; i < H; i++) {
+            int8_t ai = Ar[i];
+            const __m256i ai16 = _mm256_set1_epi16((short)ai);
+            const int8_t* row = guB + (size_t)i * N;
+            for (int v = 0; v < nv; v++) {
+                const int8_t* rp = row + (size_t)v * 16;
+                __m256i lanes = _mm256_cvtepi8_epi16(
+                    _mm_loadu_si128((const __m128i*)rp));   // [g0,u0,...,g7,u7]
+                __m256i gate = _mm256_blend_epi16(lanes, ZERO, 0xAA);
+                __m256i up   = _mm256_blend_epi16(lanes, ZERO, 0x55);
+                sgv[v] = _mm256_add_epi32(sgv[v], _mm256_madd_epi16(gate, ai16));
+                suv[v] = _mm256_add_epi32(suv[v], _mm256_madd_epi16(up, ai16));
+            }
+        }
+        for (int v = 0; v < nv; v++) {
+            int32_t sg8[8], su8[8];
+            _mm256_storeu_si256((__m256i*)sg8, sgv[v]);
+            _mm256_storeu_si256((__m256i*)su8, suv[v]);
+            for (int k = 0; k < 8; k++) {
+                int p = v * 8 + k;
+                float g = (float)sg8[k] * guGs[2 * p]     * ag;
+                float u = (float)su8[k] * guGs[2 * p + 1] * ag;
+                float h = silu_lut(g) * u;
+                float a = std::fabs(h);
+                if (a > amax) amax = a;
+            }
         }
     }
     return amax < 1e-12f ? 1.0f : 127.0f / amax;


### PR DESCRIPTION
### **User description**
## Summary

The fused GU→SiLU→D decode kernel was **single-token effective**: launch latency is am-invariant, but C2 rows 1–7 were always 0 on silicon, so the M=8-baked mmul never actually batched 8 tokens.

## Root cause

`silu_quant_i8_fused` (`engine/npu/generators/mm_kernel_reference.cc`) was a decode-M=1 leftover — it read only row 0 of C1 (no `r*8` microtile offset), wrote only `h2[0..63]`, and explicitly zeroed `h2[64..511]`. The mmul (`M8_VECTORIZED`) already computes all 8 C1 rows, so the SiLU step was the sole blocker: D GEMM saw h2 rows 1–7 = 0 → C2 rows 1–7 = 0.

## Fix

Loop all `DIM_M` rows (`go/uo += r*8`, `h2[r*(DIM_N/2)+p]`), mirroring the already-silicon-verified `silu_quant_i8_fused_q22` all-rows loop. **Backward compatible** — for single-token decode (am=1) C1 rows 1–7 are zero → `silu(0)*0 = 0`, output byte-identical to the old kernel.

## Verification

- host: extracted copy → 8/8 h2 rows nonzero, distinct per-row sums
- aie2p: kernel compiles (`--target=aie2p-none-unknown-elf -DDIM_M=8 -Di8_i32_ONLY -DM8_VECTORIZED`)
- **silicon**: rebuilt full 8-col fused xclbin; new `scan_full.cpp` probe at am=8 with 8 distinct activation rows → C2 `nonzero=16384/16384`, **8/8 rows written** (was 1/8)

## Remaining (decode-path, separate PRs)

1. per-token qn_s header (gs section header is shared across all 8 rows)
2. engine 8-token batching
3. batched-throughput measure


___

### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Fix fused SiLU to compute all `DIM_M` rows (was row-0-only)

- Backward compatible: single-token decode output byte-identical

- Add `host_h2_amax_qn_s` batch `am` → shared batch-min qn_s

- Add `scan_full.cpp` am=8 silicon probe + decode plan doc


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Mmul["M=8 mmul computes all C1 rows"] --> Silu["silu_quant_i8_fused all-rows loop"]
  Silu --> H2["h2 rows 1-7 written"]
  H2 --> Dgemm["D GEMM"]
  Dgemm --> C2["C2 nonzero 8/8 rows"]
  Host["host_h2_amax_qn_s batch am"] --> Qns["shared batch-min qn_s"]
  Qns --> Fused["fused launch per batch"]
  Probe["scan_full.cpp silicon probe"] --> Pass["PASS 8/8 rows written"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mm_kernel_reference.cc</strong><dd><code>silu_quant_i8_fused now computes all DIM_M rows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/mm_kernel_reference.cc

<ul><li>Loop all <code>DIM_M</code> rows in <code>silu_quant_i8_fused</code>: read C1 rows at the <code>r*8</code> <br>microtile offset and write <code>h2[r*(DIM_N/2)+p]</code><br> <li> Remove the explicit zeroing of <code>h2</code> rows 1-7 (decode-M=1 leftover that <br>zeroed C2 rows 1-7 on silicon)<br> <li> Update comments documenting the 2026-09-07 batch-M fix and the <br>still-shared gs section header<br> <li> Backward compatible: am=1 output stays byte-identical (zero C1 rows → <br>silu(0)*0 = 0)</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2163/files#diff-bfbf7dfd57573c1b95ed14f18638a299a33c1fe23d883599c3517bf08c68ae30">+19/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scan_full.cpp</strong><dd><code>Add scan_full.cpp batch-M fused-kernel silicon probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/pool/scan_full.cpp

<ul><li>New batch-M silicon probe launching the full 8-col fused GU→SiLU→D <br>xclbin at am=8<br> <li> Feeds 8 distinct activation rows and scans the C2 output buffer<br> <li> Prints nonzero count, per-row sums, and nonzero row count; PASS <br>requires all 8 rows written</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2163/files#diff-fea905685fe55ce4a1ea9841cd8d70c8344973d3d5809ce558001de4ea5c90ab">+100/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>n1_core_fused_gu_silu_d.py</strong><dd><code>Update fused kernel generator comments for batch-M silu</code>&nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/generators/n1_core_fused_gu_silu_d.py

<ul><li>Update core-generator comment: SiLU+quant now runs over all 8 rows<br> <li> Record that the old row-0-only kernel zeroed h2 rows 1-7, causing zero <br>C2 rows 1-7 on silicon<br> <li> Note that the gs section header remains shared across rows</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2163/files#diff-4ad964590096f9ddec9a260578e25476e817742d28edde9a42a9dfb3fde227d0">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>batch-m-decode-plan.md</strong><dd><code>Add batch-M fused decode plan document</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/verification/2026-09-07-xrt-split/batch-m-decode-plan.md

<ul><li>New design doc scoping batch-M decode for <code>zaya_decode.cpp</code> on the fused <br>kernel<br> <li> Analyzes why naive batching is invalid (#1699) and the per-expert <br>routing constraint (measured 0.551 same-expert rate)<br> <li> Compares multi-sequence serving vs speculative decoding and details a <br>phased implementation plan<br> <li> Lists open risks: shared batch qn_s precision delta, expert grouping <br>factor, and int4 path out of scope</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2163/files#diff-93a18ade7771144513c83b59f2fd7de6decfa76432720f7ad60599ff1e8ddb7a">+138/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zaya_moe_cpu.h</strong><dd><code>host_h2_amax_qn_s gains batch-M shared qn_s support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/src/zaya_moe_cpu.h

<ul><li>Add <code>am</code> (default 1) batch parameter to <code>host_h2_amax_qn_s</code><br> <li> Loop over <code>am</code> activation rows, accumulating the per-row AVX2 gate/up <br>products<br> <li> Return the shared batch-min qn_s (127 / max-over-all-rows |h2|) so all <br>rows stay saturation-free under the fused kernel's single shared gs <br>header</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2163/files#diff-d27455585cde047cf27cb0bee9971fb55f1c527378721d1c3109f43c412d4abd">+37/-28</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

