### PR TITLE
docs: #1866 is an upstream-only watch (nothing in-repo needs -O0); correct two now-false tracker claims

### DIFF
--- a/docs/TRIAGE-ISSUES-2026-08.md
+++ b/docs/TRIAGE-ISSUES-2026-08.md
@@ -13,7 +13,7 @@ upstream-vs-in-repo ownership determined.
 
 | Issue | Sev | Status | Where |
 |-------|-----|--------|-------|
-| #1838 | med | ✅ fixed + silicon-verified | KERNEL_STATIC .data; final fused kernel ELF has .data@0x7f60c/0x7f610 (g_i4_call, call counter), ZERO .bss; CPU gates ALL PASS (2026-08-28) |
+| #1838 | med | ⚠️ PARTIAL — see #2199 | `KERNEL_STATIC` .data placement exists in `engine/npu/kernel/mm_binary_q1.cc` but is **absent from the fused kernel** `mm_kernel_reference.cc` on current `main`: `g_i4_call` + the local `call` counter are in `.bss` and `build_p1i4.sh`'s own lint fails (measured 2026-09-11). The 2026-08-28 "silicon-verified, ZERO .bss" result no longer describes `main` |
 | #1834 | high | ✅ fixed | mm_binary_q1.cc union bit-casts + g_counter .data (HW-verify rebuild) |
 | #1913 | med | ✅ fixed | check_chess_aietools.sh guard + USE_XCHESSCC=1 + docs §2 |
 | #1908 | med | ✅ fixed | run_aiesim.sh 2025.2 default + 2026.1 warning |
@@ -26,14 +26,14 @@ upstream-vs-in-repo ownership determined.
 | #1869 | high | ✅ fixed (close-out) | v66 workaround at HEAD; escalate reproducer |
 | #1870 | med | ✅ fixed | fix_toolchain.sh LLVM-version match gate + libclang_rt check |
 | #1837 | high | ✅ fixed | build_p1i4.sh call-site arg-setup guard (NPU_STRICT_1837 opt-in) |
-| #1864 | high | ✅ fixed | #error guard + I4_SCALAR_C1_ACK_1864 in build_zaya_fused.sh |
+| #1864 | high | ✅ fixed | #1874 default flip to I4_SCALAR_C1 + one-off #1897 h2/C2 gate. **Correction (2026-09-11): the "#error guard" does not exist** — `ACK_1864` is in no source file and `engine/npu/generators/` has no `#error`; the `-D` is a label, not enforcement |
 | #1832 | high | ✅ fixed + live-verified | NPU universal backend loads 35B-A3B q4nx on real NPU ("worker ready" ~35s); handshake timeout 10s→300s (model pack); manifest format fix; zaya→FLM diversion; onebin links amdclang++ |
 | #1878/#1912 | med | ✅ harness merged | bench_compiler_ab.sh + README-COMPILER-AB.md on main (regression test for upstream fix) |
 | #1831 | high | ✅ interim | qwen3next CPU engine wired (CMake + backend_manager + router route for qwen35moe); full HIP port still XL |
 | #1776 | med | ✅ header gate | create_runlist() gated behind XRT>=2.25; runlist impl still env-blocked |
 | #1865 | med | ✅ fixed + NPU-verified | h2 via delivered arg, pC zeroing via arg, zero_c1 removed, #1842 pins retired; C2gate corr=1.0 bad=0/2048 BYTE-IDENTICAL on strixhalo |
 | #1907 | med | 🔶 deferred (XL) | baretorch token WITHOUT cs_lrad engine would silently mis-execute (registry comment forbids); full engine is XL |
