### PR TITLE
ci(npu): check the committed xclbin set against a UUID-keyed provenance manifest + resolve the chess toolchain roots (#1913)

### DIFF
--- a/.github/workflows/xclbin-provenance.yml
+++ b/.github/workflows/xclbin-provenance.yml
@@ -1,0 +1,60 @@
+name: Xclbin provenance
+
+# Intent: the committed NPU xclbin set is the source of truth (the MLIR/chess toolchain
+# cannot reliably rebuild it - see engine/npu/build_npu_ternary.sh's header), so its
+# hygiene and its provenance have to be checked as *committed state*, not by building.
+# Two failure modes this turns red:
+#   1. Hygiene. Four tracked *.xclbin symlinks point at /opt/fastflowlm/... which exists on
+#      none of our machines - a fresh clone is already broken - and one build ships as a real
+#      file, a byte-identical duplicate, and a symlink. Neither "fix" is safe: copying a
+#      foreign binary over a dangling link hides that it was never built here, and
+#      materialising an alias doubles the payload and hides the aliasing.
+#   2. Provenance. The artifacts record producer/format/UUID/timestamp but no toolchain
+#      version, no source revision and no generating script, so a green rebuild could never
+#      be shown to reproduce what ships. engine/npu/xclbins/PROVENANCE.json is the recorded
+#      half; an intentional change to the artifact set regenerates it in the SAME commit,
+#      which is the review point.
+#
+# Runs on stock runners with stdlib Python only - no NPU, no XRT, no toolchain. The check
+# states its population, unit and timezone because a census without them is meaningless
+# (UTC days from the embedded AXLF TimeStamp, never mtime: 102 files share one checkout
+# mtime, which yields a different census to anyone reaching for `ls -l`).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "engine/npu/xclbins/**"
+      - "engine/npu/tests/check_xclbin_provenance.py"
+      - ".github/workflows/xclbin-provenance.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "engine/npu/xclbins/**"
+      - "engine/npu/tests/check_xclbin_provenance.py"
+      - ".github/workflows/xclbin-provenance.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: xclbin-provenance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  provenance:
+    name: Xclbin set matches its manifest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.12"
+
+      # Uses `git ls-files -s`, i.e. the index - the tracked set is what a clean checkout
+      # gets, so symlink modes and dangling targets are read from the index, not guessed
+      # from a directory listing.
+      - name: Check the tracked xclbin set against PROVENANCE.json
+        run: python3 engine/npu/tests/check_xclbin_provenance.py --root .

--- a/engine/npu/build_npu_ternary.sh
+++ b/engine/npu/build_npu_ternary.sh
@@ -30,6 +30,46 @@ export PYTHONPATH="${TORCH2AIE}/toolchain/mlir_aie/python"
 export AIETOOLS_DIR="${TORCH2AIE}/toolchain"
 export MLIR_AIE_DIR="${TORCH2AIE}/toolchain/mlir_aie"
 
+# ─── Chess toolchain preflight (issue #1913) ──────────────────────
+# This script compiles kernels with xchesscc_wrapper, so it needs (a) a Vitis
+# aietools ROOT whose chess-llvm-link is present, and (b) the wrapper on PATH.
+# Both used to be assumed: the aietools root came from ${TORCH2AIE}/toolchain,
+# which does not exist here, and xchesscc_wrapper is an mlir-aie tool that the
+# Vitis root does not ship (only bin/xchesscc + bin/xchessmk). Resolve both and
+# fail before compiling anything.
+# shellcheck source=engine/npu/generators/check_chess_aietools.sh
+# shellcheck disable=SC1091
+CHESS_GUARD="$(cd "$(dirname "$0")/generators" && pwd)/check_chess_aietools.sh"
+# shellcheck source=/dev/null
+source "$CHESS_GUARD"
+if [ -z "${AIETOOLS:-}" ]; then
+    AIETOOLS="$(find_chess_aietools_root)" || {
+        echo "ERROR (#1913): no Vitis aietools root with chess-llvm-link under ${HOME}/Xilinx*" >&2
+        echo "  Set AIETOOLS=<Vitis aietools root> and retry." >&2
+        exit 1
+    }
+fi
+check_chess_aietools "$AIETOOLS" true "${AIETOOLS}/bin:" || exit 1
+export AIETOOLS
+if ! command -v xchesscc_wrapper >/dev/null 2>&1; then
+    for candidate in "${MLIR_AIE_DIR}/tools/chess-clang" \
+                     "$HOME/mlir-aie/tools/chess-clang" \
+                     "${HOME}/mlir-aie/install/bin"; do
+        if [ -x "${candidate}/xchesscc_wrapper" ]; then
+            export PATH="${candidate}:${PATH}"
+            break
+        fi
+    done
+fi
+if ! command -v xchesscc_wrapper >/dev/null 2>&1; then
+    echo "ERROR: xchesscc_wrapper not on PATH (it is an mlir-aie tool, not a Vitis one)" >&2
+    echo "  Expected at <mlir-aie tree>/tools/chess-clang/xchesscc_wrapper, e.g. ~/mlir-aie." >&2
+    echo "  NOTE: the torch2aie-derived roots above (${TORCH2AIE}) do not exist on strixhalo;" >&2
+    echo "  set MLIR_AIE_DIR / TORCH2AIE explicitly to a real mlir-aie tree and retry." >&2
+    exit 1
+fi
+export PATH="${AIETOOLS}/bin:${PATH}"   # the Vitis launcher must win the xchesscc lookup
+
 # Toolchain version check: MLIR-AIE .so files are cpython-312
 PY_VER=$(python3 --version 2>&1 | grep -oP '[0-9]+\.[0-9]+' | head -1 || echo "unknown")
 if [ "$PY_VER" != "3.12" ]; then

--- a/engine/npu/generators/build_all.sh
+++ b/engine/npu/generators/build_all.sh
@@ -1,16 +1,32 @@
 #!/bin/bash
 # Sequential build of all new xclbins with isolated workdirs
+#
+# The toolchain roots are derived from this script's location and from the mlir-aie
+# tree, never from a hardcoded absolute path: the previous KERNEL/XDIR/GEN trio
+# pointed at /home/bcloud/1bit-monster/... (lowercase), which does not exist on any
+# of our machines, and the script never mkdir'd it, so every write failed against a
+# nonexistent directory. Same "declared vs effective path" class as issue #1913.
+#
+# PEANO-only by construction: this script passes --no-xchesscc explicitly, for which
+# mlir-aie's build_tmp is the legitimate --aietools value (the chess arm needs the
+# Vitis aietools ROOT instead - see generators/check_chess_aietools.sh).
 set -e
 
-export PYTHON=/home/bcloud/mlir-aie/.venv/bin/python3
-export AIECC=/home/bcloud/mlir-aie/build_tmp/bin/aiecc
-export PEANO=/home/bcloud/mlir-aie/.venv/lib/python3.14/site-packages/llvm-aie
-export AIETOOLS=/home/bcloud/mlir-aie/build_tmp
-export KERNEL=/home/bcloud/1bit-monster/engine/npu/generators/mm_32x64x128.o
-export XDIR=/home/bcloud/1bit-monster/engine/npu/xclbins
-export GEN=/home/bcloud/1bit-monster/engine/npu/generators
-export PYTHONPATH=/home/bcloud/mlir-aie/install_tmp/python:/home/bcloud/mlir-aie/.venv/lib/python3.14/site-packages
-export LD_LIBRARY_PATH=/home/bcloud/mlir-aie/install_tmp/python/aie/_mlir_libs
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MLIR_AIE="${MLIR_AIE:-$HOME/mlir-aie}"
+
+# "xclbins\" dir = the repo's tracked set (this file lives in engine/npu/generators)
+XDIR="${XDIR:-$SCRIPT_DIR/../xclbins}"
+mkdir -p "$XDIR"
+
+export PYTHON="${PYTHON:-$MLIR_AIE/.venv/bin/python3}"
+export AIECC="${AIECC:-$MLIR_AIE/build_tmp/bin/aiecc}"
+export PEANO="${PEANO:-$MLIR_AIE/.venv/lib/python3.14/site-packages/llvm-aie}"
+export AIETOOLS="${AIETOOLS:-$MLIR_AIE/build_tmp}"
+export KERNEL="${KERNEL:-$SCRIPT_DIR/mm_32x64x128.o}"
+export GEN="${GEN:-$SCRIPT_DIR}"
+export PYTHONPATH="${PYTHONPATH:-$MLIR_AIE/install_tmp/python:$MLIR_AIE/.venv/lib/python3.14/site-packages}"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-$MLIR_AIE/install_tmp/python/aie/_mlir_libs}"
 
 build_one() {
     local tag="$1" proj="$2" K="$3" N="$4" cols="$5"

--- a/engine/npu/generators/check_chess_aietools.sh
+++ b/engine/npu/generators/check_chess_aietools.sh
@@ -54,3 +54,25 @@ check_chess_aietools() {
     fi
     return 0
 }
+
+# find_chess_aietools_root — discover a Vitis aietools root that can actually drive
+# the chess arm, i.e. one carrying chess-llvm-link at the path aiecc derives from
+# --aietools. Callers should use this instead of pinning a version or a directory
+# spelling: both known layouts are searched ($HOME/Xilinx/<ver>/Vitis/aietools and
+# $HOME/Xilinx<year>/<ver>/Vitis/aietools) and the newest qualifying version wins,
+# so a 2025.2->2026.1 move needs no edit. Note the spellings are not
+# interchangeable: on 2026-09-11 `$HOME/Xilinx2025/2025.2/Vitis/aietools` resolved
+# while the plausible-looking `$HOME/Xilinx/2025.2/Vitis/aietools` did not.
+#
+# Echoes the root and returns 0; returns 1 when nothing qualifies (the caller must
+# fail loudly rather than reach aiecc with a --aietools that cannot link chess).
+find_chess_aietools_root() {
+    local candidate
+    while IFS= read -r candidate; do
+        if [ -x "${candidate%/}/tps/lnx64/target_aie2p/bin/LNa64bin/chess-llvm-link" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done < <(printf '%s\n' "$HOME"/Xilinx*/*/Vitis/aietools 2>/dev/null | sort -rV)
+    return 1
+}

--- a/engine/npu/kernel/build_06b_kernels.sh
+++ b/engine/npu/kernel/build_06b_kernels.sh
@@ -16,9 +16,50 @@ OUTDIR="${BUILDDIR}/qwen3_0_6b_kernels"
 mkdir -p "$OUTDIR"
 
 # Toolchain paths
