### PR TITLE
feat(npu): #2139 — qwen35moe hipGraph decode (whole step captured, replay per token)

### DIFF
--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -127,6 +127,9 @@ struct Hip1bpBackend : Backend {
     hipGraph_t graph = nullptr;
     hipGraphExec_t graphExec = nullptr;
     bool graph_ok = false;
+    // #2139: q35 (qwen35moe) hipGraph decode state
+    bool q35_renorm = true;     // Q35_NORMTK default (hoisted from the per-step env read)
+    bool q35_graph_ok = false;  // qwen35_step captured + instantiated
 
     Hip1bpBackend(){type=BackendType::HIP_GPU;name="HIP 1BP GPU";}
     ~Hip1bpBackend()override{destroy();}
@@ -648,8 +651,37 @@ struct Hip1bpBackend : Backend {
                     *h_token = 0; *h_pos = 0;
                     HIP_CHECK(hipMemcpy(d_token, h_token, sizeof(int), hipMemcpyHostToDevice));
                     HIP_CHECK(hipMemcpy(d_pos, h_pos, sizeof(int), hipMemcpyHostToDevice));
+                    // #2139: hoist the per-step env read once + capture the whole
+                    // qwen35 step as a hipGraph (replaces eager decode when it succeeds).
+                    // Disabled when dump envs are set (they do host I/O) or H1BP_Q35_NOGRAPH=1.
+                    q35_renorm = getenv("Q35_NORMTK") == nullptr || atoi(getenv("Q35_NORMTK")) != 0;
+                    if (!getenv("H1BP_Q35_STAGE") && !getenv("H1BP_Q35_LOGDIR") &&
+                        !getenv("H1BP_DUMP") && !getenv("H1BP_Q35_NOGRAPH")) {
+                        hipError_t ce = hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal);
+                        if (ce == hipSuccess) {
+                            (void)qwen35_step(0, true);   // capture-time pass (token 0, pos 0)
+                            ce = hipStreamEndCapture(stream, &graph);
+                            if (ce == hipSuccess && graph) {
+                                hipError_t ie = hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0);
+                                if (ie == hipSuccess) {
+                                    q35_graph_ok = true;
+                                    printf("[hip1bp] q35 decode graph captured OK\n");
+                                } else {
+                                    fprintf(stderr, "[hip1bp] q35 graph instantiate failed: %s\n", hipGetErrorString(ie));
+                                }
+                            } else {
+                                fprintf(stderr, "[hip1bp] q35 capture failed: %s\n", hipGetErrorString(ce));
+                            }
+                            // undo the capture-time token-0 state writes
+                            qwen35_zero_state();
+                            pos = 0; *h_token = 0; *h_pos = 0; *h_res = -1;
+                            HIP_CHECK(hipMemcpy(d_token, h_token, sizeof(int), hipMemcpyHostToDevice));
+                            HIP_CHECK(hipMemcpy(d_pos, h_pos, sizeof(int), hipMemcpyHostToDevice));
+                        }
+                    }
                     initialized = true;
-                    printf("[hip1bp] ✅ qwen35moe GPU decode ready (eager)\n");
+                    printf("[hip1bp] ✅ qwen35moe GPU decode ready (%s)\n",
+                           q35_graph_ok ? "hipGraph" : "eager");
                     return true;
                 }
             }
@@ -856,6 +888,16 @@ struct Hip1bpBackend : Backend {
         int wpr = (ntc + 3) >> 2;
         int blocks = (N * wpr + 3) / 4;
         h1bp_q4nx_part_kernel<<<blocks,128,0,stream>>>(w,x,dpart,N,ntc);
+        h1bp_tq2nz_sum_kernel<<<(N + 255) / 256,256,0,stream>>>(dpart,out,N,wpr);
+    }
+
+    // #2139: expert-index-from-device variant (hipGraph-safe — no host index read).
+    void launch_q4nx_idx(const uint8_t* w, const float* x, float* out, int N, int K,
+                         size_t stride_bytes, const int* idx_d, int slot) {
+        int ntc = (K + 255) / 256;
+        int wpr = (ntc + 3) >> 2;
+        int blocks = (N * wpr + 3) / 4;
+        h1bp_q4nx_part_idx_kernel<<<blocks,128,0,stream>>>(w,x,dpart,idx_d,slot,stride_bytes,N,ntc);
         h1bp_tq2nz_sum_kernel<<<(N + 255) / 256,256,0,stream>>>(dpart,out,N,wpr);
     }
 
