### PR TITLE
fix(npu): #2139 — q35 lane: crash fix + un-gate + perf (8 commits, verified end-to-end)

### DIFF
--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -1011,11 +1011,8 @@ struct Hip1bpBackend : Backend {
     }
 
     void launch_q4nx(const uint8_t* w, const float* x, float* out, int N, int K) {
-        int ntc = (K + 255) / 256;
-        int wpr = (ntc + 3) >> 2;
-        int blocks = (N * wpr + 3) / 4;
-        h1bp_q4nx_part_kernel<<<blocks,128,0,stream>>>(w,x,dpart,N,ntc);
-        h1bp_tq2nz_sum_kernel<<<(N + 255) / 256,256,0,stream>>>(dpart,out,N,wpr);
+        // #2139 item-2: single-pass (was part+sum = 2 dispatches per GEMV).
+        h1bp_q4nx_gemv_kernel<<<(N + 7) / 8, 256, 0, stream>>>(w, x, out, N, K);
     }
 
     // #2139: expert-index-from-device variant (hipGraph-safe — no host index read).
@@ -1035,10 +1032,9 @@ struct Hip1bpBackend : Backend {
         int ntc = (K + 255) / 256;
         int wpr = (ntc + 3) >> 2;
         int blocks = (N * wpr + 3) / 4;
-        h1bp_q4nx_part_idx8_kernel<<<dim3(blocks, nslots), 128, 0, stream>>>(
-            w, x, x_slot_stride, dpart8, idx_d, stride_bytes, N, ntc);
-        h1bp_tq2nz_sum8_kernel<<<dim3((N + 255) / 256, nslots), 256, 0, stream>>>(
-            dpart8, out8, N, wpr);
+        (void)ntc; (void)wpr; (void)blocks;
+        h1bp_q4nx_gemv_idx8_kernel<<<dim3((N + 7) / 8, nslots), 256, 0, stream>>>(
+            w, x, x_slot_stride, out8, idx_d, stride_bytes, N, K);
     }
 
     void launch_rocmfp4(const uint8_t* w, const float* x, float* out, int N, int K, bool fast) {

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -8,6 +8,7 @@
 #include <hip/hip_runtime_api.h>
 #include <hip/hip_fp16.h>
 #include <cstdio>
+#include <cstring>
 #include <cmath>
 #include <vector>
 #include <chrono>
@@ -185,6 +186,10 @@ struct Hip1bpBackend : Backend {
     size_t q35_exp_bytes[3] = {0,0,0}; // per-expert bytes: [0]=gate [1]=up [2]=down (ndim==3 stacks)
     float* q35_out_f32 = nullptr;        // lm_head as f32 (F16/F32-routed output.weight)
     uint16_t* q35_out_f16 = nullptr;     // #2139: lm_head packed f16 (F16-routed output.weight)
+    // #2139 lm_head byte-reduction candidates (env H1BP_Q35_LMHEAD=int8|q4nx, default f16)
+    int8_t* q35_out_i8 = nullptr;        // int8 lm_head weights (508 MB)
+    float*  q35_out_i8s = nullptr;       // per-row int8 scales [248320]
+    uint8_t* q35_out_q4nx = nullptr;     // Q4NX-packed lm_head tiles (254 MB)
     uint8_t* q35_emb = nullptr, *q35_out = nullptr;     // token_embd / output (V x H; Q8_0 raw or Q4NX tile)
     float* q35_onorm = nullptr;                         // output_norm (H f32)
     std::vector<Q35L> q35L;
@@ -698,7 +703,34 @@ struct Hip1bpBackend : Backend {
                             (int)ow.size() == 248320 * 2048) {
                             // #2139 item-2: an F16-routed output tensor is uploaded as
                             // packed f16 (half the per-token lm_head read) instead of f32.
-                            if (ot && ot->quant == ONEBP_F16) {
+                            const char* lmh = getenv("H1BP_Q35_LMHEAD");
+                            if (ot && ot->quant == ONEBP_F16 && lmh && !strcmp(lmh, "q4nx")) {
+                                std::vector<uint8_t> qw;
+                                if (!h1bp_pack_q4nx(ow, 248320, 2048, qw) ||
+                                    hipMalloc((void**)&q35_out_q4nx, qw.size()) != hipSuccess ||
+                                    hipMemcpy(q35_out_q4nx, qw.data(), qw.size(),
+                                              hipMemcpyHostToDevice) != hipSuccess)
+                                    lok = false;
+                                else
+                                    printf("[hip1bp] q35 lm_head: Q4NX-packed (%.0f MB)\n", qw.size() / 1e6);
+                                tot += qw.size();
+                                std::vector<uint8_t>().swap(qw);
+                            } else if (ot && ot->quant == ONEBP_F16 && lmh && !strcmp(lmh, "int8")) {
+                                std::vector<int8_t> qi; std::vector<float> sc;
+                                h1bp_quant_int8(ow, 248320, 2048, qi, sc);
+                                if (hipMalloc((void**)&q35_out_i8, qi.size()) != hipSuccess ||
+                                    hipMemcpy(q35_out_i8, qi.data(), qi.size(),
+                                              hipMemcpyHostToDevice) != hipSuccess ||
+                                    hipMalloc((void**)&q35_out_i8s, sc.size() * 4) != hipSuccess ||
+                                    hipMemcpy(q35_out_i8s, sc.data(), sc.size() * 4,
+                                              hipMemcpyHostToDevice) != hipSuccess)
+                                    lok = false;
+                                else
+                                    printf("[hip1bp] q35 lm_head: int8 (%.0f MB + %.1f MB scales)\n",
+                                           qi.size() / 1e6, sc.size() * 4 / 1e6);
+                                tot += qi.size() + sc.size() * 4;
+                                std::vector<int8_t>().swap(qi); std::vector<float>().swap(sc);
+                            } else if (ot && ot->quant == ONEBP_F16) {
                                 std::vector<uint16_t> hw(ow.size());
                                 for (size_t i = 0; i < ow.size(); i++)
                                     hw[i] = h1bp_f32_to_f16_bits(ow[i]);
@@ -1559,7 +1591,11 @@ struct Hip1bpBackend : Backend {
         }
         // output norm + lm head + argmax
         h1bp_rmsnorm_kernel<<<1, 256, 0, stream>>>(dh, q35_onorm, 2048, 1e-6f);
-        if (q35_q4nx && q35_out_f16)
+        if (q35_q4nx && q35_out_q4nx)
+            h1bp_q4nx_gemv_kernel<<<(248320 + 7) / 8, 256, 0, stream>>>(q35_out_q4nx, dh, dlogits, 248320, 2048);
+        else if (q35_q4nx && q35_out_i8)
+            h1bp_int8gemv_kernel<<<(248320 + 7) / 8, 256, 0, stream>>>(dlogits, q35_out_i8, q35_out_i8s, dh, 248320, 2048);
+        else if (q35_q4nx && q35_out_f16)
             h1bp_f16gemv_kernel<<<(248320 + 7) / 8, 256, 0, stream>>>(dlogits, q35_out_f16, dh, 248320, 2048);
         else if (q35_q4nx && q35_out_f32)
             h1bp_gemv_kernel<<<248320, 256, 0, stream>>>(dlogits, q35_out_f32, dh, 248320, 2048);
@@ -1608,6 +1644,7 @@ struct Hip1bpBackend : Backend {
         }
         q35L.clear();
         hf(q35_emb); hf(q35_out); hf(q35_out_f32); hf(q35_out_f16); hf(q35_onorm);
+        hf(q35_out_i8); hf(q35_out_i8s); hf(q35_out_q4nx);
         hf(q35_sc_qkv); hf(q35_sc_qc); hf(q35_sc_q); hf(q35_sc_k); hf(q35_sc_v); hf(q35_sc_z);
         hf(q35_sc_g); hf(q35_sc_b); hf(q35_sc_qk); hf(q35_sc_v2); hf(q35_sc_att); hf(q35_sc_aout);
         hf(q35_sc_act); hf(q35_sc_moe); hf(q35_sc_exp); hf(q35_sc_expw); hf(q35_sc_expd);

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -16,6 +16,113 @@
 
 #include "hip_1bp_kernels.hip"
 
+// #2139: the 1BP Q4NX qwen35 lane is validated (same-chain corr 0.996279 /
+// 0.973922 / argmax 101-102 == the pre-PR code, 100-token stream md5-identical,
+// 23.8 ms/token vs 42.9 pre-PR) so it is enabled BY DEFAULT instead of requiring
+// H1BP_Q35_LOAD=1 H1BP_Q35_TRY=1. Either variable set to 0 opts out and restores
+// the old behaviour (the q35 path is skipped and the loader falls through to the
+// CPU/NPU generic path). Explicit =1 keeps working as before.
+static bool q35_lane_enabled() {
+    const char* ld = getenv("H1BP_Q35_LOAD");
+    const char* tr = getenv("H1BP_Q35_TRY");
+    if (ld && atoi(ld) == 0) return false;
+    if (tr && atoi(tr) == 0) return false;
+    return true;
+}
+
+// #2139 item-2 helpers: bf16 packing + the two lm_head quantizers.
+static inline uint16_t h1bp_f32_to_bf16_bits(float f) {
+    uint32_t x; memcpy(&x, &f, 4);
+    uint32_t lsb = (x >> 16) & 1u;
+    uint32_t r = (x + 0x7FFFu + lsb) >> 16;
+    return (uint16_t)r;
+}
+
+// Pack f32 [M][K] (K % 256 == 0) into Q4NX 32x256 tiles, matching
+// h1bp_q4nx_part_body: [sc 32x8 bf16][zp 32x8 bf16][codes 32x128],
+// element 2i = low nibble of code byte i, element 2i+1 = high nibble.
+// Asymmetric int4 per 32-col group: code = round((v - zp) / scale), scale = (max-min)/15.
+static bool h1bp_pack_q4nx(const std::vector<float>& w, int M, int K, std::vector<uint8_t>& out) {
+    if (K % 256) return false;
+    const int ntc = K >> 8;
+    out.assign((size_t)(M / 32) * ntc * 5120, 0);   // one 5120 B tile per 32 rows x 256 cols
+    for (int row = 0; row < M; row++) {
+        const float* wr = w.data() + (size_t)row * K;
+        const int rri = row & 31;
+        const size_t tb0 = (size_t)((row >> 5) * ntc) * 5120;
+        for (int tw = 0; tw < ntc; tw++) {
+            uint8_t* tb = out.data() + tb0 + (size_t)tw * 5120;
+            uint16_t* sc = (uint16_t*)tb;
+            uint16_t* zp = (uint16_t*)(tb + 512);
+            for (int g = 0; g < 8; g++) {
+                const int base = tw * 256 + g * 32;
+                float mn = wr[base], mx = wr[base];
+                for (int j = 1; j < 32; j++) {
+                    float v = wr[base + j];
+                    if (v < mn) mn = v;
+                    if (v > mx) mx = v;
+                }
+                float range = mx - mn;
+                float scale = range > 0.0f ? range / 15.0f : 1.0f;
+                sc[rri * 8 + g] = h1bp_f32_to_bf16_bits(scale);
+                zp[rri * 8 + g] = h1bp_f32_to_bf16_bits(mn);
+                uint8_t* codes = tb + 1024 + rri * 128 + g * 16;
+                for (int j = 0; j < 16; j++) {
+                    float v0 = wr[base + 2 * j], v1 = wr[base + 2 * j + 1];
+                    int c0 = (int)((v0 - mn) / scale + 0.5f);
+                    int c1 = (int)((v1 - mn) / scale + 0.5f);
+                    if (c0 < 0) c0 = 0; if (c0 > 15) c0 = 15;
+                    if (c1 < 0) c1 = 0; if (c1 > 15) c1 = 15;
+                    codes[j] = (uint8_t)(c0 | (c1 << 4));
+                }
+            }
+        }
+    }
+    return true;
+}
+
+// Per-row symmetric int8: scale = max|w_row| / 127.
+static void h1bp_quant_int8(const std::vector<float>& w, int M, int K,
+                            std::vector<int8_t>& q, std::vector<float>& sc) {
+    q.resize((size_t)M * K);
+    sc.resize(M);
+    for (int row = 0; row < M; row++) {
+        const float* wr = w.data() + (size_t)row * K;
+        float m = 0.0f;
+        for (int k = 0; k < K; k++) { float a = wr[k] < 0 ? -wr[k] : wr[k]; if (a > m) m = a; }
+        float s = m > 0.0f ? m / 127.0f : 1.0f;
+        sc[row] = s;
+        int8_t* qr = q.data() + (size_t)row * K;
+        for (int k = 0; k < K; k++) {
+            float v = wr[k] / s;
+            int r = (int)(v < 0 ? v - 0.5f : v + 0.5f);
+            if (r < -127) r = -127;
+            if (r > 127) r = 127;
+            qr[k] = (int8_t)r;
+        }
+    }
+}
+
+// Host-side f32 -> f16 bit conversion (RNE). Portable; no device intrinsics.
+static inline uint16_t h1bp_f32_to_f16_bits(float f) {
+    uint32_t x; memcpy(&x, &f, 4);
+    uint32_t sign = (x >> 16) & 0x8000u;
+    int32_t  e    = (int32_t)((x >> 23) & 0xFFu) - 127 + 15;
+    uint32_t man  = x & 0x7FFFFFu;
+    if (e >= 0x1F) return (uint16_t)(sign | 0x7C00u);            // inf / nan
+    if (e <= 0) {
+        if (e < -10) return (uint16_t)sign;                       // underflow -> +-0
+        man |= 0x800000u;
+        int sh = 14 - e;
+        uint32_t hm = man >> sh;
+        if (man & (1u << (sh - 1))) hm++;
+        return (uint16_t)(sign | hm);
+    }
+    uint32_t h = sign | ((uint32_t)e << 10) | (man >> 13);
+    if (man & 0x1000u) h++;
+    return (uint16_t)h;
+}
+
 extern "C" rcpp_status_t rcpp_kv_cache_attn_decode_dpos(
     const void* Q_dev, const void* K_dev, const void* V_dev, void* out_dev,
     int num_q_heads, int num_kv_heads, int head_dim,
@@ -385,8 +492,9 @@ struct Hip1bpBackend : Backend {
                                 "10 shared + kind-specific per layer; %d full-attn MHA "
                                 "layers 3,7,…,39 with split attn_q/k/v + q/k-norm, "
                                 "rest GDN fused attn_qkv 8192 rows + ssm; MoE 256x8 + "
-                                "shared): eager decode behind H1BP_Q35_LOAD+TRY "
-                                "(Q8_0 GGUF since #2127; Q4NX 1BP since M2)",
+                                "shared): GPU decode lane (Q8_0 GGUF since #2127; "
+                                "Q4NX 1BP since M2, default-on since #2139 — "
+                                "H1BP_Q35_LOAD=0/H1BP_Q35_TRY=0 opts out)",
                         H, NC, n_full);
             }
             // M3 loader/kernel self-check (env H1BP_Q35_SELFCHECK): pull
@@ -444,7 +552,7 @@ struct Hip1bpBackend : Backend {
             // device with the captured slicing — Q8_0 raw for the big weights,
             // f32 for norms/router/ssm params. Consumed by the M3 decode path
             // (tasks 3-5, not yet wired — decode still refused below).
-            if (ok && getenv("H1BP_Q35_LOAD")) {
+            if (ok && q35_lane_enabled()) {
                 size_t tot = 0;
                 q35L.assign(NC, Q35L());
                 auto q8 = [&](const char* nm, int l, uint8_t*& dst, int M, int K,
@@ -640,9 +748,9 @@ struct Hip1bpBackend : Backend {
                     fprintf(stderr, "[hip1bp] qwen35 device load FAILED — falling back\n");
                 }
             }
-            // Full device load (env H1BP_Q35_LOAD)... runs when set; decode path
-            // below enabled by H1BP_Q35_TRY (eager decode; no hipGraph for q35).
-            if (ok && getenv("H1BP_Q35_LOAD") && getenv("H1BP_Q35_TRY")) {
+            // Device load + decode are ON BY DEFAULT for a validated qwen35moe
+            // 1BP Q4NX file (#2139); q35_lane_enabled() is the opt-out.
+            if (ok && q35_lane_enabled()) {
                 if (!qwen35_alloc_state()) {
                     fprintf(stderr, "[hip1bp] qwen35 scratch alloc failed\n");
                 } else {

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -199,6 +199,10 @@ struct Hip1bpBackend : Backend {
     float* q35_sc_moe = nullptr;                        // [2048]
     float* q35_sc_exp = nullptr, *q35_sc_expw = nullptr;  // [512] expert act / [512] gate
     float* q35_sc_expd = nullptr;                       // [2048] expert down out
+    // #2139 item-2: slot-batched expert buffers (8 top-k slots)
+    float* q35_sc_exp8 = nullptr, *q35_sc_expw8 = nullptr;   // [8][512]
+    float* q35_sc_expd8 = nullptr;                           // [8][2048]
+    float* dpart8 = nullptr;                                 // [8][N][32*wpr]
     float* q35_sc_logits = nullptr;                     // [256] router logits / topk w/idx
     int* q35_sc_idx = nullptr;                          // [8]
     float* q35_sc_rout = nullptr;                       // [256] router weights
@@ -1024,6 +1028,19 @@ struct Hip1bpBackend : Backend {
         h1bp_tq2nz_sum_kernel<<<(N + 255) / 256,256,0,stream>>>(dpart,out,N,wpr);
     }
 
+    // #2139 item-2: batched expert GEMV - all nslots top-k slots in one launch pair.
+    void launch_q4nx_idx8(const uint8_t* w, const float* x, int x_slot_stride,
+                          float* out8, int N, int K, size_t stride_bytes,
+                          const int* idx_d, int nslots) {
+        int ntc = (K + 255) / 256;
+        int wpr = (ntc + 3) >> 2;
+        int blocks = (N * wpr + 3) / 4;
+        h1bp_q4nx_part_idx8_kernel<<<dim3(blocks, nslots), 128, 0, stream>>>(
+            w, x, x_slot_stride, dpart8, idx_d, stride_bytes, N, ntc);
+        h1bp_tq2nz_sum8_kernel<<<dim3((N + 255) / 256, nslots), 256, 0, stream>>>(
+            dpart8, out8, N, wpr);
+    }
+
     void launch_rocmfp4(const uint8_t* w, const float* x, float* out, int N, int K, bool fast) {
         int ntc = (K + 255) / 256;
         int wpr = (ntc + 3) >> 2;
@@ -1364,6 +1381,8 @@ struct Hip1bpBackend : Backend {
                   zz(q35_sc_v2, 512) && zz(q35_sc_att, 4096) && zz(q35_sc_aout, 2048) &&
                   zz(q35_sc_act, 2048) && zz(q35_sc_moe, 2048) && zz(q35_sc_exp, 512) &&
                   zz(q35_sc_expw, 512) && zz(q35_sc_expd, 2048) && zz(q35_sc_logits, 256) &&
+                  zz(q35_sc_exp8, 8 * 512) && zz(q35_sc_expw8, 8 * 512) &&
+                  zz(q35_sc_expd8, 8 * 2048) && zz(dpart8, (size_t)8 * 2048 * 64) &&
                   zz(q35_sc_rout, 256) && zz(q35_sc_idx, 8) &&
                   zz(q35_conv_state, (size_t)NC * 8192 * 3) &&
                   zz(q35_rec_state, (size_t)NC * 128 * 128 * 32) &&
@@ -1512,12 +1531,23 @@ struct Hip1bpBackend : Backend {
             // inside hipStreamBeginCapture — use the capture stream.
             HIP_CHECK(hipMemsetAsync(q35_sc_moe, 0, 2048 * 4, stream));
             // #2139: fixed 8 slots — expert idx + weight read on device (capturable)
-            for (int r = 0; r < 8; r++) {
+            if (q35_q4nx) {
+                // #2139 item-2: grid.y = the 8 top-k slots -> 8 dispatches/layer
+                // instead of 64 (8 slots x [2x3 GEMV + silu + scale]).
+                launch_q4nx_idx8(w.ex_u, dh, 0, q35_sc_exp8, 512, 2048, q35_exp_bytes[1], q35_sc_idx, 8);
+                launch_q4nx_idx8(w.ex_g, dh, 0, q35_sc_expw8, 512, 2048, q35_exp_bytes[0], q35_sc_idx, 8);
+                h1bp_silu_gate_mul8_kernel<<<dim3((512 + 255) / 256, 8), 256, 0, stream>>>(
+                    q35_sc_exp8, q35_sc_expw8, 512);
+                launch_q4nx_idx8(w.ex_d, q35_sc_exp8, 512, q35_sc_expd8, 2048, 512, q35_exp_bytes[2], q35_sc_idx, 8);
+                h1bp_moe_reduce8_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(
+                    q35_sc_moe, q35_sc_expd8, q35_sc_rout, 2048, 8);
+            } else {            for (int r = 0; r < 8; r++) {
                 gemvE(q35_sc_exp, w.ex_u, dh, r, 512, 2048, 1);
                 gemvE(q35_sc_expw, w.ex_g, dh, r, 512, 2048, 0);
                 h1bp_silu_gate_mul_kernel<<<(512 + 255) / 256, 256, 0, stream>>>(q35_sc_exp, q35_sc_expw, 512);
                 gemvE(q35_sc_expd, w.ex_d, q35_sc_exp, r, 2048, 512, 2);
                 h1bp_mul_acc_scaled_kernel<<<(2048 + 255) / 256, 256, 0, stream>>>(q35_sc_moe, q35_sc_expd, q35_sc_rout, r, 2048);
+            }
             }
             // shared expert + sigmoid gate
             gemv(q35_sc_exp, w.sh_u, dh, 512, 2048);
@@ -1586,6 +1616,7 @@ struct Hip1bpBackend : Backend {
         hf(q35_sc_g); hf(q35_sc_b); hf(q35_sc_qk); hf(q35_sc_v2); hf(q35_sc_att); hf(q35_sc_aout);
         hf(q35_sc_act); hf(q35_sc_moe); hf(q35_sc_exp); hf(q35_sc_expw); hf(q35_sc_expd);
         hf(q35_sc_logits); hf(q35_sc_rout); hf(q35_sc_idx);
+        hf(q35_sc_exp8); hf(q35_sc_expw8); hf(q35_sc_expd8); hf(dpart8);
         hf(q35_conv_state); hf(q35_rec_state); hf(q35_kvc); hf(q35_kv_scores); hf(q35_gate_flat);
         q35_loaded = false;
         L.clear();P.clear();model_.reset();

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -184,6 +184,7 @@ struct Hip1bpBackend : Backend {
     bool q35_q4nx = false;            // #1831 M2: weights are 1BP Q4NX tiles, not GGUF Q8_0 raw
     size_t q35_exp_bytes[3] = {0,0,0}; // per-expert bytes: [0]=gate [1]=up [2]=down (ndim==3 stacks)
     float* q35_out_f32 = nullptr;        // lm_head as f32 (F16/F32-routed output.weight)
+    uint16_t* q35_out_f16 = nullptr;     // #2139: lm_head packed f16 (F16-routed output.weight)
     uint8_t* q35_emb = nullptr, *q35_out = nullptr;     // token_embd / output (V x H; Q8_0 raw or Q4NX tile)
     float* q35_onorm = nullptr;                         // output_norm (H f32)
     std::vector<Q35L> q35L;
@@ -691,11 +692,25 @@ struct Hip1bpBackend : Backend {
                         std::vector<float> ow;
                         if (model_->get_tensor_f32("output.weight", ow) &&
                             (int)ow.size() == 248320 * 2048) {
-                            if (hipMalloc((void**)&q35_out_f32, ow.size() * 4) != hipSuccess ||
+                            // #2139 item-2: an F16-routed output tensor is uploaded as
+                            // packed f16 (half the per-token lm_head read) instead of f32.
+                            if (ot && ot->quant == ONEBP_F16) {
+                                std::vector<uint16_t> hw(ow.size());
+                                for (size_t i = 0; i < ow.size(); i++)
+                                    hw[i] = h1bp_f32_to_f16_bits(ow[i]);
+                                if (hipMalloc((void**)&q35_out_f16, ow.size() * 2) != hipSuccess ||
+                                    hipMemcpy(q35_out_f16, hw.data(), ow.size() * 2,
+                                              hipMemcpyHostToDevice) != hipSuccess)
+                                    lok = false;
+                                tot += ow.size() * 2;
+                                std::vector<uint16_t>().swap(hw);
+                            } else if (hipMalloc((void**)&q35_out_f32, ow.size() * 4) != hipSuccess ||
                                 hipMemcpy(q35_out_f32, ow.data(), ow.size() * 4,
-                                          hipMemcpyHostToDevice) != hipSuccess)
+                                          hipMemcpyHostToDevice) != hipSuccess) {
                                 lok = false;
-                            tot += ow.size() * 4;
+                            } else {
+                                tot += ow.size() * 4;
+                            }
                             ow.clear(); ow.shrink_to_fit();
                         } else lok = false;
                     }
@@ -1518,7 +1533,9 @@ struct Hip1bpBackend : Backend {
         }
         // output norm + lm head + argmax
         h1bp_rmsnorm_kernel<<<1, 256, 0, stream>>>(dh, q35_onorm, 2048, 1e-6f);
-        if (q35_q4nx && q35_out_f32)
+        if (q35_q4nx && q35_out_f16)
+            h1bp_f16gemv_kernel<<<(248320 + 7) / 8, 256, 0, stream>>>(dlogits, q35_out_f16, dh, 248320, 2048);
+        else if (q35_q4nx && q35_out_f32)
             h1bp_gemv_kernel<<<248320, 256, 0, stream>>>(dlogits, q35_out_f32, dh, 248320, 2048);
         else
             gemv(dlogits, q35_out, dh, 248320, 2048);
@@ -1564,7 +1581,7 @@ struct Hip1bpBackend : Backend {
             hf(w.sh_d); hf(w.router); hf(w.sh_gatew);
         }
         q35L.clear();
-        hf(q35_emb); hf(q35_out); hf(q35_out_f32); hf(q35_onorm);
+        hf(q35_emb); hf(q35_out); hf(q35_out_f32); hf(q35_out_f16); hf(q35_onorm);
         hf(q35_sc_qkv); hf(q35_sc_qc); hf(q35_sc_q); hf(q35_sc_k); hf(q35_sc_v); hf(q35_sc_z);
         hf(q35_sc_g); hf(q35_sc_b); hf(q35_sc_qk); hf(q35_sc_v2); hf(q35_sc_att); hf(q35_sc_aout);
         hf(q35_sc_act); hf(q35_sc_moe); hf(q35_sc_exp); hf(q35_sc_expw); hf(q35_sc_expd);

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -703,7 +703,20 @@ struct Hip1bpBackend : Backend {
                             (int)ow.size() == 248320 * 2048) {
                             // #2139 item-2: an F16-routed output tensor is uploaded as
                             // packed f16 (half the per-token lm_head read) instead of f32.
+                            // #2139 quality call (2026-09-10): the lm_head on the
+                            // 1BP Q4NX lane defaults to int8 (per-row scale). Measured
+                            // against packed f16 on the same 102-position chain: corr mean
+                            // 0.996279 -> 0.996235 (-4.4e-5, below this metric's positional
+                            // spread), argmax parity unchanged 101/102, 100-token greedy
+                            // stream bit-identical, wall 26.7 -> 21.6 ms/token (-19%).
+                            // Q4NX lm_head is NOT recommended (corr -2.6e-3, argmax 98/102,
+                            // stream differs, only 0.7 ms faster than int8) and stays behind
+                            // an explicit flag. H1BP_Q35_LMHEAD=f16 restores packed f16
+                            // exactly; =q4nx opts into the 318 MB variant.
                             const char* lmh = getenv("H1BP_Q35_LMHEAD");
+                            const bool want_f16 = lmh && (!strcmp(lmh, "f16") ||
+                                                          !strcmp(lmh, "float") ||
+                                                          !strcmp(lmh, "0"));
                             if (ot && ot->quant == ONEBP_F16 && lmh && !strcmp(lmh, "q4nx")) {
                                 std::vector<uint8_t> qw;
                                 if (!h1bp_pack_q4nx(ow, 248320, 2048, qw) ||
@@ -715,7 +728,7 @@ struct Hip1bpBackend : Backend {
                                     printf("[hip1bp] q35 lm_head: Q4NX-packed (%.0f MB)\n", qw.size() / 1e6);
                                 tot += qw.size();
                                 std::vector<uint8_t>().swap(qw);
-                            } else if (ot && ot->quant == ONEBP_F16 && lmh && !strcmp(lmh, "int8")) {
+                            } else if (ot && ot->quant == ONEBP_F16 && !want_f16) {
                                 std::vector<int8_t> qi; std::vector<float> sc;
                                 h1bp_quant_int8(ow, 248320, 2048, qi, sc);
                                 if (hipMalloc((void**)&q35_out_i8, qi.size()) != hipSuccess ||

--- a/src/backend_hip_1bp.cpp
+++ b/src/backend_hip_1bp.cpp
@@ -1107,6 +1107,24 @@ struct Hip1bpBackend : Backend {
     }
 
     bool forward(int token_id,float* hidden_out)override{
+        if (q35_loaded) {
+            // #2139: the q35 lane must not fall into forward_dev() — that walks the
+            // dense layer structs, which a qwen35moe 1BP load never populates (it
+            // segfaults; found via the engine chat path, see the SIGSEGV backtrace).
+            // Run the qwen35 step instead: it leaves the final RMS-normed hidden in
+            // dh and advances pos itself.
+            if (q35_graph_ok) {
+                *h_token = token_id; *h_pos = pos;
+                HIP_CHECK(hipGraphLaunch(graphExec, stream));
+                HIP_CHECK(hipStreamSynchronize(stream));
+                pos++;
+            } else if (qwen35_step(token_id, false) < 0) {
+                fprintf(stderr, "[hip1bp] q35 forward(): qwen35_step failed\n");
+                return false;
+            }
+            HIP_CHECK(hipMemcpy(hidden_out, dh, H * 4, hipMemcpyDeviceToHost));
+            return true;
+        }
         if(!forward_dev(token_id,true))return false;
         HIP_CHECK(hipMemcpy(hidden_out,dh,H*4,hipMemcpyDeviceToHost));
         pos++;
@@ -1160,6 +1178,31 @@ struct Hip1bpBackend : Backend {
     }
 
     bool lm_head(const float* hidden,float* logits,int* argmax)override{
+        if (q35_loaded) {
+            // #2139: q35 lm_head over the lane's own output weights, mirroring the
+            // selection used inside qwen35_step, so the engine's forward()+lm_head()
+            // sampling flow works on the q35 lane.
+            HIP_CHECK(hipMemcpy(dh, hidden, H * 4, hipMemcpyHostToDevice));
+            if (q35_out_q4nx)
+                h1bp_q4nx_gemv_kernel<<<(VOCAB + 7) / 8, 256, 0, stream>>>(q35_out_q4nx, dh, dlogits, VOCAB, H);
+            else if (q35_out_i8)
+                h1bp_int8gemv_kernel<<<(VOCAB + 7) / 8, 256, 0, stream>>>(dlogits, q35_out_i8, q35_out_i8s, dh, VOCAB, H);
+            else if (q35_out_f16)
+                h1bp_f16gemv_kernel<<<(VOCAB + 7) / 8, 256, 0, stream>>>(dlogits, q35_out_f16, dh, VOCAB, H);
+            else if (q35_out_f32)
+                h1bp_gemv_kernel<<<VOCAB, 256, 0, stream>>>(dlogits, q35_out_f32, dh, VOCAB, H);
+            else if (q35_out) {
+                // gemv() is a lambda local to qwen35_step: mirror its two cases here.
+                if (q35_q4nx) launch_q4nx(q35_out, dh, dlogits, VOCAB, H);
+                else h1bp_q8gemv_kernel<<<VOCAB, 256, 0, stream>>>(dlogits, q35_out, dh, VOCAB, H);
+            } else return false;
+            int nblk = std::min(AMX_MAXB, (VOCAB + 255) / 256);
+            h1bp_argmax_pass1_kernel<<<nblk, 256, 0, stream>>>(dlogits, VOCAB, d_amx, d_ami);
+            h1bp_argmax_pass2_kernel<<<1, 256, 0, stream>>>(d_amx, d_ami, nblk, d_argmax);
+            HIP_CHECK(hipMemcpy(logits, dlogits, (size_t)VOCAB * 4, hipMemcpyDeviceToHost));
+            if (argmax) HIP_CHECK(hipMemcpy(argmax, d_argmax, sizeof(int), hipMemcpyDeviceToHost));
+            return true;
+        }
         // Tied-embedding models (e.g. Qwen3) have no output.weight — the LM
         // head is the embedding matrix itself.
         if(!d_output&&!d_embed){memset(logits,0,VOCAB*4);logits[0]=1;if(argmax)*argmax=0;return true;}

--- a/src/hip_1bp_kernels.hip
+++ b/src/hip_1bp_kernels.hip
@@ -872,3 +872,30 @@ __global__ void h1bp_q4nx_gemv_idx8_kernel(const uint8_t* __restrict__ w,
     for (int off = 16; off; off >>= 1) acc += __shfl_down(acc, off);
     if (lane == 0) y8[(size_t)slot * N + row] = acc;
 }
+
+
+// ═══ #2139 item-2: int8 lm_head GEMV (one warp per row, per-row scale) ═══
+// output.weight is 248320x2048 = 508 MB as int8 (vs 1 GB packed f16, 2 GB f32),
+// which is the whole point: the lm_head is a pure weight-streaming op.
+__global__ void h1bp_int8gemv_kernel(float* __restrict__ y,
+                                     const int8_t* __restrict__ W,
+                                     const float* __restrict__ scales,
+                                     const float* __restrict__ x, int M, int K) {
+    const int lane = threadIdx.x & 31;
+    const int row  = (blockIdx.x * (blockDim.x >> 5)) + (threadIdx.x >> 5);
+    if (row >= M) return;
+    const uint4* wrow = reinterpret_cast<const uint4*>(W + (size_t)row * K);
+    const int n16 = K >> 4;                     // 16 int8 per uint4
+    // float accumulation: the double accumulator made this kernel slower than the
+    // 1 GB f16 path it is meant to beat (FP64 is rate-limited on gfx1151).
+    float acc = 0.0f;
+    for (int k = lane; k < n16; k += 32) {
+        uint4 v = wrow[k];
+        const int8_t* b = reinterpret_cast<const int8_t*>(&v);
+#pragma unroll
+        for (int j = 0; j < 16; j++)
+            acc += (float)b[j] * x[k * 16 + j];
+    }
+    for (int off = 16; off; off >>= 1) acc += __shfl_down(acc, off);
+    if (lane == 0) y[row] = (float)acc * scales[row];
+}

--- a/src/hip_1bp_kernels.hip
+++ b/src/hip_1bp_kernels.hip
@@ -813,3 +813,62 @@ __global__ void h1bp_moe_reduce8_kernel(float* __restrict__ acc,
     for (int k = 0; k < nslots; k++) t += src[(size_t)k * n + i] * rout_d[k];
     acc[i] = t;
 }
+
+// ═══ #2139 item-2: single-pass Q4NX GEMV (one warp per row) ═══
+// The launch_q4nx pair (part kernel -> tq2nz_sum kernel) costs 2 dispatches per
+// GEMV and a 32*wpr float partial buffer per row. Here each warp owns one row and
+// walks the K dimension tile by tile itself (lane = 32-col group, 4 groups per
+// warp per step), then warp-reduces: same math, 1 dispatch, no partial buffer.
+__device__ inline void h1bp_q4nx_row_walk(const uint8_t* __restrict__ w,
+                                          const float* __restrict__ x,
+                                          int row, int ntc, int lane, float& acc) {
+    const int g  = lane & 7;
+    const int twq = lane >> 3;
+    const int rri = row & 31;
+    for (int tw = twq; tw < ntc; tw += 4) {
+        const uint8_t* tb = w + (size_t)((row >> 5) * ntc + tw) * 5120;
+        const uint16_t* sc = (const uint16_t*)tb;
+        const uint16_t* zp = (const uint16_t*)(tb + 512);
+        float scale = h1bp_bf16_to_f32(sc[rri * 8 + g]);
+        float z     = h1bp_bf16_to_f32(zp[rri * 8 + g]);
+        const uint8_t* codes = tb + 1024 + rri * 128 + g * 16;
+        const float*   xp    = x + tw * 256 + g * 32;
+#pragma unroll
+        for (int i = 0; i < 16; i++) {
+            uint8_t b = codes[i];
+            acc += ((float)(b & 0xF) * scale + z) * xp[i * 2];
+            acc += ((float)(b >> 4)  * scale + z) * xp[i * 2 + 1];
+        }
+    }
+}
+
+__global__ void h1bp_q4nx_gemv_kernel(const uint8_t* __restrict__ w,
+                                      const float* __restrict__ x,
+                                      float* __restrict__ y, int N, int K) {
+    const int lane = threadIdx.x & 31;
+    const int row  = (blockIdx.x * (blockDim.x >> 5)) + (threadIdx.x >> 5);
+    if (row >= N) return;
+    const int ntc = (K + 255) >> 8;
+    float acc = 0.0f;
+    h1bp_q4nx_row_walk(w, x, row, ntc, lane, acc);
+    for (int off = 16; off; off >>= 1) acc += __shfl_down(acc, off);
+    if (lane == 0) y[row] = acc;
+}
+
+// #2139 item-2: single-pass Q4NX expert GEMV — grid.y = top-k slot, one warp per
+// row, expert base from idx_d[slot]; x_slot_stride != 0 for the down projection.
+__global__ void h1bp_q4nx_gemv_idx8_kernel(const uint8_t* __restrict__ w,
+        const float* __restrict__ x, int x_slot_stride, float* __restrict__ y8,
+        const int* __restrict__ idx_d, size_t stride_bytes, int N, int K) {
+    const int slot = blockIdx.y;
+    const int lane = threadIdx.x & 31;
+    const int row  = (blockIdx.x * (blockDim.x >> 5)) + (threadIdx.x >> 5);
+    if (row >= N) return;
+    const int ntc = (K + 255) >> 8;
+    const uint8_t* we = w + (size_t)idx_d[slot] * stride_bytes;
+    const float*   xe = x + (size_t)slot * x_slot_stride;
+    float acc = 0.0f;
+    h1bp_q4nx_row_walk(we, xe, row, ntc, lane, acc);
+    for (int off = 16; off; off >>= 1) acc += __shfl_down(acc, off);
+    if (lane == 0) y8[(size_t)slot * N + row] = acc;
+}

--- a/src/hip_1bp_kernels.hip
+++ b/src/hip_1bp_kernels.hip
@@ -9,6 +9,35 @@
 
 // ── Custom GEMV: y[M] = W[M,N] @ x[N], row-major W ──
 // One thread per row, block-wide reduction over columns.
+// #2139 item-2 fast path: same GEMV shape, but W is row-major f16 (packed) instead
+// of f32. Used for the lm_head, whose f32 copy costs a 2 GB weight read per token
+// (~12.2 ms/token = ~36% of q35 decode on gfx1151, bandwidth-bound); the f16 read
+// halves that. Accumulation stays in double and f16 -> f32 is exact, so results are
+// bit-identical to the f32 kernel for an f16-routed tensor.
+__global__ void h1bp_f16gemv_kernel(float* y, const unsigned short* W, const float* x, int M, int N) {
+    // one warp per row (8 rows / 256-thread block); 16-byte vector loads (8 halves)
+    // per lane per iteration for memory-level parallelism. Replaces the original
+    // one-block-per-row shape (248,320 tiny blocks -> block-issue bound) and the
+    // f32 lm_head buffer (2 GB/token read -> 1 GB).
+    int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    int row = blockIdx.x * (blockDim.x >> 5) + warp;
+    if (row >= M) return;
+    const uint4* wrow = reinterpret_cast<const uint4*>(W + (size_t)row * N);
+    int n8 = N >> 3;
+    double sum = 0;
+    for (int k = lane; k < n8; k += 32) {
+        uint4 v = wrow[k];
+        const unsigned short* h = reinterpret_cast<const unsigned short*>(&v);
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int idx = 8 * k + j;
+            sum += (double)x[idx] * (double)__half2float(__ushort_as_half(h[j]));
+        }
+    }
+    for (int off = 16; off; off >>= 1) sum += __shfl_down(sum, off);
+    if (lane == 0) y[row] = (float)sum;
+}
+
 __global__ void h1bp_gemv_kernel(float* y, const float* W, const float* x, int M, int N) {
     int row = blockIdx.x;
     if (row >= M) return;

--- a/src/hip_1bp_kernels.hip
+++ b/src/hip_1bp_kernels.hip
@@ -761,3 +761,55 @@ __global__ void h1bp_q35_kvput_kernel(float* __restrict__ dst,
     if (i < n) dst[(size_t)p * stride + off + i] = src[i];
 }
 
+
+// ═══ #2139 item-2: slot-batched expert GEMV (grid.y = top-k slot) ═══
+// The MoE block used to issue 8 separate expert GEMVs (x2 dispatches each) plus
+// per-slot silu/scale kernels => 64 dispatches/layer. With grid.y = the 8 top-k
+// slots the same work is 8 dispatches/layer. x_slot_stride != 0 lets a batched
+// caller pass per-slot activations (the down projection); 0 means shared x.
+__global__ void h1bp_q4nx_part_idx8_kernel(const uint8_t* __restrict__ w,
+        const float* __restrict__ x, int x_slot_stride, float* __restrict__ part,
+        const int* __restrict__ idx_d, size_t stride_bytes, int N, int ntc) {
+    const int slot = blockIdx.y;
+    const int exp_idx = idx_d[slot];
+    const int wpr = (ntc + 3) >> 2;
+    h1bp_q4nx_part_body(w + (size_t)exp_idx * stride_bytes,
+                        x + (size_t)slot * x_slot_stride,
+                        part + (size_t)slot * N * 32 * wpr, N, ntc);
+}
+
+__global__ void h1bp_tq2nz_sum8_kernel(const float* __restrict__ part,
+        float* __restrict__ out, int N, int wpr) {
+    const int slot = blockIdx.y;
+    const int row = blockIdx.x * (int)blockDim.x + threadIdx.x;
+    if (row >= N) return;
+    const float* p = part + (size_t)slot * N * 32 * wpr;
+    float s = 0.0f;
+    for (int i = 0; i < 32 * wpr; i++) s += p[(size_t)row * 32 * wpr + i];
+    out[(size_t)slot * N + row] = s;
+}
+
+// up8[slot][i] = up8[slot][i] * silu(gate8[slot][i])   (same math as
+// h1bp_silu_gate_mul_kernel, batched over slots)
+__global__ void h1bp_silu_gate_mul8_kernel(float* __restrict__ up,
+        const float* __restrict__ gate, int n) {
+    const int slot = blockIdx.y;
+    int i = threadIdx.x + blockIdx.x * blockDim.x;
+    if (i >= n) return;
+    float* u = up + (size_t)slot * n;
+    const float* g = gate + (size_t)slot * n;
+    u[i] = u[i] * (g[i] / (1.0f + __expf(-g[i])));
+}
+
+// acc[i] += sum_slot src8[slot][i] * rout_d[slot], with a FIXED slot order so
+// results stay bit-identical to the previous 8 sequential h1bp_mul_acc_scaled
+// launches and deterministic run to run (a grid.y version would race on acc[i]).
+__global__ void h1bp_moe_reduce8_kernel(float* __restrict__ acc,
+        const float* __restrict__ src, const float* __restrict__ rout_d,
+        int n, int nslots) {
+    int i = threadIdx.x + blockIdx.x * blockDim.x;
+    if (i >= n) return;
+    float t = acc[i];
+    for (int k = 0; k < nslots; k++) t += src[(size_t)k * n + i] * rout_d[k];
+    acc[i] = t;
+}

--- a/tests/backends/backend_hip_adapter.cpp
+++ b/tests/backends/backend_hip_adapter.cpp
@@ -250,6 +250,16 @@ public:
                      float repeat_penalty, const std::vector<int>& recent) override {
         (void)pos;
         if (!backend_ || !loaded_) return -1;
+        // #2139: a greedy request IS the argmax over the logits this path computes —
+        // sample_from_logits_local() returns `argmax` unchanged when temperature <= 0
+        // (repeat penalty/top_p only apply when temp > 0), so use the backend's
+        // token-level generate() and skip the full 248k-float logits copy to the host.
+        // Measured on the q35 1BP chat lane: 10.0 -> ~40 tok/s, identical tokens.
+        // temperature > 0 keeps the logits path, and a failing generate() falls back.
+        if (temperature <= 0.0f) {
+            const int tok = backend_->generate(token_id);
+            if (tok >= 0) return tok;
+        }
         int H = cfg_.hidden_size > 0 ? cfg_.hidden_size : cfg_.hidden;
         int V = cfg_.vocab_size > 0 ? cfg_.vocab_size : cfg_.vocab;
         if (H <= 0 || V <= 0) return forward(token_id, pos);


### PR DESCRIPTION
### **User description**
Lands the 8 q35-lane fixes from @agent-ca60cf's branches, integrated and verified end-to-end.

**Why:** main has item 1 (hipGraph capture, #2175) but none of the fixes that make the lane usable. On main the q35 lane is (a) off unless `H1BP_Q35_LOAD=1 H1BP_Q35_TRY=1` are set, (b) ~2x slower than the branch state, and (c) **segfaults as soon as it is on and driven through the engine chat path** — which is exactly the path the un-gating makes default.

**What lands** (cherry-picked with `-x`, in the lane owner's recommended order):

| # | commit | effect |
|---|---|---|
| 7 | `8f18fdec1` | **q35 `forward()`/`lm_head()` implemented — fixes the SIGSEGV** on the engine token path (dense `forward_dev()` was being called with null dense weights) |
| 6 | `56e31251d` | `q35_lane_enabled()` — lane on by default, envs become opt-outs |
| 1 | `3742e7194` | packed-f16 lm_head + warp-per-row vectorized GEMV |
| 2 | `5805c5e51` | slot-batched MoE (grid.y = top-k slot): 64 → 8 dispatches/layer |
| 3 | `e5744ba43` | single-pass Q4NX GEMV (dense + expert) |
| 4 | `3edf6d7f9` | opt-in int8/Q4NX lm_head candidates (strict-gate-failing ones stay opt-in) |
| 5 | `ed511c3b4` | int8 lm_head becomes the lane default (measured: −4.4e-5 mean corr for −19%) |
| 8 | `100e1f950` | greedy (temp≤0) takes the on-device argmax instead of D2H-ing 248k logits/token (engine chat 10 → ~32 tok/s aggregate) |

**Integration notes (two conflicts, both resolved by keeping our side):** commits 1/4 re-add the helper block (`q35_lane_enabled` + bf16/Q4NX packers) inside their branch hunks, so cherry-picking onto a tree that already has it shows as a deletion; resolved by keeping ours. Final `src/backend_hip_1bp.cpp` is **byte-identical to the lane owner's tip branch** `fix/2139-engine-greedy-fastpath`.

**Verification:**
- compile: `hipcc -c` (rocm-therock, gfx1151) clean for the merged file.
- **end-to-end A/B on the lane's real configuration** (`/var/tmp/cas/qwen35-1bp-v2.1bp`, engine `zaya` server + `POST /v1/chat/completions`):

| build | lane config | result |
|---|---|---|
| unfixed (main-equivalent) | envs required on main | **SIGSEGV** on the request (core dumped, `http=000`) |
| this branch | **no envs** (un-gated) | **HTTP 200** — real answer, `8 tokens in 388ms (20.6 tok/s)`, backend `[HIP 1BP (Qwen/Llama)]` |

Measured quality/perf detail (same-chain corr 0.996279 floor / argmax 101-102, 23.8 ms/token vs 42.9 pre-PR) lives in the #2139 thread and `~/issue-triage/` logs on strixhalo.

**Behaviour change to note:** the lane is now ON by default; `H1BP_Q35_LOAD=0` or `H1BP_Q35_TRY=0` opts out and restores the old path. Items 2/3 of #2139 remain open.

Refs #2139. Integration and verification by @agent-44437c; the fixes and their measurements are @agent-ca60cf's.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Turn the q35 1BP lane on by default

- Implement q35 `forward()`/`lm_head()`; fixes engine SIGSEGV

- Batch 8 top-k expert slots (64 → 8 dispatches/layer)

- Add f16/int8/single-pass Q4NX GEMV kernels

- Greedy sampling reuses `generate()`, skips 248k logits copy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["q35 lane: env-gated (LOAD+TRY)"] -- "q35_lane_enabled() default-on" --> B["opt-out via *_=0"]
  C["forward()/lm_head() q35 branches"] -- "fix null dense weights" --> D["engine chat path no SIGSEGV"]
  E["New kernels: f16/int8/single-pass Q4NX GEMV"] -- "smaller lm_head reads" --> F["int8 lm_head default, f16/q4nx opt-in"]
  G["grid.y = 8 top-k slots (idx8 kernels)"] -- "8 dispatches/layer" --> H["batched MoE expert pass"]
  I["Adapter greedy path (temp <= 0)"] -- "backend_->generate()" --> J["skip 248k-float logits D2H"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_hip_1bp.cpp</strong><dd><code>Default-on q35 lane, forward/lm_head, batched MoE GEMV</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_hip_1bp.cpp

<ul><li>Add <code>q35_lane_enabled()</code> making the Q4NX qwen35 lane default-on <br>(H1BP_Q35_LOAD/TRY=0 opt out) and update the structure/load/decode <br>guards.<br> <li> Add host packing/quantization helpers (<code>h1bp_pack_q4nx</code>, <br><code>h1bp_quant_int8</code>, <code>h1bp_f32_to_f16_bits</code>, <code>h1bp_f32_to_bf16_bits</code>) and new <br>lm_head members (<code>q35_out_f16</code>, <code>q35_out_i8</code>/<code>q35_out_i8s</code>, <code>q35_out_q4nx</code>) <br>selected at load time (int8 default, <code>H1BP_Q35_LMHEAD=f16|q4nx</code> opt-in).<br> <li> Implement the q35 branches of <code>forward()</code> (graph replay or eager <br><code>qwen35_step</code>, hidden copied back) and <code>lm_head()</code> (lane output weights + <br>two-pass argmax), fixing the engine token-path SIGSEGV.<br> <li> Rework GEMV/MoE dispatch: single-pass <code>launch_q4nx</code>, new <br><code>launch_q4nx_idx8</code> (grid.y = 8 slots), batched MoE path with <br><code>h1bp_moe_reduce8_kernel</code>, plus new scratch buffers, zero-state checks <br>and frees.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2183/files#diff-c4812ee96d278d2d2b452760b359c0521f1a016dce68e46c6668555b33eec182">+262/-17</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backend_hip_adapter.cpp</strong><dd><code>Greedy chat path uses backend generate() argmax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/backends/backend_hip_adapter.cpp

<ul><li>In <code>sample_token</code>, route greedy requests (<code>temperature <= 0</code>) through <br><code>backend_->generate(token_id)</code> instead of copying 248k logits and <br>sampling on CPU.<br> <li> Fall back to the existing logits path when <code>generate()</code> fails; <br><code>temperature > 0</code> behavior unchanged (measured 10 → ~40 tok/s on the q35 <br>chat lane).</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2183/files#diff-d449d6ebc94c749ef7bf2f8dd643eb6f9854b86d51b610d8ba7d787d6f036771">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hip_1bp_kernels.hip</strong><dd><code>Add f16/int8/idx8 Q4NX GEMV and batched MoE kernels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hip_1bp_kernels.hip

<ul><li>Add <code>h1bp_f16gemv_kernel</code> (warp-per-row, vectorized <code>uint4</code> loads) and <br><code>h1bp_int8gemv_kernel</code> (per-row scale, float accumulation) for the <br>lm_head.<br> <li> Add slot-batched MoE kernels (<code>h1bp_q4nx_part_idx8_kernel</code>, <br><code>h1bp_tq2nz_sum8_kernel</code>, <code>h1bp_silu_gate_mul8_kernel</code>, <br><code>h1bp_moe_reduce8_kernel</code>) with grid.y indexing the top-k slot and a <br>fixed slot reduction order.<br> <li> Add single-pass Q4NX GEMV (<code>h1bp_q4nx_row_walk</code> device helper, <br><code>h1bp_q4nx_gemv_kernel</code>, <code>h1bp_q4nx_gemv_idx8_kernel</code>) replacing the <br>part+sum dispatch pair.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2183/files#diff-e7c676fbc5592cbbf17f1c7db3df89e539cc6bfef40bfc8014de1d807ac66396">+167/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

