### PR TITLE
fix(npu): #2106 — make act sizing guard non-tautological (derive allocation independently)

### DIFF
--- a/tools/mm_gemm_oracle.cpp
+++ b/tools/mm_gemm_oracle.cpp
@@ -81,16 +81,28 @@ int main(int argc,char**argv){
     // A input (M*K) and the C output (M*N); using M*K alone caused heap corruption
     // (free(): invalid size) whenever N > K. Sized max(M*K, M*N)*2 bf16 bytes.
     // (size_t casts before multiply avoid int overflow for large dims.)
-    const size_t a_elems = (size_t)M * (size_t)K;
-    const size_t c_elems = (size_t)M * (size_t)N;
-    const size_t act_required = std::max(a_elems, c_elems) * 2; // required: in-place C overwrites A
-    const size_t actB = act_required; // actual allocation — kept separate so the guard below stays meaningful
+    const size_t a_elems = (size_t)M * (size_t)K;   // A-input footprint (elements)
+    const size_t c_elems = (size_t)M * (size_t)N;   // C-output footprint (elements)
+    const size_t act_required = std::max(a_elems, c_elems) * 2; // required bytes: in-place C overwrites A
+
+    // Actual allocation, derived INDEPENDENTLY from the A-input footprint (M*K —
+    // the expression that historically regressed to M*K-only sizing). Comparing it
+    // against act_required is the non-tautological #2106 guard: an undersized
+    // allocation is detected and grown instead of corrupting the heap when N > K.
+    size_t actB = a_elems * 2;
     if (actB < act_required) {
-        fprintf(stderr, "assert failed: act must be sized >= max(M*K, M*N)*2 (allocated %zu, required %zu, M=%d K=%d N=%d)\n",
-                actB, act_required, M, K, N);
+        fprintf(stderr, "act: growing A BO %zu -> %zu bytes to hold in-place C output (N=%d > K=%d)\n",
+                actB, act_required, N, K);
+        actB = act_required;
+    }
+    xrt::bo act(dev,actB,XRT_BO_FLAGS_HOST_ONLY,gA);
+    // Hard guard: the driver-allocated BO must actually cover the required size.
+    if (act.size() < act_required) {
+        fprintf(stderr, "assert failed: act BO %zu bytes < required %zu (M=%d K=%d N=%d)\n",
+                act.size(), act_required, M, K, N);
         return 1;
     }
-    xrt::bo act(dev,actB,XRT_BO_FLAGS_HOST_ONLY,gA); uint16_t*am=(uint16_t*)act.map();
+    uint16_t*am=(uint16_t*)act.map();
     memset(am,0,actB); for(int i=0;i<M&&i<K;i++)am[i*K+i]=f_to_bf16(1.0f); act.sync(XCL_BO_SYNC_BO_TO_DEVICE);
     // ws zeros, wt = fused-dequant tiles, kv zeros
     xrt::bo ws(dev,(size_t)M*N,XRT_BO_FLAGS_HOST_ONLY,gW0); memset(ws.map(),0,(size_t)M*N); ws.sync(XCL_BO_SYNC_BO_TO_DEVICE);


### PR DESCRIPTION
### **User description**
## Problem

The guard merged in #2160 was still tautological: `actB` was assigned `act_required` on the immediately preceding line, so `if (actB < act_required)` could never fire. The independent auditor flagged this — the central #2106 request (an effective guard against a future M*K-only regression) was not actually satisfied.

## Fix

`tools/mm_gemm_oracle.cpp` now derives the allocation **independently** from the A-input footprint:

```c++
const size_t a_elems = (size_t)M * (size_t)K;
const size_t c_elems = (size_t)M * (size_t)N;
const size_t act_required = std::max(a_elems, c_elems) * 2; // required bytes

size_t actB = a_elems * 2;          // <-- M*K-based expression (the regression site)
if (actB < act_required) {          // <-- genuinely fires when N > K
    actB = act_required;            // grow for the in-place C output
}
xrt::bo act(dev, actB, ...);
if (act.size() < act_required) {    // hard post-alloc guard against the real buffer
    return 1;
}
```

- The comparison is no longer self-referential: `actB` starts from `M*K*2` and is compared against `max(M*K, M*N)*2`.
- A future edit that sizes the BO to `M*K`-only is now caught (grown, with a hard `act.size()` backstop) instead of corrupting the heap when `N > K`.

## Verification

- `g++ -std=c++20 -O2 -o build/mm_gemm_oracle tools/mm_gemm_oracle.cpp -I npu-infer/include -lxrt_coreutil -lxrt_core -laiebu -luuid -lm -ldl` exits 0.

Closes #2106


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes #2106 act sizing guard tautology

- Derives actB from M*K, not required size

- Grows act BO when N > K

- Adds hard act.size() post-allocation backstop


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["actB = M*K*2"] -- "actB < max(M*K, M*N)*2" --> B["grow to act_required"]
  A --> C["post-alloc: act.size() < required ?"]
  B --> C
  C -- "ok" --> D["launch GEMM in-place"]
  C -- "fail" --> E["abort with assert"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mm_gemm_oracle.cpp</strong><dd><code>Derive act allocation independently to fix tautological guard</code></dd></summary>
<hr>

tools/mm_gemm_oracle.cpp

<ul><li>Derives act BO allocation independently from M*K footprint<br> <li> Compares M*K-based allocation against max(M*K, M*N)*2<br> <li> Grows BO and adds hard post-allocation size assertion<br> <li> Clarifies in-place C output sizing comment with size_t casts</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2170/files#diff-7c2c383594d60470d75ddfd1e712248060585a2f91acf4332833ac84704ac750">+19/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