-AIETOOLS="${TORCH2AIE_ROOT}/toolchain/aietools"
-MLIR_AIE="${TORCH2AIE_ROOT}/toolchain/mlir_aie"
-XCHESSCC="${AIETOOLS}/bin/xchesscc_wrapper"
+# The chess arm needs an aietools ROOT (the Vitis one), not mlir-aie's build_tmp:
+# with build_tmp aiecc silently skips chess-llvm-link and dies later with a
+# confusing 'main_input.chesslinked.ll' missing error (issue #1913). The old
+# default here (${TORCH2AIE_ROOT}/toolchain/aietools) does not exist on strixhalo,
+# and torch2aie is not installed on ryzen at all, so resolve it explicitly and
+# fail at the call site instead of inside the compiler.
+# shellcheck source=../generators/check_chess_aietools.sh
+# shellcheck disable=SC1091
+source "${SRCDIR}/../generators/check_chess_aietools.sh"
+if [ -z "${AIETOOLS:-}" ]; then
+    AIETOOLS="$(find_chess_aietools_root)" || {
+        echo "ERROR (#1913): no Vitis aietools root with chess-llvm-link found under ${HOME}/Xilinx*" >&2
+        echo "  Set AIETOOLS=<Vitis aietools root> (e.g. ~/Xilinx/2026.1/Vitis/aietools) and retry." >&2
+        exit 1
+    }
+fi
+check_chess_aietools "$AIETOOLS" true || exit 1
+MLIR_AIE="${MLIR_AIE:-$HOME/mlir-aie}"
+# xchesscc_wrapper is an mlir-aie tool, NOT part of the Vitis aietools root (that
+# ships only bin/xchesscc + bin/xchessmk). Resolve it from the same mlir-aie tree
+# the other kernel scripts use (bench_compiler_ab.sh's default), then the tree's
+# install/bin, then PATH - and fail loudly rather than letting a stale default
+# reach the compiler.
+if [ -z "${XCHESSCC:-}" ]; then
+    for candidate in "${MLIR_AIE}/tools/chess-clang/xchesscc_wrapper" \
+                     "${MLIR_AIE}/install/bin/xchesscc_wrapper"; do
+        if [ -x "$candidate" ]; then
+            XCHESSCC="$candidate"
+            break
+        fi
+    done
+fi
+if [ -z "${XCHESSCC:-}" ] || [ ! -x "$XCHESSCC" ]; then
+    XCHESSCC="$(command -v xchesscc_wrapper || true)"
+fi
+if [ -z "$XCHESSCC" ] || [ ! -x "$XCHESSCC" ]; then
+    echo "ERROR: xchesscc_wrapper not found (looked in ${MLIR_AIE}/tools/chess-clang/," >&2
+    echo "  ${MLIR_AIE}/install/bin/ and PATH)." >&2
+    echo "  Set MLIR_AIE=<mlir-aie tree> (e.g. ~/mlir-aie) or XCHESSCC=<wrapper path>." >&2
+    exit 1
+fi
+# The Vitis launcher must win the xchesscc lookup: aiecc's getAietoolsDir()
+# derives its root from `which xchesscc`, so the raw symlink must not precede it.
+export PATH="${AIETOOLS}/bin:${PATH}"
 
 # Include paths for AIE kernel compilation
 INCLUDES=(

--- a/engine/npu/tests/bench_compiler_ab.sh
+++ b/engine/npu/tests/bench_compiler_ab.sh
@@ -44,9 +44,22 @@ PYTHON="$MLIR_AIE/.venv/bin/python3"
 MLIR_AIE_INC="$MLIR_AIE/.venv/lib/python3.14/site-packages/mlir_aie/include"
 AIE_KERNELS_INC="$MLIR_AIE/aie_kernels/aie2p"
 
-# Xilinx Vitis aietools (xchesscc). 2026.1 ships chesscc X-2025.06.
-XILINX="${XILINX:-$HOME/Xilinx/2026.1}"
-XCHESS_BIN="$XILINX/Vitis/aietools/bin"
+# Xilinx Vitis aietools (xchesscc): discovered, not version-pinned (#1913).
+# Pin only via an explicit XILINX=... override; the discovery takes the newest
+# Vitis aietools that actually carries chess-llvm-link, which also makes the
+# directory-spelling trap a non-issue (Xilinx2025/2025.2 resolves; the
+# plausible-looking Xilinx/2025.2 does not).
+# shellcheck source=../../engine/npu/generators/check_chess_aietools.sh
+# shellcheck disable=SC1091
+source "$REPO/engine/npu/generators/check_chess_aietools.sh"
+VITIS_AIETOOLS="${VITIS_AIETOOLS:-$(find_chess_aietools_root || true)}"
+if [ -z "$VITIS_AIETOOLS" ]; then
+    echo "ERROR (#1913): no Vitis aietools root with chess-llvm-link under ${HOME}/Xilinx*" >&2
+    echo "  arm B (chess) cannot run; set VITIS_AIETOOLS=<root> or use arm A (peano)." >&2
+    exit 1
+fi
+XILINX="${XILINX:-$(dirname "$(dirname "$VITIS_AIETOOLS")")}"
+XCHESS_BIN="$VITIS_AIETOOLS/bin"
 
 # Generator / kernel / bench parameters (same as check_mm_kernel_2x4.sh)
 M=128; K=2048; N=8192
@@ -100,6 +113,9 @@ build_kernel_peano() { # $1 = out dir
 # raw chesscc hits the license wall — OKF log #1878).
 # NOTE: chess rejects -std= entirely (Release_LLVM default applies).
 build_kernel_chess() { # $1 = out dir
+  # Preflight the chess arm instead of dying later on a missing
+  # 'main_input.chesslinked.ll' (#1913): --aietools must be the Vitis ROOT.
+  check_chess_aietools "$VITIS_AIETOOLS" true "$XCHESS_BIN" || return 1
   xchesscc_wrapper aie2p -c \
     -I "$MLIR_AIE_INC" -I "$AIE_KERNELS_INC" \
     -O2 -DNDEBUG -D__AIE_API_AIE_ADF_HPP__ \

--- a/engine/npu/tests/check_xclbin_provenance.py
+++ b/engine/npu/tests/check_xclbin_provenance.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""check_xclbin_provenance.py — static provenance + consistency check for engine/npu/xclbins.
+
+INTENT
+------
+The NPU xclbin set is tracked in git precisely because the MLIR/chess toolchain cannot
+reliably rebuild it (see engine/npu/build_npu_ternary.sh's header: "the aiecc MLIR
+toolchain has a pre-existing version mismatch that prevents clean builds"). That makes the
+*committed* artifacts the source of truth, and it means two classes of defect can only be
+caught by inspecting the committed set rather than by building it:
+
+  1. Hygiene regressions that a clean checkout reproduces deterministically. Four of the
+     tracked *.xclbin symlinks point at /opt/fastflowlm/... which does not exist on any of
+     our machines, so a fresh clone is already broken; and one build ships as a real file,
+     a byte-identical duplicate, and a symlink, so "deduping" the set either way loses
+     something (materialising the aliases doubles the payload; copying a foreign binary
+     over a dangling link hides that it was never built here).
+  2. Provenance loss. The artifacts record their producer, format version, UUID and
+     timestamp, but no toolchain version, no source revision and no generating script - so
+     a green rebuild could never be shown to reproduce what ships. PROVENANCE.json is the
+     missing half: a manifest keyed by the embedded XclBinUUID, recording the content hash,
+     the aliases, and (to be filled by the build) the toolchain and script revision.
+
+This check runs with stdlib Python only and needs no NPU, so it can gate on stock CI
+runners. It asserts hygiene invariants that need no baseline, then compares the observed
+tree against the committed manifest; a legitimate change to the artifact set is landed by
+regenerating the manifest in the same commit (--write-manifest), which is the review point.
+
+POPULATION, UNITS, TIMEZONE (stated because a census is meaningless without them)
+--------------------------------------------------------------------------------
+* Population: tracked paths under engine/npu/xclbins/ (via `git ls-files -s`), not the
+  working directory listing - the tracked set is what a clean checkout gets.
+* Top-level *.xclbin entries = regular artifacts + symlinks. Directory recursion is
+  deliberately excluded from the artifact counts.
+* Content hash: sha256 of the artifact bytes. Distinctness key: the embedded XclBinUUID.
+* Timezone: census days are UTC, derived from the embedded AXLF TimeStamp. Never mtime -
+  102 of the files carry one checkout mtime (2026-08-20 00:49), which yields a different
+  census to anyone reaching for `ls -l`.
+* Sizes are bytes; percentages are unit-independent (MB decimal vs MiB binary differ).
+
+EXIT CODES
+----------
+0  consistent (and, if a manifest exists, matching)
+1  violation (details on stderr/stdout)
+2  usage or environment error (not a git work tree, unreadable artifact, ...)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+XCLBIN_DIR = "engine/npu/xclbins"
+MANIFEST_NAME = "PROVENANCE.json"
+
+UUID_RE = re.compile(r'"XclBinUUID":"([0-9a-fA-F]{32})"')
+TS_RE = re.compile(r'"TimeStamp":"(\d+)"')
+DANGLING_TARGET_PREFIX = "/opt/fastflowlm/"
+
+MODE_SYMLINK = "120000"
+
+
+class Failure(Exception):
+    """A conformance violation (exit 1)."""
+
+
+class EnvError(Exception):
+    """A usage/environment problem (exit 2)."""
+
+
+def git_tracked(root: Path) -> list[tuple[str, str]]:
+    """[(repo-relative path, git mode)] for every tracked path under XCLBIN_DIR."""
+    proc = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-s", "--", XCLBIN_DIR],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise EnvError(f"git ls-files failed in {root}: {proc.stderr.strip()}")
+    rows = []
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        meta, _, path = line.partition("\t")
+        fields = meta.split()
+        if len(fields) < 2 or not path:
+            raise EnvError(f"unparseable ls-files line: {line!r}")
+        rows.append((path, fields[0]))
+    if not rows:
+        raise EnvError(f"no tracked paths under {XCLBIN_DIR}/ - wrong root or empty checkout")
+    return rows
+
+
+def sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1 << 20), b""):
+                h.update(chunk)
+    except OSError as exc:
+        raise EnvError(f"cannot read {path}: {exc}") from exc
+    return h.hexdigest()
+
+
+def read_artifact(path: Path) -> tuple[str, int]:
+    """(XclBinUUID, TimeStamp epoch seconds) from the embedded AXLF mirror block."""
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise EnvError(f"cannot read {path}: {exc}") from exc
+    text = raw.decode("latin-1", "replace")
+    uuid_m = UUID_RE.search(text)
+    ts_m = TS_RE.search(text)
+    if not uuid_m or not ts_m:
+        raise Failure(
+            f"{path.name}: no XclBinUUID/TimeStamp in the AXLF metadata "
+            f"(uuid={'yes' if uuid_m else 'NO'}, timestamp={'yes' if ts_m else 'NO'})"
+        )
+    return uuid_m.group(1).lower(), int(ts_m.group(1))
+
+
+def observe(root: Path) -> dict:
+    """Snapshot the tracked artifact set: population, artifacts, symlinks, census."""
+    rows = git_tracked(root)
+    top_level = [p for p, _ in rows if os.path.dirname(p) == XCLBIN_DIR]
+    top_xclbins = sorted(p for p in top_level if p.endswith(".xclbin"))
+    if not top_xclbins:
+        raise EnvError(f"no top-level *.xclbin tracked under {XCLBIN_DIR}/")
+
+    modes = dict(rows)
+    symlinks: dict[str, str] = {}
+    regular: list[str] = []
+    for p in top_xclbins:
+        path = root / p
+        if modes[p] == MODE_SYMLINK:
+            if not os.path.islink(path):
+                raise Failure(
+                    f"{p}: tracked as a symlink (git mode 120000) but the worktree entry "
+                    "is not a symlink - an alias was materialised into a real file"
+                )
+            symlinks[p] = os.readlink(path)
+        else:
+            if not path.exists():
+                raise Failure(f"{p}: tracked artifact is missing from the worktree")
+            regular.append(p)
+    txt_symlinks = [p for p in top_level if p.endswith(".txt") and modes[p] == MODE_SYMLINK]
+
+    # which symlinks resolve, and which are declared-dangling (target absent by design)
+    dangling: dict[str, str] = {}
+    resolving: dict[str, str] = {}
+    for p, target in symlinks.items():
+        resolution = target if os.path.isabs(target) else os.path.join(os.path.dirname(p), target)
+        if (root / resolution).exists():
+            resolving[p] = target
+        else:
+            dangling[p] = target
+
+    artifacts: dict[str, dict] = {}
+    for p in regular:
+        path = root / p
+        uuid, ts = read_artifact(path)
+        digest = sha256_of(path)
+        entry = artifacts.setdefault(
+            uuid,
+            {"sha256": digest, "timestamp_utc": None, "paths": []},
+        )
+        if entry["sha256"] != digest:
+            raise Failure(
+                "duplicate UUID with differing bytes - dedup-by-UUID is unsafe:\n"
+                f"  uuid {uuid}\n"
+                f"    {entry['sha256']}  (already seen)\n"
+                f"    {digest}  ({path.name})"
+            )
+        entry["paths"].append(os.path.basename(p))
+        stamp = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        if entry["timestamp_utc"] is None:
+            entry["timestamp_utc"] = stamp
+        elif stamp < entry["timestamp_utc"]:
+            entry["timestamp_utc"] = stamp
+
+    for entry in artifacts.values():
+        entry["paths"].sort()
+        entry["aliases"] = entry["paths"][1:]
+
+    # census over distinct artifacts, UTC days
+    days: dict[str, int] = {}
+    for entry in artifacts.values():
+        day = (entry["timestamp_utc"] or "")[:10]
+        if day:
+            days[day] = days.get(day, 0) + 1
+    top_days = sorted(days.items(), key=lambda kv: (-kv[1], kv[0]))
+
+    payload_bytes = sum((root / p).stat().st_size for p in regular)
+    # redundant = the second and later copies of a duplicated artifact
+    redundant_bytes = 0
+    for entry in artifacts.values():
+        if len(entry["paths"]) > 1:
+            size = (root / XCLBIN_DIR / entry["paths"][0]).stat().st_size
+            redundant_bytes += size * (len(entry["paths"]) - 1)
+
+    return {
+        "population": {
+            "tracked_paths_under_dir": len(rows),
+            "tracked_top_level_entries": len(top_level),
+            "top_level_xclbin": len(top_xclbins),
+            "regular_artifacts": len(regular),
+            "xclbin_symlinks": len(symlinks),
+            "alias_symlinks_in_tree": len(resolving),
+            "dangling_symlinks": len(dangling),
+            "txt_symlinks": len(txt_symlinks),
+            "distinct_builds_by_uuid": len(artifacts),
+        },
+        "census": {
+            "unit": "one row per distinct XclBinUUID",
+            "timezone": "UTC (embedded AXLF TimeStamp, never mtime)",
+            "distinct_builds": len(artifacts),
+            "days_utc": dict(sorted(days.items())),
+            "top_days_utc": [{"day": d, "builds": n} for d, n in top_days[:5]],
+            "payload_bytes": payload_bytes,
+            "redundant_bytes": redundant_bytes,
+            "redundant_percent": round(redundant_bytes * 100.0 / payload_bytes, 2)
+            if payload_bytes
+            else 0.0,
+        },
+        "declared_dangling": dict(sorted(dangling.items())),
+        "symlinks": dict(sorted(symlinks.items())),
+        "artifacts": dict(sorted(artifacts.items())),
+    }
+
+
+def hygiene(obs: dict) -> list[str]:
+    """Invariants that need no baseline. Returns warnings; raises Failure on violations."""
+    notes: list[str] = []
+    pop = obs["population"]
+
+    # (b) dangling links must be declared, and must not be "fixed" with a foreign binary
+    for path, target in obs["declared_dangling"].items():
+        if not target.startswith(DANGLING_TARGET_PREFIX):
+            notes.append(
+                f"{path}: dangling to {target} - an unexpected dangling target; "
+                "if this is intentional, regenerate the manifest"
+            )
+    # (a) every non-dangling symlink must resolve (by construction, but assert the split)
+    if pop["alias_symlinks_in_tree"] + pop["dangling_symlinks"] != pop["xclbin_symlinks"]:
+        raise Failure(
+            "symlink accounting does not add up: "
+            f"{pop['alias_symlinks_in_tree']} resolving + {pop['dangling_symlinks']} dangling "
+            f"!= {pop['xclbin_symlinks']} total"
+        )
+    # (d) aliases must stay symlinks: they are counted as symlinks, and no alias may also
+    #     exist as a regular artifact of the same name
+    regular_names = {
+        name for entry in obs["artifacts"].values() for name in entry["paths"]
+    }
+    for path in obs["symlinks"]:
+        if os.path.basename(path) in regular_names:
+            raise Failure(
+                f"{path}: exists BOTH as a symlink and as a regular artifact - "
+                "an alias was materialised instead of linked"
+            )
+    # (c) dedupe correctness: paths sharing a UUID must be byte-identical (checked in observe)
+    # (d) aliases must stay symlinks AND keep pointing at their own twin. A materialised
+    #     alias shows up as an extra REGULAR path in its UUID group (caught by the manifest
+    #     comparison, which also sees the payload/redundancy move); a "repaired" alias
+    #     pointing somewhere else is caught here, without needing a baseline.
+    for uuid, entry in obs["artifacts"].items():
+        regular = set(entry["paths"])
+        for path, target in obs["symlinks"].items():
+            name = os.path.basename(path)
+            if name not in regular:
+                continue  # this symlink's own artifact is elsewhere (e.g. dangling targets)
+            if os.path.basename(target) not in regular:
+                raise Failure(
+                    f"{name}: is a link into UUID {uuid}'s group but points at "
+                    f"{target!r}, which is not a member of that group"
+                )
+    return notes
+
+
+def compare(obs: dict, manifest: dict) -> list[str]:
+    """Diff the observed snapshot against the committed manifest."""
+    problems: list[str] = []
+
+    m_pop = manifest.get("population", {})
+    for key in ("top_level_xclbin", "regular_artifacts", "xclbin_symlinks",
+                "alias_symlinks_in_tree", "dangling_symlinks", "distinct_builds_by_uuid"):
+        want, got = m_pop.get(key), obs["population"].get(key)
+        if want != got:
+            problems.append(f"population.{key}: manifest {want} != observed {got}")
+
+    m_dang = manifest.get("declared_dangling", {})
+    if m_dang != obs["declared_dangling"]:
+        only_m = {k: v for k, v in m_dang.items() if k not in obs["declared_dangling"]}
+        only_o = {k: v for k, v in obs["declared_dangling"].items() if k not in m_dang}
+        for k, v in only_m.items():
+            problems.append(f"declared_dangling: {k} was dangling to {v}, now it RESOLVES")
+        for k, v in only_o.items():
+            problems.append(f"declared_dangling: {k} is newly dangling to {v}")
+
+    m_sym = manifest.get("symlinks", {})
+    if m_sym != obs["symlinks"]:
+        for k in sorted(set(m_sym) | set(obs["symlinks"])):
+            if m_sym.get(k) != obs["symlinks"].get(k):
+                problems.append(
+                    f"symlink {k}: manifest {m_sym.get(k)!r} != observed {obs['symlinks'].get(k)!r}"
+                )
+
+    m_art = manifest.get("artifacts", {})
+    for uuid in sorted(set(m_art) | set(obs["artifacts"])):
+        a, b = m_art.get(uuid), obs["artifacts"].get(uuid)
+        if a is None:
+            problems.append(f"artifact {uuid}: present now, absent from the manifest ({b['paths']})")
+        elif b is None:
+            problems.append(f"artifact {uuid}: in the manifest, absent now ({a.get('paths')})")
+        elif a.get("sha256") != b.get("sha256"):
+            problems.append(
+                f"artifact {uuid}: content changed ({a.get('paths')}) "
+                f"{str(a.get('sha256'))[:12]} -> {str(b.get('sha256'))[:12]}"
+            )
+        elif a.get("paths") != b.get("paths"):
+            problems.append(
+                f"artifact {uuid}: alias set changed {a.get('paths')} -> {b.get('paths')}"
+            )
+    return problems
+
+
+def render_census(obs: dict) -> str:
+    pop, cen = obs["population"], obs["census"]
+    lines = [
+        f"  paths under {XCLBIN_DIR}/            {pop['tracked_paths_under_dir']}",
+        f"  top-level *.xclbin entries           {pop['top_level_xclbin']}",
+        f"    regular artifacts                  {pop['regular_artifacts']}",
+        f"    symlinks                           {pop['xclbin_symlinks']}"
+        f"  ({pop['alias_symlinks_in_tree']} in-tree aliases, {pop['dangling_symlinks']} dangling)",
+        f"  *.txt symlinks                       {pop['txt_symlinks']}",
+        f"  distinct builds by XclBinUUID        {pop['distinct_builds_by_uuid']}",
+        f"  payload / redundant (bytes)          {cen['payload_bytes']} / {cen['redundant_bytes']}"
+        f"  = {cen['redundant_percent']}% redundant",
+        f"  census days (UTC)                    {len(cen['days_utc'])}",
+    ]
+    for row in cen["top_days_utc"][:3]:
+        lines.append(f"    {row['day']}  {row['builds']} builds")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--root", default=None, help="repo root (default: inferred from this file)")
+    ap.add_argument("--manifest", default=None, help=f"path to {MANIFEST_NAME}")
+    ap.add_argument("--write-manifest", action="store_true",
+                    help="regenerate the manifest from the observed tree (land the change in the same commit)")
+    ap.add_argument("--allow-missing-manifest", action="store_true",
+                    help="do not fail when the manifest is absent (bootstrap only)")
+    args = ap.parse_args(argv)
+
+    root = Path(args.root).resolve() if args.root else Path(__file__).resolve().parents[3]
+    manifest_path = Path(args.manifest) if args.manifest else root / XCLBIN_DIR / MANIFEST_NAME
+
+    try:
+        obs = observe(root)
+        notes = hygiene(obs)
+    except (Failure, EnvError) as exc:
+        kind = "VIOLATION" if isinstance(exc, Failure) else "ENVIRONMENT"
+        print(f"{kind}: {exc}", file=sys.stderr)
+        return 1 if isinstance(exc, Failure) else 2
+
+    print(f"xclbin provenance - {root}")
+    print(render_census(obs))
+    for note in notes:
+        print(f"  note: {note}")
+
+    if args.write_manifest:
+        payload = {
+            "schema": 1,
+            "intent": (
+                "Provenance for the committed NPU xclbin set, keyed by the artifact's embedded "
+                "XclBinUUID. Regenerate with engine/npu/tests/check_xclbin_provenance.py "
+                "--write-manifest and land it in the same commit as the artifact change."
+            ),
+            "generated": {
+                "by": "pi/coding-agent",
+                "at": datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "check": "engine/npu/tests/check_xclbin_provenance.py",
+                "ref": subprocess.run(
+                    ["git", "-C", str(root), "rev-parse", "--short", "HEAD"],
+                    capture_output=True, text=True).stdout.strip(),
+            },
+            "build": {
+                "toolchain": None,
+                "toolchain_note": (
+                    "Empty by design: the artifacts record no compiler arm or version "
+                    "(no chesscc/peano/llvm/aiecc/clang marker in the AXLF metadata; "
+                    "PlatformVBNV is empty). A build that regenerates these artifacts must "
+                    "fill this in - that is the missing half of the provenance."
+                ),
+                "generating_script_revision": None,
+            },
+            "population": obs["population"],
+            "census": obs["census"],
+            "declared_dangling": obs["declared_dangling"],
+            "symlinks": obs["symlinks"],
+            "artifacts": obs["artifacts"],
+        }
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(payload, indent=1, sort_keys=True) + "\n")
+        print(f"\nwrote {manifest_path.relative_to(root)} "
+              f"({manifest_path.stat().st_size} B, {len(obs['artifacts'])} artifacts)")
+        return 0
+
+    if not manifest_path.exists():
+        if args.allow_missing_manifest:
+            print(f"\nno manifest at {manifest_path} (allowed by --allow-missing-manifest)")
+            return 0
+        print(
+            f"\nVIOLATION: no manifest at {manifest_path.relative_to(root)}\n"
+            "  The artifact set has no recorded provenance. Bootstrap it with:\n"
+            "    engine/npu/tests/check_xclbin_provenance.py --write-manifest",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ENVIRONMENT: cannot parse {manifest_path}: {exc}", file=sys.stderr)
+        return 2
+
+    problems = compare(obs, manifest)
+    if problems:
+        print(f"\nVIOLATION: the tracked set differs from {manifest_path.name} "
+              f"({len(problems)} difference(s)):", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        print(
+            "\n  If the change is intentional, regenerate and land the manifest in the SAME\n"
+            "  commit so the provenance moves with the artifacts:\n"
+            "    engine/npu/tests/check_xclbin_provenance.py --write-manifest\n"
+            "  Do not: copy a foreign xclbin over a dangling link, or materialise an alias\n"
+            "  symlink into a real file (it doubles the payload and hides the aliasing).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nOK: matches {manifest_path.name} "
+          f"({obs['population']['distinct_builds_by_uuid']} distinct builds, "
+          f"{obs['population']['dangling_symlinks']} dangling as declared)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/engine/npu/xclbins/PROVENANCE.json
+++ b/engine/npu/xclbins/PROVENANCE.json
@@ -1,0 +1,865 @@
+{
+ "artifacts": {
+  "00463dd362f5c26cf7d175247a3d1e45": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_D_zaya_m16.xclbin"
+   ],
+   "sha256": "af74e94313bbec651e041e08472f62a7dc58178047b58ba48ed7a62fbe011e46",
+   "timestamp_utc": "2026-08-22T00:08:10Z"
+  },
+  "019b5626b933bf0519296a6e303e92de": {
+   "aliases": [
+    "final_i8_O_gemma4_e4b.xclbin"
+   ],
+   "paths": [
+    "final_i8_O_K4096_N2560.xclbin",
+    "final_i8_O_gemma4_e4b.xclbin"
+   ],
+   "sha256": "ba2ff3f9829b26cc90a64e5292d7450380f3be36c8372a22f0077a0686a0ecaa",
+   "timestamp_utc": "2026-08-09T18:02:00Z"
+  },
+  "188103bc20d530a6ff09a89eed1c0786": {
+   "aliases": [
+    "final_i8_QKV_gemma4_e4b.xclbin"
+   ],
+   "paths": [
+    "final_i8_QKV_K2560_N6144.xclbin",
+    "final_i8_QKV_gemma4_e4b.xclbin"
+   ],
+   "sha256": "105c15e2b55acd879b19556ff0e997a1c5b007b20ff1acc46d74a4cf7f5bc86a",
+   "timestamp_utc": "2026-08-09T18:01:58Z"
+  },
+  "18e01542dfef1ad9b813d1753762c6c6": {
+   "aliases": [
+    "final_i8_U_phi4_mini_4b.xclbin"
+   ],
+   "paths": [
+    "final_i8_U_K3072_N8192.xclbin",
+    "final_i8_U_phi4_mini_4b.xclbin"
+   ],
+   "sha256": "6b467a0f1fef2b370df1082e1c22219b8ed1284e8c24f2364eb0f4c14e56d7ce",
+   "timestamp_utc": "2026-08-09T18:02:23Z"
+  },
+  "19f7823b984c7e3dfdf66032cd2dbda8": {
+   "aliases": [],
+   "paths": [
+    "final_i8_D_qwen3_0_6b.xclbin"
+   ],
+   "sha256": "8c8b5ba8b92ac9023f966784e77d94a3d45f969339672e6646c9968060dee35d",
+   "timestamp_utc": "2026-08-05T12:31:35Z"
+  },
+  "1bfcf3cb7066d45f233a67a204acefb9": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_FUSED_zaya.xclbin"
+   ],
+   "sha256": "d3ead0630e9d2f648b0a2e2cd414fd5093968af4471a83fc04013a0e1429b3b4",
+   "timestamp_utc": "2026-09-09T15:52:12Z"
+  },
+  "216c5e087e9679fb7fcc043dbb8882e6": {
+   "aliases": [],
+   "paths": [
+    "final_i8_GU_qwen3_0_6b.xclbin"
+   ],
+   "sha256": "dd07883082891b8440b823f9def66427c21dc8645c46b707b4e01887a34771c5",
+   "timestamp_utc": "2026-08-05T12:31:34Z"
+  },
+  "258cd881dcd62e78dd5790333f8de7d8": {
+   "aliases": [
+    "final_i8_QKV_qwen3.6-moe_35b.xclbin"
+   ],
+   "paths": [
+    "final_i8_QKV_K2048_N8192.xclbin",
+    "final_i8_QKV_qwen3.6-moe_35b.xclbin"
+   ],
+   "sha256": "bc34d6c2fc9b218357deff15c4c8a6deb73f4e97db50d5261eb245054679635c",
+   "timestamp_utc": "2026-08-09T18:02:59Z"
+  },
+  "25f31fb3834c60ca9b4a6943e3939301": {
+   "aliases": [
+    "final_i8_D_gemma4_e4b.xclbin"
+   ],
+   "paths": [
+    "final_i8_D_K12288_N2560.xclbin",
+    "final_i8_D_gemma4_e4b.xclbin"
+   ],
+   "sha256": "6aed5fba8f4eb08ae1594cc525c61b9c752b091361e9156916424a73ec922234",
+   "timestamp_utc": "2026-08-09T18:02:11Z"
+  },
+  "274e20402e98ff0923e53088e29c45df": {
+   "aliases": [],
+   "paths": [
+    "final_i8_D_qwen3_8b.xclbin"
+   ],
+   "sha256": "ccc99c8e7841962b8210bc47366cad50a3765c87e0e4469cb3685d5872eb486f",
+   "timestamp_utc": "2026-08-05T14:22:25Z"
+  },
+  "27d6cb0464ffe57c5baedf063d512afa": {
+   "aliases": [],
+   "paths": [
+    "final_i8_O_gemma4_e2b.xclbin"
+   ],
+   "sha256": "28d2f3790451e3cd0c7bd6c6d49550174d99a59322f93fa3260bcb3a10ea8551",
+   "timestamp_utc": "2026-08-05T14:22:44Z"
+  },
+  "281470b005f3c6afedd9583774faf28a": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_D_zaya.xclbin"
+   ],
+   "sha256": "fc4438eedaf3afb999c9953545c8d49c67a043163559f899663c63db2440bfb6",
+   "timestamp_utc": "2026-08-21T17:59:58Z"
+  },
+  "29b7358d85f376f5d67a28ff25237e6f": {
+   "aliases": [],
+   "paths": [
+    "final_i8_D_qwen3_vl_4b.xclbin"
+   ],
+   "sha256": "95be4c7a0841d6ac8467b0e7807be39aa3dad410318d6993685653f518aa8eff",
+   "timestamp_utc": "2026-08-05T14:22:42Z"
+  },
+  "2a51fc15a43bd95289c2f9c17d0345e1": {
+   "aliases": [],
+   "paths": [
+    "final_i8_G_llama.xclbin"
+   ],
+   "sha256": "be4a46dc49fa31fbe42af675877bb78fdff917f8f3a7b332eeb8e1633615075f",
+   "timestamp_utc": "2026-08-05T14:23:05Z"
+  },
+  "3315baf9f0d4bd29d1543b5c5316cec3": {
+   "aliases": [],
+   "paths": [
+    "final_i8_D_v.xclbin"
+   ],
+   "sha256": "85fcf77010704b7a1661a35ac50f5e5183d9935ca55a957e3cc51d4dfebe5403",
+   "timestamp_utc": "2026-07-28T22:31:24Z"
+  },
+  "38041e599c06b89548d976536f030aea": {
+   "aliases": [
+    "final_i8_ATTN_v.xclbin"
+   ],
+   "paths": [
+    "final_i8_ATTN_qwen3_0_6b.xclbin",
+    "final_i8_ATTN_v.xclbin"
+   ],
+   "sha256": "dc5ef1b4dcd5d5766d1573bd5b390aa0ec5dd2a722fcc993e42ceb9a59899e7a",
+   "timestamp_utc": "2026-07-23T17:47:50Z"
+  },
+  "38d85486faa1ce524c65d9d501343abe": {
+   "aliases": [],
+   "paths": [
+    "final_i8_D_qwen3_0_6b_m1.xclbin"
+   ],
+   "sha256": "f298d0b51b9ac89e21fc9ede91eb021b0231d795ef81b19cacd699b755ae9102",
+   "timestamp_utc": "2026-08-29T15:55:43Z"
+  },
+  "3a1ed255957b6e1be86ff141305b4bac": {
+   "aliases": [
+    "final_i8_U_gemma4_e4b.xclbin"
+   ],
+   "paths": [
+    "final_i8_U_K2560_N12288.xclbin",
+    "final_i8_U_gemma4_e4b.xclbin"
+   ],
+   "sha256": "542ee4112d8a96e24c9ec2e5a1adf8a9d9422a5bd00c02de9c9d0c82f7af2df1",
+   "timestamp_utc": "2026-08-09T18:02:08Z"
+  },
+  "3c06ebc72d8fb91ca57ac7c6186f028a": {
+   "aliases": [
+    "final_i8_U_qwen3_5_4b.xclbin"
+   ],
+   "paths": [
+    "final_i8_U_K2560_N9216.xclbin",
+    "final_i8_U_qwen3_5_4b.xclbin"
+   ],
+   "sha256": "bda217c1cddc33630276a42e3326b3897738070b8f2df192db0d80cbb3616623",
+   "timestamp_utc": "2026-08-09T18:01:52Z"
+  },
+  "4322eb560c05fec68c1241c19d72c672": {
+   "aliases": [],
+   "paths": [
+    "final_i8_GU_v.xclbin"
+   ],
+   "sha256": "86a7bea5c007cee8499119b37027f9568890bc9f465043493416bc3b821a744a",
+   "timestamp_utc": "2026-07-28T22:31:23Z"
+  },
+  "43edfca90b36ec32e6beb69078813966": {
+   "aliases": [],
+   "paths": [
+    "final_i8_QKV_gemma4_e2b.xclbin"
+   ],
+   "sha256": "9dc8bf191b486bf6755f09b7c716bc22f11eed437ab92381cb186b654d4012f2",
+   "timestamp_utc": "2026-08-05T14:22:43Z"
+  },
+  "477c39a9ff6988470e1f14e1cd86139f": {
+   "aliases": [
+    "final_i8_QKV_phi4_mini_4b.xclbin"
+   ],
+   "paths": [
+    "final_i8_QKV_K3072_N5120.xclbin",
+    "final_i8_QKV_phi4_mini_4b.xclbin"
+   ],
+   "sha256": "e9ccd99795e0b202b36e3a90021b39d5cf85f19db8b9ba992ba2ed34deb14928",
+   "timestamp_utc": "2026-08-09T18:02:14Z"
+  },
+  "4836ac19d7e4da8ef5cbaea79ab71898": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_D_qwen3.6-moe_35b.xclbin"
+   ],
+   "sha256": "09813d58964fdce1666bc9eaa34ac1eda81a521875203a03adf21aa3eeac8546",
+   "timestamp_utc": "2026-08-09T23:49:05Z"
+  },
+  "4bd9ace7bf0df38941935c9651ba2701": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_GU_qwen3.6-moe_35b.xclbin"
+   ],
+   "sha256": "bd4ea78b8b09363d85ca7bb5cd1d0033b087364efad885259614a105111c11c1",
+   "timestamp_utc": "2026-08-09T23:49:02Z"
+  },
+  "521b784dcf26658c5863cfe72f53ec31": {
+   "aliases": [
+    "final_i8_O_nanbeige4_1_3b.xclbin"
+   ],
+   "paths": [
+    "final_i8_O_K2560_N2560.xclbin",
+    "final_i8_O_nanbeige4_1_3b.xclbin"
+   ],
+   "sha256": "cc15bb7f1a5b98eb73167093fe4bfe325814865fb3127b1185d039a9059c2d2e",
+   "timestamp_utc": "2026-08-09T18:02:28Z"
+  },
+  "54fb7aaac493b3a0204b97622a545b8e": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_DSD_qwen3.6-moe_35b.xclbin"
+   ],
+   "sha256": "ca047b3d58348b4685c3f1ec73643907329796ea91cdab36f707860facece03c",
+   "timestamp_utc": "2026-08-10T00:51:55Z"
+  },
+  "55f1e688e38e5967dcff7a9382573659": {
+   "aliases": [],
+   "paths": [
+    "final_i8_D_gemma4_e2b.xclbin"
+   ],
+   "sha256": "56d1581d5b1e7d98be4859777434ea5c9545ae2fc3315d335b0c06e7069062d6",
+   "timestamp_utc": "2026-07-28T22:33:48Z"
+  },
+  "5bb6f2d4001676ad881c1324eb98c25f": {
+   "aliases": [],
+   "paths": [
+    "final_i8_QKV_qwen3_0_6b.xclbin"
+   ],
+   "sha256": "f7c8028321fce60cf6e9cd56b289cde434355e8a7886de29095aa20ee6743f0e",
+   "timestamp_utc": "2026-08-05T12:31:30Z"
+  },
+  "5e47c9b41b28ea8020211c45124e1ecd": {
+   "aliases": [
+    "final_i8_G_gemma4_e4b.xclbin"
+   ],
+   "paths": [
+    "final_i8_G_K2560_N12288.xclbin",
+    "final_i8_G_gemma4_e4b.xclbin"
+   ],
+   "sha256": "5de2a2f93eed4263b20a6874f1d4b173e878dd44cb9b0be202e51bac5bb61902",
+   "timestamp_utc": "2026-08-09T18:02:04Z"
+  },
+  "631ef330c3d31f1938d99e58612ae741": {
+   "aliases": [
+    "final_i8_G_qwen3.6-moe_35b.xclbin"
+   ],
+   "paths": [
+    "final_i8_G_K2048_N512.xclbin",
+    "final_i8_G_qwen3.6-moe_35b.xclbin"
+   ],
+   "sha256": "5a7dabc4a96e5c1ec5e779605599ceaf5d16dd5dec368547d6fce7d1d95c4ff2",
+   "timestamp_utc": "2026-08-09T18:01:36Z"
+  },
+  "671cc1f0443735d8d5b3e9c5251cf038": {
+   "aliases": [
+    "final_i8_D_qwen3_5_4b.xclbin"
+   ],
+   "paths": [
+    "final_i8_D_K9216_N2560.xclbin",
+    "final_i8_D_qwen3_5_4b.xclbin"
+   ],
+   "sha256": "e1706e79bebc6766a40b0d764e735bba78525ce3be88f4ae1c5c462030a0ec76",
+   "timestamp_utc": "2026-08-09T18:01:55Z"
+  },
+  "6a988e3b0326ba40fbef3bdd736a3930": {
+   "aliases": [],
+   "paths": [
+    "ternary_O_qwen3_0_6b.xclbin"
+   ],
+   "sha256": "8669e05b286b3d3e3e669422c4bfd1cdd10ddca50d5c64e86ec0435e55cd32f2",
+   "timestamp_utc": "2026-07-20T16:15:34Z"
+  },
+  "6bc9a1266d5f97afb3f259fafdd4bd1d": {
+   "aliases": [],
+   "paths": [
+    "final_i8_G_qwen3_vl_4b.xclbin"
+   ],
+   "sha256": "66b429f0a895049ed12649e96ebddbaabb05f5c30e2b513c347471fce0d28f70",
+   "timestamp_utc": "2026-08-05T14:22:34Z"
+  },
+  "701f346aecdb2702b5eaea4bb3617efb": {
+   "aliases": [],
+   "paths": [
+    "final_i8_D_qwen3_0_6b_m32.xclbin"
+   ],
+   "sha256": "8116082c22fcfbe62c56462f71acd152051f4617d7e52cfa2f06860e2c235504",
+   "timestamp_utc": "2026-08-30T08:16:56Z"
+  },
+  "7054c1b99ed0542ba8fca33a0550dc25": {
+   "aliases": [],
+   "paths": [
+    "final_i8_QKV_qwen3_5_4b.xclbin"
+   ],
+   "sha256": "635ff52c8d06bf83acaedf889ec2defadaa44bc6e213bf1603a6d3769d5cd4ab",
+   "timestamp_utc": "2026-08-09T18:01:43Z"
+  },
+  "71a6f5a18f733655efffa8878b2faa91": {
+   "aliases": [],
+   "paths": [
+    "final_i8_GU_qwen3.6-moe_35b.xclbin"
+   ],
+   "sha256": "d90986b264e09c2f643b5d2c18c719f3a51cf31f71202ea80a0ab02a3ada6472",
+   "timestamp_utc": "2026-08-04T20:13:38Z"
+  },
+  "736dca1d02c77ea8d375e6fe5010ae59": {
+   "aliases": [
+    "final_i8_G_phi4_mini_4b.xclbin"
+   ],
+   "paths": [
+    "final_i8_G_K3072_N8192.xclbin",
+    "final_i8_G_phi4_mini_4b.xclbin"
+   ],
+   "sha256": "36db53ae9fbcc3f737fdf64d6a49a5491cb3a9dc5d25e73b8b6bb526a195ed3d",
+   "timestamp_utc": "2026-08-09T18:02:20Z"
+  },
+  "768e5495701e425689a6e6cbd6b10f99": {
+   "aliases": [],
+   "paths": [
+    "final_i8_U_llama.xclbin"
+   ],
+   "sha256": "b312ef0728ecab31bd30cc7dc7d6521b307cd451d642c098e5139427e69dc4b1",
+   "timestamp_utc": "2026-08-05T14:23:14Z"
+  },
+  "7a23fc5a22860384547f6a218f81c68c": {
+   "aliases": [
+    "final_i8_U_nanbeige4_1_3b.xclbin"
+   ],
+   "paths": [
+    "final_i8_U_K2560_N8192.xclbin",
+    "final_i8_U_nanbeige4_1_3b.xclbin"
+   ],
+   "sha256": "417084a6766dee8559f59ea22dd0f8af54d14ac4f89426aea2d553da74f5ce35",
+   "timestamp_utc": "2026-08-09T18:02:35Z"
+  },
+  "7e4446ba70638877ce7a9a36ad8d7046": {
+   "aliases": [],
+   "paths": [
+    "final_i8_GU_qwen3_0_6b_m1.xclbin"
+   ],
+   "sha256": "c033b8bbf2742b51e865767aff1bfe317aafc3064f74461f45edecb8ef29ef16",
+   "timestamp_utc": "2026-08-29T15:55:42Z"
+  },
+  "81e11eab4247519c6035d329e09ba4e3": {
+   "aliases": [],
+   "paths": [
+    "final_i8_GU_qwen3_0_6b_m32.xclbin"
+   ],
+   "sha256": "23d29340164ce5cc68585a0fa8867253c08dcd1a28c1da552a00de8fa7df0635",
+   "timestamp_utc": "2026-08-30T08:16:54Z"
+  },
+  "82fd6702ae3a2b983ac3758da589abd7": {
+   "aliases": [],
+   "paths": [
+    "final_i8_O_llama.xclbin"
+   ],
+   "sha256": "b0359e751ef8d72e24e856927da334e0c27b4bf73b748a00f12a50d766570ba1",
+   "timestamp_utc": "2026-08-05T14:22:56Z"
+  },
+  "846206f4079801d01e553ac9a661f8c1": {
+   "aliases": [],
+   "paths": [
+    "final_i8_GUSILU_i4_qwen3_0_6b_bf16pair.xclbin"
+   ],
+   "sha256": "860ee9bfec66abc5798182f0aa1fbc7d65e3f260c7d862f69ca0223a46d53db0",
+   "timestamp_utc": "2026-09-03T00:10:48Z"
+  },
+  "85a139d66f8c362844bdb2b3eb94adad": {
+   "aliases": [
+    "final_i8_D_nanbeige4_1_3b.xclbin"
+   ],
+   "paths": [
+    "final_i8_D_K8192_N2560.xclbin",
+    "final_i8_D_nanbeige4_1_3b.xclbin"
+   ],
+   "sha256": "b1148924ec982e7bdb858dd3755a8532fe522c2a2e2fb89cdcc7e6831a3cc158",
+   "timestamp_utc": "2026-08-09T18:02:37Z"
+  },
+  "8619994f9e37f435f169328aefd4a302": {
+   "aliases": [],
+   "paths": [
+    "ternary_GU_qwen3_0_6b.xclbin"
+   ],
+   "sha256": "cb0728b15adacd516ad2581bfab5701466267c86e4c52745c2bc08998188a33c",
+   "timestamp_utc": "2026-07-20T16:16:24Z"
+  },
+  "8653cbb58764488e180daa5ff2e792ca": {
+   "aliases": [
+    "final_i8_O_qwen3.6-moe_35b.xclbin"
+   ],
+   "paths": [
+    "final_i8_O_K4096_N2048.xclbin",
+    "final_i8_O_qwen3.6-moe_35b.xclbin"
+   ],
+   "sha256": "8a7872f629226e1b61826ea2e0d5478ce38c501586936a83394cce200c05cc4f",
+   "timestamp_utc": "2026-08-09T18:01:35Z"
+  },
+  "868ba11feda655c458a5a1a347cde7e9": {
+   "aliases": [],
+   "paths": [
+    "final_i8_GU_gemma4_e2b.xclbin"
+   ],
+   "sha256": "37c536a45e6c974060ab1f2452dad0db757b4438eb72ee52d0265f9f7cea8776",
+   "timestamp_utc": "2026-08-05T14:22:48Z"
+  },
+  "88178ae0ec821e0c2ee8b67e76f9cae1": {
+   "aliases": [
+    "final_i8_U_qwen3.6-moe_35b.xclbin"
+   ],
+   "paths": [
+    "final_i8_U_K2048_N512.xclbin",
+    "final_i8_U_qwen3.6-moe_35b.xclbin"
+   ],
+   "sha256": "520a25ff452c62fbca3ba752703b82b5e85a12d6a40a124604d332ccae1696a3",
+   "timestamp_utc": "2026-08-09T18:01:38Z"
+  },
+  "892c9cf552cfb247831868c54d33fa7d": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_SD_qwen3.6-moe_35b.xclbin"
+   ],
+   "sha256": "8c45a23adebd6b072cbc803a63bc69a7cc9c611a58ebe13f6d3844d0a32c8a8c",
+   "timestamp_utc": "2026-08-09T23:49:09Z"
+  },
+  "89dde8f140ae376fb6f0eb61694f35aa": {
+   "aliases": [
+    "final_i8_D_qwen3.6-moe_35b.xclbin"
+   ],
+   "paths": [
+    "final_i8_D_K512_N2048.xclbin",
+    "final_i8_D_qwen3.6-moe_35b.xclbin"
+   ],
+   "sha256": "2556c40740af4cea95eb27af83bc143e4237fb795665a77dc7faa25161b21349",
+   "timestamp_utc": "2026-08-09T18:01:40Z"
+  },
+  "8ca6a51010711caeebb0268c1d1a0ce5": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_GU_zaya.xclbin"
+   ],
+   "sha256": "8bc50690e1c85d31e026263ed2705848f860576f81fd5894c9deb3b93c945f6f",
+   "timestamp_utc": "2026-08-21T17:59:46Z"
+  },
+  "8fe22b73a3e23c26eee3669379f39e8e": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_GU_zaya_m16.xclbin"
+   ],
+   "sha256": "c721ca286dc3a18d2702e63ee3d31e2c4b0a869a627bca049133acf9473e7bb8",
+   "timestamp_utc": "2026-08-22T00:07:38Z"
+  },
+  "923546837989560d85d1ad7428bfa6a3": {
+   "aliases": [],
+   "paths": [
+    "final_i8_QKV_v.xclbin"
+   ],
+   "sha256": "05ba709d15d73c2941d5166f6e6a6f6e0ae8e662d7030cdb426517e922bb3b4c",
+   "timestamp_utc": "2026-07-28T22:31:20Z"
+  },
+  "943ecadd0136f1085d0584db6c9cf153": {
+   "aliases": [
+    "final_i8_D_phi4_mini_4b.xclbin"
+   ],
+   "paths": [
+    "final_i8_D_K8192_N3072.xclbin",
+    "final_i8_D_phi4_mini_4b.xclbin"
+   ],
+   "sha256": "67760790342fe528ad3ebc8ceff6aed26c1048c212f6c7df03789404a1b941a7",
+   "timestamp_utc": "2026-08-09T18:02:26Z"
+  },
+  "985a73fa933965874b49be42d7bb5dee": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_D_zaya_m8h2.xclbin"
+   ],
+   "sha256": "1d4e4d0fe22ef83c7af9dadc4165497ede283f98ec7aab1d34c600a7ff602b83",
+   "timestamp_utc": "2026-08-23T08:13:40Z"
+  },
+  "9f20fbd5ecc290fd06fe3fbe39edd931": {
+   "aliases": [],
+   "paths": [
+    "final_i8_U_qwen3_8b.xclbin"
+   ],
+   "sha256": "bd48f8992c40605864777eea7aa525caedcfddf496682ada6dd0a3ebe0d8b3f0",
+   "timestamp_utc": "2026-08-05T14:22:17Z"
+  },
+  "a3cdb924dac4ab3915cd91c808b9cec1": {
+   "aliases": [],
+   "paths": [
+    "final_i8_O_v.xclbin"
+   ],
+   "sha256": "6502fcd34c131e5c6be6954fa13ec0637155b07a11f68a7cae5301a289d0ecb2",
+   "timestamp_utc": "2026-07-28T22:31:21Z"
+  },
+  "a6d2ef98910ef24eb36d84866bd373b3": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_D_zaya_m8.xclbin"
+   ],
+   "sha256": "50405deda486a42bd0bc399c41da15d1b4d98e6518c18fe068b9ea660eafd3fe",
+   "timestamp_utc": "2026-08-22T00:29:55Z"
+  },
+  "a7bbd84e68f02d6e9ae85974a4663560": {
+   "aliases": [],
+   "paths": [
+    "ternary_QKV_qwen3_0_6b.xclbin"
+   ],
+   "sha256": "48bd0c02acc3b0709b3afbb3199a8dcb60239ff2d4a3d24cba036957cc994520",
+   "timestamp_utc": "2026-07-20T16:15:04Z"
+  },
+  "a94802ab6b2a599d63b54e54092d927f": {
+   "aliases": [],
+   "paths": [
+    "final_i8_G_qwen3_8b.xclbin"
+   ],
+   "sha256": "8c8285b6840bd593a7febf312067b52224fc0dbd4dfe22d398387188dfe72c6c",
+   "timestamp_utc": "2026-08-05T14:22:09Z"
+  },
+  "af4d187ff27eb9c002f09e82ea42998b": {
+   "aliases": [],
+   "paths": [
+    "final_cascade_fused_qwen3_0_6b.xclbin"
+   ],
+   "sha256": "f302dab9d6198e618e5bcf34c91f9dde7766722685ccfe8a0771617ac78f343c",
+   "timestamp_utc": "2026-08-30T10:53:06Z"
+  },
+  "af72b09b49c50b9490032f9199b6dcd5": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_GUSILU_i4_zaya.xclbin"
+   ],
+   "sha256": "cb948a722531ba3417df1157c61de7e51f45e58dca7e0853a48369f06fafb321",
+   "timestamp_utc": "2026-08-28T14:35:43Z"
+  },
+  "b1cb0450356fb74c8bbfdbaa3209d132": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_GU_zaya_m8.xclbin"
+   ],
+   "sha256": "3f6d1a7993611480668590b3ca49b41fe07f9bd82690cad4d8065969a75fe757",
+   "timestamp_utc": "2026-08-22T00:29:54Z"
+  },
+  "b575c65133ddf89fbbf884446b134b35": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_GUSGU_qwen3.6-moe_35b.xclbin"
+   ],
+   "sha256": "9b030fcb6493a37e9bd6c0e738fb4a8fda1956fcc24a159e50b3dc9f7bb54647",
+   "timestamp_utc": "2026-08-10T00:51:52Z"
+  },
+  "b5a84ca6f3f621f2925cfaa487919a47": {
+   "aliases": [],
+   "paths": [
+    "final_i8_QKV_llama.xclbin"
+   ],
+   "sha256": "ab9ed923ad416e688d83c2394290dc7ddabd62fa944729aef1dca100d364edd0",
+   "timestamp_utc": "2026-08-05T14:22:53Z"
+  },
+  "ba2938eb28f386f20b73a6e5febb6f6b": {
+   "aliases": [],
+   "paths": [
+    "final_i8_D_qwen3_0_6b_m8.xclbin"
+   ],
+   "sha256": "0eb0cb5c093aaf2df68e6c1d1193a3337d367502410f3d87f7c5de0aeb883fcf",
+   "timestamp_utc": "2026-08-29T16:03:23Z"
+  },
+  "bb1b0f86ec1ec9a96a8957d090d7ce6e": {
+   "aliases": [],
+   "paths": [
+    "final_i8_QKV_qwen3_8b.xclbin"
+   ],
+   "sha256": "335ca9ffe9cfff42b61efba22a27fa2ced4366a564cc65a40979dec613641c4c",
+   "timestamp_utc": "2026-08-05T14:21:57Z"
+  },
+  "bddfe28de194b13c739f68025c638dee": {
+   "aliases": [],
+   "paths": [
+    "final_cascade_fused.xclbin"
+   ],
+   "sha256": "3db820765072eaba1a0fd4cee15f52f42f1ff7a57b06fed1b9b891e2b43141c4",
+   "timestamp_utc": "2026-08-31T09:54:27Z"
+  },
+  "c00b7521b344f141996044fb621b281f": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_SGU_qwen3.6-moe_35b.xclbin"
+   ],
+   "sha256": "c232c1d08b10962a8c9e62653f710e7ec767a23557c80ca9f8deb2d7a260a190",
+   "timestamp_utc": "2026-08-09T23:49:07Z"
+  },
+  "c4d1a7151b13adf9ec5cc28d0f54a0da": {
+   "aliases": [],
+   "paths": [
+    "final_i8_MOE_GUSILU_zaya.xclbin"
+   ],
+   "sha256": "e61ec9bdd5ba07af66fdc4324f98eba37629c859c28d8973ca3ca85eb085009c",
+   "timestamp_utc": "2026-08-28T14:29:48Z"
+  },
+  "c78738dd29dcac7e8b97921475645a5c": {
+   "aliases": [],
+   "paths": [
+    "final_i8_U_qwen3_vl_4b.xclbin"
+   ],
+   "sha256": "66f1ca0e0c364fd067048bb69f02f424a515d91938f61a208a78f7233810580b",
+   "timestamp_utc": "2026-08-05T14:22:38Z"
+  },
+  "d3cad01d0f88c7c8fd8340fc97bc5394": {
+   "aliases": [
+    "final_i8_O_phi4_mini_4b.xclbin"
+   ],
+   "paths": [
+    "final_i8_O_K3072_N3072.xclbin",
+    "final_i8_O_phi4_mini_4b.xclbin"
+   ],
+   "sha256": "f5a1cfdb71f0e143c9aaa198008da279932eebc59bce3451fcbc8899e9f56099",
+   "timestamp_utc": "2026-08-09T18:02:16Z"
+  },
+  "d7990f6e582c25bbe51da23609c1bcc4": {
+   "aliases": [],
+   "paths": [
+    "final_i8_D_llama.xclbin"
+   ],
+   "sha256": "42a6b55638e9e75e2ef70293eafb3e572628f97d41962b1a5a0f650c876a5ba0",
+   "timestamp_utc": "2026-08-05T14:23:23Z"
+  },
+  "d95941e021f0975a0a9beb7ced106b2a": {
+   "aliases": [
+    "final_i8_QKV_nanbeige4_1_3b.xclbin"
+   ],
+   "paths": [
+    "final_i8_QKV_K2560_N3840.xclbin",
+    "final_i8_QKV_nanbeige4_1_3b.xclbin"
+   ],
+   "sha256": "22d6157cc5435fa72739e2a570a9c18264e08250c012ae1f2ab097914dac4a3a",
+   "timestamp_utc": "2026-08-09T18:03:47Z"
+  },
+  "de231ad9d858c8220dae72555fdf9644": {
+   "aliases": [
+    "final_i8_KV_v.xclbin"
+   ],
+   "paths": [
+    "final_i8_KV_qwen3_0_6b.xclbin",
+    "final_i8_KV_v.xclbin"
+   ],
+   "sha256": "99969a8b9bc542fc37766977b0b3998f98aba75a795ba947e91d5644ef8313b6",
+   "timestamp_utc": "2026-07-05T02:53:27Z"
+  },
+  "df66d307843c4a2c17b0940a544fda25": {
+   "aliases": [
+    "final_i8_G_nanbeige4_1_3b.xclbin"
+   ],
+   "paths": [
+    "final_i8_G_K2560_N8192.xclbin",
+    "final_i8_G_nanbeige4_1_3b.xclbin"
+   ],
+   "sha256": "d96df80ce3d870a1bfd3b594b67584c457b9ae17dbf8c86d9fb5eeead75d2dd6",
+   "timestamp_utc": "2026-08-09T18:02:32Z"
+  },
+  "e24f3eb7488bb41cb70874f95d6dedba": {
+   "aliases": [],
+   "paths": [
+    "final_i8_O_qwen3_5_4b.xclbin"
+   ],
+   "sha256": "8e0eea4b87ddda163e4da69b59b418805a35d067f62d570efc8efa5911d8b205",
+   "timestamp_utc": "2026-08-09T18:01:45Z"
+  },
+  "e6795afb37cc4b704d85189de34ce730": {
+   "aliases": [],
+   "paths": [
+    "final_i8_GU_qwen3_0_6b_m8.xclbin"
+   ],
+   "sha256": "26cb5b0c6aca5747df91854eaee713608c3fbf864f4e4d9e9a0f9652127788a6",
+   "timestamp_utc": "2026-08-29T16:03:22Z"
+  },
+  "e9c90be0c89def353e83fda74941ec28": {
+   "aliases": [],
+   "paths": [
+    "final_i8_O_qwen3_vl_4b.xclbin"
+   ],
+   "sha256": "50b8a511f424cb97d22aee8207a3e6dc403abf7c94da4eb7ff800c098194c745",
+   "timestamp_utc": "2026-08-05T14:22:31Z"
+  },
+  "eadaef6c4162badf6a9de48ec663e300": {
+   "aliases": [],
+   "paths": [
+    "final_i8_GUSILU_i4_qwen3_0_6b.xclbin"
+   ],
+   "sha256": "9583d7de84c64295deb5cce79478f5e498872e78611fa8d7f70727a50ae8b8e7",
+   "timestamp_utc": "2026-08-29T19:19:14Z"
+  },
+  "ed38111ac65dbe18b5ee5be1055ca182": {
+   "aliases": [],
+   "paths": [
+    "final_i8_O_qwen3_0_6b.xclbin"
+   ],
+   "sha256": "05fc0b572b8ce3689e107a039d705e1ca6a0ae218452633aa639df9f2e03f610",
+   "timestamp_utc": "2026-08-05T12:31:31Z"
+  },
+  "f05f77ab8955584a0913ba60337350a8": {
+   "aliases": [
+    "final_i8_G_qwen3_5_4b.xclbin"
+   ],
+   "paths": [
+    "final_i8_G_K2560_N9216.xclbin",
+    "final_i8_G_qwen3_5_4b.xclbin"
+   ],
+   "sha256": "0028cffd3f8e2987fc8c3bd8f4e6c078d5b1ad68a191a96154197b5ceb6e834f",
+   "timestamp_utc": "2026-08-09T18:01:48Z"
+  },
+  "f84f1a3c11b3f1c737b2483793e73421": {
+   "aliases": [],
+   "paths": [
+    "final_i8_QKV_qwen3_vl_4b.xclbin"
+   ],
+   "sha256": "e97e5a1cc3e3ffb3b8310869109328168c8c61db133b736e95520ad3cd81257b",
+   "timestamp_utc": "2026-08-05T14:22:29Z"
+  },
+  "fa52bf09f1c28e14aff635bc771970dd": {
+   "aliases": [],
+   "paths": [
+    "final_i8_O_qwen3_8b.xclbin"
+   ],
+   "sha256": "d9187efc379d48d604bd9a1f723defa6b8db0caf93afce27277358a06a143f91",
+   "timestamp_utc": "2026-08-05T14:22:01Z"
+  },
+  "fba8f355be002acc579bf5359b925516": {
+   "aliases": [],
+   "paths": [
+    "ternary_D_qwen3_0_6b.xclbin"
+   ],
+   "sha256": "9cd96f9cafa3b976f1b38c13c6c70be5e69def62df1c4f4405be60b35582ce72",
+   "timestamp_utc": "2026-07-20T16:16:53Z"
+  },
+  "fde3cdbf188463d4e9641cf077151af2": {
+   "aliases": [],
+   "paths": [
+    "attn.xclbin"
+   ],
+   "sha256": "3e9a276a4db695efd8191a2ad0b152d0bf10659edb38f11f50592101796356e8",
+   "timestamp_utc": "2026-08-27T02:14:54Z"
+  }
+ },
+ "build": {
+  "generating_script_revision": null,
+  "toolchain": null,
+  "toolchain_note": "Empty by design: the artifacts record no compiler arm or version (no chesscc/peano/llvm/aiecc/clang marker in the AXLF metadata; PlatformVBNV is empty). A build that regenerates these artifacts must fill this in - that is the missing half of the provenance."
+ },
+ "census": {
+  "days_utc": {
+   "2026-07-05": 1,
+   "2026-07-20": 4,
+   "2026-07-23": 1,
+   "2026-07-28": 5,
+   "2026-08-04": 1,
+   "2026-08-05": 22,
+   "2026-08-09": 29,
+   "2026-08-10": 2,
+   "2026-08-21": 2,
+   "2026-08-22": 4,
+   "2026-08-23": 1,
+   "2026-08-27": 1,
+   "2026-08-28": 2,
+   "2026-08-29": 5,
+   "2026-08-30": 3,
+   "2026-08-31": 1,
+   "2026-09-03": 1,
+   "2026-09-09": 1
+  },
+  "distinct_builds": 86,
+  "payload_bytes": 9537523,
+  "redundant_bytes": 2226430,
+  "redundant_percent": 23.34,
+  "timezone": "UTC (embedded AXLF TimeStamp, never mtime)",
+  "top_days_utc": [
+   {
+    "builds": 29,
+    "day": "2026-08-09"
+   },
+   {
+    "builds": 22,
+    "day": "2026-08-05"
+   },
+   {
+    "builds": 5,
+    "day": "2026-07-28"
+   },
+   {
+    "builds": 5,
+    "day": "2026-08-29"
+   },
+   {
+    "builds": 4,
+    "day": "2026-07-20"
+   }
+  ],
+  "unit": "one row per distinct XclBinUUID"
+ },
+ "declared_dangling": {
+  "engine/npu/xclbins/final_i8_D_K3072_N1024.xclbin": "/opt/fastflowlm/share/flm/xclbins/Qwen3-0.6B-NPU2/mm.xclbin",
+  "engine/npu/xclbins/final_i8_GU_K1024_N6144.xclbin": "/opt/fastflowlm/share/flm/xclbins/Qwen3-0.6B-NPU2/mm.xclbin",
+  "engine/npu/xclbins/final_i8_O_K1024_N1024.xclbin": "/opt/fastflowlm/share/flm/xclbins/Qwen3-0.6B-NPU2/mm.xclbin",
+  "engine/npu/xclbins/final_i8_QKV_K1024_N4096.xclbin": "/opt/fastflowlm/share/flm/xclbins/Qwen3-0.6B-NPU2/mm.xclbin"
+ },
+ "generated": {
+  "at": "2026-09-11T14:46:03Z",
+  "by": "pi/coding-agent",
+  "check": "engine/npu/tests/check_xclbin_provenance.py",
+  "ref": "ef8c0cdf9"
+ },
+ "intent": "Provenance for the committed NPU xclbin set, keyed by the artifact's embedded XclBinUUID. Regenerate with engine/npu/tests/check_xclbin_provenance.py --write-manifest and land it in the same commit as the artifact change.",
+ "population": {
+  "alias_symlinks_in_tree": 12,
+  "dangling_symlinks": 4,
+  "distinct_builds_by_uuid": 86,
+  "regular_artifacts": 111,
+  "top_level_xclbin": 127,
+  "tracked_paths_under_dir": 510,
+  "tracked_top_level_entries": 249,
+  "txt_symlinks": 12,
+  "xclbin_symlinks": 16
+ },
+ "schema": 1,
+ "symlinks": {
+  "engine/npu/xclbins/final_i8_D_K3072_N1024.xclbin": "/opt/fastflowlm/share/flm/xclbins/Qwen3-0.6B-NPU2/mm.xclbin",
+  "engine/npu/xclbins/final_i8_D_qwen3_6_35b_a3b.xclbin": "final_i8_D_qwen3.6-moe_35b.xclbin",
+  "engine/npu/xclbins/final_i8_GU_K1024_N6144.xclbin": "/opt/fastflowlm/share/flm/xclbins/Qwen3-0.6B-NPU2/mm.xclbin",
+  "engine/npu/xclbins/final_i8_GU_qwen3_6_35b_a3b.xclbin": "final_i8_GU_qwen3.6-moe_35b.xclbin",
+  "engine/npu/xclbins/final_i8_G_qwen3_6_35b_a3b.xclbin": "final_i8_G_qwen3.6-moe_35b.xclbin",
+  "engine/npu/xclbins/final_i8_MOE_DSD_qwen3_6_35b_a3b.xclbin": "final_i8_MOE_DSD_qwen3.6-moe_35b.xclbin",
+  "engine/npu/xclbins/final_i8_MOE_D_qwen3_6_35b_a3b.xclbin": "final_i8_MOE_D_qwen3.6-moe_35b.xclbin",
+  "engine/npu/xclbins/final_i8_MOE_GUSGU_qwen3_6_35b_a3b.xclbin": "final_i8_MOE_GUSGU_qwen3.6-moe_35b.xclbin",
+  "engine/npu/xclbins/final_i8_MOE_GU_qwen3_6_35b_a3b.xclbin": "final_i8_MOE_GU_qwen3.6-moe_35b.xclbin",
+  "engine/npu/xclbins/final_i8_MOE_SD_qwen3_6_35b_a3b.xclbin": "final_i8_MOE_SD_qwen3.6-moe_35b.xclbin",
+  "engine/npu/xclbins/final_i8_MOE_SGU_qwen3_6_35b_a3b.xclbin": "final_i8_MOE_SGU_qwen3.6-moe_35b.xclbin",
+  "engine/npu/xclbins/final_i8_O_K1024_N1024.xclbin": "/opt/fastflowlm/share/flm/xclbins/Qwen3-0.6B-NPU2/mm.xclbin",
+  "engine/npu/xclbins/final_i8_O_qwen3_6_35b_a3b.xclbin": "final_i8_O_qwen3.6-moe_35b.xclbin",
+  "engine/npu/xclbins/final_i8_QKV_K1024_N4096.xclbin": "/opt/fastflowlm/share/flm/xclbins/Qwen3-0.6B-NPU2/mm.xclbin",
+  "engine/npu/xclbins/final_i8_QKV_qwen3_6_35b_a3b.xclbin": "final_i8_QKV_qwen3.6-moe_35b.xclbin",
+  "engine/npu/xclbins/final_i8_U_qwen3_6_35b_a3b.xclbin": "final_i8_U_qwen3.6-moe_35b.xclbin"
+ }
+}


