### PR TITLE
fix(npu): npu_xrt serves the artifact the RESOLVER resolved, not one it discovered (R8)

### DIFF
--- a/src/backend_npu.cpp
+++ b/src/backend_npu.cpp
@@ -352,10 +352,35 @@ struct NPUBackend : Backend {
             return false;
         }
 
-        const char* model_path = getenv("NPU_MODEL_PATH");
+        // R8 (goal mtvd3pmx / issue #2193): the artifact the RESOLVER resolved wins.
+        // The paragraph above states the intent, but the path handling never implemented
+        // it — this lane looked only at NPU_MODEL_PATH and then at auto-discovery, so a
+        // request naming one artifact was answered by whichever file the search happened
+        // to find. Measured: `-m ~/models/zaya1-8b.q4nx` loaded
+        // `~/.config/flm/models/Llama-3.2-1B-NPU2/model.q4nx` and reported Zaya's own
+        // dimensions over it. Precedence now: the requested artifact (`-m`), then the
+        // explicit NPU_MODEL_PATH override, then discovery. If the override disagrees with
+        // the request, the REQUEST wins and the conflict is printed — the point of the
+        // goal is that a request is answered by the artifact it named.
+        std::string resolved_model_path;
+        const char* model_path = nullptr;
+        if (!cfg.model_path.empty()) {
+            resolved_model_path = cfg.model_path;
+            model_path = resolved_model_path.c_str();
+            const char* env_mp = getenv("NPU_MODEL_PATH");
+            if (env_mp && env_mp[0] && resolved_model_path != env_mp) {
+                fprintf(stderr, "NPU: NPU_MODEL_PATH=%s conflicts with the requested artifact %s "
+                                "— serving the REQUESTED artifact (R8)\n",
+                        env_mp, resolved_model_path.c_str());
+            }
+        } else if (const char* env_mp = getenv("NPU_MODEL_PATH")) {
+            resolved_model_path = env_mp;
+            model_path = resolved_model_path.c_str();
+        }
         std::string discovered_path;
         if (!model_path) {
             // Auto-discovery: search common paths for model.q4nx (#444)
+            // Only reached when neither `-m` nor NPU_MODEL_PATH named an artifact.
             // 1. Current dir + common paths
             const char* home_model = getenv("HOME");
             static std::string home_model_path = (home_model && home_model[0]) ? std::string(home_model) + "/.local/share/1bit-monster/weights/model.q4nx" : "";


### PR DESCRIPTION
### **User description**
## What

`npu_xrt` now serves **the artifact the resolver resolved**. +26/−1 in `src/backend_npu.cpp`.

## The defect

The lane looked only at `NPU_MODEL_PATH`, then at auto-discovery — so a request naming one artifact was answered by whichever file the search happened to find. **Its own comment already stated the intent**:

> *"The worker engine only speaks Q4NX (model.q4nx via `NPU_MODEL_PATH` or auto-discovery) — it **ignores `cfg.model_path` entirely** and would silently load a different model than the one requested. Reject other formats up front so the router never selects it for them."*

The guard was real for **format** and absent for **identity**.

Measured on the goal's own acceptance (issue #2193) — `./build/1bit unified -m ~/models/zaya1-8b.q4nx`, then a chat naming it:

```
NPU: model tag set to 'model' (from /home/bcloud/.config/flm/models/Llama-3.2-1B-NPU2/model.q4nx)
NPU: loaded embed 0 floats
NPU: ready — 40 layers, H=2048, V=262272, embed=0
```

It loaded a **Llama-3.2-1B** and reported **Zaya's dimensions** over it. A lane that violates "one registry, one router" one layer *below* the router, at the executor's own file lookup.

## The change

Precedence: **the requested artifact (`-m`)** → **`NPU_MODEL_PATH`** → **discovery**. When the env override disagrees with the request, the **request wins and the conflict is printed**, because the point of the goal is that a request is answered by the artifact it named — a process-level env var must not silently redirect a resolved artifact.

Logic checked without a build, precedence replicated over five cases:

| `-m` | `NPU_MODEL_PATH` | served | note |
|---|---|---|---|
| set | — | the requested file | |
| set | agrees | the requested file | |
| set | **disagrees** | the requested file | conflict printed |
| — | set | the env file | |
| — | — | discovered | unchanged path |

Under this, the run above resolves the **requested Zaya** instead of the Llama.

## Scope — this does *not* make zaya serve

Stated plainly so the PR is not read as more than it is: with the right file attempted, the lane still reports **`loaded embed 0 floats`**, because its embed/norm pre-load reads **floats** while `zaya1-8b.q4nx` stores a **quantized** embed (`model.embed_tokens.weight` → `{"dtype":"I8"}`, measured). That is defect 2 of #2193, and it is untouched here. The lane now **fails on the artifact it was asked for** rather than quietly on a different one.

## Verification

`-fsyntax-only`: **exit 0** (project flags, other checkout's `-I` remapped onto this tree). Not built or run here; CI carries the build. Reproduction and both transcripts: issue #2193.


___

### **PR Type**
Bug fix


___

### **Description**
- `npu_xrt` now serves the artifact the resolver resolved

- Precedence: requested `-m` path, then `NPU_MODEL_PATH`, then discovery

- Conflicting `NPU_MODEL_PATH` is overridden by the request, conflict printed

- Auto-discovery reached only when neither source names an artifact


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cfg.model_path (-m, resolved)"] -- "non-empty" --> B["serve requested artifact"]
  A -- "empty" --> C["NPU_MODEL_PATH env"]
  C -- "set" --> D["serve env artifact"]
  C -- "unset" --> E["auto-discovery search paths"]
  C -. "conflicts with request" .-> F["print conflict, request wins"]
  F --> B
  B --> G["Q4NX worker subprocess"]
  D --> G
  E --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_npu.cpp</strong><dd><code>Honour the resolved artifact over env override and discovery</code></dd></summary>
<hr>

src/backend_npu.cpp

<ul><li>Replaces the <code>NPU_MODEL_PATH</code>-only lookup with a three-step precedence: <br><code>cfg.model_path</code> (the artifact the resolver resolved), then <br><code>NPU_MODEL_PATH</code>, then auto-discovery.<br> <li> Keeps the resolved path in a local <code>std::string resolved_model_path</code> so <br>the <code>const char*</code> pointer stays valid.<br> <li> Prints a conflict message when <code>NPU_MODEL_PATH</code> disagrees with the <br>requested artifact, and serves the requested one (R8 / goal mtvd3pmx).<br> <li> Comments that discovery is only reached when neither <code>-m</code> nor the env <br>var named an artifact; keeps the Q4NX-only format gate unchanged.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2195/files#diff-edb2b6fe530199d3613d69af900300a84671f317e6bc60f84124f74a781ae69a">+26/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