-| #1866 | med | ⏳ escalate | -O0 immediate range — upstream llvm-aie; -O1 workaround documented |
+| #1866 | med | ⏳ upstream-only watch | -O0 immediate range — upstream llvm-aie (PRs #1155/#1276). **Nothing in-repo needs -O0** (builds pin -O2/-O1); the #1864 workaround rationale is stale (#1864 closed 2026-08-30). Re-verified 2026-09-11 |
 | #1874 | high | ✅ mitigated | I4_SCALAR_C1 is now the production default (verified corr 1.0); mmul path opt-in via I4_USE_MMUL=1 |
 | #1872 | high | ✅ mitigated | #1874 flip removes Bb round-trip from production; I4_DIRECT_VECTOR_DEQ register path for mmul (arithmetic-verified 512000/512000); NPU gate pending |
 | #1776 | med | ⏳ env | runlist needs XRT>=2.25 (box has 2.21.75); code path is version-gated |
@@ -77,7 +77,7 @@ upstream-vs-in-repo ownership determined.
 | 19 | #1874 | high | L | Validate mmul C-store transpose hypothesis in ISS; flip I4_SCALAR_C1 to default until proven |
 | 20 | #1907 | med | XL | baretorch cs_lrad: registry token first (S), then layer math + GGUF mapping + selfcheck |
 | 21 | #1831 | high | XL | HIP 1BP: GatedDeltaNet + fused QKV + gated MoE; interim: wire qwen3next_engine.cpp as CPU fallback |
-| 22 | #1866 | med | S | Escalate upstream (-O0 immediate range) with reproducer; keep -O1 workaround |
+| 22 | #1866 | med | S | Upstream-only watch: repro attached, re-check when llvm-aie #1155/#1276 land. Nothing in-repo needs -O0 (verified 2026-09-11) |
 
 ## Per-issue detail
 
@@ -109,5 +109,5 @@ upstream-vs-in-repo ownership determined.
 ### Upstream-only (escalate)
 - **#1912 (med)** — chess external-func arg delivery. Merge A/B harness as the regression test.
 - **#1869 (high)** — pointer-arith miscompile (workaround in tree).
-- **#1866 (med)** — -O0 immediate range crash.
+- **#1866 (med)** — -O0 immediate range crash. Upstream-only watch: nothing in-repo requires -O0 (builds pin -O2/-O1); the #1864 rationale is stale. Re-check on llvm-aie #1155/#1276.
 - **#1835 (med)** — soft-float NaN (workaround in tree).

--- a/docs/TRIAGE-ISSUES-2026-09-02-round1.md
+++ b/docs/TRIAGE-ISSUES-2026-09-02-round1.md
@@ -44,7 +44,7 @@ as of the 2026-09-02 refresh recorded in the issues:
   GNOME animations off, stable since 08-31, coredumps preserved in
   `/var/log/gpu-coredumps/`). Remaining = file the upstream Mesa/amdgpu report.
 - **#1866** llvm-aie has no AIE2P -O0 range fix (newest related = AIE2PS
-  accumulator-spill a36c62b9d); `-O1` workaround stands.
+  accumulator-spill a36c62b9d); `-O1` workaround stands. **Re-verified 2026-09-11** (`main` @ `6963fc694`, llvm-aie `91977805fa`): the crash is unchanged, but **nothing in-repo requires `-O0`** — builds pin -O2/-O1 — so this is an upstream-only watch with no in-repo impact; re-check when llvm-aie #1155/#1276 land.
 - **#1945** llama.cpp PR #27218 still open+draft; hrx-system stuck at v0.3.0.
 - **#1956** local g++ 15.2.0; `std::inplace_vector`/reflection gated on g++16.
 

--- a/docs/TRIAGE-ISSUES-2026-09.md
+++ b/docs/TRIAGE-ISSUES-2026-09.md
@@ -57,7 +57,7 @@ the single-quoted string early — the shell then tried to execute the
 | #1776 (Zaya decode CPU-attention-bound) | med | Status corrected: the runtime-layer path (Qwen3 npu-infer) does **not** change the standalone Zaya path — CCA-attention-on-NPU remains the open lever. |
 | #1831 (HIP cannot run qwen3_5_moe 35B) | high | Scoped: GDN math has NPU-side references (`npu_engine_universal.cpp`, npu-infer 35B layout work) to port into `backend_hip_1bp` behind the qwen35 gate (fused QKV + GatedDeltaNet linear attention; `full_attention_interval=4` schedule). |
 | #1945 (HRX upstream watch) | med | No signal: llama.cpp #27218 still draft (08-31), hrx-system stuck at v0.3.0 (May). |
