### PR TITLE
docs(gguf): assert the guard-line count; [discover] needs a flushed run

### DIFF
--- a/src/gguf_reader.cpp
+++ b/src/gguf_reader.cpp
@@ -709,8 +709,12 @@ bool GgufReader::open(const std::string& path) {
                 //  * WHEN CHECKING A FIX OF THIS SHAPE, ASSERT ON OUTPUT IDENTITY, NOT THE EXIT
                 //    CODE: the server takes a single-instance lock whose contention path exits
                 //    rc=1 without running, so an exit code cannot distinguish a pass from a run
-                //    that never happened. The honest evidence is this message plus the
-                //    `[discover] N model(s) found` line.
+                //    that never happened. Assert on the guard-line COUNT on stderr instead —
+                //    280 lines for the store above, one per dtype-43 tensor: it is unbuffered, so
+                //    it is immune both to the lock and to who else is running. And read the
+                //    `[discover] N model(s) found` line only on a FLUSHED run, because a
+                //    redirected stdout is block-buffered: a SIGKILLed run can show 4096 B of
+                //    completed blocks with that line discarded.
                 GgufBlockInfo b = gguf_block_info(ti.dtype);
                 if (b.block_size <= 0 || b.block_bytes <= 0) {
                     fprintf(stderr, "GGUF: tensor '%s' uses unsupported dtype %u — this backend "


### PR DESCRIPTION
### **User description**
**Comment-only follow-up, committed to in #2185's review thread and recorded in its body as "OWNED by @agent-44437c" — **as of 2026-09-10T15:02Z: that agent's session ended at 14:42Z and it is no longer present on the mesh (`mesh_status`: 5 peers, no @agent-44437c), so this follow-up is ADOPTED by @agent-ca60cf; the change itself is unchanged; **content CHECKED before adopting: the diff replaces the `[discover]` line's claim with the guard-line COUNT on stderr, and carries the 4,096 B completed-block detail for a redirected stdout** — an adoption that records only ADOPTED is a report, one that records what was read is a check**.** Six insertions, two deletions, in `src/gguf_reader.cpp` — no code moved, no behaviour change, the guard and its message are untouched.

**Why the sentence needed changing.** The comment told a future reader that the honest evidence for a fix of this shape is *"this message plus the `[discover] N model(s) found` line"*. Two problems, both measured:

- **A guard-line COUNT is the assertion, because it can fail informatively.** The store in the comment emits **280** lines on stderr, one per dtype-43 tensor. stderr is unbuffered, so the count is immune both to the single-instance lock (whose contention path exits `rc=1` without running) and to another agent running concurrently on the same box.
- **The `[discover]` line is evidence only on a FLUSHED run.** A redirected stdout is block-buffered: a run killed by SIGKILL printed **4,096 B** — one completed block — with the line discarded, and re-running the same command under `stdbuf -oL` printed **2,535 B** including `[discover] 1 model(s) found in /home/bcloud/store43`. So a non-zero stdout is not evidence of completeness either; it is the output in completed 4 KiB blocks.

The replacement text says both things and keeps the original warning about the single-instance lock, which is still correct.

**Scope:** one file, comments only. The fix this documents landed as #2185 (`8bd03af61`), and its pre-registered post-merge hash check passed on `main`: a no-substitution build of the registry tooling reproduces `644,920 B / ce005c2cf1f004edc053d637354d7362`, and the live re-measure is byte-identical to the pre-merge run (`19/19/13`, stdout md5 `09b75781813aef21cfd1934292e1ad7e`).


___

### **PR Type**
Documentation


___

### **Description**
- Comment-only update in `src/gguf_reader.cpp`, no behaviour change

- Replace exit-code assertion advice with guard-line COUNT on stderr

- Note `[discover] N` is evidence only on a flushed run

- Warn that redirected stdout is block-buffered (4096 B of completed blocks)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["src/gguf_reader.cpp comment block"] -- "replaces advice" --> B["Assert guard-line COUNT on stderr<br/>(280 lines, one per dtype-43 tensor)"]
  A -- "adds caveat" --> C["[discover] N model(s) found<br/>only valid on a FLUSHED run"]
  C -- "because" --> D["Redirected stdout is block-buffered:<br/>SIGKILLed run shows 4096 B, line discarded"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gguf_reader.cpp</strong><dd><code>Comment-only clarity fix for dtype-guard verification evidence</code></dd></summary>
<hr>

src/gguf_reader.cpp

<ul><li>Rewrites the EVIDENCE/verification comment above the <code>gguf_block_info</code> <br>dtype guard in <code>GgufReader::open</code> (six insertions, two deletions).<br> <li> Drops the claim that "this message plus the <code>[discover] N model(s) </code><br><code>found</code> line" is the honest evidence for a fix of this shape.<br> <li> Directs the reader to assert on the guard-line COUNT on stderr (280 <br>lines for the cited store, one per dtype-43 tensor) since stderr is <br>unbuffered and immune to the single-instance lock.<br> <li> Adds that <code>[discover] N</code> should only be trusted on a flushed run, <br>because redirected stdout is block-buffered and a SIGKILLed run can <br>show 4096 B of completed blocks with that line discarded.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2188/files#diff-472fa7a111b054f3abe9c1430eb5d7d00bf8361c210434125e48f7fa1f0b1773">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___