### PR DESCRIPTION
### **User description**
Two things the committed NPU xclbin set has never had: a check, and provenance.

The set is the source of truth because the toolchain cannot reliably rebuild it —
`engine/npu/build_npu_ternary.sh`'s header says so ("the aiecc MLIR toolchain has a
pre-existing version mismatch that prevents clean builds"). That makes two defect classes
visible only as *committed state*, and both were unguarded.

## 1. Hygiene regressions (`fd17e5bdc`)

* **4 of the 16 tracked `*.xclbin` symlinks are dangling** into an absent
  `/opt/fastflowlm/...` install — committed that way, so a clean checkout is already broken.
* **25 pairs of artifacts are byte-identical**: one build ships as a real file, a
  byte-duplicate, and a symlink. Neither "fix" is safe. Copying a foreign binary over a
  dangling link hides that it was never built here; materialising an alias doubles the
  payload and hides the aliasing.
* **Nothing in CI looked at any of it** — `ci.yml` has no reference to the xclbin set.

## 2. Missing provenance (`fd17e5bdc`)

The AXLF metadata records producer, format version, `XclBinUUID`, `TimeStamp` and
`m_name: MLIR_AIE:MLIRAIE` — but **no toolchain version, no source revision, and no
generating script**, and `PlatformVBNV` is empty. So a green rebuild could never be shown
to reproduce what ships. `PROVENANCE.json` is the recorded half.

