### PR TITLE
fix(npu): guard the two silent chess traps, and verify the guard

### DIFF
--- a/engine/npu/generators/check_chess_aietools.sh
+++ b/engine/npu/generators/check_chess_aietools.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # check_chess_aietools.sh — pre-flight guard for the aiecc --xchesscc arm
-# (issue #1913).
+# (issue #1913, extended for #3690).
 #
 # When --xchesscc is requested, aiecc derives the chess toolchain path from
 # --aietools and looks for chess-llvm-link at:
@@ -10,17 +10,109 @@
 # aiecc SILENTLY skips the chess-llvm-link step and fails later with a
 # confusing 'main_input.chesslinked.ll' missing error at xchesscc_wrapper.
 #
-# This guard fails loudly instead. Usage:
+# Four traps are covered. Each one was measured on hardware, and each one fails
+# in a way that does NOT name its cause, which is why they are checked here:
+#
+#  1. chess-llvm-link lookup (#1913) — --aietools must be the aietools ROOT.
+#  2. aie_runtime_lib goes with the aiecc BINARY, not with --aietools: aiecc
+#     resolves <aiecc-root>/aie_runtime_lib/AIE2P/chess_intrinsic_wrapper.ll, so
+#     an aiecc whose tree lacks that file silently skips the link step and then
+#     dies with 'xchesscc Failed No such device' (#3690; measured today:
+#     build_tmp/AIE2P has no wrapper, install/AIE2P does).
+#  3. The acquire form the installed wrapper emits must match what the chess
+#     MODEL supports. The 2025.2/2026.1 aie2ps models declare only the guarded
+#     (and no_fence) intrinsic; the 2024 vitis_aie_essentials model declares only
+#     the plain one. Mismatch = 'unrecognised intrinsic ... model inconsistency'
+#     + DSFG errors + a noodle segfault (#3690), not a readable error.
+#     Separately: a guarded core does not complete on AIE2P silicon at all, so a
+#     guarded build is reported as a runtime warning even when it compiles.
+#  4. An essentials-style tree names its targets aie2p while the tools ask for
+#     aie2ps; without the two aliases the launcher cannot source its env and
+#     chesscc exits with the same opaque 'Failed No such device'.
+#
+# Usage:
 #   source check_chess_aietools.sh
-#   check_chess_aietools <aietools-dir> <true|false: use_xchesscc> [extra-path]
+#   check_chess_aietools <aietools-dir> <true|false: use_xchesscc> [extra-path] [aiecc-path]
 # Returns 0 (ok) or 1 (fatal) — does not exit on its own so callers can
 # add context to the error message.
+#
+# Standalone (for CI / a manual pre-flight):
+#   ./check_chess_aietools.sh [--aietools DIR] [--aiecc PATH] [--use-chess true|false]
 set -u
