### PR TITLE
fix(npu): refuse a tag that resolves to a differently-named model (goal mtvd3pmx R2)

### DIFF
--- a/src/backend_npu_flm.cpp
+++ b/src/backend_npu_flm.cpp
@@ -214,20 +214,40 @@ public:
         model_tag_ = flm_tag_for_model(cfg);
         fprintf(stderr, "NPU: launching FLM %s...\n", model_tag_.c_str());
 
-        // #1604: the FLM registry (model_list.json) silently overrides the
-        // requested --model path — the tag resolves to whatever the registry
-        // points at. Warn loudly when the registry's model for the resolved
-        // tag differs from the requested file, so a redirected service is
-        // discoverable without digging through the FLM child's log.
+        // #1604 / R2 (goal mtvd3pmx): the FLM registry (model_list.json) silently
+        // overrides the requested --model path — the tag resolves to whatever the
+        // registry points at, and the executor is launched as `flm serve <tag>` (see
+        // ensure_serve()), so the requested path is NEVER handed to FLM. When the
+        // registry's model for the resolved tag is a differently-named model, serving
+        // would answer a request for THIS artifact with OTHER weights. That is the
+        // failure requirement R2 forbids, so it is refused rather than warned about.
+        //
+        // Two corrections to the original check, both required before it could gate:
+        //  (1) compare the file STEM, not the whole basename. The old predicate
+        //      compared the filename including its extension, so it fired on the
+        //      CORRECT configuration — `weights/Qwen3-0.6B-NPU2.q4nx`, a symlink to
+        //      the very file the registry serves, differs from the registry name
+        //      `Qwen3-0.6B-NPU2` by ".q4nx" alone. A detector that fires on correct
+        //      setups is not a usable signal and could not have been promoted to a
+        //      gate (ADR 9.10.16).
+        //  (2) compare case-insensitively — registry names and the filenames users
+        //      give them differ in case often enough that a case-sensitive gate would
+        //      refuse legitimate setups.
+        // The refusal fires only when BOTH the stem and the containing directory
+        // differ from the registry's model name, i.e. when the engine has positively
+        // established that the tag names a different model. That covers the two
+        // legitimate shapes: `weights/<Name>.q4nx` and
+        // `<flm models root>/<Name>/model.q4nx`.
         {
             std::string tag = model_tag_, variant;
             size_t colon = tag.find(':');
             if (colon != std::string::npos) { variant = tag.substr(colon + 1); tag = tag.substr(0, colon); }
             std::ifstream f(flm_config_);
             if (f) {
+                bool lossy = false;
+                std::string reg_name;
                 try {
                     nlohmann::json j; f >> j;
-                    std::string reg_name;
                     auto models = j.value("models", nlohmann::json::object());
                     if (models.contains(tag)) {
                         auto& v = models[tag];
@@ -238,21 +258,36 @@ public:
                         }
                     }
                     if (!reg_name.empty()) {
+                        auto lower = [](std::string s) {
+                            for (char& c : s)
+                                if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
+                            return s;
+                        };
                         std::string req = cfg.model_path, req_dir = req;
                         size_t sl = req.find_last_of('/');
                         if (sl != std::string::npos) { req = req.substr(sl + 1); req_dir = req_dir.substr(0, sl); }
                         size_t dl = req_dir.find_last_of('/');
                         std::string req_dir_name = dl == std::string::npos ? req_dir : req_dir.substr(dl + 1);
-                        if (req_dir_name != reg_name && req != reg_name) {
-                            fprintf(stderr,
-                                "WARNING #1604: requested --model %s but FLM registry %s maps tag '%s' to "
-                                "registry model '%s' — serving the REGISTRY model, not the requested file. "
-                                "Set NPU_MODEL_TAG or fix model_list.json to serve the requested model.\n",
-                                cfg.model_path.c_str(), flm_config_.c_str(), model_tag_.c_str(), reg_name.c_str());
-                        }
+                        std::string req_stem = req;
+                        size_t dot = req_stem.find_last_of('.');
+                        if (dot != std::string::npos && dot > 0) req_stem = req_stem.substr(0, dot);
+                        lossy = (lower(req_stem) != lower(reg_name) &&
+                                 lower(req_dir_name) != lower(reg_name));
                     }
                 } catch (const std::exception& e) {
                     fprintf(stderr, "NPU: failed to parse %s for model validation: %s\n", flm_config_.c_str(), e.what());
+                }
+                if (lossy) {
+                    fprintf(stderr,
+                        "NPU: REFUSING --model %s — it maps to FLM tag '%s', and %s resolves that tag to "
+                        "registry model '%s'. This executor is launched as `flm serve <tag>` and never "
+                        "receives the requested path, so it would answer with the REGISTRY model's "
+                        "weights instead of the requested artifact (R2). Remedies: route this artifact "
+                        "to a path-capable lane; or set NPU_MODEL_TAG to the tag you intend; or place it "
+                        "as <flm models dir>/%s/model.q4nx so its identity matches the tag.\n",
+                        cfg.model_path.c_str(), model_tag_.c_str(), flm_config_.c_str(),
+                        reg_name.c_str(), reg_name.c_str());
+                    return false;
                 }
             }
         }


### PR DESCRIPTION
### **User description**
## What