## What is added

| file | role |
|---|---|
| `engine/npu/tests/check_xclbin_provenance.py` | stdlib only, no NPU/XRT/toolchain. Reads the tracked set with `git ls-files -s`, so symlink modes and targets come from the index — the set a clean checkout gets. Asserts hygiene invariants that need no baseline, then diffs against the manifest. |
| `engine/npu/xclbins/PROVENANCE.json` | 27 KB, **86 artifacts keyed by `XclBinUUID`** → `{sha256, UTC timestamp, alias paths}`, plus the symlink/dangling map. |
| `.github/workflows/xclbin-provenance.yml` | runs it on a stock runner, path-filtered. |

`--write-manifest` is the only way to move a pinned value, so an intentional artifact change
regenerates the manifest **in the same commit** — that is the review point.

## Nothing is hardcoded, and the reason is a measurement

Before pinning any number I compared the refs blob-wise: they share **all 510 tracked paths**
but **3 blobs differ** (`final_i8_GUSILU_i4_qwen3_0_6b_bf16pair.xclbin`,
`final_i8_MOE_FUSED_zaya.xclbin`, `insts_i8_GUSILU_i4_qwen3_0_6b_bf16pair.txt`). Hence the
manifest-as-baseline design rather than constants. Census at this ref (`ef8c0cdf9`):

