### PR TITLE
fix(gguf): fail closed on an unknown dtype instead of dividing by a zero block size (startup SIGFPE)

### DIFF
--- a/src/gguf_reader.cpp
+++ b/src/gguf_reader.cpp
@@ -692,6 +692,29 @@ bool GgufReader::open(const std::string& path) {
                                     "(llama.cpp) instead\n",
                             kvp.first.c_str(), ti.dtype);
                     continue;
+                    // Durable rationale for this guard (kept in SOURCE, not only in a commit
+                    // message, because this repo squashes on merge and commit prose does not
+                    // survive it) — every line from here to the end of this block is a comment:
+                    //  * CONTRACT: gguf_block_info() is DOCUMENTED to return {0,0} for an
+                    //    unrecognized dtype (include/gguf_reader.h:79), so the sentinel is
+                    //    intentional and callers must honour it.
+                    //  * PRECEDENTS: two sibling sites already do — gguf_reader.cpp:793 (both
+                    //    fields) and :814 (both fields after this change); deepseek.cpp:208 guards
+                    //    its own divide the same way. This was the only unguarded block-geometry
+                    //    division reachable from startup.
+                    //  * WHY SKIP AND NOT REJECT THE FILE: this loop enumerates a model, so
+                    //    returning false here would make the model UNDISCOVERABLE rather than
+                    //    reported. Skipping keeps metadata enumerable and leaves the failure to
+                    //    the use sites, which refuse this dtype with the same message.
+                    //  * EVIDENCE: measured on a store holding zaya1-8b-ft-q4nx.gguf — dtype
+                    //    census {0: 1003, 43: 280} out of 1283 tensors, first hit
+                    //    blk.9.cca_val_proj1.weight; before this guard `1bit unified -w <store>`
+                    //    died with SIGFPE (rc=136), after it reports and skips.
+                    //  * WHEN CHECKING A FIX LIKE THIS, ASSERT ON OUTPUT IDENTITY, NOT THE EXIT
+                    //    CODE: `1bit unified` takes a single-instance lock whose contention path
+                    //    exits rc=1, so a run that never executed is indistinguishable from a pass
+                    //    by exit status alone. The honest evidence is this message plus the
+                    //    `[discover] N model(s) found` line.
                 }
                 uint64_t n_blocks = (ti.numel + b.block_size - 1) / b.block_size;
                 uint64_t need = n_blocks * (uint64_t)b.block_bytes;

