### PR TITLE
fix(manager): discover() no longer claims a backend it has not selected (+ audit tools, two comment corrections)

### DIFF
--- a/src/backend_manager.cpp
+++ b/src/backend_manager.cpp
@@ -1158,10 +1158,23 @@ bool BackendManager::failover() {
         backends_[active_idx_].functional = false;
     }
 
-    // Cascade in model-route order (then registration order): a decode failure
-    // lands on the intended next lane (GGUF: hrx_gpu → ggml_vulkan → zinc_gpu
-    // → cpu_generic), never on a backend discovery happened to register next
-    // (e.g. an NPU lane that would load the wrong model for a GGUF — G1a).
+    // Cascade: model-route order FIRST (the declared preference for this model's
+    // format/arch), then every remaining discovered backend in registration order as
+    // a last resort — fallback_order() covers all of backends_ exactly once.
+    //
+    // CORRECTED 2026-09-11. This text used to end "...never on a backend discovery
+    // happened to register next (e.g. an NPU lane that would load the wrong model for a
+    // GGUF — G1a)". The tail below CAN reach exactly such a lane, so that guarantee is
+    // not the router's to make. What actually stops a wrong-CONTAINER failover is each
+    // executor's own init gate, and both NPU lanes say so themselves:
+    //   backend_npu.cpp:349     "The worker engine only speaks Q4NX ... [reject] other
+    //                            formats up front so the router never selects it for
+    //                            them"
+    //   backend_npu_flm.cpp:189 "NPU: FLM is Q4NX-only — rejecting <path>"
+    // So the router's order is a PREFERENCE; the filter is fail-closed in the executor.
+    // Stated plainly because it bounds what the router can promise: a container gate
+    // cannot detect a lane that ACCEPTS this container and serves DIFFERENT WEIGHTS from
+    // it — the npu_flm lossy-tag case passes both gates (ADR §9.10.9).
     const std::string failed_id =
         (active_idx_ < backends_.size()) ? backends_[active_idx_].id : "";
     for (const auto& id : fallback_order()) {

--- a/src/backend_manager.cpp
+++ b/src/backend_manager.cpp
@@ -479,7 +479,26 @@ void BackendManager::discover() {
 
     // Rack 'em
     rank_backends();
-    active_idx_ = 0;
+    // "No backend selected yet" — NOT backends_[0]. discover() ranks lanes; it does not
+    // choose one, and a report taken before (or without) a successful init used to name
+    // the top-RANKED lane as "Active". That is reachability reading as selection, the
+    // same inversion this manager's own route bridge warns about (model_registry_route.h:
+    // UNKNOWN must not be indistinguishable from PRESENT) — and it is exactly what a
+    // `status: "ok"` health endpoint is worst at: the failed-init case answered 200 with
+    // a plausible, never-initialized backend named.
+    //
+    // The "none" state is already anticipated everywhere, which is why this is one line:
+    // active_info()/active_backend() return nullptr (:826, :831), every read is guarded
+    // by `active_idx_ < backends_.size()`, re_evaluate() uses backends_.size() as its own
+    // not-found sentinel (:1348) and restores by id string, init_in_order() sets the
+    // index on the first successful init (:659), failover() sets it before returning
+    // true (so its callers at :942 and :1030 stay valid), and the status report already
+    // prints "none" (:1600). A generate() before init was already safe — it tests
+    // info.functional && info.instance (:867) before taking the instance.
+    // NOT changed here: /v1/health still reports status "ok" with no active backend. That
+    // is a health-CONTRACT question (clients may branch on status) rather than a bug in
+    // this field, so it is raised, not decided: see ADR §9.10.11.
+    active_idx_ = backends_.size();
 
     printf("\n  %zu backend(s) discovered.\n", backends_.size());
     printf("  Primary: %s\n\n", backends_.empty() ? "none" : backends_[0].id.c_str());

--- a/src/dynamic_router.cpp
+++ b/src/dynamic_router.cpp
@@ -76,26 +76,8 @@ DynamicRouter::BackendEntry* DynamicRouter::pick_backend() {
             return &entries_[0];
         }
         case Strategy::NPU_ONLY: {
-            // Deterministic NPU preference, NOT registration order. npu_flm (FLM,
-            // score 67.5) and npu_xrt (legacy worker subprocess, 0.06 tok/s —
-            // backend_manager.cpp:1766+) share BackendType::NPU_XRT, and npu_xrt
-            // is REGISTERED FIRST (:61 vs :162), so the old "first entry whose id
-            // is an NPU" answered npu_xrt — the ~1000x-slower lane — and would
-            // answer differently if registration order ever changed, i.e. a
-            // routing outcome decided by vector order.
-            // The registry's own answer for NPU_Q4NX/NPU_1BP is npu_flm
-            // (model_registry_route.cpp), so rank explicitly and agree with it.
-            // (The *_BACKFILL branches below still scan for the substring "npu"
-            // and keep that order sensitivity — left unchanged on purpose here.)
-            BackendEntry* best = nullptr;
-            for (auto& e : entries_) {
-                bool is_flm = (e.id == "npu_flm");
-                bool is_xrt = (e.id == "npu_xrt");
-                if (!is_flm && !is_xrt) continue;
-                if (!best) { best = &e; continue; }
-                if (is_flm && best->id != "npu_flm") best = &e;  // flm outranks xrt
-            }
-            if (best) return best;
+            for (auto& e : entries_)
+                if (e.id == "npu_flm" || e.id == "npu_xrt") return &e;
             return &entries_[0];
         }
         case Strategy::GPU_BACKFILL: {
@@ -156,19 +138,10 @@ DynamicRouter::BackendEntry* DynamicRouter::pick_backend_excluding(const std::st
             for (auto& e : entries_)
                 if ((e.id == "hip_gpu" || e.id == "zinc_gpu") && e.id != exclude_id) return &e;
             break;
-        case Strategy::NPU_ONLY: {
-            // Same explicit ranking as pick_backend(): npu_flm before npu_xrt.
-            BackendEntry* best = nullptr;
-            for (auto& e : entries_) {
-                bool is_flm = (e.id == "npu_flm");
-                bool is_xrt = (e.id == "npu_xrt");
-                if ((!is_flm && !is_xrt) || e.id == exclude_id) continue;
-                if (!best) { best = &e; continue; }
-                if (is_flm && best->id != "npu_flm") best = &e;
-            }
-            if (best) return best;
+        case Strategy::NPU_ONLY:
+            for (auto& e : entries_)
+                if ((e.id == "npu_flm" || e.id == "npu_xrt") && e.id != exclude_id) return &e;
             break;
-        }
         case Strategy::GPU_BACKFILL: {
             int cycle = round_robin_counter_++ % 5;
             if (cycle < 4) {

--- a/src/dynamic_router.cpp
+++ b/src/dynamic_router.cpp
@@ -76,8 +76,26 @@ DynamicRouter::BackendEntry* DynamicRouter::pick_backend() {
             return &entries_[0];
         }
         case Strategy::NPU_ONLY: {
-            for (auto& e : entries_)
-                if (e.id == "npu_flm" || e.id == "npu_xrt") return &e;
+            // Deterministic NPU preference, NOT registration order. npu_flm (FLM,
+            // score 67.5) and npu_xrt (legacy worker subprocess, 0.06 tok/s —
+            // backend_manager.cpp:1766+) share BackendType::NPU_XRT, and npu_xrt
+            // is REGISTERED FIRST (:61 vs :162), so the old "first entry whose id
+            // is an NPU" answered npu_xrt — the ~1000x-slower lane — and would
+            // answer differently if registration order ever changed, i.e. a
+            // routing outcome decided by vector order.
+            // The registry's own answer for NPU_Q4NX/NPU_1BP is npu_flm
+            // (model_registry_route.cpp), so rank explicitly and agree with it.
+            // (The *_BACKFILL branches below still scan for the substring "npu"
+            // and keep that order sensitivity — left unchanged on purpose here.)
+            BackendEntry* best = nullptr;
+            for (auto& e : entries_) {
+                bool is_flm = (e.id == "npu_flm");
+                bool is_xrt = (e.id == "npu_xrt");
+                if (!is_flm && !is_xrt) continue;
+                if (!best) { best = &e; continue; }
+                if (is_flm && best->id != "npu_flm") best = &e;  // flm outranks xrt
+            }
+            if (best) return best;
             return &entries_[0];
         }
         case Strategy::GPU_BACKFILL: {
@@ -138,10 +156,19 @@ DynamicRouter::BackendEntry* DynamicRouter::pick_backend_excluding(const std::st
             for (auto& e : entries_)
                 if ((e.id == "hip_gpu" || e.id == "zinc_gpu") && e.id != exclude_id) return &e;
             break;
-        case Strategy::NPU_ONLY:
-            for (auto& e : entries_)
-                if ((e.id == "npu_flm" || e.id == "npu_xrt") && e.id != exclude_id) return &e;
+        case Strategy::NPU_ONLY: {
+            // Same explicit ranking as pick_backend(): npu_flm before npu_xrt.
+            BackendEntry* best = nullptr;
+            for (auto& e : entries_) {
+                bool is_flm = (e.id == "npu_flm");
+                bool is_xrt = (e.id == "npu_xrt");
+                if ((!is_flm && !is_xrt) || e.id == exclude_id) continue;
+                if (!best) { best = &e; continue; }
+                if (is_flm && best->id != "npu_flm") best = &e;
+            }
+            if (best) return best;
             break;
+        }
         case Strategy::GPU_BACKFILL: {
             int cycle = round_robin_counter_++ % 5;
             if (cycle < 4) {

--- a/src/model_registry_route.cpp
+++ b/src/model_registry_route.cpp
@@ -22,19 +22,20 @@ bool backend_for(Capability c, BackendType& out_type, std::string& out_id,
         case Capability::NPU_1BP:
             // Type level is unambiguous: npu_flm registers as BackendType::NPU_XRT
             // (backend_manager.cpp:162) and the NPU_XRT factory prefers it
-            // (:1768-1774). The ID is npu_flm, not npu_xrt.
+            // (:1768-1774). The ID is npu_flm, not npu_xrt — npu_xrt is registered
+            // but never selected by model_router.cpp or dynamic_router.cpp.
             //
-            // The invariant, stated so it can be checked: npu_xrt is not on any
-            // model_router.cpp route (the Q4NX route there is npu_flm →
-            // cpu_generic), and under the unified server's FASTEST ranking
-            // npu_flm outranks it deterministically (rank_backends: available
-            // beats unavailable — npu_flm is hardcoded available — then scored
-            // beats unscored — 67.5 vs none). dynamic_router.cpp's NPU_ONLY
-            // strategy DOES name npu_xrt as an acceptable pick, and until
-            // 2026-09-11 it took whichever came first in registration order,
-            // which is npu_xrt (:61 before :162); that branch now ranks npu_flm
-            // first explicitly, so the two routers agree with this table.
-            // The stakes are ~1000x (67.5 vs 0.06 tok/s), not a preference.
+            // Precision added 2026-09-11 (goal mtvd3pmx), because the sentence
+            // above is slightly stronger than the code: dynamic_router.cpp's
+            // NPU_ONLY branch DOES name npu_xrt as an acceptable pick (:80, :143,
+            // "first entry whose id is npu_flm or npu_xrt"). It is still not
+            // reachable in practice, but for a better reason than registration
+            // order — rank_backends() (backend_manager.cpp:481, end of discover())
+            // ranks `functional` above `non-functional` before that strategy ever
+            // sees the list, so NPU_ONLY returns whichever NPU lane actually
+            // initialized and falls to npu_xrt only when npu_flm did not come up.
+            // The two lanes are ~1000x apart (67.5 vs 0.06 tok/s), so a plan that
+            // lands on npu_xrt reads as "served at ~0 tok/s" — not as a miss.
             out_type = BackendType::NPU_XRT;
             out_id = "npu_flm";
             // THE TRAP, from @agent-ca60cf: npu_flm is Q4NX-only. For GGUF/H1B its

--- a/src/model_registry_route.cpp
+++ b/src/model_registry_route.cpp
@@ -22,8 +22,19 @@ bool backend_for(Capability c, BackendType& out_type, std::string& out_id,
         case Capability::NPU_1BP:
             // Type level is unambiguous: npu_flm registers as BackendType::NPU_XRT
             // (backend_manager.cpp:162) and the NPU_XRT factory prefers it
-            // (:1768-1774). The ID is npu_flm, not npu_xrt — npu_xrt is registered
-            // but never selected by model_router.cpp or dynamic_router.cpp.
+            // (:1768-1774). The ID is npu_flm, not npu_xrt.
+            //
+            // The invariant, stated so it can be checked: npu_xrt is not on any
+            // model_router.cpp route (the Q4NX route there is npu_flm →
+            // cpu_generic), and under the unified server's FASTEST ranking
+            // npu_flm outranks it deterministically (rank_backends: available
+            // beats unavailable — npu_flm is hardcoded available — then scored
+            // beats unscored — 67.5 vs none). dynamic_router.cpp's NPU_ONLY
+            // strategy DOES name npu_xrt as an acceptable pick, and until
+            // 2026-09-11 it took whichever came first in registration order,
+            // which is npu_xrt (:61 before :162); that branch now ranks npu_flm
+            // first explicitly, so the two routers agree with this table.
+            // The stakes are ~1000x (67.5 vs 0.06 tok/s), not a preference.
             out_type = BackendType::NPU_XRT;
             out_id = "npu_flm";
             // THE TRAP, from @agent-ca60cf: npu_flm is Q4NX-only. For GGUF/H1B its

--- a/src/model_router.cpp
+++ b/src/model_router.cpp
@@ -18,13 +18,28 @@
 //         but the router picks the right kernel via the MoE config.
 //
 //   qwen3 architecture
-//     ├─ npu_xrt (native NPU engine — INT8, single-core)
+//     ├─ npu_flm (FLM engine — the native Q4NX owner: registered at
+//     │            backend_manager.cpp:162 with score 67.5, and the head of the
+//     │            Q4NX route in the table below)
+//     ├─ npu_xrt (legacy worker subprocess, 0.06 tok/s — backend_manager.cpp:1766+)
 //     └─ cpu_generic
-//         npu_xrt is the sole NPU route since PR #567 (2026-07-20), once its
-//         single-core GEMM kernels passed correctness verification against
-//         the HuggingFace BF16 reference. The FastFlowLM subprocess fallback
-//         (a proprietary AMD binary) was removed entirely — this project
-//         ships zero proprietary code — FLM is MIT."
+//         npu_flm is the Q4NX route's first entry (see the route table below),
+//         not npu_xrt. The two share BackendType::NPU_XRT and are easy to
+//         conflate, but they are ~1000x apart (67.5 vs 0.06 tok/s): npu_xrt is
+//         reached only when npu_flm cannot be initialised, and a lane that
+//         lands on it reads as "served at ~0 tok/s" rather than as a routing
+//         miss.
+//
+//         CORRECTED 2026-09-11 (goal mtvd3pmx): the previous text here claimed
+//         "npu_xrt is the sole NPU route since PR #567" and that the FastFlowLM
+//         subprocess fallback "was removed entirely". Both contradicted the code
+//         they sat above — the Q4NX route below returns npu_flm first, and
+//         backend_manager.cpp:162 registers npu_flm as the preferred NPU
+//         backend. The licensing claim in that text (FLM as "a proprietary AMD
+//         binary") is NOT repeated here because it was not verified; what the
+//         tree currently asserts elsewhere is "FLM engine (MIT)" at
+//         backend_manager.cpp:162. Reconcile the licence claim separately — do
+//         not inherit either version from this comment.
 //
 //   zamba2 architecture (Mamba2 hybrid SSD)
 //     └─ zamba2_gpu + cpu_generic

--- a/tools/capture_npu_acceptance.sh
+++ b/tools/capture_npu_acceptance.sh
@@ -134,6 +134,29 @@ if [ "$ready" = 1 ]; then
         -d "{\"model\":\"$REQ_MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"The capital of France is\"}],\"max_tokens\":16,\"temperature\":0}" \
         -o "$OUT/completion.json" 2>/dev/null
 
+    # ── NEGATIVE CONTROL 1 — refusal must exist ————————————————————
+    # An id that cannot exist must be REFUSED, not answered by whatever happens to be
+    # loaded. This is the fault §9.8.1 fixed; without this line a run cannot tell
+    # "served the artifact" from "served something".
+    curl -s -m 60 -o "$OUT/refusal.json" -w '%{http_code}\n' \
+        "http://127.0.0.1:$PORT/v1/chat/completions" -H 'Content-Type: application/json' \
+        -d '{"model":"__no_such_artifact__.q4nx","messages":[{"role":"user","content":"x"}],"max_tokens":1}' \
+        > "$OUT/refusal.code" 2>/dev/null
+
+    # ── NEGATIVE CONTROL 2 — the weight-discriminating one (ADR §9.10.9) ————
+    # Content agreement is NOT evidence of artifact-level service on a lane that
+    # receives a TAG instead of the file (npu_flm execs `flm serve <tag>`:
+    # src/backend_npu_flm.cpp:321). Set CONTROL_MODEL to a native artifact whose tag
+    # maps to DIFFERENT weights — on strixhalo, zaya1-8b.q4nx → qwen3:1.7b — and an
+    # ANSWER here means some lane served weights other than the requested ones. Only a
+    # refusal demonstrates artifact-level service.
+    if [ -n "${CONTROL_MODEL:-}" ]; then
+        curl -s -m 300 -o "$OUT/control.json" -w '%{http_code}\n' \
+            "http://127.0.0.1:$PORT/v1/chat/completions" -H 'Content-Type: application/json' \
+            -d "{\"model\":\"$(basename "$CONTROL_MODEL")\",\"messages\":[{\"role\":\"user\",\"content\":\"The capital of France is\"}],\"max_tokens\":16,\"temperature\":0}" \
+            > "$OUT/control.code" 2>/dev/null
+    fi
+
     # The status field that §9.8.2 quoted — captured from the live server, so we can
     # compare it against the startup banner in the same run.
     { echo "--- /v1/models"; cat "$OUT/models.json"; echo; } > "$OUT/status.txt" 2>/dev/null
@@ -156,6 +179,21 @@ fi
     echo '```'
     head -c 1200 "$OUT/completion.json" 2>/dev/null || echo "(no completion captured)"
     echo
+    echo '```'
+    echo
+    echo "## Controls (a passing completion proves less than it looks like)"
+    echo '```'
+    printf 'nonexistent id  -> HTTP %s   (must be 404 model_not_loadable_on_this_face)\n' "$(cat "$OUT/refusal.code" 2>/dev/null || echo 'not captured')"
+    if [ -n "${CONTROL_MODEL:-}" ]; then
+        printf 'control artifact %s -> HTTP %s\n' "$CONTROL_MODEL" "$(cat "$OUT/control.code" 2>/dev/null || echo 'not captured')"
+        echo "   must ALSO be a refusal: an answer means a lane served weights other than"
+        echo "   the requested file (ADR §9.10.9 — npu_flm execs a tag, never a path)."
+    else
+        echo 'CONTROL_MODEL unset — the weight-discriminating control did NOT run.'
+        echo '   Set it to a native artifact whose FLM tag maps elsewhere (strixhalo:'
+        echo '   zaya1-8b.q4nx -> qwen3:1.7b). Without it, an agreeing completion cannot'
+        echo '   distinguish "the artifact was served" from "a lane served its own model".'
+    fi
     echo '```'
     echo
     echo "## Reading guide"

--- a/tools/capture_npu_acceptance.sh
+++ b/tools/capture_npu_acceptance.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# capture_npu_acceptance.sh — run the goal mtvd3pmx literal acceptance ON AN NPU BOX
+# and KEEP THE WHOLE TRANSCRIPT. Run this instead of a bare `1bit unified ...`.
+#
+# WHY THIS EXISTS
+# ADR §9.8.2 recorded this run as three lines:
+#
+#     content: ''            finish_reason: error
+#     Active backend: npu_xrt (AMD XDNA NPU via native worker engine)   ~0 tok/s
+#
+# That was enough to declare the literal clause unsatisfiable, and not enough to say
+# WHY. The backend-selection lines that would answer it — "BackendManager: trying X...",
+# "→ creation failed", "→ skipped (issue #1427)", "Router: <reason>", "→ not registered
+# with per-token router" — were never captured. Two later attempts to explain the
+# outcome from those three lines were both wrong (ADR §9.10.5 and its §9.10.6
+# correction), because the three lines do not identify a mechanism: the quoted string
+# has no "✓" prefix, so it is the manager's status field (backend_manager.cpp:1597),
+# not the startup banner (tools/unified_server.cpp:1764). Capture the transcript first;
+# infer afterwards.
+#
+# WHAT IT ANSWERS
+#   - did `BackendManager: trying npu_flm...` appear, and what did it print after it?
+#   - which lane did `Router:` name, and did the post-init selection loop find it?
+#   - is the run's `Active backend` a selection or a default?
+#
+# Usage:  ./tools/capture_npu_acceptance.sh <model.q4nx|model-id> [port] [binary]
+# Output: <outdir>/<timestamp>/ ; prints the path of SUMMARY.md at the end.
+#
+# NOT run by the author: written on a box with no NPU and no build tree. Syntax-checked
+# with `bash -n` only. Read it before trusting it.
+set -uo pipefail
+
+MODEL="${1:?usage: $0 <model.q4nx|model-id> [port] [binary]}"
+PORT="${2:-8183}"
+BIN="${3:-./build/1bit}"
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="${OUTDIR:-$HOME/acceptance-captures}/$STAMP"
+
+# Check the binary BEFORE creating the output directory, so a typo does not leave an
+# empty capture dir behind that a later reader could mistake for a run that happened.
+if [ ! -x "$BIN" ]; then
+    echo "FATAL: binary '$BIN' not executable. Build first, or pass it as \$3." >&2
+    exit 2
+fi
+
+mkdir -p "$OUT"
+LOG="$OUT/server.log"
+: > "$LOG"
+
+echo "== capture: $OUT"
+echo "== model  : $MODEL"
+echo "== port   : $PORT"
+echo "== binary : $BIN"
+
+# The request must name the model the SAME way the server was told to load it (R8, and
+# the refusal predicate in §9.8.1: a request whose basename equals the loaded model's
+# path basename is satisfied, not refused). Using the basename keeps the two spellings
+# from diverging, which is the other thing §9.8.1 was about.
+REQ_MODEL="$(basename "$MODEL")"
+
+# NOTE ON THE CHILD PROCESSES: npu_flm spawns an `flm serve` child, and those have been
+# observed to orphan (see the log entries about five orphaned `flm serve` on strixhalo).
+# We kill the PID we started, then REPORT any survivors rather than pkill-ing a pattern
+# that may match a server some other lane is using.
+pre_flm="$(pgrep -fc 'flm serve' 2>/dev/null || echo 0)"
+
+echo "== starting server (transcript -> $LOG)"
+"$BIN" unified --port "$PORT" -m "$MODEL" >"$LOG" 2>&1 &
+PID=$!
+echo "   pid $PID" | tee -a "$LOG"
+
+cleanup() {
+    if kill -0 "$PID" 2>/dev/null; then
+        echo "== stopping pid $PID" | tee -a "$LOG"
+        kill "$PID" 2>/dev/null
+        for _ in $(seq 1 20); do kill -0 "$PID" 2>/dev/null || break; sleep 0.5; done
+        kill -9 "$PID" 2>/dev/null
+    fi
+}
+trap cleanup EXIT
+
+# Wait for readiness without assuming how long an NPU model load takes.
+ready=0
+for _ in $(seq 1 180); do
+    if ! kill -0 "$PID" 2>/dev/null; then
+        echo "== server exited before becoming ready (see $LOG)" | tee -a "$LOG"
+        break
+    fi
+    if curl -sf -m 3 "http://127.0.0.1:$PORT/v1/health" -o "$OUT/health.json" 2>/dev/null; then
+        ready=1; break
+    fi
+    sleep 1
+done
+echo "== health ready: $ready" | tee -a "$LOG"
+
+if [ "$ready" = 1 ]; then
+    curl -s -m 20 "http://127.0.0.1:$PORT/v1/models" -o "$OUT/models.json" 2>/dev/null
+
+    # The literal clause, asked for by the SAME spelling the loader was given.
+    curl -s -m 300 "http://127.0.0.1:$PORT/v1/chat/completions" \
+        -H 'Content-Type: application/json' \
+        -d "{\"model\":\"$REQ_MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"The capital of France is\"}],\"max_tokens\":16,\"temperature\":0}" \
+        -o "$OUT/completion.json" 2>/dev/null
+
+    # The status field that §9.8.2 quoted — captured from the live server, so we can
+    # compare it against the startup banner in the same run.
+    { echo "--- /v1/models"; cat "$OUT/models.json"; echo; } > "$OUT/status.txt" 2>/dev/null
+fi
+
+# The part that was lost last time, extracted so it cannot be missed.
+{
+    echo "# Acceptance capture $STAMP"
+    echo
+    echo "- model: \`$MODEL\`  (requested as \`$REQ_MODEL\`)"
+    echo "- port: $PORT   binary: \`$BIN\`   health ready: $ready"
+    echo "- full transcript: \`server.log\` (this is the artifact §9.8.2 did not keep)"
+    echo
+    echo "## Backend selection (the lines that answer \"why this lane\")"
+    echo '```'
+    grep -nE 'Router:|BackendManager: trying|→|->|skipped|creation failed|not registered|Active backend|Primary:|init (threw|timed out)|❌' "$LOG" | head -80
+    echo '```'
+    echo
+    echo "## Completion (the literal clause)"
+    echo '```'
+    head -c 1200 "$OUT/completion.json" 2>/dev/null || echo "(no completion captured)"
+    echo
+    echo '```'
+    echo
+    echo "## Reading guide"
+    echo "- If \`trying npu_flm\` is absent, the route never asked for it — read \`Router:\`."
+    echo "- If \`trying npu_flm\` is present and followed by a failure, that failure IS the"
+    echo "  answer to §9.8.2's open question (\"why was npu_flm not functional?\")."
+    echo "- If npu_flm succeeded but npu_xrt is still active, the selection loop after init"
+    echo "  is the seam (tools/unified_server.cpp:1735-1760: route order, then \"any"
+    echo "  functional backend\" with no route re-check)."
+    echo
+    echo "## Orphan check"
+    echo "- \`flm serve\` count before: $pre_flm ; now: $(pgrep -fc 'flm serve' 2>/dev/null || echo 0)"
+    echo "- survivors are reported, not killed: a pattern kill could take down another lane's server."
+} > "$OUT/SUMMARY.md"
+
+echo
+echo "== wrote:"
+echo "   $OUT/SUMMARY.md"
+echo "   $LOG"

--- a/tools/capture_npu_acceptance.sh
+++ b/tools/capture_npu_acceptance.sh
@@ -53,6 +53,35 @@ echo "== model  : $MODEL"
 echo "== port   : $PORT"
 echo "== binary : $BIN"
 
+# ── Preflight: the paths that silently decide WHICH LANE COMES UP ──────────
+# ADR §9.10.8. On strixhalo a bare `1bit unified -m <native .q4nx>` loses the FLM lane
+# before any routing happens: the engine binary bakes
+# FLM_CONFIG_PATH=/opt/fastflowlm/etc/flm/model_list.json, while the FastFlowLM package
+# ships that registry at /opt/fastflowlm/share/flm/model_list.json. npu_flm::init does
+# access(flm_config_, R_OK) and returns false when it is missing, so the legacy npu_xrt
+# lane becomes the only functional accelerator and is selected. Its worker then
+# resolves as `./npu_engine_universal` (or `build/`), while the box builds it at
+# `build/engine/npu/npu_engine_universal` — so the worker exec fails at request time.
+# Neither failure is a routing decision, and both present as "served at ~0 tok/s".
+# Print the candidates BEFORE launching so the log explains itself.
+{
+    echo "== preflight (paths that decide the lane) =="
+    for p in "${NPU_FLM_BIN:-/opt/fastflowlm/bin/flm}" \
+             "${NPU_FLM_CONFIG:-/opt/fastflowlm/etc/flm/model_list.json}" \
+             /opt/fastflowlm/share/flm/model_list.json \
+             "${NPU_FLM_XCLBINS:-/opt/fastflowlm/share/flm/xclbins}" \
+             "${NPU_ENGINE_BIN:-./npu_engine_universal}" \
+             build/npu_engine_universal \
+             build/engine/npu/npu_engine_universal \
+             /opt/rocm/bin/flm /opt/rocm/etc/flm/model_list.json; do
+        [ -e "$p" ] && st=EXISTS || st=MISSING
+        printf '   %-58s %s\n' "$p" "$st"
+    done
+    echo "   cwd: $(pwd)"
+    [ -n "${NPU_FLM_CONFIG:-}" ] || echo "   NOTE: NPU_FLM_CONFIG unset — if the FLM config above is MISSING, npu_flm::init returns false and the legacy lane is selected instead."
+    [ -n "${NPU_ENGINE_BIN:-}" ] || echo "   NOTE: NPU_ENGINE_BIN unset — the npu_xrt worker resolves by cwd; check the candidates above."
+} | tee -a "$LOG"
+
 # The request must name the model the SAME way the server was told to load it (R8, and
 # the refusal predicate in §9.8.1: a request whose basename equals the loaded model's
 # path basename is satisfied, not refused). Using the basename keeps the two spellings
@@ -66,7 +95,9 @@ REQ_MODEL="$(basename "$MODEL")"
 pre_flm="$(pgrep -fc 'flm serve' 2>/dev/null || echo 0)"
 
 echo "== starting server (transcript -> $LOG)"
-"$BIN" unified --port "$PORT" -m "$MODEL" >"$LOG" 2>&1 &
+# APPEND, not truncate: the preflight above is already in $LOG, and the whole point of
+# this script is that the evidence survives.
+"$BIN" unified --port "$PORT" -m "$MODEL" >>"$LOG" 2>&1 &
 PID=$!
 echo "   pid $PID" | tee -a "$LOG"
 

--- a/tools/q4nx/verify_zaya_layout.py
+++ b/tools/q4nx/verify_zaya_layout.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""verify_zaya_layout.py — settle a Q4NX container's decode convention against its
+SOURCE checkpoint, element-wise, with no NPU and no engine build.
+
+Why this exists: "the weights are corrupt" and "the decoder reads them wrong" are
+different claims and a self-port of the decoder cannot distinguish them (ADR
+engine-layering-and-lemonade-scope.md §9.9.3). The only witness that can is the
+published checkpoint. This tool compares them directly, so the convention is
+SETTLED BY MEASUREMENT rather than by argument.
+
+It searches the 4-way convention space (scale index layout x nibble sign) crossed
+with nibble/lane polarity and reports correlation + bias + error in units of the
+per-group scale. A correct convention is recognisable without a threshold:
+  corr -> 1, bias/scale -> 0, rms/scale -> 1/sqrt(12) = 0.2887
+(the last is exactly int4 round-to-nearest error, so it proves the payload is the
+quantised source and not merely correlated with it).
+
+Usage:
+  verify_zaya_layout.py --q4nx ~/ZAYA1-8B-Q4NX/zaya1-8b.q4nx \
+                        --source-dir ~/zaya1-8b-hf \
+                        [--tensor model.layers.0.self_attn.q_proj.weight] [--search]
+
+Exit code 0 if the best convention is unambiguous (corr >= --min-corr, default 0.99).
+"""
+import argparse
+import glob
+import json
+import os
+import struct
+import sys
+
+import numpy as np
+
+TILE_BYTES = 5120
+TILE_ROWS = 32
+TILE_COLS = 256
+RNE_RMS = 1.0 / np.sqrt(12.0)  # expected rms/scale for correct int4 round-to-nearest
+
+
+# ── container ────────────────────────────────────────────────────────────────
+def read_q4nx_manifest(path):
+    with open(path, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        return json.loads(f.read(n)), 8 + n
+
+
+def read_i8_rows(path, hdr, entry):
+    """A Q4NX I8 tensor: shape [n_i8_rows, 5120] of raw tile bytes."""
+    off = entry["data_offsets"]
+    with open(path, "rb") as f:
+        f.seek(hdr + off[0])
+        buf = f.read(off[1] - off[0])
+    return np.frombuffer(buf, dtype=np.uint8).reshape(entry["shape"][0], TILE_BYTES)
+
+
+# ── source checkpoint (minimal safetensors reader) ───────────────────────────
+def st_index(source_dir):
+    idx = {}
+    for s in sorted(glob.glob(os.path.join(source_dir, "*.safetensors"))):
+        with open(s, "rb") as f:
+            ln = struct.unpack("<Q", f.read(8))[0]
+            h = json.loads(f.read(ln))
+        base = 8 + ln
+        for k, v in h.items():
+            if k != "__metadata__":
+                idx[k] = (s, base, v)
+    return idx
+
+
+def load_source(idx, name):
+    s, base, v = idx[name]
+    with open(s, "rb") as f:
+        f.seek(base + v["data_offsets"][0])
+        buf = f.read(v["data_offsets"][1] - v["data_offsets"][0])
+    if v["dtype"] == "BF16":
+        a = (np.frombuffer(buf, dtype="<u2").astype(np.uint32) << 16).view(np.float32)
+    else:
+        raise SystemExit(f"source dtype {v['dtype']} not handled for {name}")
+    return a.reshape(v["shape"]).astype(np.float32)
+
+
+def resolve_source_name(idx, q4nx_key):
+    """Q4NX names are HF-ish but not identical: the source folds q/k/v into
+    `qkv_proj.` and drops/injects `.weight`. Match on the normalised tail."""
+    def norm(k):
+        k = k.replace(".weight", "").replace(".qkv_proj", "")
+        return k
+    if q4nx_key in idx:
+        return q4nx_key
+    want = norm(q4nx_key)
+    for k in idx:
+        if norm(k) == want:
+            return k
+    tail = ".".join(q4nx_key.split(".")[-3:])
+    for k in idx:
+        if tail in k:
+            return k
+    return None
+
+
+# ── decode ───────────────────────────────────────────────────────────────────
+def bf16(u16):
+    return (u16.astype(np.uint32) << 16).view(np.float32)
+
+
+def decode_rows(tiles, n_tile_cols, scale_layout, nibble_mode, nib_pol=0, lane_pol=0):
+    """Decode raw I8 rows to [out_rows, out_cols] float, plus the signed int4
+    codes and per-group scales (so the caller can test exactness, not just corr).
+
+    Layout facts this function encodes, all of them from the tile spec:
+      scales  bytes [0:512]    256 bf16, indexed either group-major (g*32+lr) or
+                               row-major (lr*8+g) — the ONE thing that differs
+                               between the two in-tree decoders
+      mins    bytes [512:1024] same indexing
+      nibbles bytes [1024:5120] 2 lanes x 256 cols x 8 byte_idx, lane = lr//16,
+                               byte_idx = (lr%16)//2, nibble = (lr%16)%2
+    """
+    ni = tiles.shape[0]
+    n_tile_rows = ni // n_tile_cols
+    out = np.zeros((n_tile_rows * TILE_ROWS, n_tile_cols * TILE_COLS), np.float32)
+    Q = np.zeros_like(out)
+    S = np.zeros_like(out)
+
+    sc = bf16(np.frombuffer(tiles[:, 0:512].tobytes(), dtype="<u2").reshape(ni, 256))
+    zp = bf16(np.frombuffer(tiles[:, 512:1024].tobytes(), dtype="<u2").reshape(ni, 256))
+    packed = tiles[:, 1024:TILE_BYTES].reshape(ni, 2, TILE_COLS, 8)
+
+    lr = np.arange(TILE_ROWS)
+    col = np.arange(TILE_COLS)
+    group = col // 32
+    idx = group[None, :] * 32 + lr[:, None] if scale_layout == "group_major" \
+        else lr[:, None] * 8 + group[None, :]
+    lane = (lr // 16) if lane_pol == 0 else (1 - lr // 16)
+    byte_idx = (lr % 16) // 2
+    nib = ((lr % 16) % 2) if nib_pol == 0 else (1 - (lr % 16) % 2)
+
+    for ir in range(ni):
+        b = packed[ir][lane[:, None], col[None, :], byte_idx[:, None]]
+        q = np.where(nib[:, None] == 0, b & 0x0F, (b >> 4) & 0x0F).astype(np.float32)
+        if nibble_mode == "signed":
+            q = np.where(q >= 8, q - 16, q)
+        s = sc[ir][idx]
+        w = q * s + zp[ir][idx]
+        tr, tc = ir // n_tile_cols, ir % n_tile_cols
+        sl = (slice(tr * TILE_ROWS, (tr + 1) * TILE_ROWS),
+              slice(tc * TILE_COLS, (tc + 1) * TILE_COLS))
+        out[sl], Q[sl], S[sl] = w, q, s
+    return out, Q, S
+
+
+def corr(a, b):
+    a, b = a.ravel() - a.mean(), b.ravel() - b.mean()
+    d = np.linalg.norm(a) * np.linalg.norm(b)
+    return float(a @ b / d) if d else float("nan")
+
+
+CONVENTIONS = [(sl, nm, np_, lp)
+               for sl in ("group_major", "row_major")
+               for nm in ("unsigned", "signed")
+               for np_ in (0, 1)
+               for lp in (0, 1)]
+
+
+def best_convention(tiles, src, in_features):
+    """Search the 4-way convention space x polarity. Also size the tensor against
+    the source so a transposed orientation is reported, not silently zero-corr."""
+    n_tile_cols = in_features // TILE_COLS
+    W, _, _ = decode_rows(tiles, n_tile_cols, "row_major", "signed")
+    orient = ""
+    cmp_src = src
+    if W.shape != src.shape:
+        if W.shape == src.T.shape:
+            cmp_src, orient = src.T, " (source compared TRANSPOSED)"
+        else:
+            return None, f"shape {W.shape} matches neither {src.shape} nor its transpose", None
+    scored = []
+    for sl, nm, np_, lp in CONVENTIONS:
+        w, _, _ = decode_rows(tiles, n_tile_cols, sl, nm, np_, lp)
+        scored.append((corr(w, cmp_src), sl, nm, np_, lp))
+    scored.sort(reverse=True)
+    return scored, orient, cmp_src
+
+
+def exactness(tiles, src, in_features):
+    """For the winning convention, report bias and error in units of the scale."""
+    n_tile_cols = in_features // TILE_COLS
+    W, Q, S = decode_rows(tiles, n_tile_cols, "row_major", "signed")
+    if W.shape != src.shape:
+        src = src.T
+    d = W - src
+    sm = float(S.mean())
+    q_ideal = np.clip(np.rint(src / S), -8, 7)
+    return {
+        "corr": corr(W, src),
+        "bias_over_scale": float(d.mean() / sm),
+        "rms_over_scale": float(np.sqrt((d ** 2).mean()) / sm),
+        "rne_ideal": RNE_RMS,
+        "q_match": float((q_ideal == Q).mean()),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--q4nx", default=os.path.expanduser("~/ZAYA1-8B-Q4NX/zaya1-8b.q4nx"))
+    ap.add_argument("--source-dir", default=os.path.expanduser("~/zaya1-8b-hf"))
+    ap.add_argument("--tensor", action="append", default=None,
+                    help="Q4NX tensor key to test (repeatable); default a fixed probe set")
+    ap.add_argument("--in-features", type=int, default=None,
+                    help="override in_features when the container's geometry is ambiguous")
+    ap.add_argument("--search", action="store_true", help="print the full convention search")
+    ap.add_argument("--min-corr", type=float, default=0.99)
+    args = ap.parse_args()
+
+    man, hdr = read_q4nx_manifest(args.q4nx)
+    idx = st_index(args.source_dir)
+    keys = args.tensor or [
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.0.self_attn.k_proj.weight",
+        "model.layers.0.self_attn.o_proj.weight",
+        "model.layers.0.mlp.experts.gate_up_proj.weight",
+    ]
+
+    print(f"container : {args.q4nx}  ({len(man)} manifest entries)")
+    print(f"source    : {args.source_dir}  ({len(idx)} tensors)")
+    print(f"criterion : corr>={args.min_corr}, |bias/scale|<0.05, rms/scale~={RNE_RMS:.4f}")
+    print()
+    print(f"{'tensor':<44} {'corr':>7} {'bias/s':>8} {'rms/s':>7} {'qmatch':>7}  verdict")
+    ok = True
+    for k in keys:
+        entry = man.get(k)
+        if not isinstance(entry, dict):
+            print(f"{k:<44} {'--':>7}  not in manifest")
+            ok = False
+            continue
+        sk = resolve_source_name(idx, k)
+        if sk is None:
+            print(f"{k:<44} {'--':>7}  no source tensor matched")
+            ok = False
+            continue
+        src = load_source(idx, sk)
+        if src.ndim > 2:
+            src = src.reshape(-1, src.shape[-1])
+        tiles = read_i8_rows(args.q4nx, hdr, entry)
+
+        # in_features comes from the tensor's OWN geometry when not forced: the
+        # container stores tile rows, so this is in_features/256 tile columns.
+        in_features = args.in_features
+        if in_features is None:
+            in_features = _infer_in_features(tiles.shape[0], src)
+
+        scored, orient, cmp_src = best_convention(tiles, src, in_features)
+        if scored is None:
+            print(f"{k:<44} {'--':>7}  {orient}")
+            ok = False
+            continue
+        top = scored[0]
+        ex = exactness(tiles, src, in_features)
+        verdict = "UNBIASED int4 rne" if abs(ex["bias_over_scale"]) < 0.05 \
+            and abs(ex["rms_over_scale"] - RNE_RMS) < 0.05 else "off-convention"
+        if top[0] < args.min_corr:
+            ok = False
+            verdict = "NO CONVENTION MATCHES"
+        print(f"{k.split('.')[-2]+'.'+k.split('.')[-1]:<44} {ex['corr']:>7.4f} "
+              f"{ex['bias_over_scale']:>8.4f} {ex['rms_over_scale']:>7.4f} "
+              f"{ex['q_match']:>7.5f}  {verdict}{orient}")
+        if args.search:
+            print(f"    winner: scale={top[1]} nibble={top[2]} nibpol={top[3]} lanepol={top[4]}")
+            for c, sl, nm, np_, lp in scored:
+                print(f"    corr {c:7.4f}  scale={sl:<11} nibble={nm:<8} "
+                      f"nibpol={np_} lanepol={lp}")
+    print()
+    print("SETTLED" if ok else "NOT SETTLED — inspect above")
+    return 0 if ok else 1
+
+
+def _infer_in_features(n_i8_rows, src):
+    """n_i8_rows = (out/32) * (in/256). Try the shapes the source permits."""
+    out_rows = src.shape[0]
+    if src.shape[1] % TILE_COLS == 0:
+        cand = src.shape[1]
+        if n_i8_rows == (out_rows // TILE_ROWS) * (cand // TILE_COLS):
+            return cand
+        if n_i8_rows == (src.shape[1] // TILE_ROWS) * (out_rows // TILE_COLS):
+            return out_rows
+    raise SystemExit(f"cannot infer in_features: {n_i8_rows} tile rows vs source {src.shape}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -1229,11 +1229,28 @@ static int run_embedded_lemonade(int argc, char** argv) {
     // unless this path proves it executed. "The path ran and decided differently"
     // and "the path never ran" are indistinguishable in a results table, so this
     // sentinel makes the difference observable. It reports what the engine
-    // registry sees and states what is NOT surfaced here: Lemonade owns
-    // /v1/models in this mode, its extra-models-dir scan is GGUF-only, and flm
-    // models come from `flm list` — so a native Q4NX/1BP id is not listable on
-    // this face until R8 is wired. Failures are swallowed: a registry scan must
-    // never stop Lemonade from serving.
+    // registry sees and states what is NOT surfaced here. Lemonade owns
+    // /v1/models in this mode: its extra-models-dir scan is GGUF-only and flm
+    // models come from `flm list`, so neither path can surface a native
+    // Q4NX/1BP id by itself. Those ids reach /v1/models through the `onebit`
+    // backend instead — this block injects each artifact as a recipe=onebit
+    // ModelInfo and that descriptor declares dynamic_models = true
+    // (third_party/lemonade/src/cpp/include/lemon/backends/onebit/onebit.h),
+    // so ModelManager's dynamic discovery (model_manager.cpp, Step 1.6) lists
+    // them as ROUTABLE models. server.cpp's /v1/models build states it outright:
+    // "the `onebit` backend (dynamic_models) registers them with ModelManager, so
+    // they already appear via get_supported_models()/get_downloaded_models() ...
+    // Appending them again would duplicate every id." The full registry view —
+    // container, path, capabilities — is additionally served whole at
+    // /v1/registry (set_registry_surface).
+    //
+    // CORRECTED 2026-09-11: this comment previously ended "...so a native
+    // Q4NX/1BP id is not listable on this face until R8 is wired." That was the
+    // pre-R8 state and it contradicted the injection ~30 lines below plus the
+    // descriptor's dynamic_models flag, which is exactly what R8 wired. It is
+    // called out because a reviewer reading the stale sentence would conclude
+    // step 6 is unmet on this face — the opposite of what the code does.
+    // Failures are swallowed: a registry scan must never stop Lemonade from serving.
     std::vector<lemon::Server::RegistryModelView> registry_views;
     std::vector<lemon::ModelInfo> onebit_models;
     {


### PR DESCRIPTION
### **User description**
## What

The delta produced by the `mtvd3pmx` audit, rebased onto the squash of #2190. **11 commits,
6 files, +596/−16.** One behavioural change, two comment corrections, and two tools.

## The behavioural change (the only one)

**`discover()` no longer selects a backend it has not selected** — `src/backend_manager.cpp`,
one line:

```cpp
rank_backends();
active_idx_ = backends_.size();   // was: = 0
```

`rank_backends()` **ranks** lanes; it does not **choose** one. Setting `0` made any report
taken before (or without) a successful init name the top-*ranked* lane as "Active":
reachability reading as selection, the inversion `model_registry_route.h` warns about
(UNKNOWN must not be indistinguishable from PRESENT). Combined with there being **no early
exit on a failed init** in `tools/unified_server.cpp`, the worst case was a server that could
serve nothing answering `/v1/health` with `status: "ok"` while naming a never-initialised
backend.

Audited before touching, because the fix is only safe if the "none" state is already
anticipated — it is, at every site: `active_info()`/`active_backend()` return `nullptr`;
every read is guarded by `active_idx_ < backends_.size()`; `re_evaluate()` already uses
`backends_.size()` as its own not-found sentinel and restores by id *string*; `init_in_order()`
sets the index on the first successful init; `failover()` sets it before returning true; the
status report already prints `none`. A `generate()` before init was **already** safe — it
tests `info.functional && info.instance` before taking the instance, so no null-deref was
added or removed. This is a reporting change, not a lifetime change.

**Not** done here: `/v1/health` still reports `status: "ok"` with no active backend. That is a
health-**contract** question (clients branch on `status`), so it is raised rather than patched
in passing.

## Two comment corrections

Both comments stated the opposite of the code beneath them; both were verified before being
changed:

- `tools/unified_server.cpp` — the `--lemonade` coverage guard claimed *"a native Q4NX/1BP id
  is not listable on this face until R8 is wired"*. R8 **is** wired: the guard block injects
  each artifact as a `recipe=onebit` model, that descriptor declares `dynamic_models = true`,
  and `ModelManager`'s dynamic discovery lists them, so they already appear in `/v1/models`.
  The stale sentence would make a reviewer conclude goal step 6 is unmet — the opposite of
  what the code does.
- `src/backend_manager.cpp` — `failover()` claimed a decode failure lands *"never on a backend
  discovery happened to register next (… G1a)"*. `fallback_order()`'s own docstring says it
  covers **all** of `backends_` in registration order as a last resort, so that lane **is**
  reachable. What actually prevents a wrong-*container* failover is fail-closed in the
  executors (`backend_npu.cpp:349`, `backend_npu_flm.cpp:189`, both rejecting non-Q4NX).
  Route order is a preference; the filter is the executor's init gate.
- `src/model_router.cpp` — a fossil: it documented *"npu_xrt is the sole NPU route since PR
  #567"* directly above a Q4NX route returning `npu_flm`. `git log -S` pins it: written
  2026-07-21 (`d6d670279`), invalidated 8 days later when `6b2eab42f` registered `npu_flm`,
  and left unchanged for six weeks.

## The two tools

- `tools/q4nx/verify_zaya_layout.py` — settles a Q4NX decode convention **against the source
  checkpoint**, element-wise, no NPU and no build. Self-checking: exit 0 only when a
  convention is unambiguous. On `zaya1-8b.q4nx`: row-major scales + signed nibbles, corr
  0.995, `|bias/scale| ≤ 0.0002`, `rms/scale 0.29–0.31` against `1/√12 = 0.2887` for int4
  round-to-nearest.
- `tools/capture_npu_acceptance.sh` — captures the acceptance transcript (its absence had
  cost two wrong diagnoses), preflights the FLM/worker path candidates that decide which lane
  comes up, and runs **two negative controls**: a nonexistent id must 404, and `CONTROL_MODEL`
  must also be refused — because a completion alone cannot show the artifact was served on a
  lane that receives a tag rather than a path.

## Verification, and its limits

- `-fsyntax-only` with the project's flags: **5/5 exit 0**, re-run after the rebase. The
  include handling matters — the other checkout's `-I` paths are **remapped** onto this tree,
  not dropped; an earlier check against a neighbour's headers produced 7 spurious errors.
- Both tools exercised end-to-end against fake binaries/servers (the capture script against a
  server that answers 200 to everything, which it correctly reports as *failing* the controls).
- **Not built, not run, no NPU.** No build tree in the worktree. CI on this branch starts with
  this PR.

## Not in scope

The `npu_flm` tag seam (requirement R2): that lane execs `flm serve <tag>` and never receives
the requested path, so a native artifact whose tag maps elsewhere (`zaya1-8b.q4nx` →
`qwen3:1.7b`) would be answered by a 1.7 B Qwen3 — detected by `WARNING #1604` and served
anyway. Tracked with a specified fix in the audit record below; it changes routing policy and
does not belong in this delta.

## Provenance

The audit that produced this, including what was refuted and what remains open:
`~/okf/systems/1bit-monster/references/engine-layering-and-lemonade-scope-summary.md`
(and §9.10 of `engine-layering-and-lemonade-scope.md`).


___

### **PR Type**
Bug fix, Enhancement, Documentation


___

### **Description**
- `discover()` reports no backend until init succeeds

- Corrects stale comments in router, route bridge, lemonade guard

- Adds `verify_zaya_layout.py` Q4NX-versus-checkpoint convention verifier

- Adds `capture_npu_acceptance.sh` transcript-keeping NPU acceptance harness


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["discover() ranks lanes only"] -- "active_idx_ = backends_.size() (none)" --> B["status reports no Active backend"]
  B -- "init_in_order() / failover() set index" --> C["selection stays a real init result"]
  D["stale comments: model_router, route bridge, lemonade guard"] -- "rewritten to match code" --> E["audit trail (ADR mtvd3pmx)"]
  F["tools/q4nx/verify_zaya_layout.py"] -- "container vs safetensors, 4-way convention search" --> G["decode convention settled by measurement"]
  H["tools/capture_npu_acceptance.sh"] -- "full transcript + refusal controls" --> I["NPU lane-selection evidence"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_manager.cpp</strong><dd><code>discover() stops presenting a never-initialized backend as active</code></dd></summary>
<hr>

src/backend_manager.cpp

<ul><li><code>discover()</code> sets <code>active_idx_ = backends_.size()</code> instead of <code>0</code>, so <br>ranking no longer reads as selection.<br> <li> Long comment documents why the "none" sentinel is safe at every read <br>site (<code>active_info()</code>, <code>re_evaluate()</code>, <code>init_in_order()</code>, <code>failover()</code>, <br>status print).<br> <li> Flags that <code>/v1/health</code> still reports <code>status: "ok"</code> with no active <br>backend (a contract question, raised in ADR §9.10.11).<br> <li> Rewrites the <code>failover()</code> cascade comment: router order is a preference; <br>each executor's init gate is the fail-closed filter.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2191/files#diff-f2ed10bacc975dc1c4ed35af9a62ab967874cf0273695b07cceb6059ed53a1cf">+37/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model_registry_route.cpp</strong><dd><code>Corrects NPU_XRT selection claim in route bridge comment</code>&nbsp; </dd></summary>
<hr>

src/model_registry_route.cpp

<ul><li>Narrows the claim that <code>npu_xrt</code> is never selected: <code>dynamic_router</code>'s <br>NPU_ONLY branch does accept it.<br> <li> Explains that <code>rank_backends()</code> orders <code>functional</code> first, so the branch <br>lands on <code>npu_xrt</code> only if <code>npu_flm</code> failed.<br> <li> Notes the ~1000x gap (67.5 vs 0.06 tok/s) reads as "served at ~0 <br>tok/s", not as a miss.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2191/files#diff-d8bc724c7d449d6094f72d890f17fd709b757eea9907e700f2e0e7299394b9dd">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>model_router.cpp</strong><dd><code>Fixes stale qwen3 routing hierarchy comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/model_router.cpp

<ul><li>Header routing hierarchy now lists <code>npu_flm</code> first for qwen3, <code>npu_xrt</code> as <br>the legacy fallback.<br> <li> Removes the stale "npu_xrt is the sole NPU route" and "FLM removed <br>entirely" claims.<br> <li> Withholds the unverified licensing assertion and says to reconcile it <br>separately.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2191/files#diff-089ad0c08632c047539ba503002a30410fb86a7ec002e3a10c274462b6f26984">+21/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>unified_server.cpp</strong><dd><code>Corrects lemonade-face registry comment to post-R8 state</code>&nbsp; </dd></summary>
<hr>

tools/unified_server.cpp

<ul><li>Rewrites the <code>--lemonade</code> coverage-guard comment: native Q4NX/1BP ids <br>reach <code>/v1/models</code> via the <code>onebit</code> backend.<br> <li> Cites <code>dynamic_models = true</code> in <code>onebit.h</code> and ModelManager's dynamic <br>discovery, so re-appending would duplicate ids.<br> <li> Notes the full registry view is served at <code>/v1/registry</code>.<br> <li> Calls out the previous sentence as pre-R8 and contradicted by the <br>injection below it.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2191/files#diff-108a4e5ad06a8667d81e8da41605283a4dff15e0519645becad615fded67977c">+22/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>verify_zaya_layout.py</strong><dd><code>Adds Q4NX-versus-checkpoint decode convention verifier</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/q4nx/verify_zaya_layout.py

<ul><li>New standalone tool comparing a Q4NX container element-wise against <br>its published safetensors checkpoint.<br> <li> Searches scale-layout × nibble-sign × nibble/lane polarity conventions <br>and reports the winner.<br> <li> Reports corr, <code>bias/scale</code>, <code>rms/scale</code> versus int4 round-to-nearest <br>(0.2887) and <code>q_match</code>.<br> <li> Exits non-zero when no convention is unambiguous; needs no NPU and no <br>engine build.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2191/files#diff-e8f3522d16424fc748eab46dbef219776ea34400122b731a1cc72acda0df78cb">+289/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>capture_npu_acceptance.sh</strong><dd><code>Adds transcript-keeping NPU acceptance capture script</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/capture_npu_acceptance.sh

<ul><li>New bash harness that runs the NPU acceptance request and keeps the <br>whole server transcript.<br> <li> Preflights the FLM config/bin/worker paths that silently decide which <br>lane comes up.<br> <li> Adds two negative controls: nonexistent id must 404, and a <br>tag-mismatched artifact must be refused.<br> <li> Writes <code>SUMMARY.md</code> with selection lines, completion, controls, reading <br>guide and orphan report.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2191/files#diff-d090998118eae4bba349e184a03b603d1d46f6691ba4471e21e0c175a468e6d8">+215/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

