### PR TITLE
fix(health): /v1/health reports "initialized" so a backendless run is not silent

### DIFF
--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -389,6 +389,14 @@ static json health_json(BackendManager& mgr) {
     j["service"] = "1bit-monster unified inference server";
 
     auto* active = mgr.active_info();
+    // Goal mtvd3pmx audit (§9.10.11): `status` above stays "ok" because clients branch on
+    // it, but it is NOT the honest signal on its own — a run in which every lane failed to
+    // initialise still answers 200 with status "ok". `GET /` already reports
+    // ready|initializing from this same state, and /v1/backend/status already calls this
+    // fact `initialized` (:2965), so this carries the same fact under the existing name
+    // rather than inventing one. After the `discover()` fix stopped a never-initialised
+    // lane from being *named* as active, this stops its absence from being *silent*.
+    j["initialized"] = (active != nullptr);
     if (active) {
         j["active_backend"]["id"] = active->id;
         j["active_backend"]["type"] = backend_name(active->type);


### PR DESCRIPTION
### **User description**
## What

`/v1/health` now reports **`initialized`** (boolean, from `mgr.active_info()`), so a run that initialised no backend is visible instead of silent. +8 lines, one insertion in `health_json()`.

## Why

`/v1/health` set `status: "ok"` unconditionally. There is **no early exit on a failed initialisation** in this server (`grep -n '!inited' tools/unified_server.cpp` → nothing), so a run in which *every* lane failed still answers 200 with `status: "ok"`.

The `discover()` fix (goal `mtvd3pmx`, PR #2191) stopped a never-initialised lane from being **named** as active. That left the absence **silent**: a caller could no longer be told a lie, but also could not tell "serving" from "initialised nothing".

## Why this shape

The honest form is already this file's own convention:

- `GET /` reports `ready` / `initializing` from the same `active_backend()` state (`:2983`);
- `/v1/backend/status` already calls this fact **`initialized`** (`:2965`).

So this emits the same fact under the name that already exists rather than inventing a second vocabulary for one fact — the same reasoning that makes the registry bridge keyed by engine id rather than by `BackendType`.

**`status` is deliberately left as `"ok"`.** Clients branch on it; changing a contract value is the owner's decision, not a drive-by. The boolean carries the signal, the string keeps its meaning. If the owner would rather have `status: "degraded"` when nothing is selected, that is a one-line follow-up on top of this.

## Verification

`-fsyntax-only`: **exit 0** (project flags, other checkout's `-I` remapped onto this tree). Not built or run here; CI carries the build. The `/v1/health` handler augments the JSON produced by `health_json()` and holds both `g_config_mutex` and `g_strategy_mutex`, so the field survives and the read is properly ordered.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- `/v1/health` now carries an `initialized` boolean

- Field derived from `mgr.active_info()` being non-null

- A backendless run is no longer silent

- `status: "ok"` deliberately left unchanged

- Comment documents the `mtvd3pmx` §9.10.11 rationale


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["health_json(mgr)"] -- "active_info() != nullptr" --> B["initialized = true"]
  A -- "active_info() == nullptr" --> C["initialized = false"]
  B --> D["/v1/health JSON response"]
  C --> D
  D -- "status stays \"ok\"" --> E["clients branch on status string"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>unified_server.cpp</strong><dd><code>health_json() reports `initialized` from active backend state</code></dd></summary>
<hr>

tools/unified_server.cpp

<ul><li>Adds <code>j["initialized"] = (active != nullptr);</code> to <code>health_json()</code>, driven <br>by <code>mgr.active_info()</code>.<br> <li> Leaves <code>j["status"] = "ok"</code> untouched so the existing client contract is <br>preserved.<br> <li> Adds a comment citing goal <code>mtvd3pmx</code> (§9.10.11) and aligning with <code>GET /</code> <br>ready|initializing and <code>/v1/backend/status</code>'s <code>initialized</code> name.<br> <li> Follows the <code>discover()</code> fix: a never-initialised lane is no longer <br>named active, and its absence is no longer silent.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2194/files#diff-108a4e5ad06a8667d81e8da41605283a4dff15e0519645becad615fded67977c">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