-| #1866 (llvm-aie -O0 immediate crash) | med | Upstream fix not landed (fetched 09-02; newest = AIE2PS accumulator-spill only). -O1 workaround stands. |
+| #1866 (llvm-aie -O0 immediate crash) | med | **Upstream-only watch (re-verified 2026-09-11 on `main` @ `6963fc694`)**: the `-O0` crash is unchanged, but **nothing in-repo requires `-O0`** (builds pin -O2/-O1) and its recorded impact is stale (#1864 closed 2026-08-30). Re-check when llvm-aie #1155/#1276 land. |
 | #1956 (C++26 toolchain watch) | med | No signal: local g++ 15.2.0, `std::inplace_vector`/reflection still gated on g++16/libstdc++16. |
 | #1907 (baretorch cs_lrad) | med | Unchanged — XL engine feature (registry token + safe refusal already landed). |
 | #1934 (int4 fused FFN corr cap) | high | Host contracts all merged (#1978/#1983/#1984/#1985/#1986); remaining = `npu_state_*` production wiring of the single-launch i4 fused path (auto-select + GuI4Pack bf16-pair packing for asymmetric-zp models) + silicon parity gate — multi-session NPU integration, still open. |

--- a/docs/aiesim-debugging.md
+++ b/docs/aiesim-debugging.md
@@ -251,8 +251,8 @@ strixhalo verification round:
 | Issue | Defect | Status |
 |-------|--------|--------|
 | #1834 | memcpy libcall clobbers r0/r1 | ✅ FIXED in-tree: union bit-casts everywhere incl. mm_binary_q1.cc; escal. upstream |
-| #1838 | ld.script drops .bss statics | ✅ FIXED in-tree: KERNEL_STATIC → .data, ELF-verified (.data@0x7f60c, zero .bss); escal. upstream |
-| #1864 | scalar RMW miscompile | ✅ Worked around: I4_SCALAR_C1_ACK_1864 guard + #1874 default flip; escal. upstream |
+| #1838 | ld.script drops .bss statics | ⚠️ PARTIAL — see #2199: `KERNEL_STATIC` is present in `engine/npu/kernel/mm_binary_q1.cc` but **absent from the fused kernel** `engine/npu/generators/mm_kernel_reference.cc` on `main`, so `g_i4_call` + the local `call` counter sit in `.bss` and `build_p1i4.sh`'s own lint fails (measured 2026-09-11) |
+| #1864 | scalar RMW miscompile | ✅ Worked around: #1874 default flip to I4_SCALAR_C1 + the scalar path's one-off #1897 h2/C2 gate. **Correction (2026-09-11): there is no `#error` guard** — `ACK_1864` appears in **no source file** (only as a `-D` in two build scripts) and `engine/npu/generators/` has no `#error` at all, so compiling the scalar path without the ack succeeds; the flag is a label, not enforcement |
 | #1865 | hardcoded tile addresses | ✅ FIXED in-tree: h2 via delivered arg, pC zeroing via arg, zero_c1 removed, #1842 pins retired; NPU gate pending |
 | #1869 | pointer-arith miscompile j>=8 | ✅ Worked around (v66 direct pointer math); escal. upstream with repro |
 | #1835 | soft-float (sf*0.0625)/scc NaN | ✅ Worked around (int32 ratioQ22); escal. upstream |
@@ -260,7 +260,7 @@ strixhalo verification round:
 | #1872 | Btmp byte-stores dropped | ✅ Mitigated: #1874 flip removes Bb from production; I4_DIRECT_VECTOR_DEQ for mmul path; NPU gate pending |
 | #1874 | mmul C1 store scrambled | ✅ Mitigated: I4_SCALAR_C1 is now the production default; mmul path opt-in |
 | #1878/#1912 | chess arg delivery (upstream) | ⏳ ESCALATE upstream; A/B harness on main as regression test |
