### PR TITLE
ws13: DeepSeek V4 compressed attention implemented and gated (compressor + indexer + integration), plus the arch-gap evidence

### DIFF
--- a/Testing/cmp_deepseek_v4.cpp
+++ b/Testing/cmp_deepseek_v4.cpp
@@ -4,9 +4,14 @@
 // through deepseek_v4_forward, compares the final-position logits against the
 // saved HF oracle. PASS = top-20 overlap >= min_overlap AND top1 matches.
 //
-// usage: cmp_deepseek_v4 <model_dir> <ids.txt> <hf_logits.pt> [topN] [min_overlap]
+// usage: cmp_deepseek_v4 <model_dir> <ids.txt> <hf_logits.pt> [topN] [min_overlap] [engine_states_out]
 //   ids.txt: space-separated token ids (the prompt).
 //   hf_logits.pt: torch tensor [vocab] — last-position oracle logits.
+//   engine_states_out (optional): write the per-layer residual streams for the
+//     LAST token — `nstates` states of [hc][H] float32, row-major, plus a
+//     sibling `<path>.shape` file holding "nstates hc H". State i is the input
+//     to layer i, i.e. exactly HF's `hidden_states[i]` (see
+//     Testing/cmp_deepseek_v4_layers.py for the per-layer comparison).
 #include <cstdio>
 #include <fstream>
 #include <sstream>
@@ -66,8 +71,25 @@ int main(int argc, char** argv) {
     mhc.init(model.cfg.hc_mult, model.cfg.hidden_size);
     int pos = 0;
     std::vector<float> last_logits;
+    std::vector<float> states;  // [nstates][hc][H], only filled for the last token
+    const char* states_out = argc > 6 ? argv[6] : nullptr;
     for (size_t i = 0; i < ids.size(); i++) {
-        last_logits = deepseek_v4_forward(model, ids[i], kv_cache, mhc, pos);
+        std::vector<float>* want_states = (states_out && i + 1 == ids.size()) ? &states : nullptr;
+        last_logits = deepseek_v4_forward(model, ids[i], kv_cache, mhc, pos, want_states);
+    }
+    if (states_out && !states.empty()) {
+        const int hc = model.cfg.hc_mult, H = model.cfg.hidden_size;
+        const size_t per = (size_t)hc * H;
+        FILE* f = fopen(states_out, "wb");
+        if (!f) { printf("FAIL: cannot write %s\n", states_out); return 1; }
+        fwrite(states.data(), sizeof(float), states.size(), f);
+        fclose(f);
+        char shp[512];
+        snprintf(shp, sizeof shp, "%s.shape", states_out);
+        FILE* g = fopen(shp, "w");
+        if (g) { fprintf(g, "%zu %d %d\n", states.size() / per, hc, H); fclose(g); }
+        printf("states: %zu layer-boundary states of [%d,%d] -> %s\n",
+               states.size() / per, hc, H, states_out);
     }
 
     // compare

--- a/Testing/cmp_deepseek_v4.cpp
+++ b/Testing/cmp_deepseek_v4.cpp
@@ -47,38 +47,6 @@ static bool read_npy_f32(const char* path, std::vector<float>& out) {
     return f.gcount() == (std::streamsize)(n * sizeof(float));
 }
 
-// int64 npy reader (full shape product) — for an optional index-override table
-static bool read_npy_i64(const char* path, std::vector<int64_t>& out) {
-    std::ifstream f(path, std::ios::binary);
-    if (!f) return false;
-    char magic[6];
-    f.read(magic, 6);
-    if (std::strncmp(magic, "\x93NUMPY", 6) != 0) return false;
-    f.read(magic, 2);
-    uint16_t hlen = 0;
-    f.read(reinterpret_cast<char*>(&hlen), 2);
-    std::string dict(hlen, '\0');
-    f.read(&dict[0], hlen);
-    if (dict.find("i8") == std::string::npos) return false;
-    size_t lb = dict.find("'shape': (");
-    if (lb == std::string::npos) lb = dict.find("shape: (");
-    lb = dict.find('(', lb) + 1;
-    size_t rb = dict.find(')', lb);
-    size_t total = 1, i = lb, ndim = 0;
-    while (i < rb) {
-        while (i < rb && !isdigit((unsigned char)dict[i])) i++;
-        if (i >= rb) break;
-        size_t v = 0;
-        while (i < rb && isdigit((unsigned char)dict[i])) { v = v * 10 + (size_t)(dict[i] - '0'); i++; }
-        total *= v;
-        ndim++;
-    }
-    if (!ndim || !total) return false;
-    out.resize(total);
-    f.read(reinterpret_cast<char*>(out.data()), (std::streamsize)(total * sizeof(int64_t)));
-    return (bool)f;
-}
-
 int main(int argc, char** argv) {
     if (argc < 4) { printf("usage: cmp_deepseek_v4 <model_dir> <ids.txt> <hf_logits.pt> [topN] [min_overlap]\n"); return 2; }
     int topN = argc > 4 ? atoi(argv[4]) : 20;
@@ -105,17 +73,10 @@ int main(int argc, char** argv) {
     std::vector<float> last_logits;
     std::vector<float> states;  // [nstates][hc][H], only filled for the last token
     const char* states_out = argc > 6 ? argv[6] : nullptr;
-    std::vector<int64_t> ix_override;   // optional [T, k] index table (test instrument)
-    int ix_k = 0;
-    if (argc > 7) {
-        if (!read_npy_i64(argv[7], ix_override)) { printf("FAIL: index override read\n"); return 1; }
-        ix_k = (int)(ix_override.size() / ids.size());
-        if ((size_t)ix_k * ids.size() != ix_override.size()) { printf("FAIL: override not [T,k]\n"); return 1; }
-    }
+
     for (size_t i = 0; i < ids.size(); i++) {
         std::vector<float>* want_states = (states_out && i + 1 == ids.size()) ? &states : nullptr;
-        const int* ov = ix_k > 0 ? reinterpret_cast<const int*>(&ix_override[(size_t)i * ix_k]) : nullptr;
-        last_logits = deepseek_v4_forward(model, ids[i], kv_cache, mhc, pos, want_states, ov, ix_k);
+        last_logits = deepseek_v4_forward(model, ids[i], kv_cache, mhc, pos, want_states);
     }
     if (states_out && !states.empty()) {
         const int hc = model.cfg.hc_mult, H = model.cfg.hidden_size;

--- a/Testing/cmp_deepseek_v4.cpp
+++ b/Testing/cmp_deepseek_v4.cpp
@@ -47,6 +47,38 @@ static bool read_npy_f32(const char* path, std::vector<float>& out) {
     return f.gcount() == (std::streamsize)(n * sizeof(float));
 }
 
+// int64 npy reader (full shape product) — for an optional index-override table
+static bool read_npy_i64(const char* path, std::vector<int64_t>& out) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) return false;
+    char magic[6];
+    f.read(magic, 6);
+    if (std::strncmp(magic, "\x93NUMPY", 6) != 0) return false;
+    f.read(magic, 2);
+    uint16_t hlen = 0;
+    f.read(reinterpret_cast<char*>(&hlen), 2);
+    std::string dict(hlen, '\0');
+    f.read(&dict[0], hlen);
+    if (dict.find("i8") == std::string::npos) return false;
+    size_t lb = dict.find("'shape': (");
+    if (lb == std::string::npos) lb = dict.find("shape: (");
+    lb = dict.find('(', lb) + 1;
+    size_t rb = dict.find(')', lb);
+    size_t total = 1, i = lb, ndim = 0;
+    while (i < rb) {
+        while (i < rb && !isdigit((unsigned char)dict[i])) i++;
+        if (i >= rb) break;
+        size_t v = 0;
+        while (i < rb && isdigit((unsigned char)dict[i])) { v = v * 10 + (size_t)(dict[i] - '0'); i++; }
+        total *= v;
+        ndim++;
+    }
+    if (!ndim || !total) return false;
+    out.resize(total);
+    f.read(reinterpret_cast<char*>(out.data()), (std::streamsize)(total * sizeof(int64_t)));
+    return (bool)f;
+}
+
 int main(int argc, char** argv) {
     if (argc < 4) { printf("usage: cmp_deepseek_v4 <model_dir> <ids.txt> <hf_logits.pt> [topN] [min_overlap]\n"); return 2; }
     int topN = argc > 4 ? atoi(argv[4]) : 20;
@@ -73,9 +105,17 @@ int main(int argc, char** argv) {
     std::vector<float> last_logits;
     std::vector<float> states;  // [nstates][hc][H], only filled for the last token
     const char* states_out = argc > 6 ? argv[6] : nullptr;
+    std::vector<int64_t> ix_override;   // optional [T, k] index table (test instrument)
+    int ix_k = 0;
+    if (argc > 7) {
+        if (!read_npy_i64(argv[7], ix_override)) { printf("FAIL: index override read\n"); return 1; }
+        ix_k = (int)(ix_override.size() / ids.size());
+        if ((size_t)ix_k * ids.size() != ix_override.size()) { printf("FAIL: override not [T,k]\n"); return 1; }
+    }
     for (size_t i = 0; i < ids.size(); i++) {
         std::vector<float>* want_states = (states_out && i + 1 == ids.size()) ? &states : nullptr;
-        last_logits = deepseek_v4_forward(model, ids[i], kv_cache, mhc, pos, want_states);
+        const int* ov = ix_k > 0 ? reinterpret_cast<const int*>(&ix_override[(size_t)i * ix_k]) : nullptr;
+        last_logits = deepseek_v4_forward(model, ids[i], kv_cache, mhc, pos, want_states, ov, ix_k);
     }
     if (states_out && !states.empty()) {
         const int hc = model.cfg.hc_mult, H = model.cfg.hidden_size;

--- a/Testing/cmp_deepseek_v4_compressor.cpp
+++ b/Testing/cmp_deepseek_v4_compressor.cpp
@@ -1,0 +1,110 @@
+// cmp_deepseek_v4_compressor.cpp — ws13 P1.1 stage-1 gate: the compressor alone.
+//
+// Compares `deepseek_v4_compressor_forward` against the reference's OWN compressor
+// output, captured by a forward hook during a real HF forward (so it is the
+// reference's values, not a re-derivation) and written by
+// Testing/make_mini_deepseek_v41.py as plain .npy files:
+//   attn_input_L<N>.npy  [T, H]           the collapsed attention-site input
+//   comp_ref_L<N>.npy    [n_win, head_dim] the compressed entries (post-norm, post-rope)
+//
+// This isolates P1.1's hardest maths (Ca/Cb two-series pooling with per-column
+// softmax, RMSNorm, compress-rope) from the attention integration, which is the
+// next stage — the same "gate the part, not the whole" pattern as the per-layer
+// state gate.
+//
+// usage: cmp_deepseek_v4_compressor <model_dir> <layer_idx> <attn_input.npy> <comp_ref.npy> [tol]
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "deepseek_v4.h"
+
+// minimal npy reader (float32, N-D) — the shared one in cmp_deepseek_v4.cpp only
+// computes the FIRST shape entry as the element count, which is fine for 1-D
+// logits and wrong for [T,H] / [n_win,hd]; this one multiplies the whole tuple.
+static bool read_npy_f32(const char* path, std::vector<float>& out) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) return false;
+    char magic[6];
+    f.read(magic, 6);
+    if (std::strncmp(magic, "\x93NUMPY", 6) != 0) return false;
+    f.read(magic, 2);
+    uint16_t hlen = 0;
+    f.read(reinterpret_cast<char*>(&hlen), 2);
+    std::string dict(hlen, '\0');
+    f.read(&dict[0], hlen);
+    if (dict.find("'f4'") == std::string::npos && dict.find("<f4") == std::string::npos) {
+        printf("FAIL: %s is not float32 (%s)\n", path, dict.substr(0, 80).c_str());
+        return false;
+    }
+    size_t lb = dict.find("'shape': (", 0);
+    if (lb == std::string::npos) lb = dict.find("shape: (");
+    if (lb == std::string::npos) return false;
+    lb = dict.find('(', lb) + 1;
+    size_t rb = dict.find(')', lb);
+    if (rb == std::string::npos) return false;
+    size_t total = 1, i = lb, ndim = 0;
+    while (i < rb) {
+        while (i < rb && !isdigit((unsigned char)dict[i])) i++;
+        if (i >= rb) break;
+        size_t v = 0;
+        while (i < rb && isdigit((unsigned char)dict[i])) { v = v * 10 + (size_t)(dict[i] - '0'); i++; }
+        total *= v;
+        ndim++;
+    }
+    if (!ndim || !total) return false;
+    out.resize(total);
+    f.read(reinterpret_cast<char*>(out.data()), (std::streamsize)(total * sizeof(float)));
+    return (bool)f;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 5) {
+        printf("usage: %s <model_dir> <layer_idx> <attn_input.npy> <comp_ref.npy> [tol]\n", argv[0]);
+        return 2;
+    }
+    const int layer = atoi(argv[2]);
+    const float tol = argc > 5 ? (float)atof(argv[5]) : 1e-6f;
+
+    DeepSeekV4Model model;
+    if (!model.load_from_safetensors(argv[1])) { printf("FAIL: load %s\n", argv[1]); return 1; }
+    const auto& cfg = model.cfg;
+    if (layer < 0 || layer >= (int)model.layers.size()) { printf("FAIL: layer out of range\n"); return 1; }
+    const auto& l = model.layers[layer];
+    if (l.cp_rate == 0) { printf("FAIL: layer %d has no compressor (cp_rate=0)\n", layer); return 1; }
+
+    std::vector<float> x, ref;
+    if (!read_npy_f32(argv[3], x)) { printf("FAIL: read %s\n", argv[3]); return 1; }
+    if (!read_npy_f32(argv[4], ref)) { printf("FAIL: read %s\n", argv[4]); return 1; }
+    const int T = (int)(x.size() / cfg.hidden_size);
+    if ((size_t)T * cfg.hidden_size != x.size()) { printf("FAIL: input not [T,H]\n"); return 1; }
+    const int n_win_ref = (int)(ref.size() / cfg.head_dim);
+    if ((size_t)n_win_ref * cfg.head_dim != ref.size()) { printf("FAIL: ref not [n_win,hd]\n"); return 1; }
+
+    std::vector<float> got = deepseek_v4_compressor_forward(l, cfg, l.cp_rate, x, T);
+    const int n_win = (int)(got.size() / cfg.head_dim);
+    printf("layer %d: rate=%d type=%s  T=%d  entries engine=%d ref=%d  hd=%d rope_dim=%d theta=%.0f\n",
+           layer, l.cp_rate, l.cp_rate >= 128 ? "HCA" : "CSA", T, n_win, n_win_ref,
+           cfg.head_dim, cfg.qk_rope_head_dim, cfg.compress_rope_theta);
+    if (n_win != n_win_ref) { printf("FAIL: entry count %d != %d\n", n_win, n_win_ref); return 1; }
+
+    double worst = 0.0;
+    int worst_w = -1, worst_d = -1;
+    double ref_max = 0.0;
+    for (int w = 0; w < n_win; w++)
+        for (int d = 0; d < cfg.head_dim; d++) {
+            double a = got[(size_t)w * cfg.head_dim + d], b = ref[(size_t)w * cfg.head_dim + d];
+            ref_max = std::max(ref_max, std::fabs(b));
+            if (std::fabs(a - b) > worst) { worst = std::fabs(a - b); worst_w = w; worst_d = d; }
+        }
+    printf("max|delta| = %.3e (rel %.2e)  at window %d channel %d   |ref|max=%.4f\n",
+           worst, ref_max > 0 ? worst / ref_max : worst, worst_w, worst_d, ref_max);
+    const bool pass = worst <= (double)tol;
+    printf("%s\n", pass ? "PASS" : "FAIL");
+    return pass ? 0 : 1;
+}

--- a/Testing/cmp_deepseek_v4_compressor_incremental.cpp
+++ b/Testing/cmp_deepseek_v4_compressor_incremental.cpp
@@ -1,0 +1,97 @@
+// cmp_deepseek_v4_compressor_incremental.cpp — ws13 P1.1 stage-3 prep.
+//
+// The stage-1 gate proves the compressor's MATHS on a window-batched call. Decoding
+// never gets a batch: it sees one token at a time, buffers a partial window, and
+// emits an entry the moment the window fills (the reference's own cache does the
+// same). This gate feeds the fixture's prompt token by token through
+// `deepseek_v4_compressor_step` and compares the EMITTED ENTRIES against the same
+// reference file the batched gate uses — i.e. it proves the incremental state
+// machine reproduces the full-sequence reference, which is the property stage 3
+// depends on.
+//
+// usage: cmp_deepseek_v4_compressor_incremental <model_dir> <layer_idx> <attn_input.npy> <comp_ref.npy> [tol]
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "deepseek_v4.h"
+
+static bool read_npy_f32(const char* path, std::vector<float>& out) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) return false;
+    char magic[6];
+    f.read(magic, 6);
+    if (std::strncmp(magic, "\x93NUMPY", 6) != 0) return false;
+    f.read(magic, 2);
+    uint16_t hlen = 0;
+    f.read(reinterpret_cast<char*>(&hlen), 2);
+    std::string dict(hlen, '\0');
+    f.read(&dict[0], hlen);
+    if (dict.find("f4") == std::string::npos) { printf("FAIL: %s not float32\n", path); return false; }
+    size_t lb = dict.find("'shape': (");
+    if (lb == std::string::npos) lb = dict.find("shape: (");
+    lb = dict.find('(', lb) + 1;
+    size_t rb = dict.find(')', lb);
+    size_t total = 1, i = lb, ndim = 0;
+    while (i < rb) {
+        while (i < rb && !isdigit((unsigned char)dict[i])) i++;
+        if (i >= rb) break;
+        size_t v = 0;
+        while (i < rb && isdigit((unsigned char)dict[i])) { v = v * 10 + (size_t)(dict[i] - '0'); i++; }
+        total *= v;
+        ndim++;
+    }
+    if (!ndim || !total) return false;
+    out.resize(total);
+    f.read(reinterpret_cast<char*>(out.data()), (std::streamsize)(total * sizeof(float)));
+    return (bool)f;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 5) {
+        printf("usage: %s <model_dir> <layer_idx> <attn_input.npy> <comp_ref.npy> [tol]\n", argv[0]);
+        return 2;
+    }
+    const int layer = atoi(argv[2]);
+    const float tol = argc > 5 ? (float)atof(argv[5]) : 1e-6f;
+
+    DeepSeekV4Model model;
+    if (!model.load_from_safetensors(argv[1])) { printf("FAIL: load\n"); return 1; }
+    const auto& cfg = model.cfg;
+    const auto& l = model.layers[layer];
+    if (l.cp_rate == 0) { printf("FAIL: layer %d has no compressor\n", layer); return 1; }
+
+    std::vector<float> x, ref;
+    if (!read_npy_f32(argv[3], x)) { printf("FAIL: read %s\n", argv[3]); return 1; }
+    if (!read_npy_f32(argv[4], ref)) { printf("FAIL: read %s\n", argv[4]); return 1; }
+    const int T = (int)(x.size() / cfg.hidden_size);
+    const int n_ref = (int)(ref.size() / cfg.head_dim);
+
+    DeepSeekV4CompState st;
+    st.init(l.cp_rate, l.cp_series, cfg.head_dim);
+    int emitted = 0;
+    for (int t = 0; t < T; t++)
+        if (deepseek_v4_compressor_step(l, cfg, l.cp_rate, &x[(size_t)t * cfg.hidden_size], st)) emitted++;
+
+    const int n_got = (int)(st.entries.size() / cfg.head_dim);
+    printf("layer %d: rate=%d series=%d T=%d  entries emitted=%d (steps reported %d) ref=%d\n",
+           layer, l.cp_rate, l.cp_series, T, n_got, emitted, n_ref);
+    if (n_got != n_ref) { printf("FAIL: entry count %d != %d\n", n_got, n_ref); return 1; }
+
+    double worst = 0.0;
+    int ww = -1, wd = -1;
+    for (int w = 0; w < n_got; w++)
+        for (int d = 0; d < cfg.head_dim; d++) {
+            double a = st.entries[(size_t)w * cfg.head_dim + d], b = ref[(size_t)w * cfg.head_dim + d];
+            if (std::fabs(a - b) > worst) { worst = std::fabs(a - b); ww = w; wd = d; }
+        }
+    printf("incremental vs batched reference: max|delta| = %.3e at window %d channel %d\n", worst, ww, wd);
+    const bool pass = worst <= (double)tol;
+    printf("%s\n", pass ? "PASS" : "FAIL");
+    return pass ? 0 : 1;
+}

--- a/Testing/cmp_deepseek_v4_indexer.cpp
+++ b/Testing/cmp_deepseek_v4_indexer.cpp
@@ -1,0 +1,161 @@
+// cmp_deepseek_v4_indexer.cpp — ws13 P1.1 stage-2 gate: the Lightning Indexer.
+//
+// The indexer's only output is the [T, index_topk] table of compressed-entry
+// indices (with the reference's -1 sentinel for picks a query may not use), so
+// this gate compares integers — no tolerance to hide behind. The oracle comes
+// from a forward hook on the reference's own `Indexer`, written by
+// Testing/make_mini_deepseek_v41.py as `indexer_ref_L<N>.npy` [T, k] int64.
+//
+// usage: cmp_deepseek_v4_indexer <model_dir> <layer_idx> <attn_input.npy> <indexer_ref.npy>
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "deepseek_v4.h"
+
+// minimal npy readers: float32 (N-D) and int64 (N-D), full shape product
+static bool npy_open(const char* path, std::ifstream& f, std::string& dict, size_t& total) {
+    f.open(path, std::ios::binary);
+    if (!f) return false;
+    char magic[6];
+    f.read(magic, 6);
+    if (std::strncmp(magic, "\x93NUMPY", 6) != 0) return false;
+    f.read(magic, 2);
+    uint16_t hlen = 0;
+    f.read(reinterpret_cast<char*>(&hlen), 2);
+    dict.assign(hlen, '\0');
+    f.read(&dict[0], hlen);
+    size_t lb = dict.find("'shape': (");
+    if (lb == std::string::npos) lb = dict.find("shape: (");
+    if (lb == std::string::npos) return false;
+    lb = dict.find('(', lb) + 1;
+    size_t rb = dict.find(')', lb);
+    if (rb == std::string::npos) return false;
+    total = 1;
+    size_t i = lb, ndim = 0;
+    while (i < rb) {
+        while (i < rb && !isdigit((unsigned char)dict[i])) i++;
+        if (i >= rb) break;
+        size_t v = 0;
+        while (i < rb && isdigit((unsigned char)dict[i])) { v = v * 10 + (size_t)(dict[i] - '0'); i++; }
+        total *= v;
+        ndim++;
+    }
+    return ndim > 0 && total > 0;
+}
+
+static bool read_npy_f32(const char* path, std::vector<float>& out) {
+    std::ifstream f;
+    std::string dict;
+    size_t n = 0;
+    if (!npy_open(path, f, dict, n)) return false;
+    if (dict.find("f4") == std::string::npos) { printf("FAIL: %s not float32\n", path); return false; }
+    out.resize(n);
+    f.read(reinterpret_cast<char*>(out.data()), (std::streamsize)(n * sizeof(float)));
+    return (bool)f;
+}
+
+static bool read_npy_i64(const char* path, std::vector<int64_t>& out) {
+    std::ifstream f;
+    std::string dict;
+    size_t n = 0;
+    if (!npy_open(path, f, dict, n)) return false;
+    if (dict.find("i8") == std::string::npos) { printf("FAIL: %s not int64 (%s)\n", path, dict.substr(0, 60).c_str()); return false; }
+    out.resize(n);
+    f.read(reinterpret_cast<char*>(out.data()), (std::streamsize)(n * sizeof(int64_t)));
+    return (bool)f;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 5) {
+        printf("usage: %s <model_dir> <layer_idx> <attn_input.npy> <indexer_ref.npy>\n", argv[0]);
+        return 2;
+    }
+    const int layer = atoi(argv[2]);
+    DeepSeekV4Model model;
+    if (!model.load_from_safetensors(argv[1])) { printf("FAIL: load\n"); return 1; }
+    const auto& l = model.layers[layer];
+    if (l.ix_heads == 0) { printf("FAIL: layer %d has no indexer\n", layer); return 1; }
+
+    std::vector<float> x;
+    std::vector<int64_t> ref;
+    if (!read_npy_f32(argv[3], x)) { printf("FAIL: read %s\n", argv[3]); return 1; }
+    if (!read_npy_i64(argv[4], ref)) { printf("FAIL: read %s\n", argv[4]); return 1; }
+
+    const int T = (int)(x.size() / model.cfg.hidden_size);
+    const int k = l.ix_topk;
+    if ((size_t)T * k != ref.size()) { printf("FAIL: ref size %zu != T*k = %d\n", ref.size(), T * k); return 1; }
+
+    // Optional: dump the engine's score table so the *maths* can be gated
+    // separately from the tie-broken selection.
+    if (argc > 5) {
+        std::vector<float> sc = deepseek_v4_indexer_scores(l, model.cfg, l.cp_rate, x, T);
+        const int n_win = (int)(sc.size() / T);
+        FILE* f = fopen(argv[5], "wb");
+        if (f) {
+            fwrite(sc.data(), sizeof(float), sc.size(), f);
+            fclose(f);
+            char p2[512];
+            snprintf(p2, sizeof p2, "%s.shape", argv[5]);
+            FILE* g = fopen(p2, "w");
+            if (g) { fprintf(g, "%d %d\n", T, n_win); fclose(g); }
+        }
+        printf("engine scores: [%d, %d] -> %s\n", T, n_win, argv[5]);
+    }
+
+    std::vector<int> got = deepseek_v4_indexer_topk(l, model.cfg, l.cp_rate, x, T);
+    if ((size_t)T * k != got.size()) { printf("FAIL: engine returned %zu\n", got.size()); return 1; }
+
+    int match = 0, mismatch = 0, first_t = -1, first_j = -1;
+    int64_t first_got = 0, first_ref = 0;
+    for (int t = 0; t < T; t++)
+        for (int j = 0; j < k; j++) {
+            int g = got[(size_t)t * k + j];
+            int64_t r = ref[(size_t)t * k + j];
+            if (g == r) { match++; continue; }
+            mismatch++;
+            if (first_t < 0) { first_t = t; first_j = j; first_got = g; first_ref = r; }
+        }
+    printf("layer %d indexer: T=%d k=%d heads=%d ihd=%d rate=%d  matches=%d/%d\n",
+           layer, T, k, l.ix_heads, l.ix_hd, l.cp_rate, match, T * k);
+    if (mismatch) {
+        printf("first mismatch at token %d slot %d: engine=%lld ref=%lld\n",
+               first_t, first_j, (long long)first_got, (long long)first_ref);
+        // full rows: distinguishes "same set, different order" (tie/ordering) from
+        // "different entries" (a score error).
+        printf("  token %d engine:", first_t);
+        for (int j = 0; j < k; j++) printf(" %d", got[(size_t)first_t * k + j]);
+        printf("\n  token %d ref   :", first_t);
+        for (int j = 0; j < k; j++) printf(" %lld", (long long)ref[(size_t)first_t * k + j]);
+        printf("\n");
+        // how many mismatching tokens have the same SET (ordering-only difference)?
+        int set_only = 0, real = 0;
+        for (int t = 0; t < T; t++) {
+            std::vector<int> a, b;
+            for (int j = 0; j < k; j++) { a.push_back(got[(size_t)t * k + j]); b.push_back((int)ref[(size_t)t * k + j]); }
+            std::sort(a.begin(), a.end());
+            std::sort(b.begin(), b.end());
+            if (a == b) set_only++; else real++;
+        }
+        printf("  rows with identical SET (order-only): %d ; rows differing in content: %d\n", set_only, real);
+    }
+    // Also dump the engine's index table (int64, same layout as the reference's) so
+    // the Python gate can validate the SELECTION against the reference's scores.
+    if (argc > 6) {
+        std::vector<int64_t> out64(got.begin(), got.end());
+        FILE* f = fopen(argv[6], "wb");
+        if (f) { fwrite(out64.data(), sizeof(int64_t), out64.size(), f); fclose(f); }
+    }
+    // ADVISORY, not the gate. The scorer's ReLU leaves a large share of scores at
+    // exactly 0.0, so torch.topk's order among ties is implementation-defined and
+    // exact index equality fails by construction. The real gate is
+    // Testing/cmp_deepseek_v4_indexer_scores.py: the score table within tolerance
+    // plus a selection-validity check that is order-independent. This binary
+    // reports the comparison and exits 0 so it cannot be mistaken for a gate.
+    printf("ADVISORY: index order is tie-arbitrary; gate = cmp_deepseek_v4_indexer_scores.py\n");
+    return 0;
+}

