### PR TITLE
ci(npu): kernel object lint (.bss / entry symbols / duplicate LUT) as its own job — catches #2199

### DIFF
--- a/.github/workflows/kernel-object-lint.yml
+++ b/.github/workflows/kernel-object-lint.yml
@@ -1,0 +1,56 @@
+name: Kernel object lint
+
+# The complement to the xclbin provenance check: that one asserts the *committed artifact
+# set* against its manifest, this one asserts the *generators* produce a kernel object that
+# satisfies the invariants their own lints encode — required entry symbols, no duplicate Q22
+# LUT, and no .bss symbols (issue #1838: the bare-metal ld.script drops .bss, so a
+# zero-initialised static reads back as garbage on the NPU).
+#
+# It runs on the self-hosted runner because it needs the aie2p (Peano) toolchain. It does NOT
+# need the aiecc/mlir stage, which is why it can run while that stage is blocked by a
+# toolchain version mismatch.
+
+on:
+  pull_request:
+    paths:
+      - "engine/npu/generators/**"
+      - "engine/npu/kernel/**"
+      - "engine/npu/tests/check_kernel_bss.sh"
+      - ".github/workflows/kernel-object-lint.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  kernel-object-lint:
+    name: kernel object lint (.bss / symbols / duplicate LUT)
+    runs-on: [self-hosted, strix-halo]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Run the kernel object lint
+        run: |
+          set -o pipefail
+          rc=0
+          out="$(engine/npu/tests/check_kernel_bss.sh 2>&1)" || rc=$?
+          echo "$out"
+          case "$out" in
+            *"RESULT: PASS"*)
+              echo "kernel object lint: PASS"
+              exit 0
+              ;;
+            *"RESULT: FAIL_BSS_ONLY"*)
+              # Known-red, ticket-tied, and deliberately not a gate yet: fixing it moves two
+              # statics into .data, which changes the kernel object, so it needs the #1897
+              # h2/C2 byte-identity gate re-run and the xclbin rebuilt.
+              echo "kernel object lint: KNOWN FAILING (issue #2199) — KERNEL_STATIC is absent from"
+              echo "mm_kernel_reference.cc, so g_i4_call and the matmul-local 'call' counter sit in .bss."
+              echo "This job is a monitor until #2199 lands, and becomes a gate the moment the .bss"
+              echo "count reaches 0 (i.e. when this branch starts printing RESULT: PASS)."
+              exit 0
+              ;;
+          esac
+          echo "kernel object lint: FAIL (not the known #2199 case — exit code was $rc)"
+          exit 1

--- a/engine/npu/generators/build_p1i4.sh
+++ b/engine/npu/generators/build_p1i4.sh
@@ -4,6 +4,15 @@ set -euo pipefail
 P=/home/bcloud/mlir-aie/.venv/lib/python3.14/site-packages/llvm-aie
 M=/home/bcloud/mlir-aie/.venv/lib/python3.14/site-packages/mlir_aie
 PYTHON=/home/bcloud/mlir-aie/.venv/bin/python3
+# The aie2p tools include is DERIVED, and a missing one is fatal. The previous literal
+# /home/bcloud/Xilinx/2025.2/Vitis/aietools/include does not exist (the real path is
+# ~/Xilinx2025/2025.2/...), and every compile below redirected stderr to /dev/null — so the
+# script exited 1 with no message at all and this file's own lints were unreachable.
+AIETOOLS_INC=$(ls -d "$HOME"/Xilinx*/2025.2/Vitis/aietools/include 2>/dev/null | head -n1 || true)
+if [ -z "${AIETOOLS_INC:-}" ] || [ ! -d "$AIETOOLS_INC" ]; then
+    echo "ERROR: aie2p tools include not found (looked for ~/Xilinx*/2025.2/Vitis/aietools/include)" >&2
+    exit 2
+fi
 G=$(cd "$(dirname "$0")" && pwd)
 W=/tmp/p1i4_build.$$
 mkdir -p "$W"; trap 'rm -rf "$W"' EXIT
@@ -28,21 +37,21 @@ $P/bin/clang++ --target=aie2p-none-unknown-elf --std=c++20 -O2 \
     -DDIM_M=8 -DDIM_K=64 -DDIM_N=128 -Di8_i32_ONLY -DM8_VECTORIZED \
     "${I4_FLAGS[@]}" \
     -isystem $P/include/c++/v1 \