-| #1866 | -O0 immediate range crash | ⏳ ESCALATE upstream (llvm-aie); -O1 workaround documented |
+| #1866 | -O0 immediate range crash | ⏳ UPSTREAM-ONLY WATCH — re-verified 2026-09-11 on `main` @ `6963fc694` (still crashes: −33216), but **nothing in-repo requires `-O0`** (builds pin -O2/-O1; generators never use it; every `-O0` hit is prose about this bug) and the #1864 workaround rationale is stale (#1864 closed 2026-08-30). Fix = llvm-aie PRs #1155/#1276 |
 
 Upstream reproducers to file (all have in-repo CPU-gated minimal cases):
 #1869 (rqb+j*32 vs pB4+gbase+(j<<5)), #1835 ((sf*0.0625f)/scc → NaN),

--- a/docs/issue-campaign/FIX-LIST.md
+++ b/docs/issue-campaign/FIX-LIST.md
@@ -45,7 +45,7 @@ Wave 3: #2105, #2080, #2081, #1866, #2082, #2139, #1942
 | 2105 | fused-dequant NaN (93696) | P0 | fused-dequant | Likely tile alignment | #2102 |
 | 2080 | Zaya whole-layer per-ctx ELF (M3/M4) | P2 | NPU feature | M1 done, M2 in progress | #2113, #2114, #2070 |
 | 2081 | int4 vs int8 dense-FFN product decision | P2 | decision | Open (needs data) | #2114 |
-| 1866 | aie2p -O0 backend crash | P2 | toolchain | Open | — |
+| 1866 | aie2p -O0 backend crash | P2 | toolchain | **Upstream-only watch (2026-09-11): nothing in-repo needs -O0** | #1155/#1276 |
 | 2082 | D2 HIP-prefill stability gate | P1 | hybrid | Re-probe clean | #1942 |
 | 2139 | qwen35moe 1BP fast-path + quant lanes | P2 | GPU feat | Open (gaps listed) | #2138✅ |
 | 1942 | hybrid prefill/decode (KV handoff) | P2 | hybrid design | Blocker = KV handoff | #2145, #2082 |
@@ -170,9 +170,9 @@ Each packet is send-ready (fits one mesh message). `verify` is the per-issue ver
 
 ## #1866 — aie2p -O0 backend crash (P2)
 
