### PR TITLE
docs: clarify validated hardware target + fix model-download.sh 1BP links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ pure C++26 · zero Python at runtime · GPL-3.0
 
 **One engine. Any model. Zero Python.**
 
-A model-agnostic, hardware-agnostic inference engine in a single C++26 binary. Point it at a model file — GGUF, 1BP, ONNX, H1B, safetensors — and it auto-detects the architecture and runs on whatever hardware you have: AMD XDNA 2 NPU, GPU (HIP, CUDA, Metal, Vulkan), or CPU. No config files, no per-model glue, no Python interpreter anywhere.
+A model-agnostic, hardware-agnostic inference engine in a single C++26 binary. Point it at a model file — GGUF, 1BP, ONNX, H1B, safetensors — and it auto-detects the architecture and routes it to the best available backend: AMD XDNA 2 NPU, GPU (HIP, CUDA, Metal, Vulkan), or CPU. No config files, no per-model glue, no Python interpreter anywhere.
+
+> **Validated target today: AMD Strix Halo (gfx1151).** The engine builds for NPU, GPU and CPU backends, but the prebuilt packages and the validated fast paths currently target AMD Strix Halo (Ryzen AI Max+ 395 / Radeon 8060S). CUDA compiles but has not been run on real NVIDIA hardware, and Vulkan/Metal coverage is partial. For other targets, build from source — see the [downloads page](https://1bit.monster/1bit-downloads.html).
 
 ## What you get
 
 - **One binary** — `build/1bit` is busybox-style: every server and CLI in a single ELF, dispatched by subcommand (`1bit zaya`, `unified`, `router`, `jarvis`, `vision`, …).
 - **Any model** — 566 architecture tokens mapping 1,946 HuggingFace arch strings; 321,611 / 321,611 text-generation checkpoints on the hub (100%) land on an engine token.
-- **Any hardware** — NPU (XDNA 2, reverse-engineered in 4 days — [the story](docs/journey.md)), GPU (HIP, CUDA, Metal, Vulkan), CPU (AVX-512/scalar). Auto-routed per model.
+- **Any hardware** — NPU (XDNA 2, reverse-engineered in 4 days — [the story](docs/journey.md)), GPU (HIP, CUDA, Metal, Vulkan), CPU (AVX-512/scalar). Auto-routed per model. *Currently shipped and validated on AMD Strix Halo (gfx1151); CUDA and Metal are compiled but unvalidated, Vulkan is partial.*
 - **Zero Python** — pure C++26 at runtime. No virtualenv, no interpreter, no runtime stack to babysit.
 
 ## Quick start

--- a/packaging/model-download.sh
+++ b/packaging/model-download.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # 1bit.MONSTER — Model Downloader
-# Downloads supported Q4NX models for the NPU engine.
+# Downloads ready-to-run 1BP models from the public Hugging Face mirror
+# (bong-water-water-bong). Plain GGUF models run directly and need no download
+# script; this is only for the pre-converted 1BP/NPU weights.
 #
 # Usage:
 #   model-download.sh                  # interactive menu
@@ -20,11 +22,11 @@ die()  { printf "${RED}✗${NC} %s\n" "$*"; exit 1; }
 # ── Model registry ──
 # Format: name|description|size|url|sha256
 MODELS=(
-  "qwen3-0.6b|Qwen3-0.6B — 610 MB|610M|https://huggingface.co/bong-water-water-bong/qwen3-0.6b-q4nx/resolve/main/qwen3-0.6b.q4nx|"
-  "qwen3-8b|Qwen3-8B — 6.0 GB|6.0G|https://huggingface.co/bong-water-water-bong/qwen3-8b-q4nx/resolve/main/qwen3-8b.q4nx|"
-  "qwen3-vl-4b|Qwen3-VL-4B — 3.2 GB|3.2G|https://huggingface.co/bong-water-water-bong/qwen3-vl-4b-q4nx/resolve/main/qwen3-vl-4b.q4nx|"
-  "gemma4-e2b|Gemma4-E2B — 4.7 GB|4.7G|https://huggingface.co/bong-water-water-bong/gemma4-e2b-q4nx/resolve/main/gemma4-e2b.q4nx|"
-  "llama-3.1-8b|Llama-3.1-8B — 5.7 GB|5.7G|https://huggingface.co/bong-water-water-bong/llama-3.1-8b-q4nx/resolve/main/llama-3.1-8b.q4nx|"
+  "qwen3-0.6b|Qwen3-0.6B — 356 MB|356M|https://huggingface.co/bong-water-water-bong/Qwen3-0.6B-1BP/resolve/main/Qwen3-0.6B.1bp|"
+  "qwen3-8b|Qwen3-8B — 4.8 GB|4.8G|https://huggingface.co/bong-water-water-bong/Qwen3-8B-1BP/resolve/main/Qwen3-8B-1BP.1bp|"
+  "qwen3-vl-4b|Qwen3-VL-4B — 2.3 GB|2.3G|https://huggingface.co/bong-water-water-bong/Qwen3-VL-4B-Instruct-1BP/resolve/main/Qwen3-VL-4B-Instruct-1BP.1bp|"
+  "gemma4-e2b|Gemma4-E2B — 1.3 GB|1.3G|https://huggingface.co/bong-water-water-bong/Gemma4-E2B-1BP/resolve/main/Gemma4-E2B-1BP.1bp|"
+  "llama-3.1-8b|Llama-3.1-8B — 4.7 GB|4.7G|https://huggingface.co/bong-water-water-bong/Llama-3.1-8B-1BP/resolve/main/Llama-3.1-8B-1BP.1bp|"
 )
 
 MODEL_DIR="${HOME}/.local/share/1bit/models"
@@ -42,7 +44,7 @@ list_models() {
     printf "  ${GREEN}%-20s${NC} %-45s %s\n" "$(get_field "$M" 1)" "$(get_field "$M" 2)" "$(get_field "$M" 3)"
   done
   echo ""
-  printf "  ${YELLOW}all${NC} — download all models (18 GB total)\n"
+  printf "  ${YELLOW}all${NC} — download all models (about 13.5 GB total)\n"
   echo ""
 }
 
@@ -63,7 +65,9 @@ download_model() {
     die "Unknown model: $NAME. Run 'model-download.sh list' to see available models."
   fi
 
-  local OUTFILE="${MODEL_DIR}/${NAME}.q4nx"
+  # Keep the upstream file name (e.g. Qwen3-0.6B.1bp) — the engine keys off
+  # the real extension, and a hardcoded .q4nx suffix would be misleading.
+  local OUTFILE="${MODEL_DIR}/$(basename "${URL}")"
   if [ -f "$OUTFILE" ]; then
     warn "Model already exists at ${OUTFILE}"
     return 0
@@ -145,5 +149,5 @@ esac
 echo ""
 say "Models are in ${MODEL_DIR}"
 echo "  Run: 1bit-npu --auto 16"
-echo "  Or:  1bit-npu ${MODEL_DIR}/qwen3-0.6b.q4nx 16"
+echo "  Or:  1bit-npu ${MODEL_DIR}/Qwen3-0.6B.1bp 16"
 echo ""


### PR DESCRIPTION
### **User description**
Two things reported from a user who grabbed the prebuilt and got confused by the docs:

**1. `packaging/model-download.sh` had dead links.** It pointed at `*-q4nx` HF repos (`qwen3-0.6b-q4nx`, `gemma4-e2b-q4nx`, …) that return **401 (private/missing)** for public users, so the script failed for anyone who isn't the author. Repointed the registry at the public `*-1BP` repos and made the output use the upstream filename (e.g. `Qwen3-0.6B.1bp`) rather than forcing a `.q4nx` suffix.

Verified: `bash -n` clean; `list` renders; all five resolve URLs return 200; ran a full 356 MB download of `qwen3-0.6b` end-to-end.

| entry | repo | file | size |
|---|---|---|---|
| qwen3-0.6b | `Qwen3-0.6B-1BP` | `Qwen3-0.6B.1bp` | 356 MB |
| qwen3-8b | `Qwen3-8B-1BP` | `Qwen3-8B-1BP.1bp` | 4.8 GB |
| qwen3-vl-4b | `Qwen3-VL-4B-Instruct-1BP` | `Qwen3-VL-4B-Instruct-1BP.1bp` | 2.3 GB |
| gemma4-e2b | `Gemma4-E2B-1BP` | `Gemma4-E2B-1BP.1bp` | 1.3 GB |
| llama-3.1-8b | `Llama-3.1-8B-1BP` | `Llama-3.1-8B-1BP.1bp` | 4.7 GB |

**2. README "Any hardware" overclaims.** The bullet lists NPU/HIP/CUDA/Metal/Vulkan, but the shipped prebuilt and validated fast paths are Strix Halo (gfx1151) only. Added a callout after the intro and qualified the bullet: engine is hardware-agnostic by design; CUDA/Metal are compiled but unvalidated; Vulkan is partial.

Docs/shell only — no engine symbols touched, so no GitNexus impact surface.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Repoint `model-download.sh` from dead private `*-q4nx` repos to public `*-1BP` repos
  - Update sizes and the ~13.5 GB `all` total, add header comment about the mirror

- Keep the upstream filename via `basename "${URL}"` instead of forcing a `.q4nx` suffix

- Add README callout marking AMD Strix Halo (gfx1151) as the only validated target

- Soften "runs on whatever hardware you have" to "routes to best backend"; flag CUDA/Metal unvalidated


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["model-download.sh registry"] -- "*-q4nx URLs return 401" --> B["public *-1BP Hugging Face repos"]
  B -- "basename URL" --> C["OUTFILE keeps upstream .1bp name"]
  B -- "sizes corrected" --> D["list shows ~13.5 GB total"]
  E["README"] -- "add callout" --> F["Validated target: Strix Halo gfx1151"]
  E -- "reword" --> G["'Any hardware' bullet: CUDA/Metal unvalidated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model-download.sh</strong><dd><code>Repoint download registry to public 1BP repos</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packaging/model-download.sh

<ul><li>Header comment rewritten: downloads are public 1BP/NPU weights from <br>the <code>bong-water-water-bong</code> HF mirror; plain GGUF needs no script.<br> <li> <code>MODELS</code> registry repointed from <code>*-q4nx</code> repos to public <code>*-1BP</code> repos, <br>with corrected sizes (356 MB – 4.8 GB) and real upstream filenames <br>(e.g. <code>Qwen3-0.6B.1bp</code>).<br> <li> Output path now derived from <code>basename "${URL}"</code> rather than a hardcoded <br><code>${NAME}.q4nx</code> suffix.<br> <li> <code>list</code> total updated to "about 13.5 GB" and the final usage hint updated <br>to <code>Qwen3-0.6B.1bp</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2231/files#diff-7582fa44151fb6c180c1f1ed0a170a7d25dbf1e925e68cbbd1d23d6e4e2017cd">+13/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Clarify validated hardware target in README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Reworded the intro from "runs on whatever hardware you have" to <br>"routes it to the best available backend".<br> <li> Added a blockquote callout stating AMD Strix Halo (gfx1151) is the <br>validated target; CUDA unrun, Vulkan/Metal partial, build from source <br>otherwise.<br> <li> Extended the "Any hardware" bullet with the same caveat that only <br>Strix Halo is shipped and validated.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2231/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