--- a/Testing/cmp_deepseek_v4_indexer_scores.py
+++ b/Testing/cmp_deepseek_v4_indexer_scores.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""cmp_deepseek_v4_indexer_scores.py — gate the indexer's MATHS, not its tie-breaking.
+
+Why this exists: the reference's indexer ends in `torch.topk`, and the scorer's
+`ReLU` leaves a large share of scores at exactly 0.0 (26.5% on the fixture), so
+the order among tied entries — and sometimes *which* tied entry takes the k-th
+slot — is implementation-defined. Comparing the integer index tables therefore
+fails by construction; 57 of 64 fixture rows matched as SETS and the rest
+differed only among equal scores. What an implementation can be held to is the
+score table (`deepseek_v4_indexer_scores`) — that is what this checks.
+
+Usage:
+    python3 Testing/cmp_deepseek_v4_indexer_scores.py <fixture_dir> <engine_scores.bin> \
+            [--layer 1] [--tol 1e-6] [--engine-index-file f --ref-index-file g]
+"""
+import argparse
+import os
+
+import numpy as np
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("fixture_dir")
+    ap.add_argument("engine_scores")
+    ap.add_argument("--layer", type=int, default=1)
+    ap.add_argument("--tol", type=float, default=1e-6)
+    ap.add_argument("--engine-index-file")
+    ap.add_argument("--ref-index-file")
+    args = ap.parse_args()
+
+    ref = np.load(os.path.join(args.fixture_dir, f"indexer_scores_L{args.layer}.npy"))
+    T, n_win = (int(x) for x in open(args.engine_scores + ".shape").read().split())
+    eng = np.fromfile(args.engine_scores, dtype=np.float32).reshape(T, n_win)
+    if eng.shape != ref.shape:
+        print(f"FAIL: engine scores {eng.shape} != reference {ref.shape}")
+        return 1
+
+    d = np.abs(eng.astype(np.float64) - ref.astype(np.float64))
+    print(f"layer {args.layer}: score table {ref.shape}  max|delta| = {d.max():.3e}  "
+          f"mean = {d.mean():.3e}  (tol {args.tol:g})")
+    zero = float(np.mean(ref == 0.0))
+    print(f"  reference zero-score fraction: {zero:.3f} "
+          f"(every zero is an exact tie the top-k breaks arbitrarily)")
+    worst = np.unravel_index(int(d.argmax()), d.shape)
+    print(f"  worst at token {worst[0]}, entry {worst[1]}: engine={eng[worst]:.8f} ref={ref[worst]:.8f}")
+
+    # Optional: show that integer index mismatches are tie-induced.
+    if args.engine_index_file and args.ref_index_file:
+        gi = np.fromfile(args.engine_index_file, dtype=np.int64) if args.engine_index_file.endswith(".bin") \
+            else np.load(args.engine_index_file)
+        ri = np.load(args.ref_index_file)
+        k = ri.shape[1]
+        gi = gi.reshape(T, k)
+        order_only = content = tie_explained = unexplained = 0
+        for t in range(T):
+            a, b = gi[t], ri[t]
+            if np.array_equal(a, b):
+                continue
+            if sorted(a.tolist()) == sorted(b.tolist()):
+                order_only += 1
+                continue
+            content += 1
+            # every pick in either row (that is not -1) must be a tie at the k-th
+            # boundary: the score VALUES of both rows' picks must agree within tol
+            sa = np.sort([ref[t, i] for i in a if i >= 0])
+            sb = np.sort([ref[t, i] for i in b if i >= 0])
+            if sa.shape == sb.shape and np.allclose(sa, sb, atol=args.tol):
+                tie_explained += 1
+            else:
+                unexplained += 1
+        print(f"  index rows: order-only={order_only}  content-differing={content} "
+              f"(tie-explained={tie_explained}, unexplained={unexplained})")
+
+    # Selection validity (order-independent, so ties cannot make it flaky): the
+    # reference's rule is "visible = s < (t+1)/rate, keep the k best". A correct
+    # implementation's picks must be a valid top-k of the reference's own row:
+    # every pick >= the k-th best visible score - tol, and no unpicked visible
+    # entry above it.
+    sel_ok = None
+    if args.engine_index_file:
+        gi = np.fromfile(args.engine_index_file, dtype=np.int64) if args.engine_index_file.endswith(".bin") \
+            else np.load(args.engine_index_file)
+        k = gi.shape[1] if gi.ndim > 1 else int(gi.size / T)
+        gi = gi.reshape(T, k)
+        rate = n_win and max(1, int(round(64 / n_win))) if False else None  # rate not needed below
+        bad = 0
+        for t in range(T):
+            threshold = None  # inferred: the reference's visibility rule uses (t+1)//rate
+            # infer rate from the fixture config instead of guessing
+            import json as _json
+            cfg = _json.load(open(os.path.join(args.fixture_dir, "config.json")))
+            rate = cfg["compress_rates"]["compressed_sparse_attention"]
+            threshold = (t + 1) // rate
+            vis = ref[t][:threshold]
+            if vis.size == 0:
+                if any(i >= 0 for i in gi[t]):
+                    bad += 1
+                continue
+            kth = np.sort(vis)[::-1][min(k, vis.size) - 1]
+            picks = [ref[t, i] for i in gi[t] if i >= 0]
+            if picks and min(picks) < kth - args.tol:
+                bad += 1
+        sel_ok = bad == 0
+        print(f"  selection validity vs the reference's own scores: "
+              f"{'PASS' if sel_ok else f'FAIL ({bad} row(s))'}")
+
+    ok = d.max() <= args.tol and (sel_ok is not False)
+    print(f"worst max|delta| = {d.max():.3e} -> {'PASS' if ok else 'FAIL'} (tol {args.tol:g})")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Testing/cmp_deepseek_v4_layers.py
+++ b/Testing/cmp_deepseek_v4_layers.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""cmp_deepseek_v4_layers.py — per-layer engine-vs-HF check for the V4 fixture.
+
+The logits gate (`cmp_deepseek_v4`) only sees the final distribution, so it can
+say "wrong" but not "wrong from layer 2 onward". This compares the engine's
+per-layer residual streams (written by `cmp_deepseek_v4 <dir> <ids> <logits> 20
+18 <states_out>`) against the HF oracle's `hidden_states.npz` — layer by layer,
+which is what the ws13 P0.1 acceptance asks for (<=1e-6 max|delta| per layer).
+
+Mapping (verified against transformers 5.16.1, not assumed): transformers
+appends `hidden_states` BEFORE each decoder layer, so `hidden_states[i]` is the
+input to layer i, and the final entry is the collapsed+normed output ([T, H],
+no stream equivalent — the logits gate covers it).
+
+Usage:
+    python3 Testing/cmp_deepseek_v4_layers.py <fixture_dir> <engine_states_out> [--tol 1e-6]
+
+Exit 0 = every compared state is within tolerance; 1 = some state is not.
+"""
+import argparse
+import json
+import os
+
+import numpy as np
+
+
+def stored_dtype(safetensors_path):
+    """dtype of the fixture's stored weights, from the safetensors header."""
+    try:
+        with open(safetensors_path, "rb") as f:
+            n = int.from_bytes(f.read(8), "little")
+            header = json.loads(f.read(n))
+        dtypes = {v["dtype"] for k, v in header.items() if k != "__metadata__"}
+        return ",".join(sorted(dtypes))
+    except Exception:
+        return "unknown"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("fixture_dir")
+    ap.add_argument("engine_states")
+    ap.add_argument("--tol", type=float, default=1e-6)
+    args = ap.parse_args()
+
+    ref = np.load(os.path.join(args.fixture_dir, "hidden_states.npz"))
+    keys = sorted(ref.files, key=lambda k: int(k.split("_")[1]))
+    with open(args.engine_states + ".shape") as f:
+        nstates, hc, H = (int(x) for x in f.read().split())
+    eng = np.fromfile(args.engine_states, dtype=np.float32).reshape(nstates, hc, H)
+
+    # stream-valued reference entries ([T, hc, H]); the last entry is [T, H].
+    stream_keys = [k for k in keys if ref[k].ndim == 3]
+    dtype = stored_dtype(os.path.join(args.fixture_dir, "model.safetensors"))
+
+    print(f"fixture={args.fixture_dir}  weights={dtype}  tol={args.tol:g}")
+    print(f"engine states: {nstates} x [hc={hc}, H={H}]  |  reference stream states: {len(stream_keys)}")
+    if dtype not in ("F32",) and args.tol < 1e-4:
+        print(f"  WARNING: weights stored as {dtype} — bf16 rounding alone perturbs a layer "
+              f"state by ~1e-4, so a {args.tol:g} bound cannot be met by ANY implementation. "
+              f"Regenerate with --weights-dtype float32.")
+
+    worst, n_cmp = 0.0, min(nstates, len(stream_keys))
+    for i in range(n_cmp):
+        r = ref[stream_keys[i]][-1].astype(np.float64)   # last prompt token
+        e = eng[i].astype(np.float64)
+        d = float(np.abs(r - e).max())
+        scale = float(np.abs(r).max()) or 1.0
+        worst = max(worst, d)
+        print(f"  state {i} (input to layer {i}): max|delta|={d:.3e}  rel={d/scale:.2e}  "
+              f"|ref|max={scale:.3f}")
+
+    print(f"worst max|delta| = {worst:.3e} over {n_cmp} state(s)   -> "
+          f"{'PASS' if worst <= args.tol else 'FAIL'} (tol {args.tol:g})")
+    if nstates > len(stream_keys):
+        print(f"  note: {nstates - len(stream_keys)} engine state(s) beyond the reference's "
+              f"stream entries (the final collapsed+normed state is covered by the logits gate)")
+    return 0 if worst <= args.tol else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Testing/make_mini_deepseek_v41.py
+++ b/Testing/make_mini_deepseek_v41.py
@@ -65,6 +65,10 @@ def main():
     ap.add_argument("--prompt-len", type=int, default=0,
                     help="0 = the original 5-token prompt; >5 = seeded random ids")
     ap.add_argument("--window", type=int, default=0, help="0 = profile default")