-    -I /home/bcloud/Xilinx/2025.2/Vitis/aietools/include \
+    -I "$AIETOOLS_INC" \
     -I $M/include/aie_kernels/aie2p \
-    -c "$G/mm_kernel_reference.cc" -o "$W/mm.o" 2>/dev/null
+    -c "$G/mm_kernel_reference.cc" -o "$W/mm.o"
 $P/bin/clang++ --target=aie2p-none-unknown-elf --std=c++20 -O2 \
     -DDIM_M=8 -DDIM_K=64 -DDIM_N=128 -Di8_i32_ONLY -DM8_VECTORIZED \
     -isystem $P/include/c++/v1 \
-    -I /home/bcloud/Xilinx/2025.2/Vitis/aietools/include \
+    -I "$AIETOOLS_INC" \
     -I $M/include/aie_kernels/aie2p \
-    -c "$G/attn_kernel_reference.cc" -o "$W/silu.o" 2>/dev/null
+    -c "$G/attn_kernel_reference.cc" -o "$W/silu.o"
 $P/bin/clang++ --target=aie2p-none-unknown-elf --std=c++20 -O2 \
     -isystem $P/include/c++/v1 \
-    -I /home/bcloud/Xilinx/2025.2/Vitis/aietools/include \
+    -I "$AIETOOLS_INC" \
     -I $M/include/aie_kernels/aie2p \
     -I "$G" \
-    -c "$G/i4_dequant_kernel.cc" -o "$W/dequant.o" 2>/dev/null
+    -c "$G/i4_dequant_kernel.cc" -o "$W/dequant.o"
 $P/bin/ld.lld -r "$W/mm.o" "$W/silu.o" "$W/dequant.o" -o "$W/mm_32x64x128.o"
 
 # Post-build symbol check (issue #1841 follow-up): the merged kernel object

--- a/engine/npu/tests/check_kernel_bss.sh
+++ b/engine/npu/tests/check_kernel_bss.sh
@@ -33,7 +33,7 @@
 #        2 = toolchain/environment problem — not a verdict about the kernel
 set -euo pipefail
 
-REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+REPO="$(cd "$(dirname "$0")/../../.." && pwd)"   # engine/npu/tests -> repo root
 G="$REPO/engine/npu/generators"
 
 derive() { ls -d "$@" 2>/dev/null | head -n1 || true; }

