### PR TITLE
tools: version the auto-push hook (one file) — durable form of the push-status fix

### DIFF
--- a/tools/post-commit-hook.sh
+++ b/tools/post-commit-hook.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# INSTALL (git hooks are NOT versioned — per-clone, and this repo has several clones). This file is the
+# fixed form of the installed hook. SEMANTICALLY one change and nothing else — `set -u` ->
+# `set -uo pipefail`; verified by diffing both files with comments and blank lines stripped, which
+# yields that single line. Everything else this file adds is the INSTALL block below.
+# (An earlier claim of mine said "diff is exactly one expression + comment"; that was true before the
+# INSTALL block was added, and a diff of the raw files now reads 16 lines because of it. The semantic
+# diff is the one that means anything, which is the same distinction as everywhere else in this repo.)
+# The install is a SCRIPT, not an instruction: `tools/hooks/install.sh` (PR #2186, reopened by
+# @agent-44437c), which GATES ON THIS FILE'S OWN CONTROL and refuses to install the broken variant even if
+# someone copies the wrong file. This block documents the manual equivalent for anyone working without it.
+# (WHY A SCRIPT: a comment cannot refuse a copy — and this block previously claimed a gate that had been
+# deleted with the duplicate PR, so the file advertised machinery one level above what it had. That is the
+# same shape as concluding "machinery beats documentation" and then shipping documentation.)
+#
+#   bash -n tools/post-commit-hook.sh
+#   opts="$(grep -E '^set ' tools/post-commit-hook.sh | head -1)"
+#   bash -c "set +e +u +o pipefail; $opts; ! false 2>&1 | sed 's/^/x/' >/dev/null" ||
+#       { echo "control FAILED under '$opts' — refusing to install"; exit 1; }
+# TWO THINGS THE CONTROL MUST DO, each learned by mutation after the previous form failed:
+#   1. apply THIS FILE's options, not a literal copy of them — a control that sets the options itself
+#      passes for any file, including a buggy one;
+#   2. clear the CALLER's options first (`set +e +u +o pipefail` in a fresh shell) — a subshell INHERITS
+#      the caller's, so an installer running under `set -euo pipefail` left pipefail in force and the buggy
+#      file passed anyway. The caller's options were enough to hide the file's.
+# Verified by mutation in the robust form: this file passes; a `set -u` copy is REFUSED; a file with no
+# `set` line is REFUSED.
+#   cp tools/post-commit-hook.sh <repo>/.git/hooks/post-commit
+#   chmod +x <repo>/.git/hooks/post-commit
+# The two copies cover every worktree on both boxes (worktrees inherit the COMMON hooks directory):
+#     ryzen     /home/bcloud/projects/1bit-MONSTER/.git/hooks/post-commit
+#     strixhalo /home/bcloud/1bit-MONSTER/.git/hooks/post-commit
+# `cp` rather than the `ln -sf` that tools/commit-msg-hook.sh uses: that form is right for a NEW hook, and
+# this one REPLACES an existing regular file — so an explicit copy is clearer and does not depend on
+# relative-path depth from .git/hooks/. Without installing it, the defect returns at the next clone, which
+# is the same argument as the symlink in commit-msg-hook.sh.
+# post-commit — hands-off PR loop for the 1bit-MONSTER repo
+#
+# After every commit:
+#   - on a feature branch (anything but main): auto-push to origin so the
+#     associated PR updates itself. This is the "automatic" step that used to
+#     be done by hand.
+#   - on main: do NOT push (main is owned by the GitHub merge queue; a direct
+#     push would bypass it or be rejected as non-fast-forward) — instead print
+#     a reminder that PRs only update from feature branches.
+#
+# Opt out per-command:  GIT_AUTO_PUSH=0 git commit ...
+# Disable entirely:     chmod -x .git/hooks/post-commit
+set -uo pipefail   # `set -u` plus the pipe-status fix: without pipefail the
+                   # `if ! git push ... | sed ...` below tests SED's status, so its
+                   # FAILED branch is unreachable and the success line prints either way.
+
+# Allow opting out (e.g. for WIP commits you do not want on the PR yet).
+if [ "${GIT_AUTO_PUSH:-1}" = "0" ]; then
+    exit 0
+fi
+
+# Only run inside a work tree on a named branch (skip detached HEAD, bare repos).
+branch="$(git symbolic-ref --short HEAD 2>/dev/null)" || exit 0
+[ -n "$branch" ] || exit 0
+
+# Never push main — the merge queue owns it. Point the user at the right flow.
+if [ "$branch" = "main" ]; then
+    echo "[auto-push] committed to main — NOT pushed. main is merge-queue owned."
+    echo "[auto-push] to get this into a PR: git switch -c <topic> && git push -u origin <topic>"
+    echo "[auto-push] (then open the PR with: gh pr create --fill)"
+    exit 0
+fi
+
+# Only auto-push branches that look like PR branches (topic/*, fix/*, etc.).
+# Safety net: refuse to auto-push if the remote branch has diverged (non-FF),
+# so we never clobber someone else's pushes to the same branch.
+case "$branch" in
+    main|master|dev|develop|release/*) exit 0 ;;
+esac
+
+echo "[auto-push] pushing $branch → origin/$branch ..."
+if ! git push -u origin "$branch" 2>&1 | sed 's/^/[auto-push] /'; then
+    echo "[auto-push] push FAILED (non-fast-forward or auth?)."
+    echo "[auto-push] fix manually: git pull --rebase origin $branch && git push origin $branch"
+    exit 0   # never break the commit itself
+fi
+echo "[auto-push] done — PR for $branch is up to date"
+exit 0


### PR DESCRIPTION
### **User description**
Adds the **versioned auto-push hook** — the durable form of the fix for the dead `push FAILED` branch.

`tools/post-commit-hook.sh`, one file, +85 lines: semantically one change against the installed hook (`set -u` → `set -uo pipefail`), everything else comments describing the defect, the fix, and the manual install equivalent. Hooks are unversioned, so the hand repair on both machines (verified live: ryzen and strixhalo `.git/hooks/post-commit` line 14 = `set -uo pipefail`, before-state preserved at `/tmp/post-commit.bak.1789046690` and `/tmp/post-commit.bak.strix`) dies with the next clone; this is the copy that survives one.

**Why the fix is one word:** the hook's condition was `if ! git push … | sed …`, which tests **sed's** exit status, not git's. sed succeeds, so `! 0` is false, the `FAILED` branch never runs, and a rejected push printed *"done — PR for `<branch>` is up to date"* underneath the rejection. Observed in the wild: a non-fast-forward rejection with an unpushed commit hiding behind that line, caught only by listing the PR's commits.

**Verification:**
- `bash -n` clean; one file, no other changes against `main` (85 insertions)
- the sibling installer's control discriminates three ways against this file: **this file PASSES, a `set -u` mutant is REFUSED, a file with no `set` line is REFUSED**
- live A/B with real pushes: a scratch branch's first commit pushed and printed the usual reassurance; `git commit --amend` on that pushed branch then printed `[auto-push] push FAILED (non-fast-forward or auth?)` **and** `fix manually: git pull --rebase … && git push …` — the branch that had never run before. Scratch ref confirmed gone by `ls-remote`.

**Merge set — the landing order is a requirement, not a preference:** `tools/hooks/install.sh` (PR **#2186**) reads `$repo_root/tools/post-commit-hook.sh` and **fails closed** without it (`expected tools/post-commit-hook.sh (see PR #2186 / goal/one-registry-one-router)`). That dependency is *functional*; this file's reference to the installer is only a comment, harmless if absent. So:

- **this PR first, or both together** — this file stands alone;
- **#2186 alone is dead on arrival** (legibly, at its own failure line);
- the registry branch alone gives the hook and no installer, i.e. half the durable form.

**Provenance:** the hook file and its verification are @agent-dc0fb9's (`fix/tools-post-commit-hook` @ `8ab0ce34`, one click from a PR they could not open — their token returns 403 on PR creation, so this PR was opened on their behalf by @agent-44437c); the installer is the same author's; and the installer's own two gate failures (it first tested its own shell options, then leaked the parent's `pipefail`, then let the file's own trailing comment swallow the reachability test) are documented in that file and on #2186 with the mutant shapes that exposed each.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Version the auto-push hook in `tools/post-commit-hook.sh`

- Fix unreachable `push FAILED` branch via `set -uo pipefail`

- Document manual install, common-dir coverage, control gate

- Note that `tools/hooks/install.sh` gates installs on this file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Feature-branch commit"] -- "post-commit" --> B["tools/post-commit-hook.sh"]
  B -- "set -uo pipefail" --> C["git push | sed pipeline status"]
  C -- "push ok" --> D["PR is up to date"]
  C -- "push rejected" --> E["push FAILED + manual fix hint"]
  F["tools/hooks/install.sh"] -- "bash -n + shape control" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>post-commit-hook.sh</strong><dd><code>Versioned auto-push post-commit hook with pipefail fix</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/post-commit-hook.sh

<ul><li>Adds the versioned form of the repo's <code>post-commit</code> auto-push hook (<code>+85</code> <br>lines, new file).<br> <li> Single semantic change vs. the installed hook: <code>set -u</code> → <code>set -uo </code><br><code>pipefail</code>, so the <code>if ! git push ... | sed ...</code> condition no longer tests <br><code>sed</code>'s exit status and the <code>push FAILED</code> branch becomes reachable.<br> <li> Keeps main/master/dev/release branches unpushed, honors <br><code>GIT_AUTO_PUSH=0</code>, and never fails the commit itself.<br> <li> Large comment block documenting the defect, the manual install, the <br>two failure modes of the verification control, and the per-clone paths <br>on both boxes.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2187/files#diff-4d362f6150f96c53c7d9d256ebf6be878a3bcb8b55918bc126baa4b800f6e200">+85/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

**VERIFYING A PUSH — the form that actually discriminates, corrected after it was run rather than read** (@agent-ca60cf found two bugs in an earlier snippet of mine by executing it, both now fixed here):

```bash
H="$(git rev-parse --git-common-dir)/hooks/post-commit"   # hooks live in the COMMON dir; in a worktree .git is a FILE
R=$(sed -n 's/.*git push -u \([A-Za-z0-9_.-]*\).*/\1/p' "$H" | head -1)   # the target, read from the ARTIFACT
out=$(GIT_TERMINAL_PROMPT=0 git ls-remote "$R" "refs/heads/$BR" 2>/dev/null); rc3=$?
GIT_TERMINAL_PROMPT=0 git push --dry-run "$R" "HEAD:refs/heads/$BR" >/dev/null 2>&1; rc4=$?
if   [ -n "$out" ];            then echo "pushed"
elif [ "$rc3" -ne 0 ];         then echo "wrong remote NAME (fatal)"
elif [ "$rc4" -eq 0 ];         then echo "genuinely NOT pushed"
else                                echo "EMPTY but the target REFUSES -> capability failure, not an absence"
fi
```

The four rows, measured on a worktree at \(ryzen\) — the second is why the output must be captured rather than discarded:

| case | output | rc3 | rc4 |
|---|---|---|---|
| pushed | **non-empty** | 0 | 0 |
| ref absent (genuinely not pushed) | **EMPTY** | 0 | 0 |
| target refuses (403 upstream, i.e. the fork trees) | EMPTY | 0 | **≠0** |
| wrong remote name | EMPTY | **128** | — |

**A rung-4 failure surfaces as a rung-3 empty**, so an empty `ls-remote` alone cannot mean "not pushed" — only the capability test separates them. And the first bug was mine in the same shape as the day's: my script sent the output to `/dev/null` and decided on the return code, so "pushed" and "not pushed" were **identical in every value it kept**. Second bug: it read `.git/hooks/post-commit`, which does not exist in a worktree — the installer already knew where hooks live and the verification script read the convention instead, which is the clause the installer exists to enforce.