Closes requirement **R2** of goal `mtvd3pmx`: *"Lemonade catalogs … and FLM's catalog become read-only views, **never sources**"*. One file: `src/backend_npu_flm.cpp`, +48/−13.

## The defect

`npu_flm` is launched as `execl(flm_bin_, "flm", "serve", model_tag_, …)` — a **tag**, never the requested path (`ensure_serve()`, `:321`). So the weights that answer are chosen by `flm_tag_for_model()` + FLM's `model_list.json`. When the registry's model for the tag is a *differently named* model, the engine **detected** it and printed `WARNING #1604 … serving the REGISTRY model, not the requested file` — and then served the registry model anyway. Measured consequence: `zaya1-8b.q4nx` → tag `qwen3:1.7b` → the box's registry resolves that to `Qwen3-1.7B-NPU2`, so a request for a 8B Zaya would be answered by a 1.7 B Qwen3, indistinguishably at the call site.

## The change

**Two corrections were required before the check could gate anything:**

1. **Compare the file *stem*, not the whole basename.** The old predicate compared the filename *including its extension*, so it fired on the **correct** configuration — verified on strixhalo, `~/.local/share/1bit-monster/weights/Qwen3-0.6B-NPU2.q4nx` is a **symlink to the very file the registry serves**, yet it differed from the registry name `Qwen3-0.6B-NPU2` by `.q4nx` alone. A detector that fires on correct setups is not a usable signal.
2. **Compare case-insensitively** — registry names and user filenames differ in case often enough that a case-sensitive gate would refuse legitimate setups.

The check now fires only when **both** the stem and the containing directory differ from the registry's model name — i.e. when the engine has positively established that the tag names a different model. That covers both legitimate shapes: `weights/<Name>.q4nx` and `<flm models root>/<Name>/model.q4nx`.

**Then it refuses** (`init` returns `false`) instead of warning, naming the tag, the registry model, and three remedies (route to a path-capable lane / set `NPU_MODEL_TAG` / place the artifact as `<flm models dir>/<Name>/model.q4nx`). Fail closed and fail visibly: an answer built from other weights is worse than an error.

## Evidence

Logic tested **without a build**, by replicating the predicate over five real cases:

| case | allow/refuse | new | old |
|---|---|---|---|
| `weights/Qwen3-0.6B-NPU2.q4nx` (symlink to the registry file) | allow | allow | **fires** (false positive) |
| `<flm root>/Qwen3-0.6B-NPU2/model.q4nx` | allow | allow | allow |
| `qwen3-0.6b-npu2.q4nx` (case differs) | allow | allow | **fires** (false positive) |
| `models/zaya1-8b.q4nx` → tag `qwen3:1.7b` | refuse | refuse | fires (same output) |
| `models/zaya1-8b.1bp` → same tag | refuse | refuse | fires (same output) |

The old predicate produced **identical output** for the correct artifact and the malignant one — it could not distinguish the cases it existed to separate (ADR §9.10.16). The new one separates them.

`-fsyntax-only`: **exit 0** (project flags, foreign `-I` remapped onto this tree).

## Not covered, deliberately

A **copy** of the registry model under a different name refuses, because its identity cannot be proven from names. That is the safe direction, and the error message says how to proceed. A `realpath`-based predicate (sketched in ADR §9.10.17) would avoid it but needs FLM's models-root candidates; it is not required to close R2.

## Provenance

ADR §9.10.9 (the hole), §9.10.13 (R2's status), §9.10.15 (why the failover design protects containers and not weights), §9.10.16 (why #1604 could not gate). Summary: `~/okf/systems/1bit-monster/references/engine-layering-and-lemonade-scope-summary.md`.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Refuse tags resolving to differently-named registry models

- Compare file stem case-insensitively, not full basename

- Fire only when stem and directory both differ

- Actionable error names tag, registry model, remedies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["init: cfg.model_path"] -- "flm_tag_for_model()" --> B["model_tag_ + variant"]
  B -- "read flm_config_ (model_list.json)" --> C["registry model name"]
  C -- "compare stem & dir, case-insensitive" --> D{"lossy?"}
  D -- "no" --> E["proceed: spawn flm serve tag"]
  D -- "yes" --> F["REFUSING: return false + remedies"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_npu_flm.cpp</strong><dd><code>Promote registry-override warning to fail-closed refusal</code>&nbsp; </dd></summary>
<hr>

src/backend_npu_flm.cpp

<ul><li>Replace the <code>WARNING #1604</code> registry-override message with a hard <br>refusal (<code>return false</code>) so a lossy tag never serves other weights (R2).<br> <li> Fix the detector: compare the requested file stem (extension stripped) <br>instead of the whole basename, and compare case-insensitively via a <br>new <code>lower()</code> lambda.<br> <li> Introduce <code>lossy</code>/<code>reg_name</code> state hoisted out of the <code>try</code> block; refuse <br>only when both the stem and the containing directory differ from the <br>registry model name.<br> <li> Emit an actionable error naming the tag, the registry model, the <br>config path, and three remedies (path-capable lane, <code>NPU_MODEL_TAG</code>, <br><code><models dir>/<name>/model.q4nx</code>).</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2192/files#diff-4e93577e84d75f843aa3da050ebf7a4dff693b799d8059a050d637283c0f31f3">+48/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