--- a/engine/npu/tests/check_kernel_bss.sh
+++ b/engine/npu/tests/check_kernel_bss.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# check_kernel_bss.sh — the fused int4-GU kernel object must contain no .bss symbols.
+#
+# This is the executable form of the lint inside engine/npu/generators/build_p1i4.sh
+# (lines 49-81), extracted so it can run *without* that script's aiecc stage — which is
+# currently blocked by the toolchain version mismatch the generator itself documents — and
+# so CI can run it as its own job (the complement to the xclbin provenance check).
+#
+# Why .bss is fatal (issue #1838, observed in the #1769 round): the aiecc-generated
+# bare-metal ld.script maps only .text/.data, so zero-initialised statics land in .bss,
+# which is DROPPED from the kernel ELF — kernel reads of them return garbage on the NPU.
+# mm_kernel_reference.cc is supposed to force every mutable static into .data via
+# KERNEL_STATIC (__attribute__((section(".data")))).
+#
+# STATE ON MAIN (2026-09-11): assertions 1 and 2 hold, assertion 3 FAILS with exactly two
+# symbols, which is issue #2199:
+#     b _ZL9g_i4_call
+#     b _ZZ16matmul_i8_i32_i4E4call
+# i.e. KERNEL_STATIC is absent from mm_kernel_reference.cc (it exists only in
+# engine/npu/kernel/mm_binary_q1.cc). The fix moves those two statics into .data, which
+# changes the kernel object — so it needs the #1897 h2/C2 byte-identity gate re-run and the
+# xclbin rebuilt, which is why this script exists first: it is the check that will fail
+# loudly until that lands, and pass afterwards.
+#
+# Toolchain roots are DERIVED and a missing one is fatal. The generator this replaces
+# declared /home/bcloud/Xilinx/2025.2/Vitis/aietools/include (no such path; the real one is
+# ~/Xilinx2025/2025.2/...) and redirected stderr on all three compiles, so on this box it
+# failed with exit 1 and no message at all — its own lint was unreachable.
+#
+# Usage: engine/npu/tests/check_kernel_bss.sh
+# Exit:  0 = all assertions hold (RESULT: PASS)
+#        1 = an assertion failed (RESULT: FAIL, or FAIL_BSS_ONLY for the known #2199 case)
+#        2 = toolchain/environment problem — not a verdict about the kernel
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+G="$REPO/engine/npu/generators"
+
+derive() { ls -d "$@" 2>/dev/null | head -n1 || true; }
+P="$(derive "$HOME"/mlir-aie/.venv/lib/python3*/site-packages/llvm-aie)"
+M="$(derive "$HOME"/mlir-aie/.venv/lib/python3*/site-packages/mlir_aie)"
+AI="$(derive "$HOME"/Xilinx*/2025.2/Vitis/aietools/include)"
+for pair in "llvm-aie(peano):$P" "mlir_aie:$M" "aietools-include:$AI"; do
+    name="${pair%%:*}"; val="${pair#*:}"
+    if [ -z "$val" ] || [ ! -d "$val" ]; then
+        echo "ERROR: toolchain root '$name' not found under \$HOME — cannot judge the kernels." >&2
+        exit 2
+    fi
+done
+
+W="$(mktemp -d)"; trap 'rm -rf "$W"' EXIT
+I4=(-DDIM_M=8 -DDIM_K=64 -DDIM_N=128 -Di8_i32_ONLY -DM8_VECTORIZED -DI4_SCALAR_C1 -DI4_SCALAR_C1_ACK_1864)
+INCS=(-isystem "$P/include/c++/v1" -I "$AI" -I "$M/include/aie_kernels/aie2p")
+cc() { "$P/bin/clang++" --target=aie2p-none-unknown-elf --std=c++20 -O2 "$@"; }
+
+echo "== compiling the three TUs (stderr NOT suppressed: a silent compile failure is how the generator hid this) =="
+cc "${I4[@]}" "${INCS[@]}" -c "$G/mm_kernel_reference.cc"    -o "$W/mm.o"
+cc "${I4[@]}" "${INCS[@]}" -c "$G/attn_kernel_reference.cc"  -o "$W/silu.o"
+cc "${INCS[@]}" -I "$G" -c "$G/i4_dequant_kernel.cc"         -o "$W/dequant.o"
+"$P/bin/ld.lld" -r "$W/mm.o" "$W/silu.o" "$W/dequant.o" -o "$W/mm_32x64x128.o"
+
+sym_ok=ok; dup_ok=ok; other_fail=0
+
+# 1. every entry symbol the generator links must be a defined text symbol (issue #1841:
+#    a stale/partial object otherwise surfaces as random aiecc "undefined symbol" errors).
+for sym in matmul_i8_i32_i4 silu_quant_i8_fused_i4 unpack_i4_b zero_i32; do
+    if ! "$P/bin/llvm-nm" "$W/mm_32x64x128.o" | grep -qE " T $sym\$"; then
+        echo "ERROR: merged kernel object is missing symbol '$sym' — stale or partial build?" >&2
+        sym_ok="missing:$sym"; other_fail=1
+    fi
+done
+
+# 2. the Q22 sigma LUT lives ONLY in silu_quant.h; a stray copy redefines it and silently
+#    breaks the aiecc build (issue #1845).
+if grep -q "silu_sigmoid_q22\[256\]" "$G/mm_kernel_reference.cc"; then
+    echo "ERROR: mm_kernel_reference.cc must NOT define silu_sigmoid_q22 (it lives in silu_quant.h — issue #1845)" >&2
+    dup_ok="stray-lut"; other_fail=1
+fi
+
+# 3. no zero-initialised statics may survive: .bss is dropped from the kernel ELF (#1838).
+bss_count="$("$P/bin/llvm-nm" "$W/mm_32x64x128.o" | grep -cE ' [bB] ' || true)"
+if [ "$bss_count" != "0" ]; then
+    echo "ERROR: kernel object has $bss_count .bss symbol(s) (issue #1838) — add KERNEL_STATIC (issue #2199):" >&2
+    "$P/bin/llvm-nm" "$W/mm_32x64x128.o" | grep -E ' [bB] ' >&2 || true
+fi
+
+echo "SUMMARY: symbols=$sym_ok duplicate=$dup_ok bss=$bss_count"
+if [ "$other_fail" != "0" ]; then
+    echo "RESULT: FAIL"
+    exit 1
+fi
+if [ "$bss_count" != "0" ]; then
+    echo "RESULT: FAIL_BSS_ONLY"
+    exit 1
+fi
+echo "RESULT: PASS"