```
510 tracked paths · 127 top-level *.xclbin (111 regular + 16 symlinks: 12 aliases, 4 dangling)
12 *.txt symlinks · 28 tracked symlinks total
86 distinct builds · 18 distinct UTC days · 9,537,523 B payload, 2,226,430 B (23.34%) redundant
```

(The 16-day / 23.40% figures seen elsewhere are the `feat/hrx-gfx1151-build` ref — the
counts are ref-independent, the dates and the percentage are not.)

## 3. Chess toolchain roots (`ce876f8e6`)

Three of the five scripts that can route to the chess arm never preflighted it, and their
default roots do not exist on either box, so failure surfaced late and confusingly
(`main_input.chesslinked.ll` missing — the failure `check_chess_aietools.sh` already documents
under #1913).

**Framing correction, measured:** the "12 generators on the peano-only `build_tmp`" are *not*
part of this. All 12 contain **zero chess references** and pass `--no-xchesscc` explicitly,
for which `build_tmp` is the legitimate `--aietools` value. They are deliberately untouched.
The real surface is the three unwired chess-capable scripts:

* `generators/check_chess_aietools.sh` — adds `find_chess_aietools_root()`: discovers the
  newest Vitis aietools whose `chess-llvm-link` exists, searching **both** known spellings
  (`$HOME/Xilinx/<ver>/…` and `$HOME/Xilinx<year>/<ver>/…`), so no version or directory
  spelling is pinned. The existing guard function is untouched.
* `kernel/build_06b_kernels.sh` — sources the guard; discovers `AIETOOLS`; `MLIR_AIE` now
  defaults to `~/mlir-aie` (matching `bench_compiler_ab.sh`) instead of a stub whose
  `include/aie_kernels` is empty; takes `xchesscc_wrapper` from the mlir-aie tree — **the
  Vitis root ships no wrapper**, only `bin/xchesscc` + `bin/xchessmk`, so the previous
  `${AIETOOLS}/bin/xchesscc_wrapper` could never have worked; puts the Vitis launcher first
  on `PATH` so `getAietoolsDir()` sees it.
* `build_npu_ternary.sh` — same guard preflight and wrapper resolution. Its remaining
  torch2aie-derived roots are left as-is and named in the error text rather than silently
  rewritten.
* `tests/bench_compiler_ab.sh` — `XILINX`/aietools discovered instead of pinning `2026.1`;
  the chess arm is preflighted in `build_kernel_chess()`.
* `generators/build_all.sh` — `KERNEL`/`XDIR`/`GEN` were **all three** hardcoded to
  `/home/bcloud/1bit-monster/…` (lowercase, absent on every machine) and `XDIR` was never
  `mkdir`'d, so every write failed against a nonexistent directory. All three derive from the
  script location now, with `mkdir -p` — the `zaya_*` writers' relative-`XCLBIN_DIR` pattern.
  (`${VAR:-…}` overrides are preserved, so callers can still point it elsewhere.)

## Verification

**Six negative controls**, each of which fails the check and was then reverted to a green
baseline: materialised alias symlink; tampered artifact bytes (caught by the duplicate-UUID
byte-identity invariant *first* — the one that makes dedupe-by-UUID safe); deleted tracked
artifact; a declared-dangling link that starts resolving; a manifest UUID absent from the
tree; content-hash drift.

**Eight toolchain tests**, on strixhalo where the toolchains live, with nothing heavy executed:
T1 discovery → `~/Xilinx/2026.1/Vitis/aietools` with an executable `chess-llvm-link`;
T2 no candidates → exit 1; T3 guard semantics unchanged (vitis+chess 0, build_tmp+chess 1,
build_tmp+peano 0); T4/T5 bad root → loud #1913 message, exit 1, no compile; T6 **all defaults
unset** → `AIETOOLS` discovered, `MLIR_AIE=~/mlir-aie`, `XCHESSCC` executable, `PATH[0]` = the
Vitis launcher; T7 `build_all.sh` paths resolve to the checkout and `XDIR` == the tracked
xclbins dir; T8 regression check on the wrapper change.

## Deliberately not in this PR

* `engine/npu/tests/check_mm_kernel_2x4.sh` — it is one of the five chess-routing scripts and
  keeps `AIETOOLS=~/mlir-aie/build_tmp`, but that is its *peano* default and it already wires
  the guard: when `USE_XCHESSCC=1` flips the arm, the guard fails loudly unless `AIETOOLS` is
  the Vitis root. That is the designed behaviour, so it is left as the reference implementation.
* The **per-generator lints as their own job** (`.bss`, #1838) — the complement to this check,
  being built separately by the agent who offered it. It is the half that would surface the
  `.bss` failure currently sitting on `main`.
* A rebuild-diff against the tracked artifacts. Any such check must name its ref and enumerate
  writers by pattern at the checked-out rev; a hardcoded writer list calibrated on `main`
  silently skips three writers that exist only on `feat/hrx-gfx1151-build`.


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Add stdlib xclbin provenance checker gating committed set
  - Reads `git ls-files -s`, asserts hygiene invariants, no NPU needed
  - Diffs observed artifacts against UUID-keyed manifest, exit 0/1/2

- Commit `PROVENANCE.json` manifest for 86 distinct builds
  - Records sha256, aliases, UTC timestamps, symlink/dangling map
  - Toolchain and script revision left null, to be filled by builds

- Add `xclbin-provenance.yml` CI workflow on xclbin changes

- Resolve chess toolchain roots and fail loudly instead of skipping
  - New `find_chess_aietools_root()` discovers Vitis aietools layout
  - Preflight added to build, kernel, and bench scripts (#1913)

- Replace hardcoded `/home/bcloud` toolchain paths with script-relative defaults


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["check_xclbin_provenance.py"] -- "reads index via git ls-files -s" --> B["tracked xclbin set"]
  B -- "hygiene invariants + diff" --> C["PROVENANCE.json (86 UUIDs)"]
  C -- "gated on push/PR" --> D["xclbin-provenance.yml"]
  E["check_chess_aietools.sh"] -- "find_chess_aietools_root()" --> F["build_npu_ternary.sh / build_06b_kernels.sh / bench_compiler_ab.sh"]
  G["build_all.sh"] -- "script-relative defaults" --> H["drop /home/bcloud hardcoded roots"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>check_xclbin_provenance.py</strong><dd><code>New stdlib checker for xclbin hygiene and provenance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2211/files#diff-a25966ecc8d8f2ce082ba895164b08a99a891aaeee119fe121e5aa86ce45537b">+458/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>PROVENANCE.json</strong><dd><code>UUID-keyed manifest of 86 committed xclbin builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2211/files#diff-b38f1d7dc0185e680c8a51c0c1a57b5b9220fb0e918ef02e065cfc43505b1545">+865/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>xclbin-provenance.yml</strong><dd><code>CI workflow verifying xclbin set against manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2211/files#diff-0714115f8b5011e2bcc61b0cef5b0784c490a28b354470d92d2daf18730a46f5">+60/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>check_chess_aietools.sh</strong><dd><code>Add find_chess_aietools_root discovery helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2211/files#diff-ac3b7e6065a91a0dae73d110a21f4be5c747ed315302a116ec23e6950a996903">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>build_npu_ternary.sh</strong><dd><code>Resolve aietools root and wrapper before compiling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2211/files#diff-770ccd0e122340b81e62659ab79364cecff08ac3496d4491f91d7f6a490e1b91">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>build_06b_kernels.sh</strong><dd><code>Resolve Vitis aietools root and xchesscc_wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2211/files#diff-0536ae21cf5a1670a5cc0a9d2abd642b6430580d93c625b9e0714735865275e1">+44/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bench_compiler_ab.sh</strong><dd><code>Discover Vitis aietools instead of version-pinned path</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2211/files#diff-0dfa24474b6824b91bd79ccc61fdf578e7c5f6ad01b4a77ab18caf1f07fbad18">+19/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>build_all.sh</strong><dd><code>Replace hardcoded machine paths with script-relative defaults</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2211/files#diff-9db55e7666ff670410877bf3ff6d96dbeccfe44363e28a633e7f42222e9af18b">+25/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