@@ -1077,7 +1119,17 @@ struct Hip1bpBackend : Backend {
     // generate() == forward() + lm_head() — argmax semantics unchanged.
     // Phase 2: when graph_ok, the whole step replays from the captured graph.
     int generate_fast(int token_id){
-        if (q35_loaded) return qwen35_step(token_id);
+        if (q35_loaded) {
+            // #2139: replay the captured q35 step (pos/token re-read on device)
+            if (q35_graph_ok) {
+                *h_token = token_id; *h_pos = pos;
+                HIP_CHECK(hipGraphLaunch(graphExec, stream));
+                HIP_CHECK(hipStreamSynchronize(stream));
+                pos++;
+                return *h_res;
+            }
+            return qwen35_step(token_id, false);
+        }
         if (graph_ok) {
             *h_token = token_id; *h_pos = pos;
             HIP_CHECK(hipGraphLaunch(graphExec, stream));
@@ -1168,14 +1220,13 @@ struct Hip1bpBackend : Backend {
             HIP_CHECK(hipMemcpyAsync(d, s, 128 * 4, hipMemcpyDeviceToDevice, stream));
         }
     }
-    int qwen35_step(int token_id) {
+    int qwen35_step(int token_id, bool for_capture) {
         if (!q35_loaded) return -1;
         if (pos >= max_seq - 1) { fprintf(stderr, "[hip1bp] q35 KV overflow pos=%d\n", pos); return -1; }
         *h_token = token_id; *h_pos = pos;
         HIP_CHECK(hipMemcpyAsync(d_token, h_token, sizeof(int), hipMemcpyHostToDevice, stream));
         HIP_CHECK(hipMemcpyAsync(d_pos, h_pos, sizeof(int), hipMemcpyHostToDevice, stream));
-        // embed (Q8_0 row dequant) into dh
-        HIP_CHECK(hipMemcpy(d_token, &token_id, sizeof(int), hipMemcpyHostToDevice));
+        // embed (Q8_0 row dequant) into dh — reads *d_token (set above)
         if (q35_q4nx)
             h1bp_embed_copy_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(
                 dh, d_embed, d_token, 2048, 248320);
@@ -1198,10 +1249,12 @@ struct Hip1bpBackend : Backend {
             if (q35_q4nx) launch_q4nx(W, x, y, M, K);
             else          h1bp_q8gemv_kernel<<<M, 256, 0, stream>>>(y, W, x, M, K);
         };
-        auto gemvE = [&](float* y, const uint8_t* W, const float* x, int e,
-                         int M, int K, int slot) {
-            if (q35_q4nx) launch_q4nx(W + (size_t)e * q35_exp_bytes[slot], x, y, M, K);
-            else          h1bp_q8gemv_slice_kernel<<<M, 256, 0, stream>>>(y, W, x, e, M, K, 1);
+        auto gemvE = [&](float* y, const uint8_t* W, const float* x, int slot,
+                         int M, int K, int buf) {
+            // #2139: the expert index is read from DEVICE (q35_sc_idx[slot]) so the
+            // whole qwen35 step is hipGraph-capturable (no D2H read, no host loop).
+            if (q35_q4nx) launch_q4nx_idx(W, x, y, M, K, q35_exp_bytes[buf], q35_sc_idx, slot);
+            else          h1bp_q8gemv_slice_idx_kernel<<<M, 256, 0, stream>>>(y, W, x, q35_sc_idx, slot, M, K);
         };
         for (int l = 0; l < NC; l++) {
             Q35L& w = q35L[l];
@@ -1230,9 +1283,10 @@ struct Hip1bpBackend : Backend {
                 // store k (v2) and v into the per-layer kv cache [seq][k0 k1 v0 v1]
                 int f = n_full_layers;
                 float* kvbase = q35_kvc + (size_t)f * (max_seq * 1024);
-                HIP_CHECK(hipMemcpyAsync(kvbase + (size_t)pos * 1024, q35_sc_v2, 512 * 4, hipMemcpyDeviceToDevice, stream));
+                // #2139: store at the DEVICE-read position (hipGraph-safe)
+                h1bp_q35_kvput_kernel<<<2, 256, 0, stream>>>(kvbase, q35_sc_v2, d_pos, 0, 1024, 512);
                 gemv(q35_sc_v, w.v, dh, 512, 2048);
-                HIP_CHECK(hipMemcpyAsync(kvbase + (size_t)pos * 1024 + 512, q35_sc_v, 512 * 4, hipMemcpyDeviceToDevice, stream));
+                h1bp_q35_kvput_kernel<<<2, 256, 0, stream>>>(kvbase, q35_sc_v, d_pos, 512, 1024, 512);
                 // attention over the cache, then sigmoid-gate multiply, then o_proj
                 h1bp_q35_fattn_kernel<<<16, 256, 0, stream>>>(q35_sc_att, kvbase, q35_sc_att,
                     q35_kv_scores, 16, 2, 256, max_seq, d_pos);
@@ -1287,32 +1341,23 @@ struct Hip1bpBackend : Backend {
             h1bp_rmsnorm_kernel<<<1, 256, 0, stream>>>(dh, w.pan, 2048, 1e-6f);
             h1bp_gemv_kernel<<<256, 256, 0, stream>>>(q35_sc_logits, w.router, dh, 256, 2048);
             // norm_topk: llama qwen35 uses renorm? default OFF unless env
-            bool renorm = getenv("Q35_NORMTK") == nullptr || atoi(getenv("Q35_NORMTK")) != 0;  // norm_topk default ON
-            h1bp_q35_topk_kernel<<<1, 256, 0, stream>>>(q35_sc_logits, q35_sc_rout, q35_sc_idx, 256, 8, renorm);
+            h1bp_q35_topk_kernel<<<1, 256, 0, stream>>>(q35_sc_logits, q35_sc_rout, q35_sc_idx, 256, 8, q35_renorm);
             HIP_CHECK(hipMemset(q35_sc_moe, 0, 2048 * 4));
-            int exps[8]; float wts[8];
-            HIP_CHECK(hipStreamSynchronize(stream));
-            HIP_CHECK(hipMemcpy(exps, q35_sc_idx, 8 * 4, hipMemcpyDeviceToHost));
-            HIP_CHECK(hipMemcpy(wts, q35_sc_rout, 8 * 4, hipMemcpyDeviceToHost));
+            // #2139: fixed 8 slots — expert idx + weight read on device (capturable)
             for (int r = 0; r < 8; r++) {
-                int e = exps[r];
-                gemvE(q35_sc_exp, w.ex_u, dh, e, 512, 2048, 1);
-                gemvE(q35_sc_expw, w.ex_g, dh, e, 512, 2048, 0);
+                gemvE(q35_sc_exp, w.ex_u, dh, r, 512, 2048, 1);
+                gemvE(q35_sc_expw, w.ex_g, dh, r, 512, 2048, 0);
                 h1bp_silu_gate_mul_kernel<<<(512 + 255) / 256, 256, 0, stream>>>(q35_sc_exp, q35_sc_expw, 512);
-                gemvE(q35_sc_expd, w.ex_d, q35_sc_exp, e, 2048, 512, 2);
-                h1bp_mul_scalar_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(q35_sc_expd, wts[r], 2048);
-                h1bp_acc_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(q35_sc_moe, q35_sc_expd, 2048);
+                gemvE(q35_sc_expd, w.ex_d, q35_sc_exp, r, 2048, 512, 2);
+                h1bp_mul_acc_scaled_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(q35_sc_moe, q35_sc_expd, q35_sc_rout, r, 2048);
             }
             // shared expert + sigmoid gate
             gemv(q35_sc_exp, w.sh_u, dh, 512, 2048);
             gemv(q35_sc_expw, w.sh_g, dh, 512, 2048);
             h1bp_silu_gate_mul_kernel<<<(512 + 255) / 256, 256, 0, stream>>>(q35_sc_exp, q35_sc_expw, 512);
             gemv(q35_sc_expd, w.sh_d, q35_sc_exp, 2048, 512);
-            { float sgate;
-              h1bp_gemv_kernel<<<1, 256, 0, stream>>>(q35_sc_logits, w.sh_gatew, dh, 1, 2048);
-              HIP_CHECK(hipMemcpy(&sgate, q35_sc_logits, 4, hipMemcpyDeviceToHost));
-              sgate = 1.0f / (1.0f + expf(-sgate));
-              h1bp_mul_scalar_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(q35_sc_expd, sgate, 2048); }
+            // #2139: shared-expert sigmoid gate fused on device (no D2H/sync)
+            h1bp_shgate_fused_kernel<<<1, 256, 0, stream>>>(q35_sc_expd, dh, w.sh_gatew, 2048, 2048);
             h1bp_acc_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(q35_sc_moe, q35_sc_expd, 2048);
             h1bp_copy_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dh, dsilu, 2048);
             h1bp_add_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(dh, q35_sc_moe, 2048);
@@ -1333,6 +1378,12 @@ struct Hip1bpBackend : Backend {
         int nblk = std::min(AMX_MAXB, (248320 + 255) / 256);
         h1bp_argmax_pass1_kernel<<<nblk, 256, 0, stream>>>(dlogits, 248320, d_amx, d_ami);
         h1bp_argmax_pass2_kernel<<<1, 256, 0, stream>>>(d_amx, d_ami, nblk, d_argmax);
+        if (for_capture) {
+            // #2139: capture path — per-replay result goes to pinned h_res
+            // asynchronously (a sync D2H inside a captured region is illegal).
+            HIP_CHECK(hipMemcpyAsync(h_res, d_argmax, sizeof(int), hipMemcpyDeviceToHost, stream));
+            return 0;
+        }
         int out_tok = -1;
         HIP_CHECK(hipMemcpy(&out_tok, d_argmax, sizeof(int), hipMemcpyDeviceToHost));
         pos++;

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -1342,7 +1342,9 @@ struct Hip1bpBackend : Backend {
             h1bp_gemv_kernel<<<256, 256, 0, stream>>>(q35_sc_logits, w.router, dh, 256, 2048);
             // norm_topk: llama qwen35 uses renorm? default OFF unless env
             h1bp_q35_topk_kernel<<<1, 256, 0, stream>>>(q35_sc_logits, q35_sc_rout, q35_sc_idx, 256, 8, q35_renorm);
-            HIP_CHECK(hipMemset(q35_sc_moe, 0, 2048 * 4));
+            // #2139 gate fix: a sync hipMemset targets the legacy stream and is illegal
+            // inside hipStreamBeginCapture — use the capture stream.
+            HIP_CHECK(hipMemsetAsync(q35_sc_moe, 0, 2048 * 4, stream));
             // #2139: fixed 8 slots — expert idx + weight read on device (capturable)
             for (int r = 0; r < 8; r++) {
                 gemvE(q35_sc_exp, w.ex_u, dh, r, 512, 2048, 1);

--- a/src/hip_1bp_kernels.hip
+++ b/src/hip_1bp_kernels.hip
@@ -245,10 +245,10 @@ __global__ void h1bp_tq2nz_sum_kernel(const float* __restrict__ part,
 // Tile = 32 rows × 256 cols: [scales: 32×8×2 B][zps: 512 B][codes: 32×256/2 B]
 // (5120 B/tile). code v0 = low nibble (even col), v1 = high nibble (odd col);
 // value = code*scale + zp. Same warp/part structure as the TQ2NZ kernel.
-__global__ void h1bp_q4nx_part_kernel(const uint8_t* __restrict__ w,
-                                      const float* __restrict__ x,
-                                      float* __restrict__ part,
-                                      int N, int ntc) {
+__device__ inline void h1bp_q4nx_part_body(const uint8_t* __restrict__ w,
+                                        const float* __restrict__ x,
+                                        float* __restrict__ part,
+                                        int N, int ntc) {
     const int lane = threadIdx.x & 31;
     const int wpr  = (ntc + 3) >> 2;
     const int warp = (blockIdx.x * (blockDim.x >> 5)) + (threadIdx.x >> 5);
@@ -274,6 +274,13 @@ __global__ void h1bp_q4nx_part_kernel(const uint8_t* __restrict__ w,
         acc += ((float)(b >> 4)  * scale + z) * xp[i * 2 + 1];
     }
     part[(size_t)row * 32 * wpr + (warp % wpr) * 32 + lane] = acc;
+}
+
+__global__ void h1bp_q4nx_part_kernel(const uint8_t* __restrict__ w,
+                                      const float* __restrict__ x,
+                                      float* __restrict__ part,
+                                      int N, int ntc) {
+    h1bp_q4nx_part_body(w, x, part, N, ntc);
 }
 
 // ── Device argmax (Phase 1): two-pass reduction over V logits ──
@@ -645,3 +652,83 @@ __global__ void h1bp_acc_kernel(float* __restrict__ acc, const float* __restrict
     int i = threadIdx.x + blockIdx.x * blockDim.x;
     if (i < n) acc[i] += src[i];
 }
+
+// ── #2139: hipGraph-capturable qwen35 variants ───────────────────────────────
+// The dense path captures its whole per-token step once; q35 was eager because
+// the router/expert pass read top-k indices + weights on the HOST (D2H + sync
+// + host loop) and the shared-expert gate did a host sigmoid. These variants
+// keep every decision on-device (indices/weights read from q35_sc_idx/rout at
+// launch time) so qwen35_step can run inside hipStreamBeginCapture.
+
+// Q8_0 expert GEMV with the expert index read from device (slot s of idx_d).
+__global__ void h1bp_q8gemv_slice_idx_kernel(float* y, const uint8_t* W,
+        const float* x, const int* __restrict__ idx_d, int slot,
+        int out_per_exp, int K) {
+    int exp_idx = idx_d[slot];
+    int row = blockIdx.x;               // 0..out_per_exp-1
+    if (row >= out_per_exp) return;
+    const uint8_t* wr = W + (size_t)exp_idx * ((size_t)out_per_exp * (K >> 5) * 34)
+                          + (size_t)row * ((size_t)(K >> 5) * 34);
+    double sum = 0;
+    for (int j = threadIdx.x; j < K; j += blockDim.x) {
+        int blk = j >> 5, lane = j & 31;
+        const uint8_t* bp = wr + (size_t)blk * 34;
+        float d = __half2float(__ushort_as_half(*(const unsigned short*)bp));
+        sum += (double)x[j] * (d * (float)((signed char)bp[2 + lane]));
+    }
+    __shared__ double sdata[256];
+    sdata[threadIdx.x] = sum;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s) sdata[threadIdx.x] += sdata[threadIdx.x + s];
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) y[(size_t)row] = (float)sdata[0];
+}
+
+// Q4NX expert partial-GEMV: expert base = W + idx_d[slot]*stride_bytes.
+__global__ void h1bp_q4nx_part_idx_kernel(const uint8_t* __restrict__ w,
+        const float* __restrict__ x, float* __restrict__ part,
+        const int* __restrict__ idx_d, int slot, size_t stride_bytes,
+        int N, int ntc) {
+    const int exp_idx = idx_d[slot];
+    h1bp_q4nx_part_body(w + (size_t)exp_idx * stride_bytes, x, part, N, ntc);
+}
+
+// acc += src * rout_d[slot]  (expert weight scale read from device).
+__global__ void h1bp_mul_acc_scaled_kernel(float* __restrict__ acc,
+        const float* __restrict__ src, const float* __restrict__ rout_d,
+        int slot, int n) {
+    float s = rout_d[slot];
+    int i = threadIdx.x + blockIdx.x * blockDim.x;
+    if (i < n) acc[i] += src[i] * s;
+}
+
+// Shared-expert sigmoid gate, fully on-device: out[j] *= sigmoid(gate_w . x).
+__global__ void h1bp_shgate_fused_kernel(float* __restrict__ out,
+        const float* __restrict__ x, const float* __restrict__ gate_w,
+        int n, int K) {
+    __shared__ float sdot;
+    float acc = 0.0f;
+    for (int k = threadIdx.x; k < K; k += blockDim.x) acc += gate_w[k] * x[k];
+    __shared__ float sdata[256];
+    sdata[threadIdx.x] = acc;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s) sdata[threadIdx.x] += sdata[threadIdx.x + s];
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) { sdot = 1.0f / (1.0f + __expf(-sdata[0])); }
+    __syncthreads();
+    for (int i = threadIdx.x; i < n; i += blockDim.x) out[i] *= sdot;
+}
+
+// KV store at a device-read position: dst[(*d_pos)*stride + off + i] = src[i].
+__global__ void h1bp_q35_kvput_kernel(float* __restrict__ dst,
+        const float* __restrict__ src, const int* __restrict__ d_pos,
+        int off, int stride, int n) {
+    int p = *d_pos;
+    int i = threadIdx.x + blockIdx.x * blockDim.x;
+    if (i < n) dst[(size_t)p * stride + off + i] = src[i];
+}
+


### PR DESCRIPTION
### **User description**
Implements item 1 of #2139: hipGraph capture for the qwen35 decode path ("capture the per-token graph once like the dense path").

**Why q35 was eager** (per the scoping analysis): the router read top-k indices + weights on the HOST (2× D2H + `hipStreamSynchronize`), the expert pass was a host `for r in 0..8` loop with host-chosen weight pointers, the shared-expert gate did a host sigmoid — host control flow dependent on device results is not hipGraph-capturable.

**Changes**
- **New kernels** (`hip_1bp_kernels.hip`): Q8_0 + Q4NX expert GEMV reading idx from device (`q35_sc_idx[slot]`); `h1bp_mul_acc_scaled_kernel` (scale from `q35_sc_rout[slot]`); fused `h1bp_shgate_fused_kernel` (shared-expert sigmoid, no D2H); `h1bp_q35_kvput_kernel` (KV store at the device-read position). Q4NX partial body factored into a `__device__` helper shared by the dense + idx kernels.
- **Step is now device-driven**: removed the sync `d_token` copy, the D2H idx/scale read, the stream sync and the host expert loop (now 8 fixed slots, idx/scale on device); shared-expert gate fused; `Q35_NORMTK` hoisted to an init-time member.
- **Capture/replay**: `hipStreamBeginCapture` at q35 init → `qwen35_step(0, true)` → instantiate; state re-zeroed after the capture-time pass; `generate_fast` replays via `hipGraphLaunch` (pos/token re-read on device, per-replay result via async D2H to pinned `h_res`). Escape hatches: dump envs disable capture, `H1BP_Q35_NOGRAPH=1` forces eager.

**Verified so far**: full HIP codegen compiles clean — `hipcc -c` (rocm-therock) produces objects for both `hip_1bp_kernels.hip` (134KB) and `backend_hip_1bp.cpp` (349KB), only pre-existing nodiscard warnings.

**Runtime gates pending (needs the gfx1151 lane)** — deliberately not merged until they pass: corr vs CPU ref (#2138 methodology), token parity vs eager, NaN-free, and `bench_hip_1bp` perf vs eager.

Refs #2139


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Capture whole qwen35 decode step as hipGraph

- Make router/expert pass fully device-driven (no D2H)

- Add idx-reading GEMV, fused sigmoid gate, KV-put kernels

- Replay per token, with eager escape hatches

- Fix capture abort from sync `hipMemset` in region


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["qwen35_step eager: host top-k D2H + expert loop"] -- "device-driven rewrite" --> B["Device idx/weight reads (q35_sc_idx, q35_sc_rout)"]
  C["New kernels: idx GEMV, fused shunt gate, KV put"] -- "enables" --> B
  B -- "hipStreamBeginCapture at init" --> D["graph instantiate (q35_graph_ok)"]
  D -- "hipGraphLaunch in generate_fast" --> E["Per-token replay, async result to pinned h_res"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_hip_1bp.cpp</strong><dd><code>Capture q35 step as hipGraph, make decode device-driven</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/backend_hip_1bp.cpp

<ul><li>Add <code>q35_renorm</code> (hoisted <code>Q35_NORMTK</code> env read) and <code>q35_graph_ok</code> capture <br>state to <code>Hip1bpBackend</code><br> <li> Capture/instantiate the whole <code>qwen35_step</code> at q35 init <br>(<code>hipStreamBeginCapture</code>), re-zero state after capture, and replay via <br><code>hipGraphLaunch</code> in <code>generate_fast</code><br> <li> Replace host top-k D2H reads, <code>hipStreamSynchronize</code>, host expert loop <br>and host shared-expert sigmoid with device-read idx/weights (<code>gemvE</code> now <br>takes <code>slot</code>/<code>buf</code>, <code>h1bp_mul_acc_scaled_kernel</code>, <code>h1bp_shgate_fused_kernel</code>)<br> <li> Swap KV <code>hipMemcpyAsync</code> for <code>h1bp_q35_kvput_kernel</code> and use async result <br>copy to pinned <code>h_res</code> during capture; add <code>launch_q4nx_idx</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2175/files#diff-c4812ee96d278d2d2b452760b359c0521f1a016dce68e46c6668555b33eec182">+82/-29</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hip_1bp_kernels.hip</strong><dd><code>Add hipGraph-safe q35 kernels (idx GEMV, fused gate, KV put)</code></dd></summary>
<hr>

src/hip_1bp_kernels.hip

<ul><li>Factor Q4NX partial-GEMV body into a shared <code>__device__</code> helper <br><code>h1bp_q4nx_part_body</code> used by dense and idx kernels<br> <li> Add <code>h1bp_q8gemv_slice_idx_kernel</code> and <code>h1bp_q4nx_part_idx_kernel</code> that <br>read the expert index from device (<code>idx_d[slot]</code>)<br> <li> Add <code>h1bp_mul_acc_scaled_kernel</code> (acc += src × <code>rout_d[slot]</code>) and <br><code>h1bp_shgate_fused_kernel</code> (on-device sigmoid gate, no D2H)<br> <li> Add <code>h1bp_q35_kvput_kernel</code> storing KV at the device-read sequence <br>position</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2175/files#diff-e7c676fbc5592cbbf17f1c7db3df89e539cc6bfef40bfc8014de1d807ac66396">+91/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