+    ap.add_argument("--rope-frac", type=float, default=0.125,
+                    help="partial_rotary_factor; with head_dim=16, 0.125 gives rd=2 (ONE rope "
+                         "pair, freq = theta^0 = 1, so the compress-vs-main theta is invisible) "
+                         "while 0.5 gives rd=8 and makes the theta observable")
     ap.add_argument("--index-topk", type=int, default=0,
                     help="0 = config default (8); set large to make the indexer keep every "
                          "causal-visible entry, which removes tie-broken selection from the "
@@ -80,6 +84,7 @@ def main():
     window = args.window or DEFAULT_WINDOW[args.profile]
 
     cfg = DeepseekV4Config(
+        partial_rotary_factor=args.rope_frac,
         vocab_size=1000, hidden_size=64, moe_intermediate_size=32,
         num_hidden_layers=4, num_attention_heads=4, num_key_value_heads=1,
         head_dim=16, q_lora_rank=8, o_lora_rank=8,
@@ -91,6 +96,9 @@ def main():
         mlp_layer_types=["hash_moe", "hash_moe", "moe", "moe"],
         compress_rates=COMPRESS_RATES,
     )
+    for _t, _rp in (cfg.rope_parameters or {}).items():
+        if isinstance(_rp, dict):
+            _rp["partial_rotary_factor"] = args.rope_frac
     model = DeepseekV4ForCausalLM(cfg).eval()
     n_params = sum(p.numel() for p in model.parameters())
 
@@ -212,7 +220,8 @@ def main():
     indexer = sorted({k.split(".", 2)[-1] for k in sd if ".indexer." in k})
     print(f"profile={args.profile} params={n_params} layers={len(PROFILES[args.profile])}")
     print(f"  layer_types={PROFILES[args.profile]}")
-    print(f"  window={window} prompt_len={len(prompt)} weights={args.weights_dtype}")
+    print(f"  window={window} prompt_len={len(prompt)} weights={args.weights_dtype} "
+          f"rope_frac={args.rope_frac} (rd={int(cfg.head_dim * args.rope_frac)})")
     print(f"  compressor tensors: {compressor}")
     print(f"  indexer tensors:    {indexer}")
     print(f"  top1={int(logits_last.argmax())}  wrote {args.outdir}")

--- a/Testing/make_mini_deepseek_v41.py
+++ b/Testing/make_mini_deepseek_v41.py
@@ -65,6 +65,10 @@ def main():
     ap.add_argument("--prompt-len", type=int, default=0,
                     help="0 = the original 5-token prompt; >5 = seeded random ids")
     ap.add_argument("--window", type=int, default=0, help="0 = profile default")
+    ap.add_argument("--weights-dtype", choices=("float32", "bfloat16"), default="float32",
+                    help="fixture weight storage. float32 for the per-layer gate: bf16 "
+                         "rounding alone perturbs the layer-0 state by ~1e-4, which is "
+                         "100x above the 1e-6 bound the gate wants to measure")
     args = ap.parse_args()
 
     os.makedirs(args.outdir, exist_ok=True)
@@ -120,13 +124,15 @@ def main():
     hs = {f"hidden_{i}": h[0].float().cpu().numpy() for i, h in enumerate(out.hidden_states)}
     np.savez(os.path.join(args.outdir, "hidden_states.npz"), **hs)
 
-    sd = {k: v.detach().to(torch.bfloat16).contiguous() for k, v in model.state_dict().items()}
+    wdtype = torch.float32 if args.weights_dtype == "float32" else torch.bfloat16
+    sd = {k: v.detach().to(wdtype).contiguous() for k, v in model.state_dict().items()}
     torch.save(sd, os.path.join(args.outdir, "model.pt"))
     st_save({k: v.float() for k, v in sd.items()}, os.path.join(args.outdir, "model.safetensors"))
 
     cfgd = cfg.to_dict()
     cfgd["_mini_fixture"] = True
     cfgd["_profile"] = args.profile
+    cfgd["_weights_dtype"] = args.weights_dtype
     cfgd["_prompt_ids"] = prompt[:8] + (["..."] if len(prompt) > 8 else [])
     json.dump(cfgd, open(os.path.join(args.outdir, "config.json"), "w"), indent=2)
 
@@ -135,7 +141,7 @@ def main():
     indexer = sorted({k.split(".", 2)[-1] for k in sd if ".indexer." in k})
     print(f"profile={args.profile} params={n_params} layers={len(PROFILES[args.profile])}")
     print(f"  layer_types={PROFILES[args.profile]}")
-    print(f"  window={window} prompt_len={len(prompt)}")
+    print(f"  window={window} prompt_len={len(prompt)} weights={args.weights_dtype}")
     print(f"  compressor tensors: {compressor}")
     print(f"  indexer tensors:    {indexer}")
     print(f"  top1={int(logits_last.argmax())}  wrote {args.outdir}")

--- a/Testing/make_mini_deepseek_v41.py
+++ b/Testing/make_mini_deepseek_v41.py
@@ -102,8 +102,23 @@ def main():
                 comp_out[name + ".bias"] = bias.detach().float().cpu().numpy()
         return _hook
     for i, layer in enumerate(model.model.layers):
-        if getattr(layer.self_attn, "compressor", None) is not None:
-            hooks.append(layer.self_attn.compressor.register_forward_hook(_mk(f"L{i}")))
+        comp = getattr(layer.self_attn, "compressor", None)
+        if comp is not None:
+            hooks.append(comp.register_forward_hook(_mk(f"L{i}")))
+            # CSA layers carry an indexer; capture the INDICES it returns (its only
+            # output) so stage 2 has an exact oracle: [B, S, k] int64, -1 = invalid.
+            idx = getattr(comp, "indexer", None)
+            if idx is not None:
+                def _ix(mod, args, out, name=f"L{i}"):
+                    comp_out[name + ".indexer"] = out.detach().cpu().numpy()
+                hooks.append(idx.register_forward_hook(_ix))
+                # Pre-mask indexer SCORES (the scorer's output, before the causal /
+                # sentinel handling). The indices themselves are a tie-broken top-k;
+                # the scores are what an implementation can be held to.
+                if getattr(idx, "scorer", None) is not None:
+                    def _sc(mod, args, out, name=f"L{i}"):
+                        comp_out[name + ".scores"] = out.detach().float().cpu().numpy()
+                    hooks.append(idx.scorer.register_forward_hook(_sc))
 
     ids = torch.tensor([PROMPT])
     if args.prompt_len and args.prompt_len != len(PROMPT):
@@ -141,9 +156,14 @@ def main():
         # plain .npy per compressed layer too: the C++ gate reads npy directly
         # (npz is a zip, which a C harness should not have to unzip).
         for k, v in sorted(comp_out.items()):
-            if k.endswith(".bias"):
+            if k.endswith(".bias") or k.endswith(".indexer"):
                 continue
             np.save(os.path.join(args.outdir, f"comp_ref_{k}.npy"), v[0, 0])  # [n_win, head_dim]
+        for k, v in sorted(comp_out.items()):
+            if k.endswith(".indexer"):
+                np.save(os.path.join(args.outdir, f"indexer_ref_{k[:-8]}.npy"), v[0])  # [S, k]
+            if k.endswith(".scores"):
+                np.save(os.path.join(args.outdir, f"indexer_scores_{k[:-7]}.npy"), v[0])  # [S, n_win]
         for k, v in sorted(comp_out.items()):
             if not k.endswith(".bias"):
                 print(f"  compressor ref {k}: {v.shape}")

--- a/Testing/make_mini_deepseek_v41.py
+++ b/Testing/make_mini_deepseek_v41.py
@@ -90,6 +90,21 @@ def main():
     model = DeepseekV4ForCausalLM(cfg).eval()
     n_params = sum(p.numel() for p in model.parameters())
 
+    # Exact compressor oracle: forward hooks on the real forward, so what we dump IS
+    # what the reference computed (no re-derivation, no standalone-call semantics).
+    comp_out = {}
+    hooks = []
+    def _mk(name):
+        def _hook(mod, args, out):
+            ck, bias = out if isinstance(out, tuple) else (out, None)
+            comp_out[name] = ck.detach().float().cpu().numpy()      # [B,1,n_win,head_dim]
+            if bias is not None:
+                comp_out[name + ".bias"] = bias.detach().float().cpu().numpy()
+        return _hook
+    for i, layer in enumerate(model.model.layers):
+        if getattr(layer.self_attn, "compressor", None) is not None:
+            hooks.append(layer.self_attn.compressor.register_forward_hook(_mk(f"L{i}")))
+
     ids = torch.tensor([PROMPT])
     if args.prompt_len and args.prompt_len != len(PROMPT):
         g = torch.Generator().manual_seed(args.seed + 1)
@@ -118,6 +133,38 @@ def main():
         print(f"  compressed entries the reference emits (CSA, rate "
               f"{COMPRESS_RATES['compressed_sparse_attention']}): "
               f"{n_entries} over {len(prompt)} tokens (window={window})")
+
+    for h in hooks:
+        h.remove()
+    if comp_out:
+        np.savez(os.path.join(args.outdir, "compressor_ref.npz"), **comp_out)
+        # plain .npy per compressed layer too: the C++ gate reads npy directly
+        # (npz is a zip, which a C harness should not have to unzip).
+        for k, v in sorted(comp_out.items()):
+            if k.endswith(".bias"):
+                continue
+            np.save(os.path.join(args.outdir, f"comp_ref_{k}.npy"), v[0, 0])  # [n_win, head_dim]
+        for k, v in sorted(comp_out.items()):
+            if not k.endswith(".bias"):
+                print(f"  compressor ref {k}: {v.shape}")
+    # Collapsed attention-site input per layer (the compressor's actual input): the
+    # mHC pre collapses streams -> [T, H]; hidden_states[i] above is the pre-layer
+    # STREAM state, so this is what a C++ compressor implementation must be fed.
+    attn_input = {}
+    def _cap(i):
+        def _hook(mod, args, out=None):  # torch passes (module, args[, kwargs])
+            attn_input[i] = args[0].detach().float().cpu().numpy() if args else None
+        return _hook
+    hh = [l.self_attn.register_forward_pre_hook(_cap(i)) for i, l in enumerate(model.model.layers)]
+    with torch.no_grad():
+        model(ids)
+    for h in hh:
+        h.remove()
+    np.savez(os.path.join(args.outdir, "attn_input_ref.npz"),
+             **{f"L{i}": v for i, v in attn_input.items() if v is not None})
+    for i, v in attn_input.items():
+        if v is not None:
+            np.save(os.path.join(args.outdir, f"attn_input_L{i}.npy"), v[0])  # [T, H]
 
     # Per-layer reference activations: the half of the instrument that lets P1
     # locate the FIRST diverging layer instead of only comparing final logits.

--- a/Testing/make_mini_deepseek_v41.py
+++ b/Testing/make_mini_deepseek_v41.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""make_mini_deepseek_v41.py — Phase-0 oracle fixtures for the V4/V4.1 arch work (research/ws13).
+
+A tiny, seeded DeepSeek-V4 fixture with the HF oracle logits AND per-layer hidden
+states, for two profiles:
+
+  sliding      all layers `sliding_attention`
+               → the engine PASSES today. Regression baseline for the modules that
+                 exist (mHC, shared-KV MQA, sinks, hash/top-k MoE).
+
+  compressed   1 sliding + 1 CSA + 1 HCA + 1 sliding
+               → the engine FAILS today, by design: it does not implement the
+                 compressors (CSA/HCA) or the Lightning Indexer. This is the gate
+                 that can fail — the instrument the P1 work is measured against.
+
+Why the reference is trustworthy: transformers 5.16.1 ships `DeepseekV4` **with**
+`compressed_sparse_attention` / `heavily_compressed_attention` layers,
+`compress_rates`, and `DeepseekV4CSACache` (which carries the `"indexer"` entries) —
+so the oracle implements the very machinery the engine is missing. There is no
+`DeepseekV41` class in transformers, so V4.1-only modules (engram, candidate
+blocks, `ffn.gate.bias_vl`, the MTP rewrite) have **no** reference here; that is
+recorded in research/ws13-arch-gap-closure/FINDINGS.md rather than papered over.
+
+Usage:
+    python3 Testing/make_mini_deepseek_v41.py /tmp/onebit-dsv4-csa --profile compressed
+    python3 Testing/make_mini_deepseek_v41.py /tmp/onebit-dsv4-ssl --profile sliding
+
+Env: needs torch + transformers with native DeepseekV4 (e.g. ~/ft-zaya/bin/python).
+"""
+import argparse
+import json
+import os
+
+import numpy as np
+import torch
+from safetensors.torch import save_file as st_save
+from transformers import DeepseekV4Config, DeepseekV4ForCausalLM
+
+# V4-Flash's own compress ratios (config.json: compress_ratios values {0, 4, 128}).
+COMPRESS_RATES = {"compressed_sparse_attention": 4, "heavily_compressed_attention": 128}
+
+PROFILES = {
+    "sliding": ["sliding_attention"] * 4,
+    "compressed": ["sliding_attention", "compressed_sparse_attention",
+                   "heavily_compressed_attention", "sliding_attention"],
+}
+
+# Default sliding windows per profile. The compressed profile needs a window
+# much smaller than the prompt: with the rate at 4 the compressed entries carry
+# the long-range context, so a model that ignores them cannot agree. (The first
+# version of this fixture kept window=32 with a 5-token prompt and the ENGINE
+# PASSED the compressed profile — the compressed entries were redundant with the
+# sliding window and one 4-token entry was not enough to move top-20 logits.
+# A gate that cannot fail is not a gate.)
+DEFAULT_WINDOW = {"sliding": 32, "compressed": 4}
+
+PROMPT = [5, 7, 9, 11, 3]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("outdir", nargs="?", default="/tmp/onebit-dsv4-csa")
+    ap.add_argument("--profile", choices=sorted(PROFILES), default="compressed")
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--prompt-len", type=int, default=0,
+                    help="0 = the original 5-token prompt; >5 = seeded random ids")
+    ap.add_argument("--window", type=int, default=0, help="0 = profile default")
+    args = ap.parse_args()
+
+    os.makedirs(args.outdir, exist_ok=True)
+    torch.manual_seed(args.seed)
+    window = args.window or DEFAULT_WINDOW[args.profile]
+
+    cfg = DeepseekV4Config(
+        vocab_size=1000, hidden_size=64, moe_intermediate_size=32,
+        num_hidden_layers=4, num_attention_heads=4, num_key_value_heads=1,
+        head_dim=16, q_lora_rank=8, o_lora_rank=8,
+        n_routed_experts=8, n_shared_experts=1, num_experts_per_tok=2,
+        max_position_embeddings=256, sliding_window=window,
+        # indexer dims: the Lightning Indexer needs its own heads/dim (HCA has none)
+        index_n_heads=2, index_head_dim=8, index_topk=8,
+        layer_types=PROFILES[args.profile],
+        mlp_layer_types=["hash_moe", "hash_moe", "moe", "moe"],
+        compress_rates=COMPRESS_RATES,
+    )
+    model = DeepseekV4ForCausalLM(cfg).eval()
+    n_params = sum(p.numel() for p in model.parameters())
+
+    ids = torch.tensor([PROMPT])
+    if args.prompt_len and args.prompt_len != len(PROMPT):
+        g = torch.Generator().manual_seed(args.seed + 1)
+        ids = torch.randint(0, 1000, (1, args.prompt_len), generator=g)
+    prompt = ids[0].tolist()
+    with torch.no_grad():
+        out = model(ids, output_hidden_states=True)
+
+    logits_last = out.logits[0, -1].float().cpu()
+    np.save(os.path.join(args.outdir, "logits_last.npy"), logits_last.numpy())
+    torch.save(logits_last, os.path.join(args.outdir, "logits_last.pt"))
+    torch.save(ids, os.path.join(args.outdir, "ids.pt"))
+    open(os.path.join(args.outdir, "ids.txt"), "w").write(" ".join(map(str, prompt)) + "\n")
+
+    # ── Sensitivity: measured by the engine, not assumed ─────────────────────
+    # A same-weights ablation is IMPOSSIBLE here and that is a finding: the
+    # compressor's `position_bias` is shaped [compress_rate, dim], so the rate is
+    # baked into the tensors (a real checkpoint's `compress_ratios` must be read
+    # from its weights, never guessed). So sensitivity is established by the
+    # engine instead: on this profile the engine (which ignores compressor
+    # weights entirely) must DISAGREE, while it agrees 20/20 on the sliding
+    # profile whose only difference is those two layer types. First-divergent
+    # -layer attribution is P1.1's job and uses hidden_states.npz below.
+    if "compressed_sparse_attention" in PROFILES[args.profile]:
+        n_entries = len(prompt) // COMPRESS_RATES["compressed_sparse_attention"]
+        print(f"  compressed entries the reference emits (CSA, rate "
+              f"{COMPRESS_RATES['compressed_sparse_attention']}): "
+              f"{n_entries} over {len(prompt)} tokens (window={window})")
+
+    # Per-layer reference activations: the half of the instrument that lets P1
+    # locate the FIRST diverging layer instead of only comparing final logits.
+    hs = {f"hidden_{i}": h[0].float().cpu().numpy() for i, h in enumerate(out.hidden_states)}
+    np.savez(os.path.join(args.outdir, "hidden_states.npz"), **hs)
+
+    sd = {k: v.detach().to(torch.bfloat16).contiguous() for k, v in model.state_dict().items()}
+    torch.save(sd, os.path.join(args.outdir, "model.pt"))
+    st_save({k: v.float() for k, v in sd.items()}, os.path.join(args.outdir, "model.safetensors"))
+
+    cfgd = cfg.to_dict()
+    cfgd["_mini_fixture"] = True
+    cfgd["_profile"] = args.profile
+    cfgd["_prompt_ids"] = prompt[:8] + (["..."] if len(prompt) > 8 else [])
+    json.dump(cfgd, open(os.path.join(args.outdir, "config.json"), "w"), indent=2)
+
+    # What the engine will trip over, named up front (the point of this profile).
+    compressor = sorted({k.split(".", 2)[-1] for k in sd if ".compressor." in k})
+    indexer = sorted({k.split(".", 2)[-1] for k in sd if ".indexer." in k})
+    print(f"profile={args.profile} params={n_params} layers={len(PROFILES[args.profile])}")
+    print(f"  layer_types={PROFILES[args.profile]}")
+    print(f"  window={window} prompt_len={len(prompt)}")
+    print(f"  compressor tensors: {compressor}")
+    print(f"  indexer tensors:    {indexer}")
+    print(f"  top1={int(logits_last.argmax())}  wrote {args.outdir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Testing/make_mini_deepseek_v41.py
+++ b/Testing/make_mini_deepseek_v41.py
@@ -65,6 +65,10 @@ def main():
     ap.add_argument("--prompt-len", type=int, default=0,
                     help="0 = the original 5-token prompt; >5 = seeded random ids")
     ap.add_argument("--window", type=int, default=0, help="0 = profile default")
+    ap.add_argument("--index-topk", type=int, default=0,
+                    help="0 = config default (8); set large to make the indexer keep every "
+                         "causal-visible entry, which removes tie-broken selection from the "
+                         "picture and isolates the attention integration")
     ap.add_argument("--weights-dtype", choices=("float32", "bfloat16"), default="float32",
                     help="fixture weight storage. float32 for the per-layer gate: bf16 "
                          "rounding alone perturbs the layer-0 state by ~1e-4, which is "
@@ -82,7 +86,7 @@ def main():
         n_routed_experts=8, n_shared_experts=1, num_experts_per_tok=2,
         max_position_embeddings=256, sliding_window=window,
         # indexer dims: the Lightning Indexer needs its own heads/dim (HCA has none)
-        index_n_heads=2, index_head_dim=8, index_topk=8,
+        index_n_heads=2, index_head_dim=8, index_topk=(args.index_topk or 8),
         layer_types=PROFILES[args.profile],
         mlp_layer_types=["hash_moe", "hash_moe", "moe", "moe"],
         compress_rates=COMPRESS_RATES,

--- a/Testing/make_mini_deepseek_v41.py
+++ b/Testing/make_mini_deepseek_v41.py
@@ -65,6 +65,16 @@ def main():
     ap.add_argument("--prompt-len", type=int, default=0,
                     help="0 = the original 5-token prompt; >5 = seeded random ids")
     ap.add_argument("--window", type=int, default=0, help="0 = profile default")
+    # Shape knobs: the V4.1 deltas are supposed to be MODULES, not dimensions — so the
+    # engine must work at non-default shapes. These make that testable.
+    ap.add_argument("--hidden", type=int, default=64)
+    ap.add_argument("--heads", type=int, default=4)
+    ap.add_argument("--head-dim", type=int, default=16)
+    ap.add_argument("--q-lora", type=int, default=8)
+    ap.add_argument("--o-lora", type=int, default=8)
+    ap.add_argument("--o-groups", type=int, default=8)
+    ap.add_argument("--experts", type=int, default=8)
+    ap.add_argument("--moe-int", type=int, default=32)
     ap.add_argument("--rope-frac", type=float, default=0.125,
                     help="partial_rotary_factor; with head_dim=16, 0.125 gives rd=2 (ONE rope "
                          "pair, freq = theta^0 = 1, so the compress-vs-main theta is invisible) "
@@ -85,10 +95,11 @@ def main():
 
     cfg = DeepseekV4Config(
         partial_rotary_factor=args.rope_frac,
-        vocab_size=1000, hidden_size=64, moe_intermediate_size=32,
-        num_hidden_layers=4, num_attention_heads=4, num_key_value_heads=1,
-        head_dim=16, q_lora_rank=8, o_lora_rank=8,
-        n_routed_experts=8, n_shared_experts=1, num_experts_per_tok=2,
+        vocab_size=1000, hidden_size=args.hidden, moe_intermediate_size=args.moe_int,
+        num_hidden_layers=4, num_attention_heads=args.heads, num_key_value_heads=1,
+        head_dim=args.head_dim, q_lora_rank=args.q_lora, o_lora_rank=args.o_lora,
+        o_groups=args.o_groups,
+        n_routed_experts=args.experts, n_shared_experts=1, num_experts_per_tok=2,
         max_position_embeddings=256, sliding_window=window,
         # indexer dims: the Lightning Indexer needs its own heads/dim (HCA has none)
         index_n_heads=2, index_head_dim=8, index_topk=(args.index_topk or 8),

--- a/Testing/make_ws13_fixtures.sh
+++ b/Testing/make_ws13_fixtures.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# make_ws13_fixtures.sh — generate the ws13 (DeepSeek V4/V4.1 architecture) fixtures.
+#
+# These are the tiny, seeded fixtures the ws13 gates compare against; they are NOT
+# committed (they are ~1 MB of weights, and regenerating is deterministic). Each one
+# carries the HF oracle's logits, per-layer hidden states, the reference's own
+# compressor outputs and the indexer's score table + returned indices, all captured
+# by forward hooks on a real forward (see Testing/make_mini_deepseek_v41.py).
+#
+# Requires: torch + transformers with native `DeepseekV4` (5.16.1 on this fleet) and
+# numpy. Point PYTHON at an interpreter that has them, e.g.
+#     PYTHON=~/ft-zaya/bin/python Testing/make_ws13_fixtures.sh
+#
+# Layout (override the root with WS13_FIXTURE_DIR):
+#   ssl      sliding, window 32 / 5 tokens          — the existing-modules baseline
+#   ssl64    sliding, window 4 / 64, rd 8           — truncation + visible rope theta
+#   csa      sliding+CSA+HCA, window 4 / 64         — default index_topk (ties in play)
+#   csa_nt   same, --index-topk 64                  — non-selective: the integration gate
+#   odd_nt   same but H=320/5 heads/32 experts, nt  — shape-agnosticism gate
+#   hca160   window 4 / 160, --index-topk 64        — HCA actually emits an entry
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PY="${PYTHON:-python3}"
+D="${WS13_FIXTURE_DIR:-/tmp/onebit-ws13}"
+MK="$ROOT/Testing/make_mini_deepseek_v41.py"
+mkdir -p "$D"
+
+gen() { local name="$1"; shift; echo "== $name"; "$PY" "$MK" "$D/$name" "$@"; }
+
+gen ssl      --profile sliding    --window 32 --prompt-len 5
+gen ssl64    --profile sliding    --window 4  --prompt-len 64  --rope-frac 0.5
+gen csa      --profile compressed --window 4  --prompt-len 64
+gen csa_nt   --profile compressed --window 4  --prompt-len 64  --index-topk 64
+gen odd_nt   --profile compressed --window 4  --prompt-len 64  --rope-frac 0.5 \
+             --hidden 320 --heads 5 --head-dim 16 --q-lora 24 --o-lora 24 \
+             --o-groups 4 --experts 32 --moe-int 96 --index-topk 64
+gen hca160   --profile compressed --window 4  --prompt-len 160 --index-topk 64
+
+echo "ws13 fixtures ready in $D"

--- a/Testing/run_all.sh
+++ b/Testing/run_all.sh
@@ -5,6 +5,7 @@
 set -u
 cd "$(dirname "$0")/.." || exit 1   # repo root
 CXX="${CXX:-g++}"; FLAGS="-std=c++17 -Iinclude -Isrc -O2"
+PYTHON="${PYTHON:-python3}"
 BIN=/tmp/onebit_tests; mkdir -p "$BIN"
 fail=0; total=0
 
@@ -122,6 +123,59 @@ if [ -f "$dsv4_dir/logits_last.npy" ] && [ -f "$dsv4_dir/model.safetensors" ]; t
     else echo "✗ deepseek_v4 engine: top-20 mismatch vs HF"; fail=$((fail+1)); fi
 else
     echo "  - deepseek_v4: fixture absent, skipped (python3 Testing/make_mini_deepseek_v4.py /tmp/onebit-dsv4)"
+fi
+
+# ── ws13: DeepSeek V4/V4.1 architecture gates (fixtures: Testing/make_ws13_fixtures.sh) ──
+# Every gate here compares against the REFERENCE'S OWN values captured by forward hooks.
+# Skipped when the fixtures are absent, like the V4 gate above. The compressed gates all
+# use a NON-SELECTIVE indexer (--index-topk 64): with the configured index_topk, which of
+# several exactly-equal scores wins is implementation-defined on the reference side, so
+# an index-equality gate would fail a correct implementation (see ws13 FINDINGS.md).
+ws13="${WS13_FIXTURE_DIR:-/tmp/onebit-ws13}"
+if [ -f "$ws13/csa_nt/comp_ref_L1.npy" ]; then
+    "$CXX" $FLAGS Testing/cmp_deepseek_v4_compressor.cpp src/deepseek_v4.cpp src/safetensors_reader.cpp src/q4nx_reader.cpp -o "$BIN/cmp_comp" 2>/dev/null || { echo "✗ ws13 compressor: COMPILE FAILED"; fail=$((fail+1)); }
+    "$CXX" $FLAGS Testing/cmp_deepseek_v4_compressor_incremental.cpp src/deepseek_v4.cpp src/safetensors_reader.cpp src/q4nx_reader.cpp -o "$BIN/cmp_comp_inc" 2>/dev/null || { echo "✗ ws13 compressor-incremental: COMPILE FAILED"; fail=$((fail+1)); }
+    "$CXX" $FLAGS Testing/cmp_deepseek_v4_indexer.cpp src/deepseek_v4.cpp src/safetensors_reader.cpp src/q4nx_reader.cpp -o "$BIN/cmp_indexer" 2>/dev/null || { echo "✗ ws13 indexer: COMPILE FAILED"; fail=$((fail+1)); }
+    # build our own comparator: the V4 gate above only builds $BIN/cmp_dsv4 when ITS
+    # fixture is present, so depending on it would make these gates un-runnable alone.
+    "$CXX" $FLAGS Testing/cmp_deepseek_v4.cpp src/deepseek_v4.cpp src/safetensors_reader.cpp src/q4nx_reader.cpp -o "$BIN/cmp_dsv4_ws13" 2>/dev/null || { echo "✗ ws13 e2e: COMPILE FAILED"; fail=$((fail+1)); }
+
+    # compressor maths, batched and incremental (CSA two-series, HCA single-series)
+    total=$((total+1))
+    if "$BIN/cmp_comp" "$ws13/csa_nt" 1 "$ws13/csa_nt/attn_input_L1.npy" "$ws13/csa_nt/comp_ref_L1.npy" 1e-6 >/dev/null 2>&1 \
+       && "$BIN/cmp_comp" "$ws13/hca160" 2 "$ws13/hca160/attn_input_L2.npy" "$ws13/hca160/comp_ref_L2.npy" 1e-6 >/dev/null 2>&1; then
+        echo "✓ ws13 compressor (CSA batched + HCA batched)"
+    else echo "✗ ws13 compressor: mismatch vs the reference"; fail=$((fail+1)); fi
+
+    total=$((total+1))
+    if "$BIN/cmp_comp_inc" "$ws13/csa_nt" 1 "$ws13/csa_nt/attn_input_L1.npy" "$ws13/csa_nt/comp_ref_L1.npy" 1e-6 >/dev/null 2>&1 \
+       && "$BIN/cmp_comp_inc" "$ws13/hca160" 2 "$ws13/hca160/attn_input_L2.npy" "$ws13/hca160/comp_ref_L2.npy" 1e-6 >/dev/null 2>&1; then
+        echo "✓ ws13 compressor incremental (token-by-token == batched reference)"
+    else echo "✗ ws13 compressor incremental: mismatch"; fail=$((fail+1)); fi
+
+    # compressed attention integrated: non-selective indexer -> exact per layer
+    total=$((total+1))
+    if "$BIN/cmp_dsv4_ws13" "$ws13/csa_nt" "$ws13/csa_nt/ids.txt" "$ws13/csa_nt/logits_last.npy" 20 18 "$BIN/ws13_nt.bin" >/dev/null 2>&1 \
+       && "$BIN/cmp_dsv4_ws13" "$ws13/odd_nt" "$ws13/odd_nt/ids.txt" "$ws13/odd_nt/logits_last.npy" 20 18 "$BIN/ws13_odd.bin" >/dev/null 2>&1; then
+        echo "✓ ws13 compressed attention (integration + shape-agnostic, non-selective)"
+    else echo "✗ ws13 compressed attention: mismatch"; fail=$((fail+1)); fi
+
+    # python-level gates (per-layer bound, indexer scores) — need numpy
+    if "$PYTHON" -c 'import numpy' >/dev/null 2>&1; then
+        total=$((total+1))
+        if "$PYTHON" Testing/cmp_deepseek_v4_layers.py "$ws13/csa_nt" "$BIN/ws13_nt.bin" --tol 1e-6 >/dev/null 2>&1; then
+            echo "✓ ws13 per-layer bound (<=1e-6, non-selective indexer)"
+        else echo "✗ ws13 per-layer bound: exceeded"; fail=$((fail+1)); fi
+        total=$((total+1))
+        if "$BIN/cmp_indexer" "$ws13/csa" 1 "$ws13/csa/attn_input_L1.npy" "$ws13/csa/indexer_ref_L1.npy" "$BIN/ws13_ix.bin" >/dev/null 2>&1 \
+           && "$PYTHON" Testing/cmp_deepseek_v4_indexer_scores.py "$ws13/csa" "$BIN/ws13_ix.bin" --layer 1 --tol 1e-6 >/dev/null 2>&1; then
+            echo "✓ ws13 indexer scores (<=1e-6 + order-independent selection validity)"
+        else echo "✗ ws13 indexer scores: mismatch"; fail=$((fail+1)); fi
+    else
+        echo "  - ws13 python gates skipped (no numpy in $PYTHON)"
+    fi
+else
+    echo "  - ws13: fixtures absent, skipped (PYTHON=<torch env> Testing/make_ws13_fixtures.sh)"
 fi
 
 # ── GLM-MoE-DSA gate (mini fixture, HF safetensors oracle) ──

--- a/docs/research/deepseek-v4-flash-reverse-engineering.md
+++ b/docs/research/deepseek-v4-flash-reverse-engineering.md
@@ -1,5 +1,30 @@
 # DeepSeek V4 Flash Reverse Engineering Report
 
+> ### ⚠ SUPERSEDED — read before using this report (dated 2026-09-12, agent-d4ff3d)
+>
+> **The architecture section below describes the FICTIONAL V4 design.** `include/deepseek_v4.h` states it
+> plainly: the previous implementation "was written against a fictional design (MLA + `kv_lora_rank` + a
+> 4x4 mHC mix matrix) that does not exist in V4", and the real architecture was written 2026-08-16 against
+> `modeling_deepseek_v4.py` 5.14 — shared-KV MQA (`q_a`/`q_a_norm`/`q_b`, one KV head with K=V,
+> per-head sinks, grouped `o_a`/`o_b`), mHC hyper-connections with Sinkhorn-Knopp, hash/top-k MoE, and
+> **per-layer CSA/HCA compressors + a Lightning Indexer** (which this report's "TODO — GPU path" mentions
+> but which the report's own layer list does not describe).
+>
+> **Two claims below are contradicted by the tree today:**
+>
+> 1. The "Done" checklist says `src/deepseek_v4.cpp` contains a **GGUF loader** (with FP4 dequant). It does
+>    not: the loader is **HF-safetensors-only**, and GGUF `blk.*` aliases are explicitly *not* handled
+>    (`include/deepseek_v4.h`). That work is P1.2 in `research/ws13-arch-gap-closure/` and is still open.
+> 2. The `blk.*` **tensor-name table is hypothetical** (the report says so itself, in its own words) and was
+>    never verified against a real GGUF. **Do not implement against it.** The authoritative names are the
+>    published checkpoint's (`model.safetensors.index.json`, inventoried in `Testing/arch-gaps.md` and the
+>    ws13 `FINDINGS.md`) plus the transformers reference's module names, mapped in
+>    `research/ws13-arch-gap-closure/SPEC-v41-modules.md` §1.
+>
+> Kept for the historical record — the quantisation notes (fp8/FP4, `ue8m0` block scales) are still useful;
+> the layout and the `blk.*` names are not. Verified state of the V4 path: ws13 `FINDINGS.md`
+> (per-layer gate 7.451e-09, compressor + indexer implemented, GGUF/fp8 loading still to do).
+
 **Model**: DeepSeek-V4-Flash-0731 (284B total / 13B active parameters)
 **Source**: https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
 **Release**: July 31, 2026 · MIT license · ~166.9 GB weights

--- a/include/deepseek_v4.h
+++ b/include/deepseek_v4.h
@@ -153,17 +153,61 @@ struct DeepSeekV4Model {
     void clear();
 };
 
+// Compressor state/params are needed by the KV cache below, which holds one
+// state per layer for the layer's own compressor and (CSA) the indexer's.
+struct DeepSeekV4CompState {
+    bool inited = false;
+    int n_buf = 0;              // tokens buffered toward the current window
+    int n_entries = 0;          // entries emitted so far
+    std::vector<float> buf_kv;  // [rate * series*hd] pending rows
+    std::vector<float> buf_gate;
+    std::vector<float> prev_ca, prev_ca_gate;  // previous window's Ca (CSA only)
+    std::vector<float> entries;  // [n_entries * hd], emitted in order
+    void init(int rate, int series, int hd) {
+        const size_t rows = (size_t)(rate > 0 ? rate : 1) * series * hd;
+        buf_kv.assign(rows, 0.0f);
+        buf_gate.assign(rows, 0.0f);
+        prev_ca.assign((size_t)(rate > 0 ? rate : 1) * hd, 0.0f);
+        prev_ca_gate.assign((size_t)(rate > 0 ? rate : 1) * hd, -INFINITY);
+        entries.clear();
+        n_buf = 0;
+        n_entries = 0;
+        inited = true;
+    }
+};
+
+// The compressor's weights, so the SAME state machine serves both the outer
+// compressor (head_dim) and the indexer's own compression (index_head_dim) —
+// they differ only in weights, width and series count.
+struct DeepSeekV4CompParams {
+    const float* kv = nullptr;        // [series*hd, H]
+    const float* gate = nullptr;      // [series*hd, H]
+    const float* pos_bias = nullptr;  // [rate, series*hd]
+    const float* norm = nullptr;      // [hd]
+    int series = 1;
+    int hd = 0;
+};
+
+
 // ─── KV cache ─────────────────────────────────────────────────────────────────
 struct DeepSeekV4KVCache {
     // per layer: rolling buffer [max_slots, head_dim]; single KV head, K=V
     std::vector<std::vector<float>> kv;
     int head_dim = 0;
     int max_slots = 0;
+    // per-layer compressor state (the layer's own, and — CSA only — the indexer's)
+    std::vector<DeepSeekV4CompState> cp, ix;
     void init(int n_layers, int max_seq, int hd) {
         head_dim = hd; max_slots = max_seq;
         kv.assign(n_layers, std::vector<float>((size_t)max_seq * hd, 0.0f));
+        cp.assign(n_layers, DeepSeekV4CompState());
+        ix.assign(n_layers, DeepSeekV4CompState());
     }
-    void clear() { for (auto& l : kv) std::fill(l.begin(), l.end(), 0.0f); }
+    void clear() {
+        for (auto& l : kv) std::fill(l.begin(), l.end(), 0.0f);
+        for (auto& s : cp) { s.entries.clear(); s.n_buf = 0; s.n_entries = 0; s.inited = false; }
+        for (auto& s : ix) { s.entries.clear(); s.n_buf = 0; s.n_entries = 0; s.inited = false; }
+    }
 };
 
 // ─── mHC state (hc_mult parallel streams) ─────────────────────────────────────
@@ -184,24 +228,12 @@ struct DeepSeekV4mHCState {
 // (`store_compression_weights` -> usable prefix -> one entry, Ca carried over in
 // `overlap_kv`). Both must produce the same entries; the incremental one is what
 // the attention path will consume (gated by cmp_deepseek_v4_compressor_incremental).
-struct DeepSeekV4CompState {
-    int n_buf = 0;              // tokens buffered toward the current window
-    int n_entries = 0;          // entries emitted so far
-    std::vector<float> buf_kv;  // [rate * series*hd] pending rows
-    std::vector<float> buf_gate;
-    std::vector<float> prev_ca, prev_ca_gate;  // previous window's Ca (CSA only)
-    std::vector<float> entries;  // [n_entries * hd], emitted in order
-    void init(int rate, int series, int hd) {
-        const size_t rows = (size_t)(rate > 0 ? rate : 1) * series * hd;
-        buf_kv.assign(rows, 0.0f);
-        buf_gate.assign(rows, 0.0f);
-        prev_ca.assign((size_t)(rate > 0 ? rate : 1) * hd, 0.0f);
-        prev_ca_gate.assign((size_t)(rate > 0 ? rate : 1) * hd, -INFINITY);
-        entries.clear();
-        n_buf = 0;
-        n_entries = 0;
-    }
-};
+// Feed one token through a parameterised compressor state.
+bool deepseek_v4_compressor_step_p(const DeepSeekV4CompParams& p, const DeepSeekV4Config& cfg,
+                                   int rate, const float* x_token, DeepSeekV4CompState& st);
+
+// Compressor params for a layer's Lightning Indexer (CSA layers only).
+DeepSeekV4CompParams deepseek_v4_indexer_comp_params(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg);
 
 // Feed one token (its collapsed attention-site hidden vector `x_token` [H]).
 // Returns true when this token completed a window and appended an entry.
@@ -240,6 +272,8 @@ std::vector<int> deepseek_v4_indexer_topk(const DeepSeekV4Layer& l, const DeepSe
 std::vector<float> deepseek_v4_forward(DeepSeekV4Model& model, int token_id,
                                        DeepSeekV4KVCache& kv_cache,
                                        DeepSeekV4mHCState& mhc, int& pos,
-                                       std::vector<float>* layer_states = nullptr);
+                                       std::vector<float>* layer_states = nullptr,
+                                       const int* index_override = nullptr,
+                                       int index_override_k = 0);
 
 #endif

--- a/include/deepseek_v4.h
+++ b/include/deepseek_v4.h
@@ -176,18 +176,38 @@ struct DeepSeekV4mHCState {
 };
 
 // ─── Compressor (CSA/HCA) ─────────────────────────────────────────────────────
-// Window-batched compressor forward, reproducing the reference exactly:
-//   kv   = x @ kv_proj^T                 [T, 2*head_dim]
-//   gate = x @ gate_proj^T + position_bias
-//   per window w: for CSA the slots are [previous window's Ca | this window's
-//   Cb] over 2*rate rows (Ca = columns [0,head_dim), Cb = [head_dim,2*head_dim));
-//   HCA is single-series and has no overlap — just this window's `rate` rows
-//   (measured: the HCA checkpoint tensors are [head_dim, H], half the CSA width).
-//   Slot weights are softmax(gate) per column; window 0's Ca half is kv=0,
-//   gate=-inf (softmax weight 0); then RMSNorm and the "compress" RoPE at
-//   position w*rate.
-// `x` is [T, H] — the COLLAPSED attention-site input, not the mHC streams.
-// Returns [n_win][head_dim], n_win = T / rate (0 when rate <= 0 or T < rate).
+// NOTE ON THE TWO ENTRY POINTS: `deepseek_v4_compressor_forward` below is the
+// window-batched form used by the P1.1 stage-1 gate (it matches the reference's
+// single full-sequence forward). Decoding needs the *incremental* form:
+// `deepseek_v4_compressor_step` buffers one token at a time and emits an entry
+// the moment the window fills, exactly as the reference's cache does
+// (`store_compression_weights` -> usable prefix -> one entry, Ca carried over in
+// `overlap_kv`). Both must produce the same entries; the incremental one is what
+// the attention path will consume (gated by cmp_deepseek_v4_compressor_incremental).
+struct DeepSeekV4CompState {
+    int n_buf = 0;              // tokens buffered toward the current window
+    int n_entries = 0;          // entries emitted so far
+    std::vector<float> buf_kv;  // [rate * series*hd] pending rows
+    std::vector<float> buf_gate;
+    std::vector<float> prev_ca, prev_ca_gate;  // previous window's Ca (CSA only)
+    std::vector<float> entries;  // [n_entries * hd], emitted in order
+    void init(int rate, int series, int hd) {
+        const size_t rows = (size_t)(rate > 0 ? rate : 1) * series * hd;
+        buf_kv.assign(rows, 0.0f);
+        buf_gate.assign(rows, 0.0f);
+        prev_ca.assign((size_t)(rate > 0 ? rate : 1) * hd, 0.0f);
+        prev_ca_gate.assign((size_t)(rate > 0 ? rate : 1) * hd, -INFINITY);
+        entries.clear();
+        n_buf = 0;
+        n_entries = 0;
+    }
+};
+
+// Feed one token (its collapsed attention-site hidden vector `x_token` [H]).
+// Returns true when this token completed a window and appended an entry.
+bool deepseek_v4_compressor_step(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg, int rate,
+                                 const float* x_token, DeepSeekV4CompState& st);
+
 std::vector<float> deepseek_v4_compressor_forward(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg,
                                                   int rate, const std::vector<float>& x, int T);
 

--- a/include/deepseek_v4.h
+++ b/include/deepseek_v4.h
@@ -86,6 +86,10 @@ struct DeepSeekV4Config {
     // fixture naming) or implied by `compress_ratios` (checkpoint naming).
     int csa_rate = 4;
     int hca_rate = 128;
+    // Indexer dims (Lightning Indexer; CSA only).
+    int index_n_heads = 64;
+    int index_head_dim = 128;
+    int index_topk = 512;
 };
 
 // ─── Weights ──────────────────────────────────────────────────────────────────
@@ -121,6 +125,17 @@ struct DeepSeekV4Layer {
     std::vector<float> cp_gate;      // gate_proj.weight  [cp_series*head_dim, H]
     std::vector<float> cp_pos_bias;  // position_bias     [cp_rate, cp_series*head_dim]
     std::vector<float> cp_norm;      // kv_norm.weight    [head_dim]
+    // ── Lightning Indexer (CSA layers only) ───────────────────────────────────
+    // Its own compressor at index_head_dim (2 series), a query projection off
+    // q_residual, and a ReLU-weighted head sum that ranks compressed entries.
+    int ix_heads = 0;                // index_n_heads (0 = no indexer)
+    int ix_hd = 0;                   // index_head_dim
+    int ix_topk = 0;                 // index_topk
+    std::vector<float> ix_kv, ix_gate;  // [2*ix_hd, H]
+    std::vector<float> ix_pos_bias;     // [cp_rate, 2*ix_hd]
+    std::vector<float> ix_norm;         // [ix_hd]
+    std::vector<float> ix_qb;           // [ix_heads*ix_hd, q_lora_rank]
+    std::vector<float> ix_wproj;        // [ix_heads, H]
 };
 
 struct DeepSeekV4Model {
@@ -175,6 +190,24 @@ struct DeepSeekV4mHCState {
 // Returns [n_win][head_dim], n_win = T / rate (0 when rate <= 0 or T < rate).
 std::vector<float> deepseek_v4_compressor_forward(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg,
                                                   int rate, const std::vector<float>& x, int T);
+
+// Indexer top-k for one CSA layer (batched prefill, positions 0..T-1): the
+// indexer compresses with its own weights at `index_head_dim`, scores each
+// query against those entries as `sum_h relu(q_h . K) * w_h` (both scaled),
+// masks entries past the query's causal threshold, and keeps `index_topk` of
+// them. Returns [T][k] entry indices; -1 marks a pick the query may not use
+// (fewer than k entries are ready) — the reference's sentinel, which the
+// attention path must treat as "not selected".
+// The gate-able half: the score table [T][n_win], exactly as the reference's
+// scorer returns it (before the causal mask / sentinel).
+std::vector<float> deepseek_v4_indexer_scores(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg,
+                                             int rate, const std::vector<float>& x, int T);
+
+// The selection half: the causal mask + top-k with the reference's `-1` sentinel.
+// Ties make the *order* implementation-defined (see the .cpp note), so index
+// equality is not a valid gate — the score table above is.
+std::vector<int> deepseek_v4_indexer_topk(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg,
+                                          int rate, const std::vector<float>& x, int T);
 
 // ─── Forward ──────────────────────────────────────────────────────────────────
 // One token. Returns logits [vocab]. kv_cache + mhc updated in place.

--- a/include/deepseek_v4.h
+++ b/include/deepseek_v4.h
@@ -147,8 +147,15 @@ struct DeepSeekV4mHCState {
 
 // ─── Forward ──────────────────────────────────────────────────────────────────
 // One token. Returns logits [vocab]. kv_cache + mhc updated in place.
+//
+// `layer_states`, when non-null, receives the residual streams at every layer
+// boundary for this token: `num_layers` states of `hc_mult * hidden_size`
+// floats each ([hc][H] row-major). State i is the input to layer i — the same
+// tensor HF exposes as `hidden_states[i]` (its last entry, the collapsed and
+// normed output, has no stream equivalent and is covered by the logits gate).
 std::vector<float> deepseek_v4_forward(DeepSeekV4Model& model, int token_id,
                                        DeepSeekV4KVCache& kv_cache,
-                                       DeepSeekV4mHCState& mhc, int& pos);
+                                       DeepSeekV4mHCState& mhc, int& pos,
+                                       std::vector<float>* layer_states = nullptr);
 
 #endif

--- a/include/deepseek_v4.h
+++ b/include/deepseek_v4.h
@@ -82,6 +82,10 @@ struct DeepSeekV4Config {
     // Per-layer attention compress ratio (0 = sliding). Vector indexed by layer.
     std::vector<int> compress_ratios;
     std::vector<int> layer_attn_type;  // 0=sliding, 1=CSA(4), 2=HCA(128)
+    // Window widths per flavour. Parsed from `compress_rates` (transformers /
+    // fixture naming) or implied by `compress_ratios` (checkpoint naming).
+    int csa_rate = 4;
+    int hca_rate = 128;
 };
 
 // ─── Weights ──────────────────────────────────────────────────────────────────
@@ -106,6 +110,17 @@ struct DeepSeekV4Layer {
     std::vector<float> exp_down;       // [n_routed, H, moe_int]
     // shared expert (SwiGLU)
     std::vector<float> sh_gate, sh_up, sh_down;  // [moe_int, H], [moe_int, H], [H, moe_int]
+    // ── compressor (CSA/HCA); empty on sliding layers ─────────────────────────
+    // The compressor pools every `cp_rate` tokens: softmax(gate + position_bias)
+    // over the 2*rate Ca/Cb slots (two series, stride `rate`), RMSNorm, then the
+    // "compress" RoPE at positions w*rate. See the reference
+    // DeepseekV4CSACompressor / DeepseekV4HCACompressor (transformers 5.16.1).
+    int cp_rate = 0;                 // 0 = this layer has no compressor
+    int cp_series = 1;               // 1 = HCA (single series), 2 = CSA (Ca/Cb overlap)
+    std::vector<float> cp_kv;        // kv_proj.weight    [cp_series*head_dim, H]
+    std::vector<float> cp_gate;      // gate_proj.weight  [cp_series*head_dim, H]
+    std::vector<float> cp_pos_bias;  // position_bias     [cp_rate, cp_series*head_dim]
+    std::vector<float> cp_norm;      // kv_norm.weight    [head_dim]
 };
 
 struct DeepSeekV4Model {
@@ -144,6 +159,22 @@ struct DeepSeekV4mHCState {
     void set_embed(const float* e) { for (int k = 0; k < hc; k++) std::copy(e, e + H, streams[k].begin()); }
     const float* current() const { return streams[0].data(); }
 };
+
+// ─── Compressor (CSA/HCA) ─────────────────────────────────────────────────────
+// Window-batched compressor forward, reproducing the reference exactly:
+//   kv   = x @ kv_proj^T                 [T, 2*head_dim]
+//   gate = x @ gate_proj^T + position_bias
+//   per window w: for CSA the slots are [previous window's Ca | this window's
+//   Cb] over 2*rate rows (Ca = columns [0,head_dim), Cb = [head_dim,2*head_dim));
+//   HCA is single-series and has no overlap — just this window's `rate` rows
+//   (measured: the HCA checkpoint tensors are [head_dim, H], half the CSA width).
+//   Slot weights are softmax(gate) per column; window 0's Ca half is kv=0,
+//   gate=-inf (softmax weight 0); then RMSNorm and the "compress" RoPE at
+//   position w*rate.
+// `x` is [T, H] — the COLLAPSED attention-site input, not the mHC streams.
+// Returns [n_win][head_dim], n_win = T / rate (0 when rate <= 0 or T < rate).
+std::vector<float> deepseek_v4_compressor_forward(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg,
+                                                  int rate, const std::vector<float>& x, int T);
 
 // ─── Forward ──────────────────────────────────────────────────────────────────
 // One token. Returns logits [vocab]. kv_cache + mhc updated in place.

--- a/include/deepseek_v4.h
+++ b/include/deepseek_v4.h
@@ -272,8 +272,6 @@ std::vector<int> deepseek_v4_indexer_topk(const DeepSeekV4Layer& l, const DeepSe
 std::vector<float> deepseek_v4_forward(DeepSeekV4Model& model, int token_id,
                                        DeepSeekV4KVCache& kv_cache,
                                        DeepSeekV4mHCState& mhc, int& pos,
-                                       std::vector<float>* layer_states = nullptr,
-                                       const int* index_override = nullptr,
-                                       int index_override_k = 0);
+                                       std::vector<float>* layer_states = nullptr);
 
 #endif

--- a/research/PLAN.md
+++ b/research/PLAN.md
@@ -36,10 +36,11 @@ WS-00 Baseline & measurement ── feeds every validation below
    ├─► WS-07 MoE decode & spec (DraftExpert, PagedWeight, AngelSpec)
    ├─► WS-08 MLA + KV cache (QK-Normed MLA, JoLT, Lynx) — P0 gauge probe DONE
    ├─► WS-09 Router unification (DOPS)
-   └─► WS-10 Metal/M5 + MLIR toolchain (BaseRT, AIE4ML)
+   ├─► WS-10 Metal/M5 + MLIR toolchain (BaseRT, AIE4ML)
+   └─► WS-13 Arch-gap closure (DeepSeek V4/V4.1 + Mamba-3) — scoped, no papers
 ```
 
-Dependencies: WS-01 needs P0.5 → WS-02/03 need the 40-column decision (P0.3) + WS-00 harness → WS-05 P1 needs ppl harness (WS-00) → WS-07 needs the router decision (P0.2) → WS-09 is P0.2's follow-through.
+Dependencies: WS-01 needs P0.5 → WS-02/03 need the 40-column decision (P0.3) + WS-00 harness → WS-05 P1 needs ppl harness (WS-00) → WS-07 needs the router decision (P0.2) → WS-09 is P0.2's follow-through → WS-13 P1 takes its weight path from WS-07/WS-11 and its format from WS-05.
 
 ---
 

--- a/research/README.md
+++ b/research/README.md
@@ -9,7 +9,7 @@ research/
 ├── TRACKING.md      ← status tables (single source of truth for progress)
 ├── new-workstream.sh ← scaffold a new workstream from the template
 ├── templates/workstream/
-└── ws00..ws12/      ← one folder per workstream (README = goal/tasks/validation, FINDINGS = results)
+└── ws00..ws13/      ← one folder per workstream (README = goal/tasks/validation, FINDINGS = results)
 
 ⚠ THIS DIRECTORY WAS WIPED ONCE (2026-07-31) BY AN UNKNOWN PROCESS and recreated.
   It is now git-tracked. Mirror: ~/research-papers/backup/ — keep it in sync.

--- a/research/TRACKING.md
+++ b/research/TRACKING.md
@@ -27,7 +27,7 @@
 | WS-08 | MLA & KV cache | 🔄 | 🔲 | 🔲 | gauge probe done; QK-normed MLA next |
 | WS-09 | Router unification | 🔲 | 🔲 | 🔲 | gated on P0.2 |
 | WS-10 | Metal/M5 + MLIR toolchain | 🔲 | 🔲 | 🔲 | — |
-| WS-13 | Arch-gap closure (V4/V4.1, Mamba-3) | 🔲 | 🔲 | 🔲 | scoped 2026-09-12 — see ws13/README.md + Testing/arch-gaps.md |
+| WS-13 | Arch-gap closure (V4/V4.1, Mamba-3) | ✅ | 🔄 | 🔲 | P0 done (oracle ≤1e-8, compressor ≤5.4e-07, indexer ≤1.3e-08, compressed attention exact 7.451e-09, rope-theta control, shape-agnostic 1.080e-07); P1: GGUF route CLOSED (no V4 converter; no compressor/mhc tensors) → engine-native quantisation, real-checkpoint ingest open (WS-07/WS-11); P2: V4.1 modules + Mamba-3 specified, not implemented — ws13/FINDINGS.md + SPEC-v41-modules.md |
 | WS-12 | HRX/Loom platform transition | ✅ | 🔲 | 🔲 | re-vendored 7953d7f + native `HRX_GPU` backend + decode-time failover (commits 43b38b4e, cc4fd23d, 2026-08-29) |
 
 ## Task detail

--- a/research/TRACKING.md
+++ b/research/TRACKING.md
@@ -27,9 +27,15 @@
 | WS-08 | MLA & KV cache | 🔄 | 🔲 | 🔲 | gauge probe done; QK-normed MLA next |
 | WS-09 | Router unification | 🔲 | 🔲 | 🔲 | gated on P0.2 |
 | WS-10 | Metal/M5 + MLIR toolchain | 🔲 | 🔲 | 🔲 | — |
+| WS-13 | Arch-gap closure (V4/V4.1, Mamba-3) | 🔲 | 🔲 | 🔲 | scoped 2026-09-12 — see ws13/README.md + Testing/arch-gaps.md |
 | WS-12 | HRX/Loom platform transition | ✅ | 🔲 | 🔲 | re-vendored 7953d7f + native `HRX_GPU` backend + decode-time failover (commits 43b38b4e, cc4fd23d, 2026-08-29) |
 
 ## Task detail
+
+### ws13-arch-gap-closure
+- [ ] P0: tiny-config oracle (V4.1 + Qwen3Mamba3) + compressor/indexer maths spec + runtime-format decision
+- [ ] P1: CSA/HCA compressors + Lightning Indexer; shape-agnostic loader + GGUF aliases; real V4-Flash e2e identity gate
+- [ ] P2: V4.1 deltas (engram, gate.bias_vl, candidate blocks, MTP) · vision scope decision · Mamba-3 SSM lane
 
 ### ws12-hrx-loom
 - [x] P0: Re-vendor lemonade e1b31683 → 7953d7f (hrx backend arrives) — verified onebin registers `llamacpp-hrx` on gfx1151 (2026-08-29)

--- a/research/ws13-arch-gap-closure/FINDINGS.md
+++ b/research/ws13-arch-gap-closure/FINDINGS.md
@@ -367,3 +367,45 @@ now exercised**.
 With that, stage 3's own gates are: exact (≤1.9e-08) on rd-8 fixtures at the default `index_topk = 8`
 for **both** the sliding and compressed stacks, with the tie-driven selection difference documented as
 the only remaining, implementation-defined divergence.
+
+---
+
+# P1.2 scoping — the GGUF path, measured against the tree (and a trap defused)
+
+P1.2 is "GGUF `blk.*` aliases", i.e. running a real checkpoint from the quantized format the fleet
+actually uses. Scoped from the tree rather than assumed:
+
+* **The loader is HF-safetensors-only.** `src/deepseek_v4.cpp` maps `model.layers.N.*` names; the header
+  says GGUF aliases are not handled. GGUF `blk.*` handling for other architectures lives in the *backend*
+  files (`src/backend_generic.cpp`, `backend_hip_1bp.cpp`, `backend_mamba1.cpp`, …), not in a per-arch
+  loader, so there is nothing to extend — a V4 GGUF path is new code.
+* **The dequantisation primitives already exist**: `src/gguf_reader.cpp` carries llama.cpp-ported
+  `dequant_q4_0/q4_1/q5_0/…`. Reuse is possible; it is the *wiring plus metadata* that is missing.
+* **GGUF does not escape the residency problem.** A GGUF is quantized on disk but
+  `GgufReader::get_tensor_f32` materialises f32 — for the 284B/13B-active V4 class that is the same wall
+  as the fp8 checkpoint (166.9 GB on disk). So P1.2 alone does not produce a runnable real checkpoint;
+  P1.3 still needs WS-07/WS-11 staging. Worth stating because "serve it from GGUF" *sounds* like it
+  solves the memory limit and does not.
+* **The artifact that would have made this cheap is gone**: the 82.7 GB DeepSeek-V4-Flash IQ2XXS GGUF
+  that was on strixhalo is no longer there (only Zaya/Qwen GGUFs remain), so a real-checkpoint test needs
+  a download or a conversion.
+
+## Trap defused: `docs/research/deepseek-v4-flash-reverse-engineering.md`
+
+That report **describes the fictional V4 design** (MLA + `kv_lora_rank` + a 4×4 mHC mix matrix) — the
+very design `include/deepseek_v4.h` names as what the previous implementation got wrong — and its
+checklist claims as **done** a GGUF loader in `src/deepseek_v4.cpp` that does not exist. Its `blk.*`
+name table is marked hypothetical **by the report itself**. A correction is now at its head (dated,
+original kept) pointing at the authoritative sources; the quantisation notes stay useful, the layout and
+names do not. Anyone starting P1.2 from that file would have built the wrong loader.
+
+## Concrete P1.2/P1.3 task shape
+
+1. GGUF metadata → `DeepSeekV4Config` (arch `deepseek_v4`, hyperparameters, `compress_ratios`).
+2. `blk.N.*` → the layer fields of `DeepSeekV4Layer` **plus the compressor/indexer tensors** — note that
+   whether a converted GGUF even *contains* CSA/HCA compressor weights is unverified, and a conversion
+   that drops them makes compressed layers unrunnable. Verify against a real file's tensor list before
+   writing the map.
+3. Dequantisation wiring (reuse `gguf_reader`), with the f32-residency ceiling stated up front.
+4. Then P1.3 proper: the streamed, quantized path (WS-07/WS-11), where `ue8m0`/fp4 block scales are the
+   new loader requirement.

--- a/research/ws13-arch-gap-closure/FINDINGS.md
+++ b/research/ws13-arch-gap-closure/FINDINGS.md
@@ -206,3 +206,78 @@ the compressor maths is correct but is not yet wired into attention (that is sta
   end-to-end gate at state 2 (16/20 → ≥18/20) and the per-layer bound.
 * Then the same for a real checkpoint's `compress_ratios` + `*_source_layer_ids` (two-level candidate
   selection), which needs the per-layer source wiring described in `SPEC-v41-modules.md` §3.
+
+---
+
+# P1.1 stage 2 — the Lightning Indexer, and what it can be gated on (≤1.3e-8)
+
+**Implemented** (`deepseek_v4_indexer_scores` + `deepseek_v4_indexer_topk`): the indexer's own 2-series
+compression at `index_head_dim`, the query projection off `q_residual` with the compress-rope, the
+ReLU-weighted head sum `Σ_h relu(q_h·K) · w_h` (both scaled by `index_head_dim^-0.5` and
+`index_n_heads^-0.5`), the causal rule `s < (t+1)/rate`, and the reference's `-1` sentinel.
+
+| check | result |
+|---|---|
+| score table `[64,16]` vs the reference's own scorer | **max&#124;Δ&#124; = 1.304e-08**, mean 9.488e-10 → PASS |
+| selection validity (order-independent: every pick ≥ the k-th best visible score) | **PASS** |
+| index rows differing in content | 7, **all tie-explained, 0 unexplained** |
+| index rows differing only in the ORDER of equal-scored entries | 57 of 64 |
+
+**The finding that shaped the gate: the indexer cannot be gated on its indices.** The scorer applies
+`ReLU` per head before summing, so **26.5 % of the fixture's scores are exactly 0.0**; `torch.topk`'s
+order among tied entries — and sometimes *which* tied entry takes the k-th slot — is
+implementation-defined. An index-equality gate would therefore fail a correct implementation, which is
+exactly what the first run showed (463/512, first mismatch at token 18 slot 2 between two entries that
+both score 0.0). `Testing/cmp_deepseek_v4_indexer.cpp` now prints that comparison as **ADVISORY and exits
+0**; the gate is `Testing/cmp_deepseek_v4_indexer_scores.py` (score table + order-independent selection
+validity). Generalisable form: *gate the continuous quantity, not the argmax-derived artefact, when the
+argmax has ties.*
+
+Note the scores can be NEGATIVE (the head weights are signed), so "zero fraction" above is about the
+per-head `relu` zeroing dots, not the summed score; the ties come from every head's dot being negative.
+
+## Still open in P1.1
+
+* **Stage 3 — attention integration**: concatenate the sliding window with the compressed entries, apply
+  the per-query block mask (HCA: causality; CSA: causality ∩ indexer validity), keep the per-head sinks,
+  and conjugate-rotate the output. This is what flips the end-to-end gate at state 2 (16/20 → ≥18/20)
+  and the per-layer bound, and it needs per-layer compressor/indexer *incremental state* (a pending
+  partial window + the previous window's Ca slice + the emitted entries), which is the substantive part
+  of the work.
+
+---
+
+# P1.1 stage 3 (prep) — the incremental compressor state, and a sliding-window control
+
+**Decoding never gets a batch.** Stage 1's compressor gate runs on a full-sequence call; a token-at-a-time
+decode must buffer a partial window and emit an entry the moment the window fills — the same thing the
+reference's own cache does (`store_compression_weights` → usable prefix → emit, with Ca carried in
+`overlap_kv`). `deepseek_v4_compressor_step` + `DeepSeekV4CompState` implement that, and
+`Testing/cmp_deepseek_v4_compressor_incremental.cpp` feeds the fixture's prompt **token by token** and
+compares the emitted entries with the *batched* reference file — i.e. it proves the state machine
+reproduces the full-sequence reference, which is exactly what stage 3 needs.
+
+| layer | rate / series | tokens | entries | incremental vs batched reference |
+|---|---|---|---|---|
+| CSA L1 | 4 / 2 | 64 | 16 | **max&#124;Δ&#124; = 4.768e-07** PASS |
+| HCA L2 | 128 / 1 | 160 | 1 | **max&#124;Δ&#124; = 5.364e-07** PASS |
+
+**Control: the sliding path under real truncation.** Every previous sliding validation used a window
+larger than the prompt (32 / 5 tokens), so the window never truncated and the semantics were untested
+where they would matter most for the compressed fixture. An all-sliding fixture with **window 4 and 64
+tokens** now checks it: end-to-end **20/20** (top1 296 = 296) and per-layer worst **1.304e-08** → PASS.
+So the base attention (truncation, sinks, softmax scale, conjugate output rotation) is correct *with
+truncation*, and any remaining divergence on the compressed fixture is attributable to the
+compressor/indexer integration rather than to the sliding base.
+
+## What remains in stage 3
+
+1. **Attention concatenation** per compressed layer: `kv = [sliding window | compressed entries]`, then
+   the per-query mask over the compressed slots (HCA: causality only; CSA: causality ∩ indexer
+   validity), with the per-head sinks and the conjugate rotation already in place.
+2. **The indexer's incremental state**: its compression is structurally the same 2-series machine
+   (at `index_head_dim`), so it should reuse `DeepSeekV4CompState` parameterised by the indexer's
+   weights rather than a second copy — plus the per-token selection (top-k over the entries visible at
+   that query, `index_topk`, `-1` below the causal threshold).
+3. Then the end-to-end gate at state 2 should flip (16/20 → ≥18/20) and the per-layer bound should hold
+   at 1e-6 — with the *scores* gate (not the index order) as the indexer's own check.

--- a/research/ws13-arch-gap-closure/FINDINGS.md
+++ b/research/ws13-arch-gap-closure/FINDINGS.md
@@ -1,0 +1,55 @@
+# ws13 FINDINGS — Phase 0: the oracle exists, and the gate can fail
+
+**Date:** 2026-09-12 · **Box:** ryzen · **Env:** `~/ft-zaya/bin/python` — transformers **5.16.1**, torch 2.9.0+rocm6.4
+**Instrument:** `Testing/make_mini_deepseek_v41.py` (new) + the existing `Testing/cmp_deepseek_v4.cpp` comparator, **unmodified**.
+
+## 1. What the reference can and cannot give us
+
+`transformers` 5.16.1 ships native `DeepseekV4` — **including** `compressed_sparse_attention` (CSA) / `heavily_compressed_attention` (HCA) layer types, `compress_rates`, and `DeepseekV4CSACache`, which carries the `"indexer"` entries. So the executable reference **implements exactly the machinery the engine is missing** (P1 no longer needs to source an oracle).
+
+It does **not** know V4.1: no `DeepseekV41*` class and no `deepseek_v41` in `AutoConfig`'s `CONFIG_MAPPING`. Consequences recorded for planning:
+
+* V4.1-only modules (`engram`, `candidate_*`, `ffn.gate.bias_vl`, the MTP rewrite) have **no** transformers reference. Their authority is DeepSeek's own inference code — `inference/engram.py`, `inference/model.py`, `inference/vision.py` in `deepseek-ai/DeepSeek-V4.1-Flash` (fetched, not yet read → P0.2).
+* The old `~/models/venv-zaya` interpreter used by `make_mini_deepseek_v4.py` is **gone from both boxes**; the instrument now runs on the surviving `ft-zaya` venv. The generator also no longer hardcodes a site-packages path.
+
+## 2. Measured gates
+
+Commands (from the repo root, `g++ -std=c++17 -Iinclude -Isrc -O2` — the `run_all.sh` line, unchanged):
+
+```
+python3 Testing/make_mini_deepseek_v41.py /tmp/onebit-dsv41-ssl    --profile sliding
+python3 Testing/make_mini_deepseek_v41.py /tmp/onebit-dsv41-csa64  --profile compressed --prompt-len 64
+python3 Testing/make_mini_deepseek_v41.py /tmp/onebit-dsv41-hca160 --profile compressed --prompt-len 160
+/tmp/cmp_dsv4 <fixture-dir> <fixture-dir>/ids.txt <fixture-dir>/logits_last.npy 20 18
+```
+
+| fixture | layer types | window / prompt | compressor entries | engine vs reference | exit |
+|---|---|---|---|---|---|
+| `ssl` | 4 × sliding | 32 / 5 | 0 | top1 **342 = 342**, overlap **20/20** | 0 **PASS** |
+| `csa64` | sliding, CSA, HCA, sliding | **4** / 64 | CSA 16 | top1 534 ≠ **685**, overlap **16/20** | 1 FAIL |
+| `hca160` | sliding, CSA, HCA, sliding | **4** / 160 | CSA 40 + HCA 1 | top1 301 ≠ **207**, overlap **14/20** | 1 FAIL |
+
+`(need 18)` is the comparator's threshold. `top1=342` on the sliding profile **reproduces the 2026-08-16 mini-gate exactly** ("mini-gate top1 342 == HF, 20/20"), so the generalized generator is faithful to the original fixture.
+
+**The instrument has the property that matters: it is green on the modules that exist and red on the ones that do not.** The divergence grows with how much the compressor matters (0 entries → 20/20; 16 → 16/20; 40+1 → 14/20), which is what a sensitive gate looks like.
+
+## 3. Traps found (each cost a wrong result before it was measured)
+
+1. **A gate that cannot fail is not a gate.** The first compressed fixture used `sliding_window=32` with a 5-token prompt: the compressed entry was redundant with the sliding window and the **engine PASSED the compressed profile** (top1 390 = 390, 18/20). The fixture was blind to the very mechanism it existed to test. Fixed by making the compressed branch load-bearing (`--window 4`, prompt ≈ 16 × rate). *The reference emits one entry per window of `compress_rate` tokens, so the fixture must be longer than the rate and its window smaller than its prompt.*
+2. **The compress rate is baked into the tensors.** `compressor.position_bias` is shaped `[compress_rate, dim]` (`[4,32]` CSA, `[128,16]` HCA here), so a same-weights ablation by changing the rate is **impossible** (`load_state_dict` shape mismatch). A real loader must read `compress_ratios` from the checkpoint/config rather than assume a default, and the fixture's rate is part of its identity.
+3. **The reference and the published checkpoint disagree on names for the same maths.** transformers nests `self_attn.compressor.{kv_proj,gate_proj,kv_norm,position_bias}` and `self_attn.compressor.indexer.{kv_proj,gate_proj,kv_norm,q_b_proj,position_bias,scorer.weights_proj}`. The published V4-Flash/V4.1 **checkpoint** uses `attn.compressor.{wgate,wkv,norm,ape}` and a separate `attn.indexer.{wq_b,wk_b?,weights_proj,...}`. P1.1 needs an explicit name map, and the maths must be read against the checkpoint names while being validated against the executable one.
+4. **HCA is barely covered.** With rate 128 it emits nothing until the prompt exceeds 128 tokens (1 entry at 160). A CSA-only fixture would silently leave the HCA branch untested — the same blindness as trap 1, one level up. `hca160` exists for this reason; a dedicated HCA-sensitive fixture (smaller HCA rate) is still owed.
+
+## 4. Status against the ws13 plan
+
+* **P0.1 — partially done.** The existing modules reproduce the reference on the sliding profile (20/20, top1 identical), and the reference now writes per-layer `hidden_states.npz`. The stated acceptance (≤1e-6 **per layer**) is *not yet measurable*: the engine side has no per-layer dump — `cmp_deepseek_v4.cpp` compares final logits only. Next instrument step: make the comparator (or a sibling) write engine hidden states so the bound can be taken layer by layer.
+* **P0.2 — not started.** Read DeepSeek's `inference/model.py` + `inference/engram.py` for the maths of CSA/HCA/indexer and the V4.1-only modules (no transformers reference exists).
+* **P0.3 — not started** (runtime format for real checkpoints: fp8 / GGUF / Q4NX / 1BP).
+* **P0.4 — not started** (Mamba-3 oracle).
+* **P1.1 — has its gate.** `hca160` (and `csa64`) are the fixtures the compressor + indexer implementation must flip to PASS, with `hidden_states.npz` to find the first diverging layer instead of guessing from logits.
+
+## 5. Notes for whoever picks this up
+
+* Fixtures are cheap and deterministic (`--seed 0`, ~4×10⁵ params, seconds to build) and live in `/tmp`; regenerate them on demand rather than committing model weights.
+* `Testing/run_all.sh` currently *skips* the V4 gate when the fixture is absent — it must stay that way: `hca160`/`csa64` are **expected-fail** fixtures, so wiring them into the suite as pass/fail would make the suite red by design until P1.1 lands. Add them as a separate, explicitly-expected-red gate when P1.1 starts.
+* The thin logits-overlap margin (16/20 against a threshold of 18) is a deliberate *fixture* property, not a robust metric — prefer the per-layer dumps for P1.1's acceptance and keep the logits overlap as a smoke signal.

--- a/research/ws13-arch-gap-closure/FINDINGS.md
+++ b/research/ws13-arch-gap-closure/FINDINGS.md
@@ -281,3 +281,49 @@ compressor/indexer integration rather than to the sliding base.
    that query, `index_topk`, `-1` below the causal threshold).
 3. Then the end-to-end gate at state 2 should flip (16/20 → ≥18/20) and the per-layer bound should hold
    at 1e-6 — with the *scores* gate (not the index order) as the indexer's own check.
+
+---
+
+# P1.1 stage 3 DONE — the compressed attention is integrated, and it is exact (7.5e-09 per layer)
+
+**What now runs in the engine**: for a layer with a compressor, each token (1) steps the compressor
+state and — CSA — the indexer's own compressor, (2) decides which compressed entries this query may see
+(HCA: causality; CSA: the indexer's top-k ∩ causality), (3) attends over `[sliding window | allowed
+compressed entries]` with the per-head sinks and the conjugate output rotation. Also fixed by reading
+the reference rather than guessing:
+
+* **the compressor/indexer are fed `input_layernorm(collapsed)`**, the attention's actual input — not
+  the raw mHC-collapsed vector. This was the big one: state 2 went from **3.997e-03 → 1.490e-08**;
+* **a per-layer rope theta**: `rope_layer_type = "main" if sliding_attention else "compress"`
+  (reference line 768), so a compressed layer ropes its queries, its sliding KV **and** the output
+  de-rotation with `compress_rope_theta`. Correct as fixed — but **not observable in these fixtures**,
+  because `qk_rope_head_dim = 2` has a single pair whose frequency is `theta^0 = 1` for any theta. A
+  fixture with a larger `partial_rotary_factor` is owed before this can be called validated.
+
+| run (fixture, 160 tokens, layer types sliding/CSA/HCA/sliding) | per-layer worst | end-to-end |
+|---|---|---|
+| before this stage | — | 16/20 (FAIL) |
+| integrated, `index_topk = 8` (config default) | 1.208e-02 (state 2) | **20/20 PASS** |
+| integrated, **`index_topk = 64`** (indexer keeps every causal entry) | **7.451e-09 — PASS** | PASS |
+| same, 64-token fixture with the reference's selection injected | 1.490e-08 (state 2) | PASS |
+
+**The remaining divergence is the indexer's tie-breaking, and that is now proven rather than assumed:**
+making the indexer non-selective (`index_topk = 64`) drives every layer to 7.451e-09, so the integration
+itself is exact; with `index_topk = 8` the only difference left is *which* of several exactly-equal
+scores wins the k-th slot. The reference ends in `torch.topk`, whose order among ties is
+implementation-defined (see the stage-2 finding: 26.5 % of fixture scores come from `relu`-zeroed dots,
+and 7 of 64 rows already differed only by ties). Reproducing that arbitrary order is neither achievable
+nor desirable; the defensible gates are the ones used here.
+
+## Instrument added
+
+`deepseek_v4_forward` gained an optional per-token index override (defaulted, so nothing else changes)
+and `cmp_deepseek_v4` a 7th argument to supply the reference's own index table — which is how "is the
+attention maths exact?" was separated from "does my top-k break ties the way torch does?". The generator
+gained `--index-topk` for the same reason.
+
+## New fixture limitation to close
+
+`qk_rope_head_dim = 2` in the tiny config means the compress-vs-main rope theta is unobservable (single
+pair, `freq = 1`). Regenerating with a larger `partial_rotary_factor` (e.g. 0.5 → `rd = 8`) would
+exercise it, and would also make the indexer's tie structure less degenerate. Worth doing before P1.3.

--- a/research/ws13-arch-gap-closure/FINDINGS.md
+++ b/research/ws13-arch-gap-closure/FINDINGS.md
@@ -300,12 +300,20 @@ the reference rather than guessing:
   because `qk_rope_head_dim = 2` has a single pair whose frequency is `theta^0 = 1` for any theta. A
   fixture with a larger `partial_rotary_factor` is owed before this can be called validated.
 
-| run (fixture, 160 tokens, layer types sliding/CSA/HCA/sliding) | per-layer worst | end-to-end |
+| run | per-layer worst | end-to-end |
 |---|---|---|
-| before this stage | — | 16/20 (FAIL) |
-| integrated, `index_topk = 8` (config default) | 1.208e-02 (state 2) | **20/20 PASS** |
-| integrated, **`index_topk = 64`** (indexer keeps every causal entry) | **7.451e-09 — PASS** | PASS |
-| same, 64-token fixture with the reference's selection injected | 1.490e-08 (state 2) | PASS |
+| **before** this stage (160-token fixture) | 1.208e-02 (state 2) | 16/20 FAIL |
+| integrated, 160-token fixture, `index_topk = 8` (default) | 1.523e-02 | top1 **207 = 207** but overlap 15/20 |
+| integrated, 160-token fixture, **`index_topk = 64`** (indexer keeps every causal entry) | **7.451e-09 — all four states PASS** | top1 117 = 117, 20/20 PASS |
+| integrated, 64-token fixture, `index_topk = 8` | 1.490e-08 (state 2) | top1 **685 = 685**, **20/20 PASS** |
+
+The `index_topk = 64` row is a **controlled comparison** — same weights, same config except the
+indexer's selectivity — and it is what proves the integration: when the selection cannot be contested
+by ties, every layer reproduces the reference to 7.451e-09. At the default `k = 8` the selection *is*
+contested: the stage-2 gate measured my index table differing from the reference's in content on 23 of
+160 rows (and 7 of 64), because `torch.topk`'s order among exactly-equal scores is
+implementation-defined. On the 64-token fixture that does not move the logits at all (top1 and top-20
+match); on the 160-token fixture top1 still matches but the top-20 ordering does not.
 
 **The remaining divergence is the indexer's tie-breaking, and that is now proven rather than assumed:**
 making the indexer non-selective (`index_topk = 64`) drives every layer to 7.451e-09, so the integration
@@ -315,12 +323,18 @@ implementation-defined (see the stage-2 finding: 26.5 % of fixture scores come f
 and 7 of 64 rows already differed only by ties). Reproducing that arbitrary order is neither achievable
 nor desirable; the defensible gates are the ones used here.
 
-## Instrument added
+## Instrument: `--index-topk` kept, an index-override **withdrawn**
 
-`deepseek_v4_forward` gained an optional per-token index override (defaulted, so nothing else changes)
-and `cmp_deepseek_v4` a 7th argument to supply the reference's own index table — which is how "is the
-attention maths exact?" was separated from "does my top-k break ties the way torch does?". The generator
-gained `--index-topk` for the same reason.
+`Testing/make_mini_deepseek_v41.py --index-topk N` is what produced the controlled comparison above and
+is the evidence for this stage.
+
+An attempt to isolate selection differently — an optional per-token **index override** on
+`deepseek_v4_forward` (inject the reference's own index table) plus a 7th `cmp_deepseek_v4` argument —
+was **withdrawn**: it behaved inconsistently, making an *exact* run worse (64-token fixture: 1.490e-08
+without it, 9.622e-03 with it, with the table bounds-checked and row-aligned). The cause was not found,
+and an instrument that can turn a passing run into a failing one without explanation is worse than no
+instrument, so the plumbing is gone rather than left in the tree. Recorded here so it is not
+re-derived; the controlled `--index-topk` comparison carries the claim instead.
 
 ## New fixture limitation to close
 

--- a/research/ws13-arch-gap-closure/FINDINGS.md
+++ b/research/ws13-arch-gap-closure/FINDINGS.md
@@ -120,3 +120,89 @@ exit 1. The `csa64`/`hca160` fixtures remain expected-fail by design and stay ou
 * **P0.2 — next** (read DeepSeek's `inference/engram.py` + `model.py` for the V4.1-only maths, which
   transformers cannot provide: no `DeepseekV41` class exists).
 * **P0.3, P0.4 — not started.**
+
+---
+
+# P0.3 — runtime format decision (in writing, as the plan requires)
+
+**Decision: P1's architecture work targets the HF safetensors names at whatever precision the
+checkpoint stores (fp8/f32) on *tiny fixtures*, and the real-checkpoint milestone (P1.3) is served from
+a quantized/streamed path owned by WS-05/WS-07/WS-11 — this workstream does not invent a format.**
+
+Evidence (all measured earlier in this file, plus a reader audit today):
+
+| fact | value |
+|---|---|
+| V4-Flash tensors / size | 69,187 / **159.6 GB** fp8 (e4m3, `ue8m0` block scales, block [128,128]) |
+| V4.1-Flash tensors / size | 96,085 / **510.3 GB** fp8 + `expert_dtype: fp4`, block [32,32] |
+| the V4 loader's precision | `get_tensor_f32` → every tensor resident as **f32** (~2 TB for V4.1) |
+| what the reader already accepts | `F32`, `F16`, `BF16`, **`F8_E4M3`**, **`F8_E5M2`** (so fp8 is readable, not the blocker) |
+| existing storage paths in-tree | `gguf_loader/reader` (incl. `IQ2_XXS`), `q4nx_reader`, `h1b_loader`, `safetensors_reader` |
+
+Consequences the plan must keep:
+
+1. **The blocker is residency, not parsing.** Since fp8 tensors already load, the honest statement is
+   "the engine can read the format and cannot hold the model": ~2 TB as f32 for V4.1.
+2. **Block scales are a new loader requirement.** The V4.1 checkpoint stores `ue8m0` block scales as
+   sibling tensors (`*.scale`, e.g. the engram embed's `weight`/`scale` pair and the experts'
+   `fp4` weights). The current fp8 path has no block-scale concept, so P1.1's loader work includes
+   reading `*.scale` alongside `*.weight` — and the compressor/indexer tensors are ordinary f32/dense,
+   so their maths can land before the quantized path does.
+3. **P1.3's target is a streamed, quantized checkpoint**, i.e. a consumer of WS-07 (expert staging /
+   PagedWeight) and WS-11 (NVMe→DRAM→SRAM tiering), with WS-05's 1BP v2 as a candidate wire format.
+   Trying to reach a real checkpoint by widening the f32 loader would be the wrong direction and is
+   explicitly out of scope here.
+4. **The oracle is unaffected by all of this**, which is why P0/P1 can proceed now: `transformers` runs
+   the fixture in fp32 and the gate is a numerical bound on the implementation, not on the format.
+
+---
+
+# P1.1 stage 1 — the compressor is implemented and gated (both flavours), ≤5.4e-7
+
+**Instrument:** `Testing/make_mini_deepseek_v41.py` now also captures the reference's **own compressor
+output** with a forward hook during a real HF forward (so the dump IS the reference's values, not a
+re-derivation) plus the **collapsed attention-site input** each compressor is fed, written as plain
+`.npy` (`comp_ref_L<N>.npy`, `attn_input_L<N>.npy`). `Testing/cmp_deepseek_v4_compressor.cpp` loads the
+engine's compressor for one layer and compares entry by entry.
+
+**Implemented** (`src/deepseek_v4.cpp` + `include/deepseek_v4.h`): per-layer compressor loading, and
+`deepseek_v4_compressor_forward` — window pooling with `softmax(gate + position_bias)` **per output
+column**, RMSNorm, then the "compress" RoPE (θ = `compress_rope_theta`) at position `w * rate`.
+
+| flavour | layer / fixture | entries | max&#124;Δ&#124; | rel | gate |
+|---|---|---|---|---|---|
+| **CSA** (2 series, Ca/Cb overlap) | L1, 64-token fixture | 16 | **4.768e-07** | 2.02e-07 | PASS |
+| **CSA** | L1, 160-token fixture | 40 | **4.768e-07** | 1.69e-07 | PASS |
+| **HCA** (1 series) | L2, 160-token fixture | 1 | **5.364e-07** | 2.84e-07 | PASS |
+
+Regression: with the loader change in, the sliding end-to-end gate is unchanged (20/20, top1 342, and
+per-layer worst 1.118e-08), and the compressed end-to-end gate still fails at **state 2** as designed —
+the compressor maths is correct but is not yet wired into attention (that is stage 3).
+
+## Findings from this stage
+
+1. **HCA is single-series and CSA is two-series — measured, not assumed.** The loader's first attempt
+   compared tensor widths and failed loudly: HCA's compressor tensors are `[head_dim, H]` and
+   `[rate, head_dim]`, exactly **half** the CSA width (`[2*head_dim, H]`, `[rate, 2*head_dim]`). This
+   matches the reference (`HCACompressor.kv_proj = Linear(H, head_dim)`, no Ca/Cb overlap) but the plan
+   had described the two-series layout as if it were shared. `cp_series` now carries the flavour
+   (1 = HCA, 2 = CSA) and the loader derives both the expected shapes and the branch.
+2. **The shared npy reader only parses the first shape entry.** `read_npy_f32` in
+   `Testing/cmp_deepseek_v4.cpp` computes the element count from the *first* number in the shape tuple —
+   fine for the 1-D logits it was written for, silently wrong for `[T,H]` (it read 64 of 4096 floats and
+   quietly reported `T=1`). The new harness has a reader that multiplies the whole tuple; any other
+   `cmp_*` gate that starts reading multi-dimensional npy files has the same latent trap.
+3. **The reference's own modules are the cheapest oracle** for intermediate values: no re-derivation, no
+   standalone-call semantics to argue about — a forward hook on the module during the real forward.
+
+## Still open in P1.1
+
+* **Stage 2 — the indexer**: its own compressor at `index_head_dim` (also 2-series, but with the
+  `2*head_dim` projection split into Ca/Cb at *index* head dim), `scorer = Σ_h w_{t,h}·ReLU(q_{t,h}·K_s)`,
+  `topk(index_topk)`, and the `-1` sentinel for queries whose causal threshold is below the candidate.
+* **Stage 3 — attention integration**: concatenate the sliding window with the compressed entries, apply
+  the per-query block mask (HCA: causality only; CSA: causality ∩ indexer validity), keep the per-head
+  sinks, and conjugate-rotate the output (K=V means V picked up rope). This is what flips the
+  end-to-end gate at state 2 (16/20 → ≥18/20) and the per-layer bound.
+* Then the same for a real checkpoint's `compress_ratios` + `*_source_layer_ids` (two-level candidate
+  selection), which needs the per-layer source wiring described in `SPEC-v41-modules.md` §3.

--- a/research/ws13-arch-gap-closure/FINDINGS.md
+++ b/research/ws13-arch-gap-closure/FINDINGS.md
@@ -341,3 +341,29 @@ re-derived; the controlled `--index-topk` comparison carries the claim instead.
 `qk_rope_head_dim = 2` in the tiny config means the compress-vs-main rope theta is unobservable (single
 pair, `freq = 1`). Regenerating with a larger `partial_rotary_factor` (e.g. 0.5 → `rd = 8`) would
 exercise it, and would also make the indexer's tie structure less degenerate. Worth doing before P1.3.
+
+---
+
+# P1.1 stage 3, validation closed — the per-layer rope theta is now observable and load-bearing
+
+The stage-3 write-up had to flag one fix as *correct but unobservable*: with `qk_rope_head_dim = 2`
+(head_dim 16 × 0.125) a head has a single rope pair whose frequency is `theta^0 = 1` for **any** theta,
+so `compress_rope_theta` vs `rope_theta` made no difference to the numbers. The generator now takes
+`--rope-frac`, which also rewrites the per-type `rope_parameters` entries the reference's rotary actually
+reads.
+
+With `--rope-frac 0.5` (rd = **8**, four pairs, so the frequency spread is real):
+
+| fixture | end-to-end | per-layer worst |
+|---|---|---|
+| sliding, window 32 / 5 tokens, rd 8 | top1 **306 = 306**, 20/20 | **1.490e-08** PASS |
+| compressed, window 4 / 64 tokens, rd 8 | top1 **699 = 699**, 20/20 | **1.863e-08** PASS (all four states) |
+
+**And the control that makes the claim:** rebuilding with the compressed layers forced back to the main
+theta — a one-off build, not committed — gives state 2 = **4.545e-03** and state 3 = 5.061e-03 (FAIL at
+1e-6), i.e. ~250 000× the error. So the theta rule is not merely present, it is **load-bearing and
+now exercised**.
+
+With that, stage 3's own gates are: exact (≤1.9e-08) on rd-8 fixtures at the default `index_topk = 8`
+for **both** the sliding and compressed stacks, with the tie-driven selection difference documented as
+the only remaining, implementation-defined divergence.

--- a/research/ws13-arch-gap-closure/FINDINGS.md
+++ b/research/ws13-arch-gap-closure/FINDINGS.md
@@ -409,3 +409,66 @@ names do not. Anyone starting P1.2 from that file would have built the wrong loa
 3. Dequantisation wiring (reuse `gguf_reader`), with the f32-residency ceiling stated up front.
 4. Then P1.3 proper: the streamed, quantized path (WS-07/WS-11), where `ue8m0`/fp4 block scales are the
    new loader requirement.
+
+---
+
+# P1.2 decision — GGUF is NOT the route, and the loader is shape-agnostic
+
+## The GGUF route is closed (with evidence), not deferred
+
+The P1.2 scoping left one question open — whether a converted GGUF even carries the CSA/HCA compressor
+weights. Answer, from the fork's own converter and tensor-mapping table
+(`bong-water-water-bong/llama.cpp`: `conversion/deepseek.py`, `gguf-py/gguf/tensor_mapping.py`):
+
+* the converter's newest DeepSeek class is **`DeepseekV32Model`** (DSA indexer: `index_n_heads`,
+  `index_head_dim`, `index_topk`) — there is **no V4 class**, and no `src/models/deepseek4.cpp` (the
+  reference to one in `include/deepseek_v4.h` is stale);
+* the mapping table knows the **DSA indexer** (`model.layers.{bid}.self_attn.indexer.{k_norm,weights_proj,wk,wq_b}`)
+  and `q_a_proj` (deepseek2) and `sinks` (openai-moe), but has **no `compressor`, `ape` or `mhc` entry**.
+
+So a llama.cpp-converted V4 GGUF cannot carry the compressed-attention tensors, which means the
+compressed layers would be unrunnable from it. **Decision: P1.3 goes engine-native — quantise from the
+published fp8 safetensors into the engine's own formats (WS-05 1BP v2 / Q4NX), with residency handled by
+WS-07/WS-11 staging and `ue8m0`/fp4 block scales as the new loader requirement.** Do not spend effort
+writing speculative `blk.*` aliases for a file that cannot exist yet.
+
+## The reference constrains the fixture: `rope_dim <= index_head_dim`
+
+A fixture with `head_dim 32 × factor 0.5 = rd 16` against `index_head_dim 8` makes the *reference itself*
+fail (`The size of tensor a (8) must match the size of tensor b (16)`) — the indexer ropes its 8-dim
+heads with a 16-channel cos/sin. A real config satisfies this (V4.1: 512 × 0.125 = 64 ≤ 128), and it is a
+useful sanity check to assert on a checkpoint before loading it.
+
+## Shape agnosticism — measured at non-default dimensions
+
+The V4.1 deltas are supposed to be **modules**, not dimensions, so the engine must work at shapes other
+than V4-Flash's. Fixture: H=**320**, 5 heads, head_dim 16, `q_lora`/`o_lora` 24, `o_groups` 4, 32 experts,
+`moe_int` 96, rd 8, window 4 / 64 tokens, layer types sliding/CSA/HCA/sliding:
+
+| fixture | end-to-end | per-layer worst |
+|---|---|---|
+| odd shape, `index_topk = 8` (ties in play) | top1 484 ≠ 733, overlap 14/20 | 1.720e-02 |
+| odd shape, **`index_topk = 64`** (non-selective) | top1 **733 = 733**, **20/20 PASS** | **1.080e-07 PASS** |
+
+The 1.080e-07 (vs 7.451e-09 at the V4-Flash shape) is the expected scale-up with larger dimensions, and
+it is inside the 1e-6 bound. **So the loader and the attention path are shape-agnostic; what V4.1 adds is
+the modules in `SPEC-v41-modules.md`, not new dimension handling.** (And the selective run's divergence is
+the already-documented indexer tie effect, which grows when there are more tied scores.)
+
+## Where the workstream stands
+
+**Done and validated**: gap evidence · oracle instrument (`≤1e-8` per layer on the modules that exist) ·
+the per-layer bound itself · compressor (CSA two-series + HCA single-series, batched **and** incremental,
+≤5.4e-07) · indexer (score table ≤1.3e-08 + order-independent selection validity) · compressed attention
+integration (**7.451e-09** with non-tied selection; exact on the default fixture for the 64-token case) ·
+per-layer rope theta (control: wrong theta → 4.545e-03) · shape agnosticism (1.080e-07 at non-default
+dims) · runtime-format decision · the GGUF-route decision.
+
+**Open, specified, not implemented**: the real-checkpoint ingest (block scales + streamed experts —
+WS-07/WS-11 surface) · the V4.1-only modules (engram, candidate blocks, `ffn.gate.bias_vl`, the MTP/DSpark
+head and the vision tower — `SPEC-v41-modules.md`) · the Mamba-3 lane (spec'd as a second lane, oracle
+not built).
+
+**Documented limitation, not a defect**: with the indexer at its configured `index_topk`, selection
+depends on `torch.topk`'s order among exactly-equal scores, which is implementation-defined; the
+integration is gated with a non-selective indexer for that reason.

--- a/research/ws13-arch-gap-closure/FINDINGS.md
+++ b/research/ws13-arch-gap-closure/FINDINGS.md
@@ -53,3 +53,70 @@ python3 Testing/make_mini_deepseek_v41.py /tmp/onebit-dsv41-hca160 --profile com
 * Fixtures are cheap and deterministic (`--seed 0`, ~4×10⁵ params, seconds to build) and live in `/tmp`; regenerate them on demand rather than committing model weights.
 * `Testing/run_all.sh` currently *skips* the V4 gate when the fixture is absent — it must stay that way: `hca160`/`csa64` are **expected-fail** fixtures, so wiring them into the suite as pass/fail would make the suite red by design until P1.1 lands. Add them as a separate, explicitly-expected-red gate when P1.1 starts.
 * The thin logits-overlap margin (16/20 against a threshold of 18) is a deliberate *fixture* property, not a robust metric — prefer the per-layer dumps for P1.1's acceptance and keep the logits overlap as a smoke signal.
+
+---
+
+# Phase 0 continued — P0.1 measured (per-layer bound MET), and the gate localizes the gap
+
+**Date:** 2026-09-12 · **Instrument:** `Testing/cmp_deepseek_v4.cpp` (extended with an optional
+per-layer dump) + `Testing/cmp_deepseek_v4_layers.py` (new) + `Testing/make_mini_deepseek_v41.py`
+(`--weights-dtype` added).
+
+## 1. P0.1 acceptance: the existing modules reproduce the reference PER LAYER
+
+The logits gate said "20/20 overlap"; that is not the stated acceptance. With the engine now
+dumping its residual streams at every layer boundary and the reference's `hidden_states` compared
+layer by layer (`Testing/cmp_deepseek_v4_layers.py`), on the **fp32** sliding fixture:
+
+| state (input to layer) | max&#124;Δ&#124; | rel | &#124;ref&#124;max |
+|---|---|---|---|
+| 0 | **0.000e+00** (bit-exact) | 0.00e+00 | 0.052 |
+| 1 | 7.451e-09 | 1.36e-07 | 0.055 |
+| 2 | 9.313e-09 | 1.68e-07 | 0.055 |
+| 3 | 1.118e-08 | 2.25e-07 | 0.050 |
+
+**worst = 1.118e-08 against a 1e-6 tolerance → PASS**, ~90× inside the bound, and the layer-0 state
+(the expanded embedding) is bit-exact. Modules covered: mHC (Sinkhorn-Knopp streams), shared-KV MQA
+with per-head sinks and partial RoPE, hash routing (`tid2eid`) on layers 0–1, top-k sqrtsoftplus MoE
+on layers 2–3, shared SwiGLU experts with `swiglu_limit`. **P0.1 is done for the modules that exist.**
+
+**Mapping verified, not assumed:** transformers appends `hidden_states` *before* each decoder layer,
+so `hidden_states[i]` is the input to layer i and there are `num_layers` stream-valued entries plus a
+final collapsed+normed `[T, H]`. The engine records at the top of each layer iteration for the same
+reason, and its extra post-last-layer state has no reference counterpart (the logits gate covers the
+collapsed head).
+
+**A bf16 fixture cannot carry this claim.** Re-loading the bf16-roundtripped weights perturbs the
+layer-0 state by **1.13e-04** — 100× above the bound — so the fixture stores **fp32** by default now
+(`--weights-dtype bfloat16` is still available for logits-level work), and the comparator *warns* when
+the stored dtype and the tolerance are inconsistent. The 1e-6 bound is a statement about the
+implementation only with fp32 weights.
+
+## 2. The same instrument localizes the missing machinery
+
+Same run on the **compressed** fixture (fp32, window 4, 64 tokens, layer types
+`[sliding, CSA, HCA, sliding]`, 16 CSA entries):
+
+| state (input to layer) | after which layer | max&#124;Δ&#124; | verdict |
+|---|---|---|---|
+| 0 | — (init) | **0.000e+00** | bit-exact |
+| 1 | 0 (`sliding_attention`) | **7.451e-09** | matches |
+| 2 | 1 (**`compressed_sparse_attention`**) | **1.171e-02** | **first divergence** |
+| 3 | 2 (`heavily_compressed_attention`) | 1.798e-02 | error propagates |
+
+The engines agrees exactly everywhere the machinery it has is exercised, and diverges at **exactly
+the layer that carries the compressor + indexer** — 6 orders of magnitude above the bound, not a
+marginal miss. That is the bisect instrument P1.1 needs: implement the compressor and the gate flips
+state 2 (then the logits gate, 16/20 → ≥18/20) instead of leaving a "logits differ" mystery.
+
+(For completeness, the logits gate on this fixture: engine top1 534 vs ref 685, overlap 16/20 → FAIL,
+exit 1. The `csa64`/`hca160` fixtures remain expected-fail by design and stay out of `run_all.sh`.)
+
+## 3. Status
+
+* **P0.1 — DONE** (per-layer ≤1e-8 on the modules that exist; instrument committed).
+* **P1.1 — gate + bisect instrument ready** (state 2 of the compressed fixture is the acceptance
+  target; `hidden_states.npz` gives the per-layer reference).
+* **P0.2 — next** (read DeepSeek's `inference/engram.py` + `model.py` for the V4.1-only maths, which
+  transformers cannot provide: no `DeepseekV41` class exists).
+* **P0.3, P0.4 — not started.**

--- a/research/ws13-arch-gap-closure/README.md
+++ b/research/ws13-arch-gap-closure/README.md
@@ -1,0 +1,80 @@
+# ws13-arch-gap-closure — Run the architectures the census flags (DeepSeek V4/V4.1, Mamba-3)
+
+**Status:** 🔲 scoped, not started — scope + evidence: this file and `Testing/arch-gaps.md`
+**Owner:** engine (CPU/attention + SSM lanes)
+**Papers:** none specific — the oracle is the vendors' own reference code (`HF modeling_deepseek_v4.py 5.14`, already the oracle for the existing V4 path) and the model configs themselves.
+
+## Goal
+
+Turn the census's `!! SIGNIFICANT` arrivals from *flagged* into *runnable*: complete the DeepSeek V4 attention machinery, add the V4.1 deltas, and add a Mamba-3 SSM path — each with a reference-oracle gate and a measured "runs the real checkpoint" line. Nothing here is an alias; the evidence that these are new architectures (not renames) is in `Testing/arch-gaps.md`.
+
+## Measured state (2026-09-12, from the published configs + `model.safetensors.index.json`)
+
+**What the engine has today** (`include/deepseek_v4.h` + `src/deepseek_v4.cpp`, 552 lines, CPU f32, HF safetensors names):
+
+| implemented | not implemented |
+|---|---|
+| mHC streams + Sinkhorn-Knopp (`hc_mult`, 20 iters) + final `hc_head` | **per-layer compressors** — CSA ratio 4 / HCA ratio 128 |
+| shared-KV MQA (1 KV head, K=V), `q_a/q_a_norm/q_b` (unweighted) / `kv_proj/kv_norm`, partial RoPE on the last `qk_rope_head_dim`, per-head attention sinks, grouped `o_a`/`o_b` | **Lightning Indexer** (block selection) |
+| MoE: sqrtsoftplus routing, `e_score_correction_bias`, `tid2eid` hash routing (`num_hash_layers`), fused `experts.gate_up_proj` + `down_proj`, shared SwiGLU + `swiglu_limit` | **GGUF `blk.*` aliases** ("NOT handled by this loader yet") |
+
+The existing path was validated on a **mini gate with `compress_ratios == 0`** (sliding layers only) — i.e. against a *shape*, not a checkpoint.
+
+**What the real checkpoints actually contain** (tensor-inventory diff of the two official indexes):
+
+| | `deepseek-ai/DeepSeek-V4-Flash` | `deepseek-ai/DeepSeek-V4.1-Flash` |
+|---|---|---|
+| shape | 43 layers, H=4096, 64 heads/1 kv, 256 experts, moe_int 2048, 3 hash layers | 40 layers, H=**5120**, 384 experts, moe_int **2304**, **no hash layers** |
+| compress_ratios | nonzero **41/44**, values {0, 4, 128} | nonzero 38/43, values {0, 1, 2} — but only **4** layers carry compressor/`indexer.k_norm` tensors and **8** carry indexer tensors |
+| tensors / size | 69,187 / **159.6 GB** | 96,085 / **510.3 GB** |
+| quantization | fp8 e4m3, `ue8m0` block scales, block [128,128] | fp8 + `expert_dtype: fp4`, block **[32,32]** |
+| V4.1-only module families | — | `attn.indexer.k_norm/wk`; **`engram.*`** (`embed.weight/scale`, `q_weight`, `k_weight`, `wkv.weight/scale`, 2 layers); `ffn.gate.bias_vl` (all 40); a rewritten **MTP** stack (`main_norm`/`main_proj`/`markov_head`/`confidence_head` vs V4's `e_proj`/`e_norm`/`h_proj`/`h_norm`); **vision tower** (`vision.blocks.*`, `patch_embed`, `norm`) + `aligner.wN` + image tokens |
+| dropped vs V4 | — | `compressor.ape`, `ffn.gate.tidNeid` (hash routing gone), V4-style MTP projections |
+
+**The scale is the real constraint.** The loader materializes every tensor as **f32** (`get_tensor_f32`). A real V4.1 Flash is 510 GB in *fp8* — as f32 that is ~2 TB, so "add the architecture" without a quantized/streamed weight path is dead on arrival. That is not new work for this workstream to invent: expert staging is **WS-07** (PagedWeight/DraftExpert) and the tier stream is **WS-11** (NVMe→DRAM→SRAM), with **WS-05** supplying a 1BP v2 format. This workstream supplies the *architecture*, and takes the loading constraint as an input.
+
+## Theory
+
+The V4 attention stack is one design with three layer flavours, and V4.1 keeps it: **sliding** (what we have), and two **compressed-sparse** branches that pool the KV stream through a learned gate (`compressor.wgate`/`wkv`(+`norm`, `ape` in V4)) and then attend over a *selected* subset chosen by the **Lightning Indexer** (an auxiliary low-dim query/key score with its own norm and `wq_b`). The compressor is a pooling operator, so its cost is dominated by the *selection* math in fp32 — cheap on CPU relative to experts.
+
+Consequences that shape the plan:
+
+1. **One implementation serves both families.** V4 needs compressors on 41/44 layers, V4.1 on ~4/40 — the same code with different ratios and a candidate-block variant on top. So do the compressed-attention work once and both checkpoints move.
+2. **Config is already shape-agnostic** (`DeepSeekV4Config` reads everything from JSON); the risk is in *assumptions* baked into the loops (head counts, `o_groups`, expert tensors), not in the constants.
+3. **V4.1 is a superset, not a variant.** Engram layers, `gate.bias_vl`, candidate blocks and the MTP rewrite are additive; hash routing is *removed*, so a V4-only path is not a correct V4.1 path even where the names match.
+4. **Mamba-3 is a different sub-system** (SSM recurrence), so it is a separate lane inside this workstream, not a variant of lane A.
+
+## Tasks
+
+### P0 — instrument first (nothing below is claimed without it)
+- [ ] **P0.1 tiny-config oracle.** Build a 2–4 layer V4.1-shaped reference (config fields from the official `text_config`, `num_hidden_layers=2`, `n_routed_experts=8`, H=256, head_dim=64) and dump per-layer weights + activations from the HF reference implementation. Gate: the **existing** modules (mHC, shared-KV MQA, MoE, sinks) reproduce it to ≤1e-6 max|Δ| per layer — i.e. the instrument is proven before it is used to prove new code. The pattern already exists in `Testing/e2e_gen_check_hf.py` (real HF model + torch fp32, no mocks); why it cannot be used as-is: that harness loads a *whole* checkpoint in fp32, which the 510 GB fp8 V4.1 makes impossible — hence a tiny config plus per-layer dumps.
+- [ ] **P0.2 write the maths spec** for `compressor` + `indexer` from the reference code (no new code): pooling, gate, `ape`, block selection, how `topk`/`index_topk` interact, and the exact tensor-name map for both repositories.
+- [ ] **P0.3 fix the runtime target in writing**: which format a real checkpoint is served from (fp8 direct? GGUF? Q4NX/1BP?) and the memory ceiling it implies. Inputs to WS-05/WS-07/WS-11; output is a decision, not code.
+- [ ] **P0.4 Mamba-3 lane 0**: a tiny-config `Qwen3Mamba3` oracle (same instrument pattern) + the parameter list read from the config (`mamba_mimo_rank`, `mamba_bc_norm_eps`, `mamba_bc_bias_init`, `mamba_rope_fraction`, `mamba_a_floor`, `mamba_chunk_size`, `mamba_d_head/d_state`, `mamba_expand`, `mamba_n_groups/n_heads`, `mamba_dt_*`).
+
+### P1 — the compressed-sparse attention path (unblocks real V4 *and* most of V4.1)
+- [ ] **P1.1** implement the compressor (CSA ratio 4 + HCA ratio 128) and the Lightning Indexer; gate per-layer against P0.1 on a config with `compress_ratios ≠ 0`.
+- [ ] **P1.2** make the loader shape-agnostic (40/43 layers, H=4096/5120, 256/384 experts, `o_groups`) and add the GGUF `blk.*` alias map.
+- [ ] **P1.3** run a **real** V4-Flash checkpoint end-to-end (from whatever P0.3 chose) and measure: coherent continuation, first-N-token identity vs the independent GGUF/llama.cpp reference (`Testing/e2e_deepseek.cpp` is the existing GGUF e2e-gate pattern for the V2/MLA path), decode tok/s on strixhalo.
+
+### P2 — V4.1 deltas, then Mamba-3
+- [ ] **P2.1** `engram` layers (2), `ffn.gate.bias_vl`, candidate-block selection, and the MTP rewrite; shape 40/H5120/384/2304; **no** hash routing.
+- [ ] **P2.2** vision tower + `aligner` — scope decision first (text-only serving is a legitimate, statable scope; claiming multimodal support is not).
+- [ ] **P2.3** **Mamba-3**: extend the SSM path (`src/mamba2_kernels.{cpp,h,hip}`, `src/backend_mamba1.cpp`, the hybrid engines `falconh1_engine.cpp` / `nemotron_h_engine.cpp` / `granitemoehybrid_engine.cpp`) for MIMO rank, BC normalisation, the rope fraction and `a_floor`; gate against P0.4.
+
+## Validation
+
+- **Instrument rule**: every phase ships with the harness that could refute it (WS-00 pattern). No phase is done on an argument.
+- Numbers to hit (honesty tags in the WS-00 style):
+  - P0.1/P0.4: tiny-config per-layer **max|Δ| ≤ 1e-6** — `validated`, with the dump committed under `FINDINGS/`.
+  - P1.1: same bound on a `compress_ratios ≠ 0` config — the new code's *own* gate.
+  - P1.3: real checkpoint → **first-8-token identity** with the independent GGUF/llama.cpp reference; then tok/s on strixhalo, tagged `optimized` only after the identity line passes.
+  - P2.3: Mamba-3 tiny-config per-layer bound, then a real hybrid checkpoint.
+- **Not claimed** by this workstream: 100% HF coverage, multimodal (P2.2 is a scope decision), any speed claim before P1.3's identity gate.
+
+## Notes
+
+- Evidence for "not an alias": `Testing/arch-gaps.md` (config diffs for `deepseekv41`, `qwen3mamba3`, `molmoact2`, `cosmos3edge`), which lands with PR #2244; the census (`Testing/hf_new_models.py`, routed by `scripts/census-watch.sh`) is the detector that keeps this list honest.
+- Reuse, do not duplicate: **WS-07** expert staging/PagedWeight, **WS-11** NVMe→DRAM→SRAM tiering, **WS-05** 1BP v2, **WS-08** compressed-KV machinery (different mechanism — MLA latent vs CSA/HCA pooling — but the same `codec_gauge_probe.py` style applies).
+- Known traps to expect: `ue8m0` block-scale conventions; per-head attention sinks; top-k ties at 384 experts; candidate-block index arithmetic; `ape` present in V4 and absent in V4.1; MTP tensors that must **not** be loaded into the main stack.
+- `molmoact2` (VLA, action expert) and `cosmos3edge` (video world model) are deliberately **out** of this workstream: neither is a text-decoder job, and both need a scope decision before code.

--- a/research/ws13-arch-gap-closure/README.md
+++ b/research/ws13-arch-gap-closure/README.md
@@ -1,7 +1,34 @@
 # ws13-arch-gap-closure — Run the architectures the census flags (DeepSeek V4/V4.1, Mamba-3)
 
-**Status:** 🔲 scoped, not started — scope + evidence: this file and `Testing/arch-gaps.md`
+**Status:** 🔄 **P0 complete, P1 half-complete, P2 specified** (updated 2026-09-12 — see `FINDINGS.md` for every number)
 **Owner:** engine (CPU/attention + SSM lanes)
+
+## Where it stands (2026-09-12)
+
+Validated with per-layer and per-stage gates against the reference's own values:
+
+* **P0.1 oracle** — tiny seeded fixtures + per-layer dumps; existing modules reproduce the reference to
+  **1.118e-08** (sliding) and the instrument *localizes* a missing mechanism to its layer.
+* **P0.2 spec** — `SPEC-v41-modules.md`: name map (checkpoint ↔ transformers), Engram (hashed n-gram
+  memory added to the mHC residual), two-level candidate selection, and DSpark = the MTP/draft head
+  (off the generation path).
+* **P0.3** — runtime format decided (engine-native quantisation; fp8 is already readable, residency is
+  the wall).
+* **P1.1 STAGES 1–3 DONE** — compressor (CSA two-series + HCA single-series) **batched and incremental**
+  ≤5.4e-07; Lightning Indexer score table ≤1.3e-08 with order-independent selection validity; compressed
+  attention integrated, **exact at 7.451e-09** per layer with a non-selective indexer, and the 64-token
+  default-config fixture matches the reference exactly (top1 685 = 685, 20/20). Per-layer rope theta
+  validated by a control (wrong theta → 4.545e-03). Loader/attention proven **shape-agnostic**
+  (1.080e-07 at H=320 / 5 heads / 32 experts / o_groups 4).
+* **P1.2 decision** — the GGUF route is **closed with evidence**: the fork's converter has no V4 class and
+  its tensor map has no compressor/ape/mhc entries, so a converted GGUF could not carry the compressed
+  layers. P1.3 goes engine-native.
+* **P2** — V4.1-only modules and the Mamba-3 lane are specified, **not implemented**.
+
+**Open:** real-checkpoint ingest (`ue8m0`/fp4 block scales + streamed experts — WS-07/WS-11), the V4.1-only
+modules, Mamba-3. **Documented limitation:** with the indexer at its configured `index_topk`, which of
+several exactly-equal scores wins is implementation-defined on the reference side, so the integration is
+gated with a non-selective indexer.
 **Papers:** none specific — the oracle is the vendors' own reference code (`HF modeling_deepseek_v4.py 5.14`, already the oracle for the existing V4 path) and the model configs themselves.
 
 ## Goal

--- a/research/ws13-arch-gap-closure/SPEC-v41-modules.md
+++ b/research/ws13-arch-gap-closure/SPEC-v41-modules.md
@@ -1,0 +1,115 @@
+# ws13 SPEC — the V4.1-only modules (P0.2)
+
+**What this is:** the maths and name map for the modules **for which no `transformers` reference
+exists** — `transformers` 5.16.1 has `DeepseekV4` but no `DeepseekV41` class, so `engram`,
+candidate-block selection and DSpark have no executable oracle there. Their authority is DeepSeek's own
+inference code, fetched 2026-09-12:
+
+* `deepseek-ai/DeepSeek-V4.1-Flash/inference/engram.py` — 184 lines, the hashed n-gram memory.
+* `deepseek-ai/DeepSeek-V4.1-Flash/inference/model.py` — 1309 lines: `ModelArgs`, `Compressor` (:429),
+  `Indexer` (:488), `select_candidate_blocks` (:583), `Attention` (:613), `Engram` (:328),
+  `DSparkAttention` (:1032), `DSparkMarkovHead` (:1077), `DSparkConfidenceHead` (:1089),
+  `DSparkBlock` (:1100).
+
+The shared machinery (compressor, indexer, sliding/CSA/HCA attention) *does* have an executable oracle
+in `transformers` — that is what the Phase-0 fixtures exercise — but the two disagree on names, so the
+map below is required before either can be trusted.
+
+## 1. Name map: published checkpoint ↔ transformers reference
+
+| maths | checkpoint (`model.safetensors.index.json`) | transformers 5.16.1 (`DeepseekV4`) |
+|---|---|---|
+| compressor projection | `attn.compressor.wkv` | `self_attn.compressor.kv_proj` |
+| compressor gate | `attn.compressor.wgate` | `self_attn.compressor.gate_proj` |
+| compressor norm | `attn.compressor.norm` | `self_attn.compressor.kv_norm` |
+| per-position pooling bias | `attn.compressor.ape` | `self_attn.compressor.position_bias` |
+| indexer query projection | `attn.indexer.wq_b` | `self_attn.compressor.indexer.q_b_proj` |
+| indexer score weights | `attn.indexer.weights_proj` | `self_attn.compressor.indexer.scorer.weights_proj` |
+| indexer's own compressor | `attn.indexer.compressor.{wkv,wgate,norm,ape}` | nested as `compressor.indexer.{kv_proj,gate_proj,kv_norm,position_bias}` |
+
+Read the maths from `model.py` (it matches the checkpoint naming) and validate against the executable
+reference through this map. Shape evidence for the bias: `position_bias` is `[compress_rate, head_dim]`
+(measured: `[4,32]` for CSA=4, `[128,16]` for HCA=128), which is also why the rate is baked into the
+tensors.
+
+## 2. Engram — hashed n-gram memory added to the residual stream
+
+`Engram` (`model.py:328`), used only on the layers in `engram_layer_ids` (`Block.__init__`: `if
+engram_layout is not None and layer_id in engram_layout.layer_ids`). It is **not** a new matmul kernel:
+it is a hashing + gather + small linear, which is why this is the cheapest of the three to implement.
+
+**Steps (`engram.py`), all CPU-reproducible:**
+
+1. **Compressed token map.** `build_compressed_token_map(tokenizer)` normalises each token
+   (NFKC → NFD → StripAccents → Lowercase → collapse whitespace → Strip, with a private-use sentinel so
+   a token that is exactly one space survives) and maps every token id onto that smaller id space, so
+   `" The"`, `"the"` and `"THE"` hash identically. **Trap:** `NgramHashState.__init__` asserts the
+   resulting size equals `args.engram_compressed_vocab_size` — every hash multiplier derives from it, so
+   a mismatch silently rehashes the whole table instead of failing.
+2. **Per-(layer, n-gram, head) bucket space.** `EngramLayout` draws *disjoint* primes in order
+   (`find_next_prime` upward from `engram_vocab_size - 1`, never reused); each (n-gram size, head) pair
+   owns its own prime-sized range; `offsets` make the concatenated ranges disjoint.
+3. **Hash multipliers.** `compute_hash_multipliers`: one per (layer, lookback) from a per-layer RNG
+   (`np.random.default_rng(10007 * layer_id)`), forced odd (`value * 2 + 1`) and bounded so
+   `token_id * multiplier` cannot overflow int64.
+4. **The hash itself.** For each lookback `shift` in `0..max_ngram_size-1`, gather the token `shift`
+   positions back; block the position if `pos < shift` or the source token is `DEAD`; replace blocked
+   slots with `engram_pad_id` (default **2**, "matches training"). Then a running XOR of
+   `token * multiplier` accumulates the 2-gram … `max_ngram_size`-gram hashes, each taken `% primes`,
+   plus `offsets`. Output `[B, L, n_engram_layers, n_hash_cols]`.
+5. **DEAD tokens and images.** `token_mask` marks image spans; a blocked n-gram can never span one, and
+   the state cache carries this across the prefill/decode split (so a decode step sees the same hashes
+   a full prefill would).
+6. **Insertion.** `Engram.embed = ParallelEngramEmbedding(num_embeddings[layer_hash_index], head_dim)`
+   (`model.py:296`) holds `weight` as **fp8 e4m3** with a per-block `scale`
+   (`dim // block_size` columns) — i.e. the table is quantised and needs the same `ue8m0` block-scale
+   handling as the experts. The retrieved rows are consumed by
+   `wkv: Linear(n_hash_cols * head_dim → dim * (hc_mult + 1))`, with `q_weight` / `k_weight` as
+   `[hc_mult, dim]` parameters (initialised to ones) and `clamp_value = 1e-6`; the `(hc_mult + 1)`
+   output width is how the result lands in the **mHC residual streams** (`hc_mult`) plus one extra
+   channel — an additive n-gram memory, not an attention.
+
+Checkpoint tensors involved: `layers.N.engram.{embed.weight,embed.scale,q_weight,k_weight,wkv.weight,wkv.scale}`
+(present on 2 layers in V4.1-Flash).
+
+## 3. Candidate pre-filtering — a second selection level before the indexer
+
+`select_candidate_blocks` (`model.py:583`) and the `Indexer` docstring ("rectified then combined by
+`weights_proj`. With a candidate source this is the second of two levels; `select_candidate_blocks` is
+the first") describe **two-stage sparse selection**:
+
+* `candidate_source_layer` (`< 0` disables it; `Indexer.is_candidate_source` marks the producing layer,
+  `uses_candidates = 0 <= candidate_source_layer < layer_id` the consumers),
+* `candidate_topk_blocks`, `candidate_block_size` — the cheap block-level filter,
+* then the indexer keeps its `index_topk` best compressed positions per query (`Indexer` docstring).
+
+The wiring keys in the config are the *source layer* lists: `candidate_source_layer_id`,
+`index_source_layer_ids`, `kv_source_layer_ids` (`Indexer.owns_k = layer_id in args.kv_source_layers`).
+Consequence for the engine: the compressed-attention path is not "attend over compressed entries with
+top-k" but a **two-level** scheme whose first level reads an earlier layer's state — a data dependency
+the current single-layer, single-pass engine does not express, so P1's design must carry per-layer
+source indices rather than a per-layer flag.
+
+## 4. DSpark is the MTP/draft head — it does not belong on the generation path
+
+`ModelArgs` comments say it plainly ("dspark draft head. Only the forward pass is implemented here —
+nothing calls `forward_spec`"), and the classes are `DSparkAttention` / `DSparkMarkovHead` /
+`DSparkConfidenceHead` / `DSparkBlock` with `dspark_block_size`, `dspark_noise_token_id`,
+`dspark_target_layer_ids`, `dspark_markov_rank`, `dspark_n_routed_experts`,
+`dspark_n_activated_experts`. These are the `mtp.*` tensor families seen in the inventory
+(`markov_head`, `confidence_head`, `main_proj`, `main_norm`).
+
+**Scope consequence:** plain autoregressive generation does not need DSpark/MTP weights loaded. That
+removes `mtp.*` (and its `N`-layer stack) from the critical path — the workstream's P2 should say so
+explicitly rather than loading everything a checkpoint contains.
+
+## 5. What this changes in the plan
+
+* **P2.1 splits.** Load-bearing for text generation: `engram` (2 layers), `ffn.gate.bias_vl`,
+  candidate-block selection, the new shape. *Not* load-bearing: DSpark/MTP (draft head), the vision
+  tower + `aligner` (still a scope decision).
+* **P1's design constraint is now explicit**: two-level candidate selection with source-layer
+  dependencies, and a compressor whose pooling bias is rate-shaped per layer — so the loader must carry
+  `compress_ratios`, `*_source_layer_ids` and `index_topk` per layer, not infer them.
+* **Engram needs no new kernel** (hashing + gather + one linear per engram layer), but its embedding
+  table is fp8 with per-block scales, so it depends on the same block-scale machinery as the experts.

--- a/src/deepseek_v4.cpp
+++ b/src/deepseek_v4.cpp
@@ -366,12 +366,12 @@ void DeepSeekV4Model::clear() {
 }
 
 // ─── compressor (CSA/HCA) ─────────────────────────────────────────────────────
-bool deepseek_v4_compressor_step(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg, int rate,
-                                 const float* x_token, DeepSeekV4CompState& st) {
+bool deepseek_v4_compressor_step_p(const DeepSeekV4CompParams& p, const DeepSeekV4Config& cfg,
+                                   int rate, const float* x_token, DeepSeekV4CompState& st) {
     using namespace ds4math;
-    const int H = cfg.hidden_size, hd = cfg.head_dim;
-    if (rate <= 0 || l.cp_rate == 0 || !x_token) return false;
-    const int series = (l.cp_series == 2) ? 2 : 1;
+    const int H = cfg.hidden_size, hd = p.hd;
+    if (rate <= 0 || !x_token || !p.kv || !p.gate || !p.pos_bias || !p.norm) return false;
+    const int series = (p.series == 2) ? 2 : 1;
     const int out_w = series * hd;
     const int n_slots = series * rate;
 
@@ -379,12 +379,12 @@ bool deepseek_v4_compressor_step(const DeepSeekV4Layer& l, const DeepSeekV4Confi
     float* row_kv = &st.buf_kv[(size_t)st.n_buf * out_w];
     float* row_gate = &st.buf_gate[(size_t)st.n_buf * out_w];
     for (int j = 0; j < out_w; j++) {
-        const float* wk = &l.cp_kv[(size_t)j * H];
-        const float* wg = &l.cp_gate[(size_t)j * H];
+        const float* wk = &p.kv[(size_t)j * H];
+        const float* wg = &p.gate[(size_t)j * H];
         float a = 0.0f, b = 0.0f;
         for (int i = 0; i < H; i++) { a += x_token[i] * wk[i]; b += x_token[i] * wg[i]; }
         row_kv[j] = a;
-        row_gate[j] = b + l.cp_pos_bias[(size_t)st.n_buf * out_w + j];
+        row_gate[j] = b + p.pos_bias[(size_t)st.n_buf * out_w + j];
     }
     st.n_buf++;
     if (st.n_buf < rate) return false;
@@ -420,7 +420,7 @@ bool deepseek_v4_compressor_step(const DeepSeekV4Layer& l, const DeepSeekV4Confi
     }
     const size_t off = st.entries.size();
     st.entries.resize(off + hd);
-    rmsnorm(&st.entries[off], pooled.data(), l.cp_norm.data(), hd, cfg.rms_norm_eps);
+    rmsnorm(&st.entries[off], pooled.data(), p.norm, hd, cfg.rms_norm_eps);
     // entry w sits at token position w*rate — the reference's `first_window_position
     // + w*rate`, i.e. the count of entries already emitted times the rate.
     rope_partial(&st.entries[off], hd, cfg.qk_rope_head_dim, st.n_entries * rate,
@@ -434,6 +434,30 @@ bool deepseek_v4_compressor_step(const DeepSeekV4Layer& l, const DeepSeekV4Confi
             }
     st.n_buf = 0;
     return true;
+}
+
+bool deepseek_v4_compressor_step(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg, int rate,
+                                 const float* x_token, DeepSeekV4CompState& st) {
+    if (l.cp_rate == 0) return false;
+    DeepSeekV4CompParams p;
+    p.kv = l.cp_kv.data();
+    p.gate = l.cp_gate.data();
+    p.pos_bias = l.cp_pos_bias.data();
+    p.norm = l.cp_norm.data();
+    p.series = l.cp_series;
+    p.hd = cfg.head_dim;
+    return deepseek_v4_compressor_step_p(p, cfg, rate, x_token, st);
+}
+
+DeepSeekV4CompParams deepseek_v4_indexer_comp_params(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg) {
+    DeepSeekV4CompParams p;
+    p.kv = l.ix_kv.data();
+    p.gate = l.ix_gate.data();
+    p.pos_bias = l.ix_pos_bias.data();
+    p.norm = l.ix_norm.data();
+    p.series = 2;                 // the indexer compresses with the CSA two-series layout
+    p.hd = cfg.index_head_dim;
+    return p;
 }
 
 std::vector<float> deepseek_v4_compressor_forward(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg,
@@ -665,7 +689,8 @@ std::vector<int> deepseek_v4_indexer_topk(const DeepSeekV4Layer& l, const DeepSe
 std::vector<float> deepseek_v4_forward(DeepSeekV4Model& model, int token_id,
                                        DeepSeekV4KVCache& kv_cache,
                                        DeepSeekV4mHCState& mhc, int& pos,
-                                       std::vector<float>* layer_states) {
+                                       std::vector<float>* layer_states,
+                                       const int* index_override, int index_override_k) {
     using namespace ds4math;
     const auto& cfg = model.cfg;
     const int H = cfg.hidden_size;
@@ -719,6 +744,11 @@ std::vector<float> deepseek_v4_forward(DeepSeekV4Model& model, int token_id,
                     hc, cfg.hc_eps, cfg.hc_sinkhorn_iters, cfg.rms_norm_eps, collapsed, post, comb);
         rmsnorm(norm.data(), collapsed.data(), l.rms_attn_w.data(), H, cfg.rms_norm_eps);
 
+        // A compressed layer ropes its queries, its sliding KV and the output
+        // de-rotation with the COMPRESS theta; sliding layers use the main one
+        // (reference: `rope_layer_type = "main" if sliding_attention else "compress"`).
+        const float attn_rope_theta = (l.cp_rate != 0) ? cfg.compress_rope_theta : cfg.rope_theta;
+
         // ── Q compression: q_a = norm @ W_q_a ; q_a_norm ; q_b = q_a @ W_q_b ──
         matmul(q_a.data(), norm.data(), l.q_a.data(), cfg.q_lora_rank, H);
         rmsnorm(q_a.data(), q_a.data(), l.q_a_norm.data(), cfg.q_lora_rank, cfg.rms_norm_eps);
@@ -729,32 +759,119 @@ std::vector<float> deepseek_v4_forward(DeepSeekV4Model& model, int token_id,
                     nullptr, cfg.head_dim, cfg.rms_norm_eps);
         // partial rope on last qk_rope_head_dim of each head
         for (int h = 0; h < cfg.num_heads; h++)
-            rope_partial(&q_full[(size_t)h * cfg.head_dim], cfg.head_dim, cfg.qk_rope_head_dim, pos, cfg.rope_theta);
+            rope_partial(&q_full[(size_t)h * cfg.head_dim], cfg.head_dim, cfg.qk_rope_head_dim, pos, attn_rope_theta);
 
         // ── KV: kv = norm @ W_kv ; kv_norm ; rope; store ──
         matmul(kv.data(), norm.data(), l.kv_w.data(), cfg.head_dim, H);
         rmsnorm(kv.data(), kv.data(), l.kv_norm.data(), cfg.head_dim, cfg.rms_norm_eps);
-        rope_partial(kv.data(), cfg.head_dim, cfg.qk_rope_head_dim, pos, cfg.rope_theta);
+        rope_partial(kv.data(), cfg.head_dim, cfg.qk_rope_head_dim, pos, attn_rope_theta);
         float* cache_row = kv_cache.kv[il].data() + (size_t)pos * cfg.head_dim;
         std::copy(kv.begin(), kv.end(), cache_row);
 
-        // ── attention (shared KV head, K=V, per-head sinks) ──
+        // ── compressor / indexer: emit this token's entries, then decide which
+        // compressed entries THIS query may see — HCA by causality alone, CSA by
+        // the Lightning Indexer's top-k intersected with causality. The reference
+        // then concatenates them after the sliding window and masks the tail. ──
+        const bool has_cp = (l.cp_rate != 0);
+        std::vector<char> cp_allowed;
+        if (has_cp) {
+            DeepSeekV4CompState& cst = kv_cache.cp[il];
+            if (!cst.inited) cst.init(l.cp_rate, l.cp_series, cfg.head_dim);
+            deepseek_v4_compressor_step(l, cfg, l.cp_rate, norm.data(), cst);
+
+            cp_allowed.assign((size_t)cst.n_entries, 0);
+            const int thr = (pos + 1) / l.cp_rate;   // entries w < thr are causal
+            if (l.ix_heads > 0 && index_override && index_override_k > 0) {
+                // TEST INSTRUMENT: use a supplied selection (the reference's own top-k)
+                // instead of computing one. Isolates "is the attention maths exact?"
+                // from "does my top-k break ties the way torch does?".
+                for (int j = 0; j < index_override_k; j++) {
+                    int w = index_override[j];
+                    if (w >= 0 && w < cst.n_entries) cp_allowed[w] = 1;
+                }
+            } else if (l.ix_heads > 0) {
+                DeepSeekV4CompState& ist = kv_cache.ix[il];
+                if (!ist.inited) ist.init(l.cp_rate, 2, cfg.index_head_dim);
+                DeepSeekV4CompParams ip = deepseek_v4_indexer_comp_params(l, cfg);
+                deepseek_v4_compressor_step_p(ip, cfg, l.cp_rate, norm.data(), ist);
+
+                const int ihd = cfg.index_head_dim, nh = l.ix_heads, ql = cfg.q_lora_rank;
+                const int nvis = std::min(ist.n_entries, thr);
+                if (nvis > 0) {
+                    std::vector<float> ixq((size_t)nh * ihd), wpr((size_t)nh);
+                    for (int h = 0; h < nh; h++) {
+                        float* qh = &ixq[(size_t)h * ihd];
+                        for (int d = 0; d < ihd; d++) {
+                            const float* wr = &l.ix_qb[(size_t)(h * ihd + d) * ql];
+                            float a = 0.0f;
+                            for (int i = 0; i < ql; i++) a += q_a[i] * wr[i];
+                            qh[d] = a;
+                        }
+                        rope_partial(qh, ihd, cfg.qk_rope_head_dim, pos, cfg.compress_rope_theta);
+                        const float* wr2 = &l.ix_wproj[(size_t)h * H];
+                        float b = 0.0f;
+                        for (int i = 0; i < H; i++) b += norm[i] * wr2[i];
+                        wpr[h] = b;
+                    }
+                    const float isc = 1.0f / std::sqrt((float)ihd);
+                    const float wsc = 1.0f / std::sqrt((float)nh);
+                    std::vector<float> ix_score((size_t)nvis);
+                    for (int s2 = 0; s2 < nvis; s2++) {
+                        float acc = 0.0f;
+                        for (int h = 0; h < nh; h++) {
+                            const float* qh = &ixq[(size_t)h * ihd];
+                            const float* Ks = &ist.entries[(size_t)s2 * ihd];
+                            float dot = 0.0f;
+                            for (int d = 0; d < ihd; d++) dot += qh[d] * Ks[d];
+                            acc += std::max(dot, 0.0f) * isc * wpr[h] * wsc;
+                        }
+                        ix_score[s2] = acc;
+                    }
+                    const int ksel = std::min(l.ix_topk, nvis);
+                    for (int j = 0; j < ksel; j++) {
+                        int best = -1;
+                        for (int s2 = 0; s2 < nvis; s2++)
+                            if (ix_score[s2] > -INFINITY && (best < 0 || ix_score[s2] > ix_score[best])) best = s2;
+                        if (best < 0) break;
+                        cp_allowed[best] = 1;
+                        ix_score[best] = -INFINITY;
+                    }
+                }
+            } else {
+                for (int w = 0; w < cst.n_entries; w++) cp_allowed[w] = (w < thr) ? 1 : 0;
+            }
+        }
+
+        // ── attention (shared KV head, K=V, per-head sinks): the sliding window
+        // followed by the allowed compressed entries ──
         const int seq_len = pos + 1;
         const float scale = 1.0f / std::sqrt((float)cfg.head_dim);
         int win_start = std::max(0, seq_len - cfg.sliding_window);
+        std::vector<const float*> vrows;
+        vrows.reserve((size_t)cfg.sliding_window + (has_cp ? kv_cache.cp[il].n_entries : 0) + 1);
+        for (int s = win_start; s < seq_len; s++)
+            vrows.push_back(kv_cache.kv[il].data() + (size_t)s * cfg.head_dim);
+        if (has_cp) {
+            const DeepSeekV4CompState& cst = kv_cache.cp[il];
+            for (int w = 0; w < cst.n_entries; w++)
+                if (cp_allowed[w]) vrows.push_back(&cst.entries[(size_t)w * cfg.head_dim]);
+        }
+        const int n_rows = (int)vrows.size();
+        if ((int)scores_buf.size() < n_rows + 1) {
+            scores_buf.resize((size_t)n_rows + 1);
+            probs_buf.resize((size_t)n_rows + 1);
+        }
         std::fill(attn_out.begin(), attn_out.end(), 0.0f);
         for (int h = 0; h < cfg.num_heads; h++) {
             const float* qh = &q_full[(size_t)h * cfg.head_dim];
-            float sink = l.sinks[h];
-            // scores over window + sink (S+1 entries)
             int n = 0;
-            for (int s = win_start; s < seq_len; s++) {
-                const float* krow = kv_cache.kv[il].data() + (size_t)s * cfg.head_dim;
+            for (int i = 0; i < n_rows; i++) {
+                const float* krow = vrows[i];
                 float acc = 0;
                 for (int d = 0; d < cfg.head_dim; d++) acc += qh[d] * krow[d];
                 scores_buf[n++] = acc * scale;
             }
-            scores_buf[n] = sink; n++;
+            scores_buf[n] = l.sinks[h]; n++;
             // softmax
             float mx = scores_buf[0];
             for (int i = 1; i < n; i++) mx = std::max(mx, scores_buf[i]);
@@ -762,9 +879,9 @@ std::vector<float> deepseek_v4_forward(DeepSeekV4Model& model, int token_id,
             for (int i = 0; i < n; i++) { probs_buf[i] = std::exp(scores_buf[i] - mx); ssum += probs_buf[i]; }
             // weighted sum of V (drop the sink entry)
             float* outh = &attn_out[(size_t)h * cfg.head_dim];
-            for (int i = 0; i < n - 1; i++) {
+            for (int i = 0; i < n_rows; i++) {
                 float w = probs_buf[i] / ssum;
-                const float* vrow = kv_cache.kv[il].data() + (size_t)(win_start + i) * cfg.head_dim;
+                const float* vrow = vrows[i];
                 for (int d = 0; d < cfg.head_dim; d++) outh[d] += w * vrow[d];
             }
         }
@@ -779,7 +896,7 @@ std::vector<float> deepseek_v4_forward(DeepSeekV4Model& model, int token_id,
                 float* outh = &attn_out[(size_t)h * cfg.head_dim];
                 float* rope = outh + (cfg.head_dim - rd);
                 for (int p = 0; p < n_pairs; p++) {
-                    float freq = 1.0f / std::pow(cfg.rope_theta, (float)(2 * p) / rd);
+                    float freq = 1.0f / std::pow(attn_rope_theta, (float)(2 * p) / rd);
                     float angle = pos * freq;
                     float c = std::cos(angle), s = std::sin(angle);
                     float x0 = rope[2 * p], x1 = rope[2 * p + 1];

--- a/src/deepseek_v4.cpp
+++ b/src/deepseek_v4.cpp
@@ -366,6 +366,76 @@ void DeepSeekV4Model::clear() {
 }
 
 // ─── compressor (CSA/HCA) ─────────────────────────────────────────────────────
+bool deepseek_v4_compressor_step(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg, int rate,
+                                 const float* x_token, DeepSeekV4CompState& st) {
+    using namespace ds4math;
+    const int H = cfg.hidden_size, hd = cfg.head_dim;
+    if (rate <= 0 || l.cp_rate == 0 || !x_token) return false;
+    const int series = (l.cp_series == 2) ? 2 : 1;
+    const int out_w = series * hd;
+    const int n_slots = series * rate;
+
+    // rows for this token, with the position bias of its slot INSIDE the window
+    float* row_kv = &st.buf_kv[(size_t)st.n_buf * out_w];
+    float* row_gate = &st.buf_gate[(size_t)st.n_buf * out_w];
+    for (int j = 0; j < out_w; j++) {
+        const float* wk = &l.cp_kv[(size_t)j * H];
+        const float* wg = &l.cp_gate[(size_t)j * H];
+        float a = 0.0f, b = 0.0f;
+        for (int i = 0; i < H; i++) { a += x_token[i] * wk[i]; b += x_token[i] * wg[i]; }
+        row_kv[j] = a;
+        row_gate[j] = b + l.cp_pos_bias[(size_t)st.n_buf * out_w + j];
+    }
+    st.n_buf++;
+    if (st.n_buf < rate) return false;
+
+    // window complete: slots = [previous window's Ca | this window's Cb]
+    std::vector<float> new_kv((size_t)n_slots * hd), new_gate((size_t)n_slots * hd);
+    if (series == 2) {
+        for (int a = 0; a < rate; a++)
+            for (int d = 0; d < hd; d++) {
+                new_kv[(size_t)a * hd + d] = st.prev_ca[(size_t)a * hd + d];
+                new_gate[(size_t)a * hd + d] = st.prev_ca_gate[(size_t)a * hd + d];
+                new_kv[(size_t)(rate + a) * hd + d] = st.buf_kv[(size_t)a * out_w + hd + d];
+                new_gate[(size_t)(rate + a) * hd + d] = st.buf_gate[(size_t)a * out_w + hd + d];
+            }
+    } else {
+        for (int a = 0; a < rate; a++)
+            for (int d = 0; d < hd; d++) {
+                new_kv[(size_t)a * hd + d] = st.buf_kv[(size_t)a * out_w + d];
+                new_gate[(size_t)a * hd + d] = st.buf_gate[(size_t)a * out_w + d];
+            }
+    }
+    std::vector<float> pooled(hd);
+    for (int d = 0; d < hd; d++) {
+        float mx = -INFINITY;
+        for (int a = 0; a < n_slots; a++) mx = std::max(mx, new_gate[(size_t)a * hd + d]);
+        float sum = 0.0f, acc = 0.0f;
+        for (int a = 0; a < n_slots; a++) {
+            float e = std::exp(new_gate[(size_t)a * hd + d] - mx);
+            sum += e;
+            acc += e * new_kv[(size_t)a * hd + d];
+        }
+        pooled[d] = acc / sum;
+    }
+    const size_t off = st.entries.size();
+    st.entries.resize(off + hd);
+    rmsnorm(&st.entries[off], pooled.data(), l.cp_norm.data(), hd, cfg.rms_norm_eps);
+    // entry w sits at token position w*rate — the reference's `first_window_position
+    // + w*rate`, i.e. the count of entries already emitted times the rate.
+    rope_partial(&st.entries[off], hd, cfg.qk_rope_head_dim, st.n_entries * rate,
+                 cfg.compress_rope_theta);
+    st.n_entries++;
+    if (series == 2)
+        for (int a = 0; a < rate; a++)
+            for (int d = 0; d < hd; d++) {
+                st.prev_ca[(size_t)a * hd + d] = st.buf_kv[(size_t)a * out_w + d];
+                st.prev_ca_gate[(size_t)a * hd + d] = st.buf_gate[(size_t)a * out_w + d];
+            }
+    st.n_buf = 0;
+    return true;
+}
+
 std::vector<float> deepseek_v4_compressor_forward(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg,
                                                   int rate, const std::vector<float>& x, int T) {
     using namespace ds4math;

--- a/src/deepseek_v4.cpp
+++ b/src/deepseek_v4.cpp
@@ -287,7 +287,8 @@ void DeepSeekV4Model::clear() {
 // ─── forward ──────────────────────────────────────────────────────────────────
 std::vector<float> deepseek_v4_forward(DeepSeekV4Model& model, int token_id,
                                        DeepSeekV4KVCache& kv_cache,
-                                       DeepSeekV4mHCState& mhc, int& pos) {
+                                       DeepSeekV4mHCState& mhc, int& pos,
+                                       std::vector<float>* layer_states) {
     using namespace ds4math;
     const auto& cfg = model.cfg;
     const int H = cfg.hidden_size;
@@ -324,6 +325,14 @@ std::vector<float> deepseek_v4_forward(DeepSeekV4Model& model, int token_id,
 
     for (int il = 0; il < cfg.num_layers; il++) {
         const auto& l = model.layers[il];
+        // Instrumentation (ws13 P0.1): the state ENTERING this layer is exactly
+        // HF's `hidden_states[il]` (transformers appends before each layer), so
+        // recording here gives a per-layer comparison target instead of only
+        // final logits.
+        if (layer_states) {
+            for (int k = 0; k < hc; k++)
+                layer_states->insert(layer_states->end(), mhc.streams[k].begin(), mhc.streams[k].end());
+        }
         const float* x = mhc.streams[0].data(); // for norms below we use collapsed
 
         // Debug: dump stream-0 of the CURRENT token after each sublayer

--- a/src/deepseek_v4.cpp
+++ b/src/deepseek_v4.cpp
@@ -689,8 +689,7 @@ std::vector<int> deepseek_v4_indexer_topk(const DeepSeekV4Layer& l, const DeepSe
 std::vector<float> deepseek_v4_forward(DeepSeekV4Model& model, int token_id,
                                        DeepSeekV4KVCache& kv_cache,
                                        DeepSeekV4mHCState& mhc, int& pos,
-                                       std::vector<float>* layer_states,
-                                       const int* index_override, int index_override_k) {
+                                       std::vector<float>* layer_states) {
     using namespace ds4math;
     const auto& cfg = model.cfg;
     const int H = cfg.hidden_size;
@@ -781,15 +780,7 @@ std::vector<float> deepseek_v4_forward(DeepSeekV4Model& model, int token_id,
 
             cp_allowed.assign((size_t)cst.n_entries, 0);
             const int thr = (pos + 1) / l.cp_rate;   // entries w < thr are causal
-            if (l.ix_heads > 0 && index_override && index_override_k > 0) {
-                // TEST INSTRUMENT: use a supplied selection (the reference's own top-k)
-                // instead of computing one. Isolates "is the attention maths exact?"
-                // from "does my top-k break ties the way torch does?".
-                for (int j = 0; j < index_override_k; j++) {
-                    int w = index_override[j];
-                    if (w >= 0 && w < cst.n_entries) cp_allowed[w] = 1;
-                }
-            } else if (l.ix_heads > 0) {
+            if (l.ix_heads > 0) {
                 DeepSeekV4CompState& ist = kv_cache.ix[il];
                 if (!ist.inited) ist.init(l.cp_rate, 2, cfg.index_head_dim);
                 DeepSeekV4CompParams ip = deepseek_v4_indexer_comp_params(l, cfg);

--- a/src/deepseek_v4.cpp
+++ b/src/deepseek_v4.cpp
@@ -178,6 +178,52 @@ bool DeepSeekV4Model::load_from_safetensors(const std::string& dir, const DeepSe
         if (json_find_float(txt, "hc_eps", fv)) cfg.hc_eps = fv;
         if (json_find_float(txt, "rms_norm_eps", fv)) cfg.rms_norm_eps = fv;
         if (json_find_float(txt, "rope_theta", fv)) cfg.rope_theta = fv;
+        if (json_find_float(txt, "compress_rope_theta", fv)) cfg.compress_rope_theta = fv;
+        // Compressor window widths: `compress_rates` (transformers/fixture naming)
+        // or, for checkpoint naming, `compress_ratios` below.
+        if (json_find_int(txt, "compressed_sparse_attention", iv) && iv > 0) cfg.csa_rate = iv;
+        if (json_find_int(txt, "heavily_compressed_attention", iv) && iv > 0) cfg.hca_rate = iv;
+        // layer_types: ["sliding_attention", "compressed_sparse_attention", ...]
+        {
+            size_t p = txt.find("\"layer_types\"");
+            if (p != std::string::npos) {
+                size_t lb = txt.find('[', p), rb = txt.find(']', p);
+                if (lb != std::string::npos && rb != std::string::npos && rb > lb) {
+                    std::string arr = txt.substr(lb, rb - lb);
+                    size_t i = 0;
+                    while (true) {
+                        size_t a = arr.find('"', i);
+                        if (a == std::string::npos) break;
+                        size_t b = arr.find('"', a + 1);
+                        if (b == std::string::npos) break;
+                        std::string v = arr.substr(a + 1, b - a - 1);
+                        int t = 0;
+                        if (v.find("compressed_sparse") != std::string::npos) t = 1;
+                        else if (v.find("heavily_compressed") != std::string::npos) t = 2;
+                        cfg.layer_attn_type.push_back(t);
+                        i = b + 1;
+                    }
+                }
+            }
+            // `compress_ratios` (checkpoint naming): 0 = sliding, >0 = rate.
+            size_t cr = txt.find("\"compress_ratios\"");
+            if (cfg.layer_attn_type.empty() && cr != std::string::npos) {
+                size_t lb = txt.find('[', cr), rb = txt.find(']', cr);
+                if (lb != std::string::npos && rb != std::string::npos && rb > lb) {
+                    std::string arr = txt.substr(lb + 1, rb - lb - 1);
+                    size_t i = 0;
+                    while (i < arr.size()) {
+                        while (i < arr.size() && !isdigit((unsigned char)arr[i])) i++;
+                        if (i >= arr.size()) break;
+                        int v = atoi(arr.c_str() + i);
+                        while (i < arr.size() && isdigit((unsigned char)arr[i])) i++;
+                        cfg.compress_ratios.push_back(v);
+                        cfg.layer_attn_type.push_back(v == 0 ? 0 : (v >= 128 ? 2 : 1));
+                        if (v > 0) { if (v >= 128) cfg.hca_rate = v; else cfg.csa_rate = v; }
+                    }
+                }
+            }
+        }
         // qk_rope_head_dim via partial_rotary_factor
         float prf = 0;
         if (json_find_float(txt, "partial_rotary_factor", prf) && prf > 0)
@@ -256,6 +302,20 @@ bool DeepSeekV4Model::load_from_safetensors(const std::string& dir, const DeepSe
         ok &= get(name("mlp.shared_experts.gate_proj.weight"), l.sh_gate, (size_t)cfg.moe_intermediate * H);
         ok &= get(name("mlp.shared_experts.up_proj.weight"), l.sh_up, (size_t)cfg.moe_intermediate * H);
         ok &= get(name("mlp.shared_experts.down_proj.weight"), l.sh_down, (size_t)H * cfg.moe_intermediate);
+        // ── compressor (CSA/HCA): present only when this layer's type says so ──
+        if (il < (int)cfg.layer_attn_type.size() && cfg.layer_attn_type[il] != 0) {
+            const int hd = cfg.head_dim;
+            const bool hca = (cfg.layer_attn_type[il] == 2);
+            l.cp_rate = hca ? cfg.hca_rate : cfg.csa_rate;
+            // CSA projects 2 series (Ca/Cb overlap); HCA is single-series.
+            l.cp_series = hca ? 1 : 2;
+            const int out_w = l.cp_series * hd;
+            ok &= get(name("self_attn.compressor.kv_proj.weight"), l.cp_kv, (size_t)out_w * H);
+            ok &= get(name("self_attn.compressor.gate_proj.weight"), l.cp_gate, (size_t)out_w * H);
+            ok &= get(name("self_attn.compressor.position_bias"), l.cp_pos_bias,
+                      (size_t)l.cp_rate * out_w);
+            ok &= get(name("self_attn.compressor.kv_norm.weight"), l.cp_norm, hd);
+        }
 
         if (il < cfg.num_hash_layers) {
             // hash routing: tid2eid [vocab, top_k]
@@ -282,6 +342,82 @@ void DeepSeekV4Model::clear() {
     embed.clear(); final_norm_w.clear(); lm_head.clear();
     hc_head_fn.clear(); hc_head_base.clear(); hc_head_scale.clear();
     layers.clear();
+}
+
+// ─── compressor (CSA/HCA) ─────────────────────────────────────────────────────
+std::vector<float> deepseek_v4_compressor_forward(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg,
+                                                  int rate, const std::vector<float>& x, int T) {
+    using namespace ds4math;
+    std::vector<float> out;
+    const int H = cfg.hidden_size, hd = cfg.head_dim;
+    if (rate <= 0 || l.cp_rate == 0 || (int)x.size() < (size_t)T * H) return out;
+    const int n_win = T / rate;
+    if (n_win <= 0) return out;
+    out.assign((size_t)n_win * hd, 0.0f);
+
+    const int series = (l.cp_series == 2) ? 2 : 1;   // 2 = CSA (Ca/Cb), 1 = HCA
+    const int out_w = series * hd;
+    const int n_slots = series * rate;
+    std::vector<float> kv((size_t)rate * out_w), gt((size_t)rate * out_w);
+    std::vector<float> new_kv((size_t)n_slots * hd), new_gate((size_t)n_slots * hd);
+    // Window 0's Ca half has no predecessor: kv 0, gate -inf (softmax weight 0).
+    std::vector<float> prev_ca((size_t)rate * hd, 0.0f);
+    std::vector<float> prev_ca_gate((size_t)rate * hd, -INFINITY);
+    std::vector<float> pooled(hd);
+
+    for (int w = 0; w < n_win; w++) {
+        const float* xw = &x[(size_t)w * rate * H];
+        for (int t = 0; t < rate; t++) {
+            const float* xt = xw + (size_t)t * H;
+            for (int j = 0; j < out_w; j++) {
+                const float* wk = &l.cp_kv[(size_t)j * H];
+                const float* wg = &l.cp_gate[(size_t)j * H];
+                float a = 0.0f, b = 0.0f;
+                for (int i = 0; i < H; i++) { a += xt[i] * wk[i]; b += xt[i] * wg[i]; }
+                kv[(size_t)t * out_w + j] = a;
+                gt[(size_t)t * out_w + j] = b + l.cp_pos_bias[(size_t)t * out_w + j];
+            }
+        }
+        if (series == 2) {
+            // slots: [previous window's Ca | this window's Cb]
+            for (int a = 0; a < rate; a++)
+                for (int d = 0; d < hd; d++) {
+                    new_kv[(size_t)a * hd + d] = prev_ca[(size_t)a * hd + d];
+                    new_gate[(size_t)a * hd + d] = prev_ca_gate[(size_t)a * hd + d];
+                    new_kv[(size_t)(rate + a) * hd + d] = kv[(size_t)a * out_w + hd + d];
+                    new_gate[(size_t)(rate + a) * hd + d] = gt[(size_t)a * out_w + hd + d];
+                }
+        } else {
+            for (int a = 0; a < rate; a++)
+                for (int d = 0; d < hd; d++) {
+                    new_kv[(size_t)a * hd + d] = kv[(size_t)a * out_w + d];
+                    new_gate[(size_t)a * hd + d] = gt[(size_t)a * out_w + d];
+                }
+        }
+        // softmax over the slots, per column (the reference softmaxes dim=2 of
+        // [.., n_slots, head_dim], i.e. independently per output channel)
+        for (int d = 0; d < hd; d++) {
+            float mx = -INFINITY;
+            for (int a = 0; a < n_slots; a++) mx = std::max(mx, new_gate[(size_t)a * hd + d]);
+            float sum = 0.0f, acc = 0.0f;
+            for (int a = 0; a < n_slots; a++) {
+                float e = std::exp(new_gate[(size_t)a * hd + d] - mx);
+                sum += e;
+                acc += e * new_kv[(size_t)a * hd + d];
+            }
+            pooled[d] = acc / sum;
+        }
+        rmsnorm(&out[(size_t)w * hd], pooled.data(), l.cp_norm.data(), hd, cfg.rms_norm_eps);
+        rope_partial(&out[(size_t)w * hd], hd, cfg.qk_rope_head_dim, w * rate,
+                     cfg.compress_rope_theta);
+        if (series == 2)
+            for (int a = 0; a < rate; a++)
+                for (int d = 0; d < hd; d++) {
+                    prev_ca[(size_t)a * hd + d] = kv[(size_t)a * out_w + d];
+                    prev_ca_gate[(size_t)a * hd + d] = gt[(size_t)a * out_w + d];
+                }
+    }
+    return out;
 }
 
 // ─── forward ──────────────────────────────────────────────────────────────────

--- a/src/deepseek_v4.cpp
+++ b/src/deepseek_v4.cpp
@@ -183,6 +183,9 @@ bool DeepSeekV4Model::load_from_safetensors(const std::string& dir, const DeepSe
         // or, for checkpoint naming, `compress_ratios` below.
         if (json_find_int(txt, "compressed_sparse_attention", iv) && iv > 0) cfg.csa_rate = iv;
         if (json_find_int(txt, "heavily_compressed_attention", iv) && iv > 0) cfg.hca_rate = iv;
+        if (json_find_int(txt, "index_n_heads", iv) && iv > 0) cfg.index_n_heads = iv;
+        if (json_find_int(txt, "index_head_dim", iv) && iv > 0) cfg.index_head_dim = iv;
+        if (json_find_int(txt, "index_topk", iv) && iv > 0) cfg.index_topk = iv;
         // layer_types: ["sliding_attention", "compressed_sparse_attention", ...]
         {
             size_t p = txt.find("\"layer_types\"");
@@ -315,6 +318,24 @@ bool DeepSeekV4Model::load_from_safetensors(const std::string& dir, const DeepSe
             ok &= get(name("self_attn.compressor.position_bias"), l.cp_pos_bias,
                       (size_t)l.cp_rate * out_w);
             ok &= get(name("self_attn.compressor.kv_norm.weight"), l.cp_norm, hd);
+            // Lightning Indexer — CSA only; HCA has no indexer by construction.
+            if (!hca) {
+                const int ihd = cfg.index_head_dim, nh = cfg.index_n_heads;
+                l.ix_heads = nh;
+                l.ix_hd = ihd;
+                l.ix_topk = cfg.index_topk;
+                ok &= get(name("self_attn.compressor.indexer.kv_proj.weight"), l.ix_kv,
+                          (size_t)2 * ihd * H);
+                ok &= get(name("self_attn.compressor.indexer.gate_proj.weight"), l.ix_gate,
+                          (size_t)2 * ihd * H);
+                ok &= get(name("self_attn.compressor.indexer.position_bias"), l.ix_pos_bias,
+                          (size_t)l.cp_rate * 2 * ihd);
+                ok &= get(name("self_attn.compressor.indexer.kv_norm.weight"), l.ix_norm, ihd);
+                ok &= get(name("self_attn.compressor.indexer.q_b_proj.weight"), l.ix_qb,
+                          (size_t)nh * ihd * cfg.q_lora_rank);
+                ok &= get(name("self_attn.compressor.indexer.scorer.weights_proj.weight"),
+                          l.ix_wproj, (size_t)nh * H);
+            }
         }
 
         if (il < cfg.num_hash_layers) {
@@ -416,6 +437,156 @@ std::vector<float> deepseek_v4_compressor_forward(const DeepSeekV4Layer& l, cons
                     prev_ca[(size_t)a * hd + d] = kv[(size_t)a * out_w + d];
                     prev_ca_gate[(size_t)a * hd + d] = gt[(size_t)a * out_w + d];
                 }
+    }
+    return out;
+}
+
+std::vector<float> deepseek_v4_indexer_scores(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg,
+                                             int rate, const std::vector<float>& x, int T) {
+    using namespace ds4math;
+    const int H = cfg.hidden_size, ihd = l.ix_hd, nh = l.ix_heads;
+    const int n_win = (rate > 0) ? T / rate : 0;
+    std::vector<float> out;
+    if (l.ix_heads == 0 || n_win <= 0) return out;
+    out.assign((size_t)T * n_win, 0.0f);
+
+    // ── 1. the indexer's own compressed keys (2-series, same layout as CSA) ──
+    const int two = 2 * ihd;
+    std::vector<float> K((size_t)n_win * ihd, 0.0f);
+    {
+        std::vector<float> kv((size_t)rate * two), gt((size_t)rate * two);
+        std::vector<float> nk((size_t)2 * rate * ihd), ng((size_t)2 * rate * ihd);
+        std::vector<float> prev_ca((size_t)rate * ihd, 0.0f);
+        std::vector<float> prev_ca_gate((size_t)rate * ihd, -INFINITY);
+        std::vector<float> pooled(ihd);
+        for (int w = 0; w < n_win; w++) {
+            const float* xw = &x[(size_t)w * rate * H];
+            for (int t = 0; t < rate; t++) {
+                const float* xt = xw + (size_t)t * H;
+                for (int j = 0; j < two; j++) {
+                    const float* wk = &l.ix_kv[(size_t)j * H];
+                    const float* wg = &l.ix_gate[(size_t)j * H];
+                    float a = 0.0f, b = 0.0f;
+                    for (int i = 0; i < H; i++) { a += xt[i] * wk[i]; b += xt[i] * wg[i]; }
+                    kv[(size_t)t * two + j] = a;
+                    gt[(size_t)t * two + j] = b + l.ix_pos_bias[(size_t)t * two + j];
+                }
+            }
+            for (int a = 0; a < rate; a++)
+                for (int d = 0; d < ihd; d++) {
+                    nk[(size_t)a * ihd + d] = prev_ca[(size_t)a * ihd + d];
+                    ng[(size_t)a * ihd + d] = prev_ca_gate[(size_t)a * ihd + d];
+                    nk[(size_t)(rate + a) * ihd + d] = kv[(size_t)a * two + ihd + d];
+                    ng[(size_t)(rate + a) * ihd + d] = gt[(size_t)a * two + ihd + d];
+                }
+            for (int d = 0; d < ihd; d++) {
+                float mx = -INFINITY;
+                for (int a = 0; a < 2 * rate; a++) mx = std::max(mx, ng[(size_t)a * ihd + d]);
+                float sum = 0.0f, acc = 0.0f;
+                for (int a = 0; a < 2 * rate; a++) {
+                    float e = std::exp(ng[(size_t)a * ihd + d] - mx);
+                    sum += e;
+                    acc += e * nk[(size_t)a * ihd + d];
+                }
+                pooled[d] = acc / sum;
+            }
+            rmsnorm(&K[(size_t)w * ihd], pooled.data(), l.ix_norm.data(), ihd, cfg.rms_norm_eps);
+            rope_partial(&K[(size_t)w * ihd], ihd, cfg.qk_rope_head_dim, w * rate,
+                         cfg.compress_rope_theta);
+            for (int a = 0; a < rate; a++)
+                for (int d = 0; d < ihd; d++) {
+                    prev_ca[(size_t)a * ihd + d] = kv[(size_t)a * two + d];
+                    prev_ca_gate[(size_t)a * ihd + d] = gt[(size_t)a * two + d];
+                }
+        }
+    }
+
+    // ── 2. q_residual (q_a project + norm), then q per head with rope ──
+    const int ql = cfg.q_lora_rank;
+    std::vector<float> qres((size_t)T * ql);
+    for (int t = 0; t < T; t++) {
+        const float* xt = &x[(size_t)t * H];
+        std::vector<float> raw(ql);
+        for (int j = 0; j < ql; j++) {
+            const float* wr = &l.q_a[(size_t)j * H];
+            float s = 0.0f;
+            for (int i = 0; i < H; i++) s += xt[i] * wr[i];
+            raw[j] = s;
+        }
+        rmsnorm(&qres[(size_t)t * ql], raw.data(), l.q_a_norm.data(), ql, cfg.rms_norm_eps);
+    }
+    std::vector<float> q((size_t)T * nh * ihd);
+    for (int t = 0; t < T; t++)
+        for (int h = 0; h < nh; h++) {
+            float* qh = &q[((size_t)t * nh + h) * ihd];
+            const float* qr = &qres[(size_t)t * ql];
+            for (int d = 0; d < ihd; d++) {
+                const float* wr = &l.ix_qb[(size_t)(h * ihd + d) * ql];
+                float s = 0.0f;
+                for (int i = 0; i < ql; i++) s += qr[i] * wr[i];
+                qh[d] = s;
+            }
+            rope_partial(qh, ihd, cfg.qk_rope_head_dim, t, cfg.compress_rope_theta);
+        }
+
+    // ── 3. score + causal mask + top-k (the score is a ReLU-weighted head sum) ──
+    std::vector<float> wproj((size_t)T * nh);
+    for (int t = 0; t < T; t++)
+        for (int h = 0; h < nh; h++) {
+            const float* wr = &l.ix_wproj[(size_t)h * H];
+            const float* xt = &x[(size_t)t * H];
+            float s = 0.0f;
+            for (int i = 0; i < H; i++) s += xt[i] * wr[i];
+            wproj[(size_t)t * nh + h] = s;
+        }
+    const float softmax_scale = 1.0f / std::sqrt((float)ihd);
+    const float weights_scale = 1.0f / std::sqrt((float)nh);
+    for (int t = 0; t < T; t++)
+        for (int s = 0; s < n_win; s++) {
+            float acc = 0.0f;
+            for (int h = 0; h < nh; h++) {
+                const float* qh = &q[((size_t)t * nh + h) * ihd];
+                const float* Ks = &K[(size_t)s * ihd];
+                float dot = 0.0f;
+                for (int d = 0; d < ihd; d++) dot += qh[d] * Ks[d];
+                acc += std::max(dot, 0.0f) * softmax_scale * wproj[(size_t)t * nh + h] * weights_scale;
+            }
+            out[(size_t)t * n_win + s] = acc;
+        }
+    return out;
+}
+
+// Top-k over the scores above, with the reference's causal rule and `-1` sentinel.
+// NOTE ON TIES: the reference ends with torch.topk, and the scorer's ReLU leaves a
+// large fraction of scores at exactly 0.0 (26.5% on the fixture), so the *order*
+// among tied entries — and sometimes WHICH tied entry makes the k-th slot — is
+// implementation-defined. Exact index equality is therefore not a valid gate; the
+// score table is (Testing/cmp_deepseek_v4_indexer_scores.py). This function mirrors
+// the reference's rule: visible entries are `s < (t+1)/rate`, the rest are -inf,
+// and anything not selected stays -1.
+std::vector<int> deepseek_v4_indexer_topk(const DeepSeekV4Layer& l, const DeepSeekV4Config& cfg,
+                                          int rate, const std::vector<float>& x, int T) {
+    std::vector<int> out;
+    const int n_win = (rate > 0) ? T / rate : 0;
+    if (l.ix_heads == 0 || n_win <= 0) return out;
+    std::vector<float> score = deepseek_v4_indexer_scores(l, cfg, rate, x, T);
+    if ((int)score.size() != T * n_win) return out;
+    const int k = std::min(l.ix_topk, n_win);
+    out.assign((size_t)T * k, -1);
+    for (int t = 0; t < T; t++) {
+        const int threshold = (t + 1) / rate;
+        for (int s = 0; s < n_win; s++)
+            if (s >= threshold) score[(size_t)t * n_win + s] = -INFINITY;
+        for (int j = 0; j < k; j++) {
+            int best = -1;
+            for (int s = 0; s < n_win; s++) {
+                float v = score[(size_t)t * n_win + s];
+                if (v > -INFINITY && (best < 0 || v > score[(size_t)t * n_win + best])) best = s;
+            }
+            if (best < 0) break;
+            out[(size_t)t * k + j] = best;
+            score[(size_t)t * n_win + best] = -INFINITY;
+        }
     }
     return out;
 }


### PR DESCRIPTION
### **User description**
Scoping only — **no engine code in this PR.** It exists so the next person starts from measurements instead of re-deriving them, and so nobody closes the census alert with an alias.

## Why the flagged families are not aliases
Recorded in `Testing/arch-gaps.md` (lands with #2244), from the official HF configs: V4.1 is 40L/H5120/**384 experts** against V4's 43L/H4096/256 and adds `engram_*`/`candidate_*`/dspark; Mamba-3 carries parameters (`mamba_mimo_rank`, `mamba_bc_norm_eps`, `mamba_rope_fraction`, `mamba_a_floor`) that have no Mamba-2 equivalent; `molmoact2` is a VLA with a flow-matching action expert; `cosmos3edge` is a video world model.

## What is measured here (from `model.safetensors.index.json`, the real tensor inventory)
| | V4-Flash | V4.1-Flash |
|---|---|---|
| tensors / size | 69,187 / **159.6 GB** | 96,085 / **510.3 GB** |
| compress_ratios nonzero | **41/44** {0,4,128} | 38/43 {0,1,2}, but only 4 layers carry compressor tensors, 8 carry indexer tensors |
| fp8 | e4m3, block [128,128] | e4m3 + `expert_dtype: fp4`, block [32,32] |
| V4.1-only | — | `engram.*` (2 layers), `attn.indexer.k_norm/wk`, `ffn.gate.bias_vl` (40), rewritten MTP, vision tower + aligner |
| dropped | — | `compressor.ape`, `ffn.gate.tidNeid` (hash routing), V4-style MTP projections |

The engine's V4 path (`include/deepseek_v4.h`) implements mHC, shared-KV MQA, sinks and MoE; it does **not** implement the CSA/HCA compressors or the Lightning Indexer — the existing gate used sliding-only layers. So a **real V4 checkpoint** needs them too, and one implementation serves both families (V4.1 simply uses fewer such layers).

## The binding constraint
The loader materializes every tensor as f32, so 510 GB fp8 is ~2 TB resident. The workstream therefore takes its weight path from **WS-07** (expert staging/PagedWeight) and **WS-11** (NVMe→DRAM→SRAM) and its format from **WS-05** (1BP v2), instead of inventing a fourth mechanism.

## Phases and gates
P0 instrument first (tiny-config HF oracle; the pattern is `Testing/e2e_gen_check_hf.py`, unusable as-is because it loads a whole checkpoint in fp32) → P1 compressors + indexer + shape-agnostic loader + GGUF aliases, then a **real V4-Flash identity gate** against the independent GGUF reference → P2 V4.1 deltas, a vision scope decision, and the Mamba-3 lane. Honesty-tag policy per WS-00: nothing is claimed without the number.

Also updates `research/PLAN.md`, `research/TRACKING.md` (WS-13 row) and the `research/README.md` tree.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Implement CSA/HCA compressors and Lightning Indexer in engine

- Parse `layer_types`/`compress_ratios`, add compress-rope theta

- Wire compressed entries into sliding-window attention, plus per-layer state dump

- Add HF-oracle gates, fixture generator and ws13 research docs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HF fixture generator<br/>make_mini_deepseek_v41.py"] -- "forward hooks" --> B["compressor_ref / indexer_scores / hidden_states"]
  C["config.json<br/>layer_types, compress_ratios"] -- "parse" --> D["deepseek_v4.cpp<br/>compressor + indexer + attention"]
  B -- "1e-6 oracle" --> E["cmp_deepseek_v4_compressor / _incremental"]
  B -- "score table gate" --> F["cmp_deepseek_v4_indexer_scores.py"]
  D -- "per-layer streams" --> G["cmp_deepseek_v4_layers.py"]
  H["run_all.sh"] -- "builds + runs" --> E
  H -- "builds + runs" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>deepseek_v4.cpp</strong><dd><code>Implement CSA/HCA compressors, Lightning Indexer and attention </code><br><code>integration</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-97e9f2e1d1790ecd5713e6792dcc6cc8782031a8330de3aa9d1e127a272597e9">+506/-12</a></td>

</tr>

<tr>
  <td><strong>deepseek_v4.h</strong><dd><code>Declare compressor config, params, state and new signatures</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-ab06226750544fd8153609e891331ef5050c8404838941ed57b362ec4660d448">+125/-2</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>cmp_deepseek_v4_compressor.cpp</strong><dd><code>New gate comparing batched compressor output to HF reference</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-86623e36d5a149b5f4087d5972e8bff56b06a2fcb8888f371848baf5eb9d65d8">+110/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>cmp_deepseek_v4_compressor_incremental.cpp</strong><dd><code>New gate for token-by-token compressor state machine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-da121dbd238a6a4d1e3c92cd7062d38ca4789a896e959787ca51df69200a8d6c">+97/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cmp_deepseek_v4_indexer.cpp</strong><dd><code>Indexer comparison harness with score dump and tie analysis</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-ca44136b342a9882187c48279ba9eaada8f345309dad2acb4e8d8803ec68f69a">+161/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>cmp_deepseek_v4_indexer_scores.py</strong><dd><code>Python gate for indexer score table and selection validity</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-6a67f9ecc9e3e4eaffde5e877c7c7bedce27779473fba1af4ed4f1378a890878">+114/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>cmp_deepseek_v4_layers.py</strong><dd><code>Per-layer engine-vs-HF residual stream bound check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-d3084bcc74324de65c8f1905c65afdfd6464f01c4705837394a86b342e1236db">+82/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cmp_deepseek_v4.cpp</strong><dd><code>Add optional per-layer state dump output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-299135e8982a05827eb519ecff427f101d0688f789c1726a160f01e0290feec6">+25/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>make_mini_deepseek_v41.py</strong><dd><code>Generate tiny V4 fixtures with hook-captured oracles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-082a50188505972f7c280e07563c521fc422c79eee4166d4cdd97690a60e9111">+242/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>make_ws13_fixtures.sh</strong><dd><code>Script generating the seven ws13 fixture profiles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-caaa3406add622282509c16175df73a1cb3cdbb37631978e12c9866151fae9aa">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>run_all.sh</strong><dd><code>Wire ws13 compressor, indexer and per-layer gates into CI</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-60779953d5d72f0d8ef3aea52f86b0b365bbdb42457aae2e5955d6320e32eb2c">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>deepseek-v4-flash-reverse-engineering.md</strong><dd><code>Mark report superseded and flag fictional architecture claims</code></dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-4cf8c49ecb0e4291ad16bac3c059b42ef735ee4f84a27ac84bad4322491c178f">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TRACKING.md</strong><dd><code>Add WS-13 row with measured gate results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-484bdea931535c909d752bdac46da38ca729de4b22399cc5fe8582b6da2010ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PLAN.md</strong><dd><code>Add WS-13 workstream to the roadmap graph</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-f3f7ddf6a6fbad119bdc11a5f3de7606ae3cbb2809a092d12e286407d0086fe7">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Index the ws13 arch-gap-closure research folder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-7457dc94d4573a7b15c63d74287dc45d204bc028ca7a5c11b5b374389e6c34e0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FINDINGS.md</strong><dd><code>Record measured gates, closed GGUF route and findings</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-a3b25a364f3b753c94cc328976ba49ede08b4bf3a439fb2682eddf2e716de4b8">+474/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SPEC-v41-modules.md</strong><dd><code>Specify V4.1-only modules and Mamba-3 lane</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-88e9bab69a9e6cebe28c8689523c6a36f01b64778caf63725a40404444790e97">+115/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Describe the ws13 workstream scope and layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2245/files#diff-c2f5f54483e0c02b3faaa4618f2e77b69000edc27d2c6d5fab3def686dde35ba">+107/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

