### PR TITLE
fix(tokenizer): consult the artifact's own directory before borrowing a GGUF vocab

### DIFF
--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -1490,8 +1490,12 @@ int main(int argc, char** argv) {
     // ── Load tokenizer ──
     std::string tok_path = tokenizer_path();
     if (!g_tokenizer.load(tok_path)) {
-        printf("  ⚠  Tokenizer not found at %s\n", tok_path.c_str());
-        printf("     Using fallback tokenizer (ASCII passthrough)\n");
+        // Deliberately NOT "using fallback ASCII" here: this runs before the model is known,
+        // and load_model_tokenizer() — called later with the resolved artifact — now also
+        // consults the artifact's own directory (a tokenizer.htok beside a native container).
+        // Claiming a degraded state now contradicts what the log says a few lines later.
+        printf("  ·  No global tokenizer at %s\n", tok_path.c_str());
+        printf("     Will try the model's own directory once the model is known\n");
     } else {
         printf("  ✓  Tokenizer loaded\n");
     }
@@ -1742,6 +1746,13 @@ int main(int argc, char** argv) {
     // much as backend routing for arbitrary (non-Zaya) models. Falls back
     // silently (keeps whatever tokenizer was already loaded) if unavailable.
     load_model_tokenizer(cfg.model_path);
+    // State the OUTCOME, once, after the per-model lookup has had its chance. Without this the
+    // only tokenizer message was the pre-model warning above, which could be superseded — and a
+    // run that decoded correctly would still read as if it had fallen back to ASCII.
+    if (g_tokenizer.use_bpe && g_tokenizer.bpe_tok)
+        printf("  ✓  Tokenizer ready (BPE)\n");
+    else
+        printf("  ⚠  No tokenizer for this model — output will be [id][id] ASCII passthrough\n");
     // The flip: the registry resolver is consumed here. The merge is a UNION — the
     // registry can demote the head only for a stated exclusion, and never drops a
     // router lane — so this cannot lose a route the engine has today.

--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -233,6 +233,26 @@ static std::string tokenizer_path() {
 // as garbage [id][id] through the ASCII fallback.
 static void load_model_tokenizer(const std::string& model_path) {
     if (g_tokenizer.load_from_gguf(model_path)) return;
+    // Prefer a tokenizer that sits BESIDE the artifact. Every candidate below this point is a
+    // GGUF the loader borrows vocabulary from, so a native container (Q4NX/1BP) with no GGUF
+    // sibling could never be detokenised — the lookup never considered its own directory. The
+    // only other path consulted is the WEIGHTS DIR (tokenizer_path()), which is wrong for an
+    // artifact kept anywhere else. Measured on strixhalo: a served zaya1-8b.q4nx from
+    // ~/models returned "[81930][129662]…" -- correct generation, ASCII fallback for text.
+    // `model.q4nx + tokenizer.htok in one directory` is the natural layout, so it wins here.
+    {
+        auto exists2 = [](const std::string& p) {
+            std::ifstream f(p, std::ios::binary);
+            return f.good();
+        };
+        auto slash2 = model_path.find_last_of('/');
+        std::string dir2 = (slash2 != std::string::npos) ? model_path.substr(0, slash2 + 1) : "";
+        auto dot2 = model_path.find_last_of('.');
+        std::string stem2 = (dot2 != std::string::npos) ? model_path.substr(0, dot2) : model_path;
+        for (const std::string& c : {dir2 + "tokenizer.htok", stem2 + ".htok"}) {
+            if (exists2(c) && g_tokenizer.load(c)) return;
+        }
+    }
     // NOTE: no early return for .gguf paths — load_from_gguf needs the ZINC
     // lib (usually absent → ZINC_DISABLED), so even real GGUFs must fall
     // through to .htok synthesis below, or the server decodes their output


### PR DESCRIPTION
### **User description**
## What

`load_model_tokenizer()` now consults the **artifact's own directory** before falling back to GGUF-derived vocabularies. +20 lines in `tools/unified_server.cpp`.

## Why

A native container (Q4NX/1BP) could not be detokenised unless a **GGUF sibling** happened to exist. The loader tries the model path, then a list of derived GGUF names, then a directory scan for a GGUF with a matching stem — all GGUF vocabulary borrowing. The only other path consulted is the **weights dir** (`tokenizer_path()`), which is wrong for an artifact kept anywhere else.

Measured on strixhalo once the `npu_xrt` fixes made a native artifact serve at all (#2196):

```console
No .htok at /home/bcloud/.local/share/1bit-monster/weights//tokenizer.json — using fallback ASCII tokenizer
content: '[81930][129662][18761][44751][44751]…'
```

Correct generation (16 tokens, `finish_reason: stop`, NPU matching CPU at corr 0.9996) with ids instead of text — because *"`model.q4nx` + `tokenizer.htok` in one directory"*, the natural layout for a native container, was never a candidate.

## The change

The artifact's directory is consulted **first**, before any GGUF borrowing:

| candidate | why |
|---|---|
| `<dir>/tokenizer.htok` | the shared name in a model directory |
| `<stem>.htok` | a per-model name |

Behaviour is unchanged when a GGUF sibling exists. This turns "put the tokenizer next to the model" into something the loader honours — the same family as the rest of this line of work, an artifact outside the expected root being invisible to a fixed path.

## Scope

This does **not** supply a tokenizer for `zaya1-8b.q4nx` on strixhalo: none exists beside it, so that run still needs one provisioned (an `.htok`, or a GGUF to synthesise from). It makes the provisioning *work* when it is done — previously an `.htok` placed next to a native artifact was ignored.

## Verification

`-fsyntax-only`: **exit 0**. CI carries the build.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Consult the artifact's own directory before any GGUF vocabulary borrowing

- Prefer `<dir>/tokenizer.htok`, then `<stem>.htok` beside the model

- Replace premature "fallback ASCII" startup warning with neutral wording

- Print the final tokenizer outcome after the per-model lookup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["load_model_tokenizer(model_path)"] -- "load_from_gguf(model_path)" --> B["GGUF vocab available?"]
  B -- "yes" --> Z["tokenizer loaded, return"]
  B -- "no" --> C["NEW: consult artifact's own directory"]
  C -- "dir + tokenizer.htok, stem + .htok" --> D["g_tokenizer.load(candidate)"]
  D -- "loaded" --> Z
  D -- "not found" --> E["legacy GGUF borrowing / .htok synthesis"]
  F["startup tokenizer_path()"] -- "miss" --> G["neutral 'No global tokenizer' message"]
  H["after load_model_tokenizer"] -- "g_tokenizer.use_bpe" --> I["print Tokenizer ready (BPE) or ASCII passthrough warning"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>unified_server.cpp</strong><dd><code>Look for tokenizer beside artifact and report final outcome</code></dd></summary>
<hr>

tools/unified_server.cpp

<ul><li>In <code>load_model_tokenizer()</code>, adds a new block that checks the artifact's <br>own directory first: <code><dir>/tokenizer.htok</code> and <code><stem>.htok</code>, using a local <code>exists2</code> <br>helper and <code>dir2</code>/<code>stem2</code> derived from <code>model_path</code>.<br> <li> On a successful <code>g_tokenizer.load(c)</code> the function returns before any <br>GGUF-borrowing fallback, so a native Q4NX/1BP container with no GGUF <br>sibling can now be detokenised.<br> <li> Startup message for a missing <code>tokenizer_path()</code> is changed from a <br>"fallback ASCII tokenizer" warning to a neutral "No global tokenizer <br>... Will try the model's own directory once the model is known".<br> <li> After <code>load_model_tokenizer(cfg.model_path)</code>, prints the actual outcome: <br><code>✓ Tokenizer ready (BPE)</code> when <code>g_tokenizer.use_bpe && </code><br><code>g_tokenizer.bpe_tok</code>, else a warning that output will be <code>[id][id]</code> ASCII <br>passthrough.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2197/files#diff-108a4e5ad06a8667d81e8da41605283a4dff15e0519645becad615fded67977c">+33/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