+
+# ── which acquire form does the installed wrapper emit? ──────────────────────
+# $1 = aiecc path. Prints: plain | guarded | absent | unknown
+chess_wrapper_form() {
+    local aiecc="$1" root wrapper
+    root=$(dirname "$(dirname "$aiecc")")
+    wrapper="${root%/}/aie_runtime_lib/AIE2P/chess_intrinsic_wrapper.ll"
+    if [ ! -f "$wrapper" ]; then echo "absent"; return 0; fi
+    if grep -q "chessintr_void_acquire____uint___uint" "$wrapper" 2>/dev/null; then
+        echo "plain"; return 0
+    fi
+    if grep -q "chessintr_void_acquire_guarded" "$wrapper" 2>/dev/null; then
+        echo "guarded"; return 0
+    fi
+    echo "unknown"
+}
+
+# ── which acquire form does the chess MODEL declare? ─────────────────────────
+# $1 = aietools dir. Prints: plain | guarded | unknown
+#
+# Two details this must get right (both measured the hard way):
+#  * scope it to the AIE2P model. An essentials tree ships three models
+#    (aie2p, aie_ml, versal_prod) and only aie2p is ours; scanning the whole
+#    data/ tree returns whichever file the walk reaches first (aie_ml is guarded,
+#    aie2p is plain), i.e. the wrong answer.
+#  * use -l with -a (list matching files, treat them as text). Some of these
+#    generated headers read as binary to grep, and `grep -o` then prints nothing
+#    even though the file matches.
+chess_model_acquire_form() {
+    local t="$1" d dirs=()
+    for d in "$t/data/aie2p" "$t/data/aie2ps" \
+             "$t/tps/lnx64/target_aie2p" "$t/tps/lnx64/target_aie2ps"; do
+        [ -d "$d" ] && dirs+=("$d")
+    done
+    if [ ${#dirs[@]} -eq 0 ]; then echo "unknown"; return 0; fi
+    if timeout 90 grep -rlsa "chessintr_void_acquire____uint___uint" "${dirs[@]}" \
+            >/dev/null 2>&1; then
+        echo "plain"; return 0    # 2024 vitis_aie_essentials aie2p model
+    fi
+    if timeout 90 grep -rlsa -e "chessintr_void_acquire_guarded" \
+            -e "chessintr_void_acquire_no_fence" "${dirs[@]}" >/dev/null 2>&1; then
+        echo "guarded"; return 0  # 2025.2 / 2026.1 aie2ps models
+    fi
+    echo "unknown"
+}
+
+# ── essentials-style trees need their aie2ps aliases (trap 4) ────────────────
+check_chess_aie2ps_aliases() { # $1 = aietools dir
+    local t="$1" rc=0
+    # Only essentials-style trees ship a real target_aie2p directory; a Vitis
+    # aietools root symlinks target_aie2p -> target_aie2ps and needs nothing.
+    if [ -d "$t/tps/lnx64/target_aie2p" ] && [ ! -L "$t/tps/lnx64/target_aie2p" ]; then
+        if [ ! -e "$t/tps/lnx64/target_aie2ps" ]; then
+            echo "ERROR (#3690): $t ships no tps/lnx64/target_aie2ps, but aiecc asks" >&2
+            echo "  for target_aie2ps: the launcher cannot source its env and chesscc" >&2
+            echo "  exits with 'Failed No such device'.  Fix:" >&2
+            echo "    ln -s target_aie2p $t/tps/lnx64/target_aie2ps" >&2
+            rc=1
+        fi
+        if [ ! -e "$t/data/aie2ps" ]; then
+            echo "ERROR (#3690): $t ships no data/aie2ps (chesscc needs data/aie2ps/lib)." >&2
+            echo "  Fix:" >&2
+            echo "    ln -s aie2p $t/data/aie2ps" >&2
+            rc=1
+        fi
+    fi
+    return $rc
+}
 
 check_chess_aietools() {
     local aietools="$1"
     local use_chess="$2"
     local extra_path="${3:-}"
+    local aiecc="${4:-}"
 
     if [ "$use_chess" != "true" ]; then
         return 0   # peano arm: --aietools may legitimately be mlir-aie build_tmp
@@ -52,27 +144,86 @@ check_chess_aietools() {
                 ;;
         esac
     fi
+
+    # Trap 4: essentials-style target/data naming.
+    check_chess_aie2ps_aliases "$aietools" || return 1
+
+    # Traps 2 and 3: the runtime wrapper, and whether its acquire form matches
+    # the model. The aiecc that will run decides the path, so prefer an explicit
+    # argument, then $AIECC, then PATH.
+    if [ -z "$aiecc" ]; then
+        aiecc="${AIECC:-}"
+    fi
+    if [ -z "$aiecc" ]; then
+        aiecc=$(command -v aiecc 2>/dev/null || true)
+    fi
+    if [ -z "$aiecc" ] || [ ! -x "$aiecc" ]; then
+        echo "WARNING (#3690): no aiecc found to inspect, so the chess runtime lib" >&2
+        echo "  (aie_runtime_lib/AIE2P/chess_intrinsic_wrapper.ll) was NOT checked." >&2
+        return 0
+    fi
+
+    local form model
+    form=$(chess_wrapper_form "$aiecc")
+    model=$(chess_model_acquire_form "$aietools")
+
+    if [ "$form" = "absent" ]; then
+        echo "ERROR (#3690): no chess_intrinsic_wrapper.ll in the aiecc tree:" >&2
+        echo "  $(dirname "$(dirname "$aiecc")")/aie_runtime_lib/AIE2P/chess_intrinsic_wrapper.ll" >&2
+        echo "  aiecc resolves aie_runtime_lib relative to ITSELF (not --aietools), so with" >&2
+        echo "  this aiecc the chess-llvm-link step is SKIPPED SILENTLY and the compile dies" >&2
+        echo "  later with an opaque 'xchesscc Failed No such device'." >&2
+        echo "  Use the aiecc whose tree has the file — e.g. <mlir-aie>/install/bin/aiecc" >&2
+        echo "  rather than <mlir-aie>/build_tmp/bin/aiecc." >&2
+        return 1
+    fi
+
+    if [ "$model" = "plain" ] && [ "$form" = "guarded" ]; then
+        echo "ERROR (#3690): the installed wrapper emits the GUARDED acquire, but this" >&2
+        echo "  chess model declares only the PLAIN one ($aietools). chesscc then reports" >&2
+        echo "  'unrecognised intrinsic ... model inconsistency', DSFG errors, and a noodle" >&2
+        echo "  segfault.  Swap the wrapper's 2 calls + 2 declarations to the plain names" >&2
+        echo "  for this build and restore them afterwards (bench_compiler_ab.sh does this" >&2
+        echo "  with LEGACY_PATCH_WRAPPER=1)." >&2
+        return 1
+    fi
+
+    if [ "$model" = "guarded" ] && [ "$form" = "plain" ]; then
+        echo "WARNING (#3690): the wrapper emits the PLAIN acquire while this model declares" >&2
+        echo "  only guarded/no_fence — a 2025.2/2026.1 chesscc may reject it.  The plain" >&2
+        echo "  form is what the 2024 vitis_aie_essentials model provides." >&2
+    elif [ "$form" = "guarded" ]; then
+        echo "WARNING (#3690): this build emits the GUARDED acquire.  It compiles, but on" >&2
+        echo "  AIE2P silicon a core stuck on that encoding never completes (all-zero output" >&2
+        echo "  / ERT timeout).  The plain form needs the 2024 vitis_aie_essentials model." >&2
+    fi
     return 0
 }
 
-# find_chess_aietools_root — discover a Vitis aietools root that can actually drive
-# the chess arm, i.e. one carrying chess-llvm-link at the path aiecc derives from
-# --aietools. Callers should use this instead of pinning a version or a directory
-# spelling: both known layouts are searched ($HOME/Xilinx/<ver>/Vitis/aietools and
-# $HOME/Xilinx<year>/<ver>/Vitis/aietools) and the newest qualifying version wins,
-# so a 2025.2->2026.1 move needs no edit. Note the spellings are not
-# interchangeable: on 2026-09-11 `$HOME/Xilinx2025/2025.2/Vitis/aietools` resolved
-# while the plausible-looking `$HOME/Xilinx/2025.2/Vitis/aietools` did not.
-#
-# Echoes the root and returns 0; returns 1 when nothing qualifies (the caller must
-# fail loudly rather than reach aiecc with a --aietools that cannot link chess).
-find_chess_aietools_root() {
-    local candidate
-    while IFS= read -r candidate; do
-        if [ -x "${candidate%/}/tps/lnx64/target_aie2p/bin/LNa64bin/chess-llvm-link" ]; then
-            printf '%s\n' "$candidate"
-            return 0
-        fi
-    done < <(printf '%s\n' "$HOME"/Xilinx*/*/Vitis/aietools 2>/dev/null | sort -rV)
-    return 1
-}
+# ── standalone mode ──────────────────────────────────────────────────────────
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    AIETOOLS_ARG="${AIETOOLS:-}"
+    AIECC_ARG="${AIECC:-}"
+    USE_CHESS="true"
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --aietools)  AIETOOLS_ARG="${2:-}"; shift 2 ;;
+            --aiecc)     AIECC_ARG="${2:-}"; shift 2 ;;
+            --use-chess) USE_CHESS="${2:-}"; shift 2 ;;
+            -h|--help)   sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+            *) echo "unknown argument: $1" >&2; exit 2 ;;
+        esac
+    done
+    if [ -z "$AIETOOLS_ARG" ]; then
+        echo "usage: $0 --aietools DIR [--aiecc PATH] [--use-chess true|false]" >&2
+        exit 2
+    fi
+    if check_chess_aietools "$AIETOOLS_ARG" "$USE_CHESS" "" "$AIECC_ARG"; then
+        printf 'chess pre-flight OK: aietools=%s aiecc=%s wrapper=%s model=%s\n' \
+            "$AIETOOLS_ARG" "${AIECC_ARG:-<from PATH>}" \
+            "$(chess_wrapper_form "${AIECC_ARG:-$(command -v aiecc 2>/dev/null || echo none)}")" \
+            "$(chess_model_acquire_form "$AIETOOLS_ARG")"
+        exit 0
+    fi
+    exit 1
+fi

--- a/engine/npu/tests/check_mm_kernel_2x4.sh
+++ b/engine/npu/tests/check_mm_kernel_2x4.sh
@@ -48,8 +48,11 @@ echo "== 1/4 compile kernel (i8_i32, 32x64x128) =="
 
 echo "== 2/4 generate design + build xclbin (QKV 128x2048x8192) =="
 cd "$W"
+# The 4th argument is the aiecc that will actually run: the chess runtime lib
+# (aie_runtime_lib/AIE2P/chess_intrinsic_wrapper.ll) belongs to the aiecc tree,
+# not to --aietools, and an aiecc without it silently skips the link step (#3690).
 if ! check_chess_aietools "$AIETOOLS" "$([ "$USE_XCHESSCC" = "1" ] && echo true || echo false)" \
-    "/home/bcloud/Xilinx/2026.1/2026.1/Vitis/bin:/opt/xilinx/xrt/bin"; then
+    "/home/bcloud/Xilinx/2026.1/2026.1/Vitis/bin:/opt/xilinx/xrt/bin" "$AIECC"; then
     exit 1
 fi
 "$PYTHON" "$GEN/n1_core_i8_v27.py" -M 128 -K 2048 -N 8192 -m 32 -k 64 -n 128 -c 8 -r 4 -b 5 \

--- a/engine/npu/tests/test_check_chess_aietools.sh
+++ b/engine/npu/tests/test_check_chess_aietools.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# test_check_chess_aietools.sh — verification for the chess pre-flight guard.
+#
+# A guard that has never been shown to fail is documentation. This drives
+# check_chess_aietools.sh through every path that matters, asserting exit status
+# AND the text that names the cause, plus the model detector itself in both
+# directions (an essentials tree must read plain, a 2025.2/2026.1 tree guarded).
+#
+# It builds its own throwaway aiecc trees, so it touches nothing shared, and it
+# skips (exit 0) when the toolchains it needs are not installed.
+#
+# Usage: ./test_check_chess_aietools.sh [essentials-dir] [vitis-aietools-dir] [mlir-aie-root]
+set -u
+
+GEN="$(cd "$(dirname "$0")/../generators" && pwd)"
+GUARD="$GEN/check_chess_aietools.sh"
+
+ESSENTIALS="${1:-${LEGACY_AIETOOLS:-$HOME/Downloads/ryzen_ai-1.3.0/vitis_aie_essentials}}"
+VITIS="${2:-${VITIS_AIETOOLS:-$(ls -d "$HOME"/Xilinx/*/Vitis/aietools 2>/dev/null | tail -1)}}"
+MLIR_AIE="${3:-${MLIR_AIE:-$HOME/mlir-aie}}"
+
+pass=0; fail=0; skipped=0
+expect() { # $1 = label, $2 = expected rc, $3 = required substring, rest = command
+    local label="$1" want_rc="$2" want_txt="$3"; shift 3
+    local out rc
+    out=$("$@" 2>&1); rc=$?
+    if [ "$rc" = "$want_rc" ] && { [ -z "$want_txt" ] || printf '%s' "$out" | grep -qF "$want_txt"; }; then
+        printf '  PASS  %-58s rc=%s\n' "$label" "$rc"; pass=$((pass+1))
+    else
+        printf '  FAIL  %-58s rc=%s (wanted %s, text %s)\n' "$label" "$rc" "$want_rc" "$want_txt"
+        printf '        %s\n' "$(printf '%s' "$out" | head -2 | tr '\n' ' ')"
+        fail=$((fail+1))
+    fi
+}
+skip() { printf '  SKIP  %s\n' "$1"; skipped=$((skipped+1)); }
+
+[ -f "$GUARD" ] || { echo "guard not found at $GUARD" >&2; exit 2; }
+
+# ── private fixtures: two throwaway aiecc trees + a PLAIN wrapper ────────────
+WORK=$(mktemp -d /tmp/chess-guard-test.XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/plain/bin" "$WORK/plain/aie_runtime_lib/AIE2P" "$WORK/none/bin"
+printf '#!/bin/sh\nexit 0\n' > "$WORK/plain/bin/aiecc"; chmod +x "$WORK/plain/bin/aiecc"
+printf '#!/bin/sh\nexit 0\n' > "$WORK/none/bin/aiecc";  chmod +x "$WORK/none/bin/aiecc"
+
+INSTALL_AIECC="$MLIR_AIE/install/bin/aiecc"
+BUILD_AIECC="$MLIR_AIE/build_tmp/bin/aiecc"
+WRAPPER="$MLIR_AIE/install/aie_runtime_lib/AIE2P/chess_intrinsic_wrapper.ll"
+
+# A PLAIN wrapper derived from the installed one, so the fixture needs no /tmp state.
+derived_plain_ok=0
+if [ -f "$WRAPPER" ]; then
+    sed -e 's/void_acquire_guarded___uint___uint/void_acquire____uint___uint/g' \
+        -e 's/void_release_guarded___uint___sint/void_release____uint___sint/g' \
+        "$WRAPPER" > "$WORK/plain/aie_runtime_lib/AIE2P/chess_intrinsic_wrapper.ll"
+    derived_plain_ok=1
+fi
+
+echo "== check_chess_aietools.sh guard =="
+expect "A peano arm short-circuits (no checks, no toolchain needed)" 0 "" \
+    bash "$GUARD" --aietools /nonexistent --use-chess false
+
+if [ -n "$VITIS" ] && [ -x "$INSTALL_AIECC" ] && [ "$derived_plain_ok" = 1 ]; then
+    expect "B Vitis chess + install aiecc (guarded/guarded compiles)" 0 "never completes" \
+        bash "$GUARD" --aietools "$VITIS" --aiecc "$INSTALL_AIECC"
+else
+    skip "B (needs Vitis aietools, install aiecc and the wrapper)"
+fi
+
+if [ -n "$ESSENTIALS" ] && [ -x "$INSTALL_AIECC" ]; then
+    expect "C essentials model (plain) + guarded wrapper = FATAL" 1 "LEGACY_PATCH_WRAPPER=1" \
+        bash "$GUARD" --aietools "$ESSENTIALS" --aiecc "$INSTALL_AIECC"
+else
+    skip "C (needs the vitis_aie_essentials tree)"
+fi
+
+if [ -n "$VITIS" ] && [ -x "$BUILD_AIECC" ]; then
+    expect "D aiecc tree with no runtime lib is rejected, names the fix" 1 "install/bin/aiecc" \
+        bash "$GUARD" --aietools "$VITIS" --aiecc "$BUILD_AIECC"
+else
+    skip "D (needs mlir-aie build_tmp/bin/aiecc)"
+fi
+
+if [ -n "$ESSENTIALS" ]; then
+    expect "E essentials + PLAIN wrapper = the working configuration" 0 "pre-flight OK" \
+        bash "$GUARD" --aietools "$ESSENTIALS" --aiecc "$WORK/plain/bin/aiecc"
+    expect "F no runtime lib at all is rejected, names the fix" 1 "install/bin/aiecc" \
+        bash "$GUARD" --aietools "$ESSENTIALS" --aiecc "$WORK/none/bin/aiecc"
+    expect "G essentials-style tree missing its aie2ps aliases is FATAL" 1 "ln -s aie2p" \
+        bash -c "source '$GUARD'; rm -rf '$WORK/ess'; mkdir -p '$WORK/ess/tps/lnx64/target_aie2p' '$WORK/ess/data'; check_chess_aie2ps_aliases '$WORK/ess'"
+    expect "H essentials-style tree WITH aliases passes that check" 0 "" \
+        bash -c "source '$GUARD'; check_chess_aie2ps_aliases '$ESSENTIALS'"
+else
+    skip "E/F/G/H (needs the vitis_aie_essentials tree)"
+fi
+
+expect "I wrong --aietools names chess-llvm-link (#1913)" 1 "chess-llvm-link not found" \
+    bash "$GUARD" --aietools "$WORK/none" --aiecc "${INSTALL_AIECC:-$WORK/plain/bin/aiecc}"
+
+echo "== model detector (it is itself a check: both answers must be produced) =="
+if [ -n "$ESSENTIALS" ]; then
+    expect "J essentials aie2p model reads PLAIN" 0 "plain" \
+        bash -c "source '$GUARD'; r=\$(chess_model_acquire_form '$ESSENTIALS'); echo \$r; [ \$r = plain ]"
+else
+    skip "J (needs the vitis_aie_essentials tree)"
+fi
+if [ -n "$VITIS" ]; then
+    expect "K Vitis 2025.2/2026.1 aie2p model reads GUARDED" 0 "guarded" \
+        bash -c "source '$GUARD'; r=\$(chess_model_acquire_form '$VITIS'); echo \$r; [ \$r = guarded ]"
+else
+    skip "K (needs Vitis aietools)"
+fi
+
+echo "== $pass passed, $fail failed, $skipped skipped =="
+[ "$fail" = 0 ]


### PR DESCRIPTION
### **User description**
## Why

`check_chess_aietools.sh` guarded one chess trap (#1913: the `chess-llvm-link` lookup). Getting the
chess arm to actually *run* today (#3690) turned up three more, and each one fails in a way that does
**not** name its cause:

1. **The runtime lib belongs to the aiecc binary, not `--aietools`.** aiecc resolves
   `<aiecc-root>/aie_runtime_lib/AIE2P/chess_intrinsic_wrapper.ll`; `build_tmp` has no wrapper while
   `install` does. Missing → aiecc *silently* skips the `chess-llvm-link` step and dies later with
   `xchesscc Failed No such device`.
2. **The wrapper's acquire form must match the model's.** 2025.2/2026.1 aie2ps models declare only
   `acquire_guarded`/`acquire_no_fence`; the 2024 `vitis_aie_essentials` **aie2p** model declares only
   the plain form. Mismatch → `unrecognised intrinsic ... model inconsistency`, DSFG errors, and a
   `noodle` segfault. And a guarded build is a *runtime* hazard too: a core stuck on that encoding never
   completes on AIE2P.
3. **Essentials-style trees need their `aie2ps` aliases** (`tps/lnx64/target_aie2ps -> target_aie2p`,
   `data/aie2ps -> aie2p`); without them the launcher cannot source its env and chesscc exits with that
   same opaque message.

## What

* `check_chess_aietools.sh` gains those checks, a standalone entry point, and an **arch-scoped** model
  detector. The scoping matters: an essentials tree ships `aie2p`, `aie_ml` and `versal_prod` models, so
  scanning all of `data/` returns whichever file the walk reaches first — `aie_ml` is guarded, `aie2p`
  is plain — i.e. the wrong answer. It reads with `-lsa` because some of those generated headers look
  binary to `grep`.
* `check_mm_kernel_2x4.sh` passes its `$AIECC` (new 4th argument) so the runtime lib is checked against
  the aiecc that will actually run.
* `test_check_chess_aietools.sh` verifies the guard: 11 scenarios asserting exit status **and** the text
  that names each cause, with private throwaway aiecc trees, a PLAIN wrapper derived from the installed
  one, and clean skips when a toolchain is absent. **11/11 on strixhalo**, 0 skipped.

A guard that has never been shown to fail is documentation, so the suite asserts the failures as
explicitly as the successes — including the detector's two answers (`essentials -> plain`,
`Vitis -> guarded`).

Context: Xilinx/mlir-aie#3690.


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Extends the chess pre-flight guard with three more traps

- Checks aiecc-tree runtime lib and wrapper acquire form

- Adds essentials-style aie2ps alias check and standalone CLI

- New test script verifies guard exit status and messages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["check_chess_aietools.sh"] -- "adds trap 2/3 checks" --> B["chess_wrapper_form + chess_model_acquire_form"]
  A -- "adds trap 4" --> C["check_chess_aie2ps_aliases"]
  A -- "adds standalone mode" --> D["--aietools / --aiecc / --use-chess CLI"]
  E["check_mm_kernel_2x4.sh"] -- "passes aiecc as 4th arg" --> A
  F["test_check_chess_aietools.sh"] -- "drives every guard path" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>check_chess_aietools.sh</strong><dd><code>Add chess runtime-lib, acquire-form and alias pre-flight guards</code></dd></summary>
<hr>

engine/npu/generators/check_chess_aietools.sh

<ul><li>Extends the <code>--xchesscc</code> pre-flight guard from one trap (#1913) to four, <br>documenting each silent failure mode.<br> <li> Adds <code>chess_wrapper_form</code> (plain/guarded/absent/unknown) resolving <br><code>aie_runtime_lib/AIE2P/chess_intrinsic_wrapper.ll</code> relative to the aiecc <br>binary, and <code>chess_model_acquire_form</code>, which arch-scopes the <code>grep -rlsa</code> <br>model scan to <code>data/aie2p</code>, <code>data/aie2ps</code> and the matching <br><code>tps/lnx64/target_*</code> dirs.<br> <li> Adds <code>check_chess_aie2ps_aliases</code> for essentials-style trees <br>(non-symlink <code>target_aie2p</code>) requiring <code>tps/lnx64/target_aie2ps</code> and <br><code>data/aie2ps</code> symlinks, plus the acquire-form mismatch ERROR/runtime <br>WARNING branches and a 4th <code>aiecc</code> argument.<br> <li> Adds a standalone entry point (<code>--aietools</code>, <code>--aiecc</code>, <code>--use-chess</code>, <code>-h</code>) <br>and removes the <code>find_chess_aietools_root</code> discovery helper.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2233/files#diff-ac3b7e6065a91a0dae73d110a21f4be5c747ed315302a116ec23e6950a996903">+175/-24</a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>check_mm_kernel_2x4.sh</strong><dd><code>Pass the actual aiecc path into the guard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tests/check_mm_kernel_2x4.sh

<ul><li>Passes <code>$AIECC</code> as the 4th argument to <code>check_chess_aietools</code> so the <br>runtime lib is validated against the aiecc that will actually run.<br> <li> Adds a comment explaining that <code>aie_runtime_lib</code> belongs to the aiecc <br>tree rather than <code>--aietools</code> (#3690).</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2233/files#diff-59b4224f6274e754d605223aa14e714167be20c289bc1bb0e2a40ade4f9bbb7b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_check_chess_aietools.sh</strong><dd><code>Add verification suite for the chess pre-flight guard</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/npu/tests/test_check_chess_aietools.sh

<ul><li>New self-contained test harness that asserts exit status and the <br>cause-naming text for every guard path (A–K), skipping cleanly when <br>toolchains are absent.<br> <li> Builds throwaway aiecc trees under <code>mktemp -d</code> and derives a PLAIN <br>wrapper from the installed one to test the mismatch branches without <br>touching shared state.<br> <li> Verifies the model detector in both directions: essentials must read <br><code>plain</code>, Vitis 2025.2/2026.1 must read <code>guarded</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2233/files#diff-c0ec2a46641e658934fb47caa1e52f0704b092d0154d8a21ca7ea109bba55c86">+115/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

