### PR TITLE
feat(npu): the fused engine samples from its own RNG (NPU_SEED), not the process-global stream

### DIFF
--- a/engine/npu/src/npu_engine_fused.hip
+++ b/engine/npu/src/npu_engine_fused.hip
@@ -65,6 +65,53 @@
 #include <omp.h>
 #include <immintrin.h>
 
+// ── Private sampling RNG ──────────────────────────────────────────
+// Sampling must not use the process-global rand(). That stream is shared: libLLVM
+// (loaded via libamdhip64) calls srand() once with a time-derived value at init, and
+// llvm::sys::fs::createUniquePath draws from the same stream during HIP/comgr file
+// churn. Sampling from it inherits a *variable stream offset*, so two runs with
+// identical inputs produce different tokens, and nothing outside can fix it except
+// pinning the whole process' RNG.
+//
+// So the sampler carries its own state: seeded from NPU_SEED when set (reproducible
+// decode), otherwise from the clock (previous behaviour, minus the shared stream).
+// Draws are counted and reported under NPU_DIAG so a check can assert "this engine no
+// longer reads the global stream" instead of inferring it from silence.
+static unsigned long long g_rng_state = 0;
+static unsigned long long g_rng_seed = 0;
+static unsigned long long g_rng_draws = 0;
+static const char* g_rng_seed_src = "unset";
+
+static unsigned long long rng_seed_once() {
+    if (g_rng_state) return g_rng_state;
+    const char* s = getenv("NPU_SEED");
+    if (s && *s) {
+        g_rng_state = strtoull(s, nullptr, 0);
+        g_rng_seed_src = "NPU_SEED";
+    } else {
+        g_rng_state = (unsigned long long)std::chrono::system_clock::now()
+                          .time_since_epoch().count() ^ ((unsigned long long)getpid() << 32);
+        g_rng_seed_src = "clock^pid";
+    }
+    if (!g_rng_state) g_rng_state = 0x9E3779B97F4A7C15ULL;   // xorshift needs non-zero
+    g_rng_seed = g_rng_state;
+    return g_rng_state;
+}
+
+// xorshift64* — one state word, no libc, same result on every architecture.
+static inline unsigned long long rng_next() {
+    unsigned long long x = rng_seed_once();
+    x ^= x >> 12; x ^= x << 25; x ^= x >> 27;
+    g_rng_state = x;
+    g_rng_draws++;
+    return x * 0x2545F4914F6CDD1DULL;
+}
+
+// Uniform in [0,1), same resolution as the previous rand()/RAND_MAX expression.
+static inline float rng_uniform() {
+    return (float)((rng_next() >> 40) * (1.0 / 16777216.0));
+}
+
 // ── Forward declarations ──────────────────────────────────────────
 extern "C" float* dequant_i8_to_float(const uint8_t*, int, int*, int*);
 extern "C" int rcpp_kv_cache_attn_decode(
@@ -783,7 +830,7 @@ int main(int argc, char** argv) {
                 logits_out[n] = expf(d);
                 sum += logits_out[n];
             }
-            float r = (float)rand() / RAND_MAX * (float)sum, acc = 0;
+            float r = rng_uniform() * (float)sum, acc = 0;
             for (int n = 0; n < NV; n++) {
                 acc += logits_out[n];
                 if (acc >= r) return n;
@@ -851,7 +898,7 @@ int main(int argc, char** argv) {
             logits[n] = expf(d);
             sum += logits[n];
         }
-        float r = (float)rand() / RAND_MAX * (float)sum, acc = 0;
+        float r = rng_uniform() * (float)sum, acc = 0;
         for (int n = 0; n < cfg.NV; n++) {
             acc += logits[n];
             if (acc >= r) return n;
@@ -1171,6 +1218,10 @@ int main(int argc, char** argv) {
         std::chrono::steady_clock::now() - t_gen).count();
     printf("\n=== %.1f ms/tok (%.0f tok/s) ===\n",
            gen_s * 1000 / n_gen, n_gen / gen_s);
+    if (getenv("NPU_DIAG")) {
+        printf("[npu] sampling: draws=%llu seed=0x%llx (%s) — own RNG, not the process-global stream\n",
+               g_rng_draws, g_rng_seed, g_rng_seed_src);
+    }
 
     // ── Cleanup ───────────────────────────────────────────────────
     for (int l = 0; l < cfg.NC; l++) {

--- a/engine/npu/src/npu_engine_fused.hip
+++ b/engine/npu/src/npu_engine_fused.hip
@@ -107,7 +107,10 @@ static inline unsigned long long rng_next() {
     return x * 0x2545F4914F6CDD1DULL;
 }
 
-// Uniform in [0,1), same resolution as the previous rand()/RAND_MAX expression.
+// Uniform in [0,1). The resolution differs from the expression it replaces (glibc's
+// rand()/RAND_MAX gives 31 bits, this gives 24 — rng_next() >> 40), which is irrelevant for
+// inverse-CDF over ~150k logits but is stated rather than implied: the surrounding comments
+// are exact and this one should not read as a claim.
 static inline float rng_uniform() {
     return (float)((rng_next() >> 40) * (1.0 / 16777216.0));
 }


### PR DESCRIPTION
## What

The fused engine's sampler no longer reads the process-global RNG. It carries its own state, seeded from `NPU_SEED`.

## Why — measured, not assumed

`rand()` is the **process-global** glibc stream. `libLLVM` (loaded via `libamdhip64`) calls `srand()` once with a time-derived value at init, and `llvm::sys::fs::createUniquePath` draws from that same stream during HIP/comgr file churn. Sampling from it inherits a **variable stream offset**, so two runs with identical inputs produce different tokens.

No environment arrangement fixes that, and three were tried and refuted:

| isolation attempt | result |
|---|---|
| private `TMPDIR` | worse — draws 60/66/72 vs 46, three distinct outputs |
| private `$HOME` | worse — 94/106/100 |
| private `XDG_CACHE_HOME` (the *correct* knob for comgr's cache) | worse — 94/106/100, i.e. the same experiment as private `$HOME` |

Isolating the cache makes it **cold**, and cold is what causes the collisions (`createUniquePath` only redraws when its candidate already exists): a warm run touches **zero** files in `~/.cache/comgr`. So the only lever is to stop reading the shared stream.

## How

- **xorshift64\*** private state, seeded from `NPU_SEED` when set, otherwise `clock^pid` — so the default behaviour is unchanged apart from no longer consuming the shared stream.
- Both sampling sites use it (`HipLmHead::sample` and the `sample_cpu` lambda); they were the only two `rand()` users in the file.
- `NPU_DIAG=1` prints `[npu] sampling: draws=N seed=0x… (NPU_SEED|clock^pid)` so a check can assert *"this engine no longer reads the global stream"* rather than inferring it from silence.

## Evidence (strixhalo, built with the recipe from #2209)

| check | result |
|---|---|
| `NPU_SEED=12345`, run twice | **byte-identical** 8-token output `82512 91168 25 65550 63513 45155 0 43594` — previously different every run |
| per-caller RNG shim | the engine no longer appears as a `rand()` consumer at all (only `libLLVM createUniquePath`, n=38) |
| `NPU_DIAG=1` | `draws=8 seed=0x3039 (NPU_SEED)` — one draw per token |
| admissibility guard, post-change mode | **ADMISSIBLE** — "engine has NO rand() draws" |
| same guard against the **pre-change** binary | **INADMISSIBLE** — "engine drew 8, expected 0": the check still fails where it should |
| no `NPU_SEED` | still varies across runs, by design; the global stream is untouched |

## A guard bug this change exposed, fixed

The admissibility guard used to validate these runs (a private tool, not in this repo) had a real defect that only its **first post-change use** revealed: "engine entry absent" was treated as *unreadable → fail closed* rather than *zero draws → positive evidence*. That would have made the very change this guard exists to certify look like a failure. Fixed, and the pre-change binary is retained as the negative control so the branch cannot silently pass everything.

## Scope

Sampling only. There is no temperature or top-k to change (plain inverse-CDF over the softmax), the GPU/NPU compute path is untouched, and the claim is deliberately narrow: **same seed ⇒ same tokens**, not a numerics statement about the kernels.

## Division of labour note

This branch is cut from the commit *before* #2209 so the two changes are reviewable independently; it contains only `engine/npu/src/npu_engine_fused.hip`. #2209 carries the two build-recipe path fixes and nothing else.

---

## What this does NOT claim — added after independent verification

**The sampler is reproducible; the engine is not (yet).** With `NPU_SEED` fixed, the sampling **input** is provably identical — one draw per token, the same draw count, zero reads of the process-global stream — and the output still diverges under concurrency, which localises the remainder **upstream of sampling**, i.e. the compute path. Measured independently and reproduced here:

| test | result |
|---|---|
| 6 concurrent, `NPU_SEED=42`, `NPU_DIAG=1` | **all `draws=8`** (the only draw count observed); **4 of 6** sequences distinct, diverging from token 2 or 3 |
| 4 concurrent, same seed | 3 of 4 distinct |
| 6 sequential, same seed | 5 identical + 1 differing at the final token (reviewer's sample); 6/6 identical in mine — rare uncontended, amplified by concurrency |
| **pre-this-change, same concurrency test** | 6/6 distinct — so this change strictly improves reproducibility; it does not cause the residual |

Filed as **#2213** with the elimination argument, the repro and the candidate mechanisms (GPU reduction order, GPU/NPU overlap, NPU phase ordering).

So the claim is deliberately bounded: **reproducible with `NPU_SEED` in the uncontended case, with a residual compute-side nondeterminism isolated but unresolved.** It is not "decode is now deterministic", and the per-caller evidence above is what makes the isolation possible — the sampler is out of the picture by construction, so any future divergence report can skip the RNG entirely.

Head is `97b98be`; the only change since the independently verified head `c7ae5650` is a comment fix — `rng_uniform()` is 24-bit where `rand()/RAND_MAX` is 31-bit, now stated rather than implied.