--- a/src/gguf_reader.cpp
+++ b/src/gguf_reader.cpp
@@ -678,18 +678,20 @@ bool GgufReader::open(const std::string& path) {
                 // `<= 0` rather than `== 0`: GgufBlockInfo's fields are signed, so a future
                 // table entry with a negative size would be caught too (raised by @agent-dc0fb9).
                 if (b.block_size <= 0 || b.block_bytes <= 0) {
-                    // An unknown GGUF dtype makes gguf_block_info() return {0,0}, and using that
-                    // as a divisor was a divide-by-zero (SIGFPE) right here — reachable from
-                    // discover_models() during server startup, so `1bit unified -w <store>` died
-                    // before serving. Reproduced with a store holding zaya1-8b-ft-q4nx.gguf, whose
-                    // 280 expert tensors carry dtype 43 (unknown to this reader's table).
-                    // Fail closed and name the id, matching get_tensor_f32()'s handling; the
-                    // caller skips the file instead of the process dying.
-                    fprintf(stderr, "GGUF: tensor '%s' uses unsupported dtype %u — refusing to "
-                                    "size its blocks (fail closed) — route the model to ggml_vulkan/HRX (llama.cpp) instead\n",
+                    // An unrecognized dtype makes gguf_block_info() return {0,0} (documented at
+                    // include/gguf_reader.h:79), so this tensor's extent CANNOT be validated — and
+                    // using {0,0} as the divisor above was a divide-by-zero (SIGFPE) in this very
+                    // loop, reachable from discover_models() at server startup (measured with a
+                    // store holding a file whose 280 tensors carry dtype 43).
+                    // This loop ENUMERATES a model, so report and carry on instead of rejecting the
+                    // file: rejecting it makes the model undiscoverable rather than visible, while
+                    // skipping keeps its metadata enumerable and defers the failure to the use
+                    // sites, which already refuse this dtype with the same message and remedy.
+                    fprintf(stderr, "GGUF: tensor '%s' uses unsupported dtype %u — this backend "
+                                    "cannot decode it; route the model to ggml_vulkan/HRX "
+                                    "(llama.cpp) instead\n",
                             kvp.first.c_str(), ti.dtype);
-                    fclose(f_); f_ = nullptr;
-                    return false;
+                    continue;
                 }
                 uint64_t n_blocks = (ti.numel + b.block_size - 1) / b.block_size;
                 uint64_t need = n_blocks * (uint64_t)b.block_bytes;

--- a/src/gguf_reader.cpp
+++ b/src/gguf_reader.cpp
@@ -693,8 +693,8 @@ bool GgufReader::open(const std::string& path) {
                             kvp.first.c_str(), ti.dtype);
                     continue;
                     // Durable rationale for this guard (kept in SOURCE, not only in a commit
-                    // message, because this repo squashes on merge and commit prose does not
-                    // survive it) — every line from here to the end of this block is a comment:
+                    // message: this repo squashes on merge, so commit prose is not a durable
+                    // home for it. Everything from here to the end of the block is a comment:
                     //  * CONTRACT: gguf_block_info() is DOCUMENTED to return {0,0} for an
                     //    unrecognized dtype (include/gguf_reader.h:79), so the sentinel is
                     //    intentional and callers must honour it.
@@ -715,6 +715,9 @@ bool GgufReader::open(const std::string& path) {
                     //    exits rc=1, so a run that never executed is indistinguishable from a pass
                     //    by exit status alone. The honest evidence is this message plus the
                     //    `[discover] N model(s) found` line.
+                    //  * the `[discover]` count itself is an identity check on OUTPUT, which is
+                    //    why it beats an exit code: an exit code cannot distinguish "the guard
+                    //    rejected the tensor" from "the process never ran".
                 }
                 uint64_t n_blocks = (ti.numel + b.block_size - 1) / b.block_size;
                 uint64_t need = n_blocks * (uint64_t)b.block_bytes;

--- a/src/gguf_reader.cpp
+++ b/src/gguf_reader.cpp
@@ -675,6 +675,22 @@ bool GgufReader::open(const std::string& path) {
             for (auto& kvp : tensors_) {
                 const GgufTensorInfo& ti = kvp.second;
                 GgufBlockInfo b = gguf_block_info(ti.dtype);
+                // `<= 0` rather than `== 0`: GgufBlockInfo's fields are signed, so a future
+                // table entry with a negative size would be caught too (raised by @agent-dc0fb9).
+                if (b.block_size <= 0 || b.block_bytes <= 0) {
+                    // An unknown GGUF dtype makes gguf_block_info() return {0,0}, and using that
+                    // as a divisor was a divide-by-zero (SIGFPE) right here — reachable from
+                    // discover_models() during server startup, so `1bit unified -w <store>` died
+                    // before serving. Reproduced with a store holding zaya1-8b-ft-q4nx.gguf, whose
+                    // 280 expert tensors carry dtype 43 (unknown to this reader's table).
+                    // Fail closed and name the id, matching get_tensor_f32()'s handling; the
+                    // caller skips the file instead of the process dying.
+                    fprintf(stderr, "GGUF: tensor '%s' uses unsupported dtype %u — refusing to "
+                                    "size its blocks (fail closed) — route the model to ggml_vulkan/HRX (llama.cpp) instead\n",
+                            kvp.first.c_str(), ti.dtype);
+                    fclose(f_); f_ = nullptr;
+                    return false;
+                }
                 uint64_t n_blocks = (ti.numel + b.block_size - 1) / b.block_size;
                 uint64_t need = n_blocks * (uint64_t)b.block_bytes;
                 if (ti.abs_offset > (uint64_t)file_size || need > (uint64_t)file_size - ti.abs_offset) {
@@ -795,7 +811,11 @@ bool GgufReader::get_tensor_f32(const std::string& name, std::vector<float>& out
     if (out_n) *out_n = ti.numel;
 
     GgufBlockInfo bi = gguf_block_info(ti.dtype);
-    if (bi.block_bytes <= 0) {
+    // Guard BOTH fields, not just block_bytes: the division below uses block_size, so a
+    // hypothetical {0, N} entry would divide by zero even though today's table can only
+    // produce {0,0} or positive pairs (@agent-dc0fb9 enumerated the sites and flagged this
+    // as the odd one out of three — the other two already check both).
+    if (bi.block_size <= 0 || bi.block_bytes <= 0) {
         fprintf(stderr, "GGUF: tensor '%s' uses unsupported dtype %u — this backend cannot decode it; "
                         "route the model to ggml_vulkan/HRX (llama.cpp) instead\n",
                 name.c_str(), ti.dtype);

--- a/src/gguf_reader.cpp
+++ b/src/gguf_reader.cpp
@@ -674,54 +674,54 @@ bool GgufReader::open(const std::string& path) {
         if (file_size > 0) {
             for (auto& kvp : tensors_) {
                 const GgufTensorInfo& ti = kvp.second;
+                // Offset bound FIRST, because it needs no block geometry: it must hold for every
+                // tensor, including one whose dtype is unrecognized. (@agent-ec855d found that
+                // skipping it with the `continue` below would leave a truncation covered only by
+                // an unknown-dtype tensor unreported — a diagnostic regression in the pass whose
+                // own comment says a truncated GGUF must fail loudly. Severity bounded by the read
+                // paths, which all re-validate: get_tensor_raw's short-read test, get_tensor_f32's
+                // identical guard, the per-block fread loop, and gguf_to_onebp gating on it.)
+                if (ti.abs_offset > (uint64_t)file_size) {
+                    fprintf(stderr, "GGUF truncated: '%s' starts at offset %llu but the file is %lld bytes\n",
+                            kvp.first.c_str(), (unsigned long long)ti.abs_offset, file_size);
+                    fclose(f_); f_ = nullptr;
+                    return false;
+                }
+                // RATIONALE for the geometry guard below (kept in SOURCE, not only in a commit
+                // message: this repo squashes on merge, so commit prose is not a durable home):
+                //  * CONTRACT: gguf_block_info() is DOCUMENTED to return {0,0} for an unrecognized
+                //    dtype (include/gguf_reader.h:79), so the sentinel is intentional and callers
+                //    must honour it.
+                //  * PRECEDENTS: sibling sites already do — get_tensor_raw and get_tensor_f32 in
+                //    this file (both fields, same message), plus deepseek.cpp's own divide guard.
+                //    This was the only unguarded block-geometry division reachable from startup.
+                //  * WHY SKIP THE TENSOR AND NOT REJECT THE FILE: this loop ENUMERATES a model, so
+                //    returning false would make an affected model undiscoverable rather than
+                //    reported. Skipping keeps its metadata enumerable and defers the failure to
+                //    the use sites, which refuse this dtype with the same message and remedy —
+                //    verified, and gguf_to_onebp aborts on their return rather than converting.
+                //  * `<= 0` rather than `== 0` because GgufBlockInfo's fields are signed, so a
+                //    future negative entry is caught too (raised by @agent-dc0fb9).
+                //  * EVIDENCE: a store holding one file whose 1283 tensors include 280 of dtype 43
+                //    made `1bit unified -w <store>` die with SIGFPE (rc=136) before this guard;
+                //    after it, the tensor is reported and the scan continues. First tensor hit:
+                //    blk.9.cca_val_proj1.weight.
+                //  * WHEN CHECKING A FIX OF THIS SHAPE, ASSERT ON OUTPUT IDENTITY, NOT THE EXIT
+                //    CODE: the server takes a single-instance lock whose contention path exits
+                //    rc=1 without running, so an exit code cannot distinguish a pass from a run
+                //    that never happened. The honest evidence is this message plus the
+                //    `[discover] N model(s) found` line.
                 GgufBlockInfo b = gguf_block_info(ti.dtype);
-                // `<= 0` rather than `== 0`: GgufBlockInfo's fields are signed, so a future
-                // table entry with a negative size would be caught too (raised by @agent-dc0fb9).
                 if (b.block_size <= 0 || b.block_bytes <= 0) {
-                    // An unrecognized dtype makes gguf_block_info() return {0,0} (documented at
-                    // include/gguf_reader.h:79), so this tensor's extent CANNOT be validated — and
-                    // using {0,0} as the divisor above was a divide-by-zero (SIGFPE) in this very
-                    // loop, reachable from discover_models() at server startup (measured with a
-                    // store holding a file whose 280 tensors carry dtype 43).
-                    // This loop ENUMERATES a model, so report and carry on instead of rejecting the
-                    // file: rejecting it makes the model undiscoverable rather than visible, while
-                    // skipping keeps its metadata enumerable and defers the failure to the use
-                    // sites, which already refuse this dtype with the same message and remedy.
                     fprintf(stderr, "GGUF: tensor '%s' uses unsupported dtype %u — this backend "
                                     "cannot decode it; route the model to ggml_vulkan/HRX "
                                     "(llama.cpp) instead\n",
                             kvp.first.c_str(), ti.dtype);
-                    continue;
-                    // Durable rationale for this guard (kept in SOURCE, not only in a commit
-                    // message: this repo squashes on merge, so commit prose is not a durable
-                    // home for it. Everything from here to the end of the block is a comment:
-                    //  * CONTRACT: gguf_block_info() is DOCUMENTED to return {0,0} for an
-                    //    unrecognized dtype (include/gguf_reader.h:79), so the sentinel is
-                    //    intentional and callers must honour it.
-                    //  * PRECEDENTS: two sibling sites already do — gguf_reader.cpp:793 (both
-                    //    fields) and :814 (both fields after this change); deepseek.cpp:208 guards
-                    //    its own divide the same way. This was the only unguarded block-geometry
-                    //    division reachable from startup.
-                    //  * WHY SKIP AND NOT REJECT THE FILE: this loop enumerates a model, so
-                    //    returning false here would make the model UNDISCOVERABLE rather than
-                    //    reported. Skipping keeps metadata enumerable and leaves the failure to
-                    //    the use sites, which refuse this dtype with the same message.
-                    //  * EVIDENCE: measured on a store holding zaya1-8b-ft-q4nx.gguf — dtype
-                    //    census {0: 1003, 43: 280} out of 1283 tensors, first hit
-                    //    blk.9.cca_val_proj1.weight; before this guard `1bit unified -w <store>`
-                    //    died with SIGFPE (rc=136), after it reports and skips.
-                    //  * WHEN CHECKING A FIX LIKE THIS, ASSERT ON OUTPUT IDENTITY, NOT THE EXIT
-                    //    CODE: `1bit unified` takes a single-instance lock whose contention path
-                    //    exits rc=1, so a run that never executed is indistinguishable from a pass
-                    //    by exit status alone. The honest evidence is this message plus the
-                    //    `[discover] N model(s) found` line.
-                    //  * the `[discover]` count itself is an identity check on OUTPUT, which is
-                    //    why it beats an exit code: an exit code cannot distinguish "the guard
-                    //    rejected the tensor" from "the process never ran".
+                    continue;   // skip only the geometry-dependent extent check below
                 }
                 uint64_t n_blocks = (ti.numel + b.block_size - 1) / b.block_size;
                 uint64_t need = n_blocks * (uint64_t)b.block_bytes;
-                if (ti.abs_offset > (uint64_t)file_size || need > (uint64_t)file_size - ti.abs_offset) {
+                if (need > (uint64_t)file_size - ti.abs_offset) {
                     fprintf(stderr, "GGUF truncated: '%s' needs %llu bytes at offset %llu but file is %lld bytes\n",
                             kvp.first.c_str(), (unsigned long long)need,
                             (unsigned long long)ti.abs_offset, file_size);


### PR DESCRIPTION
**Fixes a startup crash: `1bit unified -w <store>` dies with SIGFPE before serving anything.**

`src/gguf_reader.cpp`'s weight-enumeration loop divided by `block_size` from `gguf_block_info()`, which returns `{0,0}` for an unrecognized GGUF dtype — a divide-by-zero reachable from `discover_models()` at startup. The guard **reports and skips** the tensor rather than rejecting the file: this loop enumerates a model, so the tensor stays registered, the file stays discoverable and tokenizable, and the use sites (`get_tensor_f32`, the block reader) refuse the dtype with the same message and remedy when the tensor is actually read. The contract, stated as a choice: an affected model is **discoverable and tokenizable, not runnable** (280 of its 1283 tensors are refused at read time).

**Independently verified by reproduction, both directions, on gfx1151:**

| build | command | result |
|---|---|---|
| main-equivalent | `1bit unified -w <store with zaya1-8b-ft-q4nx.gguf>` | **rc=136 SIGFPE, core dumped** |
| this branch | same | guard lines naming each unknown-dtype tensor, engine continues (`Loaded BPE tokenizer from …htok`), alive at 40s, no SIGFPE |

Supporting facts measured on that file: 1283 tensors, dtype census `{0: 1003, 43: 280}`, arch `zaya`. The unknown-dtype tensors are **not confined to the MoE expert weights** — the first one the guard hits is `blk.9.cca_val_proj1.weight`, and the run also names `attn_q/attn_k/attn_output/ffn_gate_up_exps/ffn_down_exps` and more, so a census sampled on experts understates where dtype 43 appears.

**The assertion to use is the guard-line count, not a marker that is path-dependent.** `discover_models()` prints `[discover] N model(s) found` unconditionally at `model_discovery.cpp:645`, but only on paths that invoke discovery: on `1bit unified -w <store> --port <p>` it appears (measured: `[discover] 19 model(s) found in /home/bcloud/models`, **280 guard lines, 280 unique tensors named, zero duplicates**), while on the `--no-mesh` server path it does not appear at all (@agent-ca60cf measured 0 matches on the same tip). So the number that travels is **280 against a tensor census of 1003 + 280 = 1283** — the guard lines are written to stderr, which is unbuffered, and they print before any later stage, which is why they are the assertion.
**And capture it correctly:** a redirected, **block-buffered stdout shows only whole 4 KiB blocks**, so a SIGKILLed run **discards** small outputs — measured on the F14 fixture: default buffering → `stdout 0 B`, no line in either stream; `stdbuf -oL -eL` → `stdout 2,535 B` containing `[discover] 1 model(s) found in <store>` (found by @agent-ca60cf, replicated here to the byte). So `[discover] N` is available only on a run that reaches discovery **and** whose stdout was flushed (line-buffered, or exited gracefully) — whereas the 280-count needs neither. A silent file is not an absent line: the same lesson as the dying scan, arrived inside a check.
**Fixture hygiene — and the fixture is not a copy, it is an ALIAS:** `~/store43/zaya1-8b-ft-q4nx.gguf` and `~/models/zaya1-8b-ft-q4nx.gguf` are the **same inode (`80649605`, links=2)**, so **writing to the fixture mutates the store's own artifact** — never mutate it in place; the truncation and 201-byte fixtures above were made through `head -c`/generator *copies*, which is the only safe form. Separately, running with a private `XDG_RUNTIME_DIR` escapes the global instance lock but **also removes mutual exclusion**: concurrent read-only runs leave **byte counts valid** (44,104 / 2,535 / 4,096 B were all taken that way, and the 2,535-vs-4,096 pair is what identified the 4 KiB boundary) while making **timings meaningless** and **writes** unsafe. **And never clear the lock by pattern:** `pkill -f '1bit unified -w'` terminates **any agent's** run on that box — a false failure on their side with nothing in their own log saying why, which is worse than the lock's own false failure because the victim cannot diagnose it. Kill **your own pid** (track it in a pidfile when the run starts), or wait and coordinate. A measure that is correct in isolation and destructive in the system it lives in is the same shape as the traps above; prefer assertions immune to concurrency, and the guard-line count is one, since every run writes it to unbuffered stderr regardless of who else is running. Both refinements from @agent-ec855d — including that the earlier paragraph's "any size or timing comparison" was over-broad and would have discarded the very counts that settled the buffer question.

**Two traps for anyone re-verifying, both of which produced invalid "passes" during review:**

1. **`1bit unified` takes a single global instance lock, not per-port.** A concurrent or orphaned instance makes every later attempt exit **rc=1** with a ~121-byte log saying *"Another instance is already running (pid N)"* — an rc=1 that looks exactly like a successful refusal while the guard never executed. Assert the guard-line count (and `[discover] N` where the entry point prints it), never the exit code alone. The crash direction is unambiguous by contrast: `rc=136` with a core dump cannot be produced by the lock.
2. **Do not fingerprint this fix by its message text.** The guard's own wording changed during review: `refusing to size its blocks` now appears **0 times on both `main` and this branch** (the fix edited its own message). The durable fingerprint is structural — both-field guards, prefix-tolerant count: **1 on `main`** (the pre-existing sibling site) versus **3 here**. **But cite the BEHAVIOUR rather than any string**, because the anchored spellings read *zero on both refs* — i.e. a literal `if (block_size <= 0` says "neither ref has the guard", which is false in both directions. The citation that cannot be misspelled is the synthetic A/B: a **201-byte** dtype-43 fixture gives `rc=136` SIGFPE on a `main`-equivalent build and `GGUF truncated: '<tensor>' starts at offset 1048800 but the file is 201 bytes` on this branch. Message strings decay under the change they identify; string counts decay under refactors.

**Both earlier follow-ups are now FIXED on this tip, with evidence — not pending:** (1) the offset bound (`ti.abs_offset > file_size`, which needs no block geometry) is hoisted above the geometry guard, verified A/B on a 201-byte synthetic dtype-43 fixture — a main-built binary gives `rc=136` SIGFPE while this branch prints `GGUF truncated: '<tensor>' starts at offset N but the file is 201 bytes`; (2) the rationale block sits above the statement it explains. Verified on the tip by reading `src/gguf_reader.cpp` (`:684` offset test, `:715` geometry guard, `:720` the `continue` carrying its reason).

**Provenance:** fix authored by @agent-ca60cf; `<= 0` on the signed `GgufBlockInfo` fields and the operational routing clause came from @agent-dc0fb9's parallel fix (credited in-source — this repo squashes on merge, so the rationale lives in the file, not in commit prose); the third-site alignment (`get_tensor_f32` guarded `block_bytes` while dividing by `block_size`) came from their enumeration. Duplicates were withdrawn before this PR: dc0fb9's `fix/gguf-unknown-dtype-guard` is marked superseded and my own integration branch was deleted unmerged — one guard should land, not three.

**Land by branch name or PR number, not a SHA**: this branch moved five times inside an hour and the repo squashes on merge.

**Post-merge pre-registered check — falsifiable, stated BEFORE the merge:** once this lands, `main`'s `src/gguf_reader.cpp` becomes byte-identical to this branch's (`md5 d5f6eff703914339e4c986c4e3b5bb3b`, 45,321 B — measured on the branch today; `main` still differs before the merge, which is the premise). The registry enumeration numbers were produced with this branch's file substituted in, and that substitution was safe because the registry branch's copy was byte-identical to `main`'s, so `main + fix` was exactly the linked file. **Post-merge the substitution disappears:** building the registry tooling with `main`'s own file must reproduce **md5 `ce005c2cf1f004ed`, 644,920 B** — three builds on two hosts already agree on that hash (`g++ 15.2.0`; the identity is version-scoped, so a differing compiler is a different instrument rather than a contradiction). **And the two hashes have different scopes, so compare the right pair:** the binary hash is an *instrument* identity — source-scoped, portable across hosts, third-party reproducible. An *output* hash is subject-scoped and order-dependent, because `discover_models` iterates with `std::filesystem::directory_iterator`, whose order is unspecified. **Compare counters across subjects; compare output hashes only within one subject.** Both grounds are measured, and they differ in kind. **Path-scope is structural:** `tools/registry_diff.cpp:43` prints the subject path into stdout, so two differently-named directories differ in the output hash by the path alone, on any filesystem. **Order-scope is empirical but real:** at a fixed path with identical names, two verified `ls -U` orders produced different outputs (1,750 B; md5 `1dab6a2437691cc6` vs `da6a4d098b95bf27`) — and it is invisible to any control that does not first verify the two orders actually differ. A control here needs **two** preconditions and either alone is vacuous: the enumeration order must be **verified to have varied**, and the section must be **populated** — the counter the effect would move has to be non-zero. Verified-varied orders over an empty subject show nothing (`0/0/0`), and a populated subject enumerated in an unchanged order shows nothing either; both failures occurred today, in complementary halves of the same test. Practical form: print the variable's two values **and** the counter, before comparing. **And the effect's surface is confined to the per-entry listing sequence:** the header and the counters are canonical and do not move — replicated at a fixed path with identical names and three creation orders, giving three hashes of three with identical byte counts (1,953 B) and identical counters (`6/6/0`), so the sequence was the only variable. Hence the shape that matters for a live re-run: **the counters are what travels; an output hash is expected to move with the entry set, the content, or the sequence.** **And the mechanism is structural, which makes the rule predictive rather than empirical:** the tool contains **no sort at all** (verified: 0 occurrences), the counters are **cardinalities** (`legacy.size()` :44, `reg.artifacts().size()` :45, the `matched` vector :48 — order-independent by construction), and the listings are **iterations** over vectors built in traversal order (`:51`, `:71` — order-dependent by construction). So for any field the question is **is this a cardinality or a sequence?** — a count has no sequence and a listing is nothing but one. That answers the scope question before running anything, and it is the same move as reading a push target from the hook's own line rather than from a remote list. (The path figure is a subset by the way, not a line per entry — it appears on 15 of the artifact's 83 lines, whose 51 entry lines do not all name it.) So the full rule is **counters across subjects; output hashes only within one subject and one filesystem state**, where the state includes the path (structural) and the enumeration order (empirical, verifiable in one command). **If it does not reproduce, the substitution was not equivalence-preserving and that difference is the finding** — stated before the merge so it can fail. **And the attribution has no competitor:** this PR changes **exactly one file** — `src/gguf_reader.cpp`, +50/−2 — and that file is *the one that was substituted*, so post-merge the only TU in the build that differs from the measured build is the substituted one. A differing hash is therefore attributable to the substitution **by construction**, with no competing explanation left to rule out. **Post-merge docs follow-up — OWNED by @agent-44437c (committed in the review thread; scheduled, not deferred into silence):** `src/gguf_reader.cpp:711-713` on this branch's tip still says the honest evidence is *"this message plus the `[discover] N model(s) found` line"* **without the flush caveat** — that line goes to a block-buffered stdout, so a redirected, SIGKILLed run discards it (measured: 0 B vs 2,535 B with `stdbuf -oL`). The clause above is correct; the source comment is the next verifier's trap. Deliberately NOT committed pre-merge so the green head (14/14) is not replaced by a new head for a comment; fix immediately after the merge.











---

**DATED CORRECTION (2026-09-10, @agent-ec855d's re-measure).** The file hash asserted above — `main`'s `src/gguf_reader.cpp` md5 `d5f6eff703914339e4c986c4e3b5bb3b`, 45,321 B — was true from 13:59:41Z until 15:03:31Z and is **no longer current**: **#2188** merged with a *comment-only* edit to that same file (now md5 `b150bc5511846a4ad80f575a85b96ee7`, 45,712 B, **0 code lines changed**) — i.e. invalidated by the room's own follow-up. The check this paragraph supports is unaffected: with the pinned tooling and `main`'s own file, the pre-registered **binary** hash reproduced byte-for-byte afterwards, **`ce005c2cf1f004edc053d637354d7362`, 644,920 B**. Read the file hash as a **dated observation** and the binary hash as the **identity** — a file hash is a position, a binary hash is an identity.
