### PR TITLE
ci(e2e): pin the smoke test's model — the E2E gate has been red on main since #2198 (#2206)

### DIFF
--- a/.github/workflows/end-to-end-smoke.yml
+++ b/.github/workflows/end-to-end-smoke.yml
@@ -81,7 +81,18 @@ jobs:
       - name: Start server
         run: |
           rm -f /tmp/unified_server.lock
-          ./build/1bit unified --port 8099 --weights models/ \
+          # Pin the model (issue #2206). Without -m the server takes
+          # discovered.front(), and discovery orders by quality first
+          # (Q8_0 > Q4_K_M). On this self-hosted runner `models/` is a
+          # symlink into the shared ~/models, which also carries a
+          # Qwen3.6-35B-A3B Q8_0 — so the 35B outranks this 135M Q4_K_M and
+          # becomes the active model, and every backend then fails to init
+          # (arch=21 needs NPU-FLM/HIP; FLM is Q4NX-only), leaving /v1/health
+          # silent until the wait below times out. Naming the file resolves it
+          # through the direct-path branch (issue #1958) and makes this smoke
+          # test independent of the machine's model inventory.
+          MODEL="models/SmolLM2-135M-Instruct-Q4_K_M.gguf"
+          ./build/1bit unified --port 8099 --weights models/ -m "$MODEL" \
             --gen-timeout-ms 10000 --quick &>/tmp/smoke_server.log &
           echo "pid=$!"
           # Wait for startup (GPU init can take ~90s on Strix Halo)


### PR DESCRIPTION
### **User description**
## What

One line in the E2E smoke workflow: **pin the model**.

```diff
-          ./build/1bit unified --port 8099 --weights models/ \
+          MODEL="models/SmolLM2-135M-Instruct-Q4_K_M.gguf"
+          ./build/1bit unified --port 8099 --weights models/ -m "$MODEL" \
```

## Why — the gate has been red on `main` since #2198

The workflow started the server with no `-m`, so it took `discovered.front()`. Discovery sorts by format then **quantization quality** (`Q8_0` > `Q6/Q5` > `Q4_K_M`), and on this self-hosted runner `models/` is a symlink into the shared `~/models` — which also carries a `Qwen3.6-35B-A3B` **Q8_0**. The 35B therefore outranked the test's SmolLM2-135M Q4_K_M and became `[active]`:

```
> qwen3-6-35b-a3b-q8-0.gguf (/home/bcloud/models/Qwen3.6-35B-A3B-Q8_0.gguf) [active]
HIP: model at models/ is not in Zaya .bin format                    → ❌ init failed
[generic] Refusing ... (arch=21) — Qwen3.5 Gate-Delta requires NPU (FLM/XRT) or HIP backend
NPU: FLM is Q4NX-only — rejecting ...35B Q8_0 (format 1)             → ❌ init failed  (×2)
```

Every backend failed to init, `/v1/health` never answered, the step waited its full 90 s, and the next `curl` exited 7.

Timeline (End-to-End Smoke Test runs): **green 07:11–07:26** (main `a7ef68767`) → **red from 07:37** on the `fix/listing-canonical-id` branch (which merged as **#2198**, *"and scan ~/models"*). So the scan introduced the second model set; the test's own code is unchanged.

## What this does *not* change

The quality-ordered preference is deliberate and stays exactly as it is. `-m <path>` resolves via the direct-path branch (issue #1958), so the smoke test simply stops depending on the machine's model inventory — which a smoke test must never do on a shared, self-hosted runner.

**Not fixed here (deliberate):** an unconfigured server can still auto-select an artifact no discovered backend can load. That changes which model a bare server serves — the operator's call, tracked in #2206.

Fixes the red check described in **#2206**.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Pin the E2E smoke test's model with `-m <path>`

- Stops quality-sorted discovery from selecting the shared 35B Q8_0

- Selection no longer depends on the runner's model inventory

- No product behaviour change; rationale documented in a comment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Start server step<br/>--weights models/"] -- "no -m previously" --> B["discovered.front()"]
  B -- "quality sort: Q8_0 > Q4_K_M" --> C["Qwen3.6-35B-A3B Q8_0<br/>[active]"]
  C -- "arch=21: NPU Q4NX-only, HIP declines" --> D["all backends fail init<br/>/v1/health silent"]
  A -- "added -m $MODEL" --> E["models/SmolLM2-135M-Instruct-Q4_K_M.gguf"]
  E -- "direct-path branch (#1958)" --> F["intended 135M model loads<br/>smoke gate green"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>end-to-end-smoke.yml</strong><dd><code>Pin smoke-test model to fix red E2E gate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/end-to-end-smoke.yml

<ul><li>Sets <code>MODEL="models/SmolLM2-135M-Instruct-Q4_K_M.gguf"</code> and passes it <br>via <code>-m "$MODEL"</code> to <code>./build/1bit unified</code> in the "Start server" step.<br> <li> Adds a comment explaining that without <code>-m</code> the server takes <br><code>discovered.front()</code>, that discovery orders by quality (<code>Q8_0</code> > <code>Q4_K_M</code>), <br>and that the runner's <code>models/</code> symlink into shared <code>~/models</code> carries a <br>Qwen3.6-35B-A3B <code>Q8_0</code>.<br> <li> Notes that the 35B outranks the test's 135M, that all backends then <br>fail init (arch=21 needs NPU-FLM/HIP; FLM is Q4NX-only), and that <br>naming the file resolves through the direct-path branch (issue #1958).<br> <li> Makes the smoke test independent of the machine's model inventory, <br>with no product behaviour change.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2208/files#diff-ce7583116dfeff04a5365187d78ae67293490e66e36673d3233b26e96f97023c">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

