### PR TITLE
ci(census): #2166 — exclude esmcar + hca/Mnemosyne from text-gen coverage

### DIFF
--- a/Testing/census_coverage.py
+++ b/Testing/census_coverage.py
@@ -231,6 +231,15 @@ NON_TEXT_GEN = {
     "plusmodel",  # LiltForTokenClassification (token classification, not causal LM)
     "kosine",  # SpeechT5 TTS
     "helloworld",  # junk test repo (model_type custom)
+
+    # ── 2026-09-09 pass-5: #2166 watch breach — biology-domain + junk classes ──
+    # Both arch-string and model_type forms covered (sweep emits either).
+    "esmcar", "esmc_ar",  # ESM-C AR (EsmcARForCausalLM / model_type esmc_ar — evolutionary-
+               #   scale Cambrian): causal PROTEIN-sequence LM, non-text-token domain — biology
+               #   precedent prot2text/torchmultiomics (pass-3/4); not in engine roster
+    "hca",  # HCAForCausalLM / model_type hca: single ~0-download repo
+             #   BIBLIOKLEPT/Mnemosyne-64M-Instruct — unverifiable custom arch / test-uploader
+    "mnemosyne", "mnemosyneforcausallm",  # same junk repo under its arch-string form
 }
 
 

--- a/Testing/census_full_summary.json
+++ b/Testing/census_full_summary.json
@@ -124,6 +124,7 @@
   "microloopfordiffusionlm": 1,
   "minimaxm3vl": 2,
   "mlongformerencoderdecoder": 1,
+  "mnemosyne": 1,
   "mobilebertforpretraining": 1,
   "modelarchitecture": 1,
   "modernmarianmt": 1,
@@ -500,7 +501,7 @@
   "LIGHTBRAINHYBRID": 2,
   "LIGHTNINGTRANSFORMER": 1,
   "LLADA2": 34,
-  "LLAMA": 114963,
+  "LLAMA": 114962,
   "LLAMA4": 113,
   "LLAMAMOE": 12,
   "LLAVAMONET": 1,
@@ -796,9 +797,9 @@
   "ZZJRABBIT22": 2,
   "ZZJRABBIT3": 1
  },
- "n_archs": 2050,
+ "n_archs": 2049,
  "no_arch": 79543,
- "registry_covered": 321611,
+ "registry_covered": 321610,
  "total": 405884,
- "with_arch": 321611
+ "with_arch": 321610
 }


### PR DESCRIPTION
### **User description**
Fixes #2166 (census coverage breach, watch run 34332480137).

Classified the two uncovered classes from their real configs:
- `esmcar`/`esmc_ar` — ESM-C AR (evolutionary-scale Cambrian, e.g. IvanHU/esmc-ar-371m-5b): causal **protein-sequence** LM — non-text-token domain. Biology precedent: `prot2text`/`torchmultiomics` (pass-3/4).
- `hca`/`HCAForCausalLM` (BIBLIOKLEPT/Mnemosyne-64M-Instruct): single ~0-download repo, unverifiable custom arch / test-uploader junk (tail-exclusion precedent).

Neither aliases a known family nor warrants a real implementation → pass-5 NON_TEXT_GEN exclusions (both arch-string and model_type forms covered: esmcar, esmc_ar, hca, mnemosyne, mnemosyneforcausallm).

Verification: `python3 Testing/census_coverage.py` → 321,611 → **321,610** with_arch, still **100% registry-covered**; census_full_summary.json regenerated. Next watch/sweep should report clean on these classes.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add pass-5 exclusions for `esmcar`, `esmc_ar`, `hca`, `mnemosyne`

- Classify protein-sequence LM and junk-repo model families

- Re-run census and regenerate `census_full_summary.json`

- Keep registry coverage at 100% (321,610 models)


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["Census watch breach #2166"] --> B["Classify esmcar & hca models"]
  B --> C["Add pass-5 exclusions"]
  C --> D["Re-run census_coverage.py"]
  D --> E["Regenerate full summary JSON"]
  E --> F["100% registry-covered"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>census_coverage.py</strong><dd><code>Add pass-5 exclusions for newly uncovered model classes</code>&nbsp; &nbsp; </dd></summary>
<hr>

Testing/census_coverage.py

<ul><li>Add pass-5 exclusions for <code>esmcar</code>, <code>esmc_ar</code>, <code>hca</code>, and <br><code>mnemosyne</code>/<code>mnemosyneforcausallm</code><br> <li> Cover both arch-string and model_type classification forms<br> <li> Document rationale: protein-sequence LM domain and unverifiable junk <br>repo</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2173/files#diff-befedb1939f5e29b9adb314097114a5276bbd056d9070272884eb3359e82a9f3">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>census_full_summary.json</strong><dd><code>Regenerate census summary with updated coverage counts</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Testing/census_full_summary.json

<ul><li>Regenerate summary after coverage re-run<br> <li> Add <code>mnemosyne</code> model_type count; decrement <code>LLAMA</code> and <code>n_archs</code><br> <li> Update totals: <code>registry_covered</code> and <code>with_arch</code> now 321,610</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2173/files#diff-0e68f31988561dc3db7df1c6ca7365d5f6313e3e53a3072e375b7e21102749cf">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