### PR DESCRIPTION
### **User description**
## What

The complement to the xclbin provenance check: **that one asserts the committed *artifact set* against its manifest; this one asserts the *generators* produce a kernel object that satisfies the invariants their own lints encode.**

Adds `engine/npu/tests/check_kernel_bss.sh` + `.github/workflows/kernel-object-lint.yml`, and fixes the two reasons `build_p1i4.sh` could not reach its own lints.

## Why it can run at all

The three invariants live inside `engine/npu/generators/build_p1i4.sh` (lines 49–81), whose `aiecc` stage is blocked by the toolchain version mismatch that script itself documents. The invariants do not need that stage — they need only the aie2p/Peano compile — so they are now their own job:

1. every entry symbol the generator links must be a defined `T` symbol (`matmul_i8_i32_i4`, `silu_quant_i8_fused_i4`, `unpack_i4_b`, `zero_i32`) — a stale/partial object otherwise surfaces as random aiecc `undefined symbol` errors that look like kernel bugs (#1841);
2. `mm_kernel_reference.cc` must not define `silu_sigmoid_q22[256]` — the LUT lives only in `silu_quant.h` (#1845);
3. **no `.bss` symbols** — the aiecc bare-metal `ld.script` maps only `.text`/`.data`, so a zero-initialised static is dropped from the kernel ELF and reads back as garbage on the NPU (#1838).

## State on main

```
SUMMARY: symbols=ok duplicate=ok bss=2
RESULT: FAIL_BSS_ONLY
    b g_i4_call
    b matmul_i8_i32_i4::call
```

That is **issue #2199**: `KERNEL_STATIC` (`__attribute__((section(".data")))`) is absent from `mm_kernel_reference.cc`; it exists only in `engine/npu/kernel/mm_binary_q1.cc`.

**Deliberately not fixed here.** Moving those two statics into `.data` changes the kernel object, so it needs the #1897 h2/C2 byte-identity gate re-run and the xclbin rebuilt (and the xclbin cannot currently be rebuilt — see the same toolchain mismatch). So the job treats `RESULT: FAIL_BSS_ONLY` as a **ticket-tied known failure, not a red gate**, and becomes a gate automatically the moment the `.bss` count reaches 0.

## Controls (run from an archive of this commit, not the worktree)

| case | result |
|---|---|
| main's sources, unmodified | `bss=2` → `RESULT: FAIL_BSS_ONLY` — catches #2199 |
| the two statics annotated `KERNEL_STATIC` in a scratch copy | `bss=0` → **`RESULT: PASS`** — the check is not stuck-red |
| an entry symbol unresolved | `RESULT: FAIL` — not the known case, so the workflow fails hard |

## Generator-side fixes (why the lint was unreachable)

`build_p1i4.sh` declared `-I /home/bcloud/Xilinx/2025.2/Vitis/aietools/include`, **which does not exist** (the real path is `~/Xilinx2025/2025.2/...`), and all three compiles sent stderr to `/dev/null` — so on this box the script exited `1` with **no message at all**, and its own lints never ran. The root is now derived (a missing one exits 2 with a message) and stderr is no longer suppressed. Its own comment already records that this suppression hid a compile error once (#1845), so this is the same lesson applied again.

## Not touched

`engine/npu/xclbins/**` and `.github/workflows/xclbin-provenance.yml` belong to the provenance check (branched separately); this job is its complement and the two should be read together. Issue #2199 remains open and is the prerequisite for turning this into a gate.


___

### **PR Type**
Tests, Enhancement, Bug fix


___

### **Description**
- Adds standalone kernel object lint job

- New `check_kernel_bss.sh` asserts symbols, LUT, .bss

- Derives toolchain roots, fatal when missing

- Fixes `build_p1i4.sh` include path, stops stderr suppression

- Treats known #2199 `.bss` failure as monitor


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["PR touches engine/npu/generators"] -- "triggers" --> B["kernel-object-lint.yml"]
  B -- "runs on self-hosted strix-halo" --> C["check_kernel_bss.sh"]
  C -- "compile aie2p TUs" --> D["ld.lld -r merged object"]
  D -- "assert 1" --> E["entry symbols T"]
  D -- "assert 2" --> F["no duplicate Q22 LUT"]
  D -- "assert 3" --> G["no .bss symbols"]
  G -- "bss>0 => #2199" --> H["RESULT: FAIL_BSS_ONLY (non-gating)"]
  G -- "bss==0" --> I["RESULT: PASS (gate)"]
  J["build_p1i4.sh fixes"] -- "derived AIETOOLS_INC" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_p1i4.sh</strong><dd><code>Derive aie2p include root and stop hiding compile stderr</code>&nbsp; </dd></summary>
<hr>

engine/npu/generators/build_p1i4.sh

<ul><li>Replaces the hardcoded, non-existent <br><code>/home/bcloud/Xilinx/2025.2/Vitis/aietools/include</code> with a derived <br><code>AIETOOLS_INC</code> computed from <code>~/Xilinx*/2025.2/...</code>.<br> <li> Fails loudly with exit 2 and an explicit message when the aie2p tools <br>include cannot be found.<br> <li> Drops <code>2>/dev/null</code> from all three <code>clang++</code> compiles so compile errors <br>are no longer hidden.<br> <li> Keeps the existing merged-object symbol check intact.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2212/files#diff-41ac41dad6738f907ea6549b037f18522c62e3408de975520c953747ff2f1e4c">+15/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>check_kernel_bss.sh</strong><dd><code>Add standalone kernel object invariant lint script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tests/check_kernel_bss.sh

<ul><li>New executable form of the <code>build_p1i4.sh</code> lint, runnable without its <br>blocked aiecc stage.<br> <li> Derives <code>llvm-aie</code>, <code>mlir_aie</code> and ai-tools roots, exiting 2 on any <br>missing toolchain.<br> <li> Compiles <code>mm_kernel_reference.cc</code>, <code>attn_kernel_reference.cc</code>, <br><code>i4_dequant_kernel.cc</code> and merges with <code>ld.lld -r</code>.<br> <li> Asserts entry symbols (<code>matmul_i8_i32_i4</code>, <code>silu_quant_i8_fused_i4</code>, <br><code>unpack_i4_b</code>, <code>zero_i32</code>), no duplicate <code>silu_sigmoid_q22[256]</code>, and zero <br><code>.bss</code> symbols.<br> <li> Emits machine-readable <code>SUMMARY:</code>/<code>RESULT:</code> lines distinguishing <code>FAIL</code>, <br><code>FAIL_BSS_ONLY</code> and <code>PASS</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2212/files#diff-cb5267ef358026ff59e2c57944c8f6c9e64538b64ad570b8137d065bc10a3aa2">+96/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kernel-object-lint.yml</strong><dd><code>Add kernel object lint CI workflow with known-red handling</code></dd></summary>
<hr>

.github/workflows/kernel-object-lint.yml

<ul><li>New workflow running the kernel object lint on the self-hosted <br><code>strix-halo</code> runner.<br> <li> Triggered by changes to <code>engine/npu/generators/**</code>, <br><code>engine/npu/kernel/**</code>, the lint script or itself, plus <br><code>workflow_dispatch</code>.<br> <li> Parses the script output: <code>RESULT: PASS</code> exits 0, <code>RESULT: FAIL_BSS_ONLY</code> <br>is reported as the known #2199 case and stays non-gating, anything <br>else fails the job.<br> <li> Uses <code>contents: read</code> permissions, pinned checkout action and a <br>15-minute timeout.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2212/files#diff-c2699a291e8e051c082c8a0886764f49ddf303fd00e26607a75ac66c6126ff7b">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