-- **Status:** Open. `clang++ --target=aie2p-none-unknown-elf -O0` crashes: "immediate operand value -33216 is out of range [-32768, -64]". -O2 miscompiles scalar RMW (#1864); -O1 same miscompile. Any venv c9c5ecb7 / IRON cb664e8c / HEAD 4e567bd91.
-- **Repro:** `<peano>/bin/clang++ --target=aie2p-none-unknown-elf --std=c++20 -O0 -DDIM_M=8 -DDIM_K=64 -DDIM_N=128 -Di8_i32_ONLY -DM8_VECTORIZED -DNPU_C1_DUMP -c engine/npu/generators/mm_kernel_reference.cc`.
-- **verify:** minimal repro + root cause in peano aie2p backend + workaround documented.
+- **Status:** **Upstream-only watch (re-verified 2026-09-11, goal `mtwoc3im-zdxsxb`).** The crash is real — on `main` @ `6963fc694` with llvm-aie `91977805fa`, `-O0` still dies with "immediate operand value -33216 is out of range [-32768, -64]" (−O1/−O2 compile). **But nothing in-repo requires `-O0`:** the kernel builds pin `-O2` (`build_c1b_iron.sh`) and `-O1` (`build_c1b_iron_o1.sh`), the generators never ask for it, and every remaining `-O0` reference that concerns aie2p is prose about this bug. The impact recorded here ("-O2 miscompiles scalar RMW (#1864); -O1 same miscompile") is **stale**: #1864 was fixed in-tree on 2026-08-29 and closed.
+- **Repro:** `<peano>/bin/clang++ --target=aie2p-none-unknown-elf --std=c++20 -O0 -DDIM_M=8 -DDIM_K=64 -DDIM_N=128 -Di8_i32_ONLY -DM8_VECTORIZED -I<aietools>/include -c engine/npu/generators/mm_kernel_reference.cc`. *(On strixhalo the include root is `~/Xilinx2025/2025.2/Vitis/aietools/include`; the `~/Xilinx/2025.2/...` path in `build_p1i4.sh` does not exist there.)*
+- **verify:** re-run the repro when llvm-aie PRs **#1155** ("[AIE2P] Range-check the spill immediate offset in eliminateFrameIndex") or **#1276** land; expect `-O0` to compile via the indexed-addressing fallback. Until then `-O1`/`-O2` are the paths and nothing waits on this. Verification comment: [#1866 comment](https://github.com/1bit-MONSTER/1bit-MONSTER/issues/1866#issuecomment-5631463570).
 
 ## #2082 — D2 HIP-prefill lane stability gate (P1)
 


### PR DESCRIPTION
### **User description**
## What

Tracker/doc rows for **#1866** now reflect the measurement, and two adjacent claims the same check disproved are corrected. Docs only — no code, no kernel, no build-path change.

## The measurement (goal `mtwoc3im-zdxsxb`)

On `main` @ `6963fc694`, toolchain `llvm-aie 91977805fa`:

| | |
|---|---|
| `-O0` | **still crashes** — `immediate operand value -33216 is out of range [-32768, -64]`, 29 frames, no object |
| `-O1` / `-O2` | compile (16144 B / 18716 B) |
| **in-repo `-O0` requirement** | **none** — `engine/npu` 0 files, `tests/` 0, `src/` 0, `.github/` 0; builds pin `-O2` (`build_c1b_iron.sh`) and `-O1` (`build_c1b_iron_o1.sh`); the only non-doc hits are unrelated host/HIP `-O0 -g` debug flags |

The issue's recorded impact — *"prevents using a lower optimization level to work around the -O2 scalar codegen bugs (#1864)"* — is **stale**: #1864 was fixed in-tree 2026-08-29 and is closed. So #1866 becomes an **upstream-only watch** with an explicit re-check trigger (llvm-aie **#1155**/**#1276**) and a corrected repro command (the include root on strixhalo is `~/Xilinx2025/2025.2/...`; the `~/Xilinx/2025.2/...` path in the docs and in `build_p1i4.sh` does not exist there).

## Two adjacent claims corrected (same check, same rows)

1. **#1864 "`#error` guard" — it does not exist.** `ACK_1864` appears in **no source file** (only as a `-D` in `build_p1i4.sh`/`build_zaya_fused.sh`), and `engine/npu/generators/` contains **no `#error` at all**: compiling the scalar-C1 path *without* the ack exits 0. The real protection is the #1874 default flip plus the one-off #1897 gate.
2. **#1838 `.data` placement — not in effect for the fused kernel on `main`.** The rows claimed *"✅ fixed + silicon-verified … g_i4_call, call counter … ZERO .bss"*. On current `main`, `KERNEL_STATIC` has **0** occurrences in `engine/npu/generators/mm_kernel_reference.cc` (it exists in `engine/npu/kernel/mm_binary_q1.cc`), both symbols are in `.bss`, and **`build_p1i4.sh`'s own lint fails on the merged production object**:

```
build_p1i4.sh's exact .bss lint → fails (script would exit 1)
  00000000 b _ZL9g_i4_call
  00000000 b _ZZ16matmul_i8_i32_i4E4call
```

Filed as **#2199**; these rows now point there rather than asserting a fixed state.

## Scope

Deliberately untouched: the kernel, the build scripts, and CI. Restoring the `.data` placement (or re-landing it from `feat/community-join-links`, where the commit that added it — `1b4f468b2` — still lives) is #2199's job and needs the #1897 h2/C2 gate re-run before the xclbin is trusted.


___

### **PR Type**
Documentation


___

### **Description**
- Mark #1866 as upstream-only watch, no in-repo -O0 need

- Correct #1864 claim: the "#error guard" does not exist

- Downgrade #1838 .data placement to PARTIAL, see #2199

- Add re-check trigger (llvm-aie #1155/#1276) and corrected repro


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["#1866 -O0 crash re-verified on main"] -- "repo-wide scan" --> B["Nothing in-repo needs -O0"]
  B --> C["Upstream-only watch"]
  C -- "re-check trigger" --> D["llvm-aie PRs #1155/#1276"]
  E["claim: #1864 #error guard"] -- "same check disproved" --> F["Correction: ACK_1864 in no source file"]
  G["claim: #1838 .data fixed"] -- "same check disproved" --> H["PARTIAL - see #2199"]
  F --> I["Tracker rows updated"]
  H --> I
  C --> I
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TRIAGE-ISSUES-2026-08.md</strong><dd><code>Tracker rows updated for #1866, #1838 and #1864</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/TRIAGE-ISSUES-2026-08.md

<ul><li>Repurpose #1866 rows to "upstream-only watch": nothing in-repo needs <br><code>-O0</code>, <code>#1864</code> rationale stale, re-verified 2026-09-11.<br> <li> Rewrite #1838 row as PARTIAL, pointing to #2199: <code>.data</code> placement <br>absent from the fused kernel on <code>main</code>.<br> <li> Correct #1864 row: the claimed <code>#error</code> guard does not exist; <code>ACK_1864</code> <br>is only a <code>-D</code> label.<br> <li> Update the per-issue detail and upstream-only lists with the new <br>disposition and re-check trigger.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2200/files#diff-48c959b01c9ed8a2ba62546c08d9f6faf32a1630335ea952930fc19c776ab4e7">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TRIAGE-ISSUES-2026-09-02-round1.md</strong><dd><code>Re-verification note appended to #1866 round-1 row</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/TRIAGE-ISSUES-2026-09-02-round1.md

<ul><li>Extend the #1866 entry with a 2026-09-11 re-verification note on <code>main</code> <br>@ <code>6963fc694</code>.<br> <li> State that nothing in-repo requires <code>-O0</code> (builds pin <code>-O2</code>/<code>-O1</code>), making <br>it an upstream-only watch.<br> <li> Add the re-check condition: llvm-aie #1155/#1276 landing.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2200/files#diff-3f5ffe009348ac9a04bcdf83e185f56c32bc71382cca560504b6953138e5e285">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TRIAGE-ISSUES-2026-09.md</strong><dd><code>#1866 status cell updated in September triage table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/TRIAGE-ISSUES-2026-09.md

<ul><li>Replace the #1866 status cell with the upstream-only-watch wording and <br>the 2026-09-11 re-verification.<br> <li> Record that the crash is unchanged but the recorded impact is stale <br>since #1864 closed.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2200/files#diff-29c41817d23b52e3b4efdd155762524a6bfe0956236b8ff98fd749d30576b971">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>aiesim-debugging.md</strong><dd><code>AIESim debugging table rows rewritten with measured status</code></dd></summary>
<hr>

docs/aiesim-debugging.md

<ul><li>Rework §8 table rows for #1838, #1864 and #1866 with the measured <br>2026-09-11 findings.<br> <li> #1838 downgraded to PARTIAL referencing #2199 (fused kernel keeps <br>statics in <code>.bss</code>).<br> <li> #1864 correction: no <code>#error</code> guard, protection comes from the #1874 <br>flip plus the #1897 gate.<br> <li> #1866 becomes UPSTREAM-ONLY WATCH with the llvm-aie #1155/#1276 fix <br>pointer.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2200/files#diff-b96a6473b9d34ca9f031dc1d716202d0bcb4df6a0acad920f0a1fc2c68783a48">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FIX-LIST.md</strong><dd><code>FIX-LIST #1866 section and table row reworked</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/issue-campaign/FIX-LIST.md

<ul><li>Wave-3 table row for #1866 now reads "Upstream-only watch" and links <br>#1155/#1276.<br> <li> Rewrite the #1866 section: status, corrected repro command with <br><code>-I<aietools>/include</code>, and new <code>verify</code> trigger.<br> <li> Note the strixhalo include-root path discrepancy and link the <br>verification comment.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2200/files#diff-84540b06d85b4a62cb8eec3848b55fab7e77f6401c662355a12514dbc41122d3">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

