### PR TITLE
fix(engine): the per-model tokenizer wins over a shared directory tokenizer.htok (#2205)

### DIFF
--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -242,25 +242,33 @@ static std::string tokenizer_path() {
 // as garbage [id][id] through the ASCII fallback.
 static void load_model_tokenizer(const std::string& model_path) {
     if (g_tokenizer.load_from_gguf(model_path)) return;
-    // Prefer a tokenizer that sits BESIDE the artifact. Every candidate below this point is a
-    // GGUF the loader borrows vocabulary from, so a native container (Q4NX/1BP) with no GGUF
-    // sibling could never be detokenised — the lookup never considered its own directory. The
-    // only other path consulted is the WEIGHTS DIR (tokenizer_path()), which is wrong for an
-    // artifact kept anywhere else. Measured on strixhalo: a served zaya1-8b.q4nx from
-    // ~/models returned "[81930][129662]…" -- correct generation, ASCII fallback for text.
-    // `model.q4nx + tokenizer.htok in one directory` is the natural layout, so it wins here.
+    // Prefer a tokenizer that sits BESIDE the artifact: `<stem>.htok` (#2197). Every candidate
+    // below this point is a GGUF the loader borrows vocabulary from, so a native container
+    // (Q4NX/1BP) with no GGUF sibling could never be detokenised: the lookup never considered
+    // its own directory. The only other path consulted is the WEIGHTS DIR (tokenizer_path()),
+    // which is wrong for an artifact kept anywhere else. Measured on strixhalo: a served
+    // zaya1-8b.q4nx from ~/models returned "[81930][129662]..." -- correct generation, ASCII
+    // fallback for text.
+    //
+    // The directory-level `<dir>/tokenizer.htok` is deliberately NOT tried here. That name is a
+    // single-model convention (`model.q4nx + tokenizer.htok` in one directory), but it used to
+    // be tried FIRST, so in a SHARED directory -- the normal case, e.g. ~/models holding ~30
+    // models -- one model's vocabulary was applied to every model in it (#2205): serving
+    // Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf from ~/models loaded the 9,045,287-byte zaya
+    // `tokenizer.htok` (BOS=0, EOS=106) instead of the model's own 3,494,480-byte
+    // `<gguf>.htok`, so text decoded through the wrong ids->text mapping while token-level
+    // behaviour stayed correct. It is now the LAST resort (see the fallback at the end of this
+    // function), which keeps the #2197 native-container layout working without leaking across
+    // artifacts.
     {
         auto exists2 = [](const std::string& p) {
             std::ifstream f(p, std::ios::binary);
             return f.good();
         };
-        auto slash2 = model_path.find_last_of('/');
-        std::string dir2 = (slash2 != std::string::npos) ? model_path.substr(0, slash2 + 1) : "";
         auto dot2 = model_path.find_last_of('.');
         std::string stem2 = (dot2 != std::string::npos) ? model_path.substr(0, dot2) : model_path;
-        for (const std::string& c : {dir2 + "tokenizer.htok", stem2 + ".htok"}) {
-            if (exists2(c) && g_tokenizer.load(c)) return;
-        }
+        std::string own = stem2 + ".htok";
+        if (exists2(own) && g_tokenizer.load(own)) return;
     }
     // NOTE: no early return for .gguf paths — load_from_gguf needs the ZINC
     // lib (usually absent → ZINC_DISABLED), so even real GGUFs must fall
@@ -347,6 +355,20 @@ static void load_model_tokenizer(const std::string& model_path) {
             std::string c = dir + n;
             if (load_or_synthesize(c)) return;
         }
+    }
+
+    // Last resort: the directory-level `tokenizer.htok` (#2197). A native container
+    // (Q4NX/1BP/H1B) carries no GGUF to borrow a vocabulary from, so `model.q4nx +
+    // tokenizer.htok in one directory` is its only in-directory source. Reaching this point
+    // means nothing model-specific was found, so a shared directory can no longer substitute
+    // another model's tokenizer *before* the artifact's own vocabulary is tried (#2205): a
+    // real GGUF is always served by the self/sibling synthesis above.
+    {
+        auto slash3 = model_path.find_last_of('/');
+        std::string dir3 = (slash3 != std::string::npos) ? model_path.substr(0, slash3 + 1) : "";
+        std::string shared = dir3 + "tokenizer.htok";
+        std::ifstream f(shared, std::ios::binary);
+        if (f.good() && g_tokenizer.load(shared)) return;
     }
 }
 


### PR DESCRIPTION
### **User description**
## Description

`load_model_tokenizer()` tried the **directory-level** `<dir>/tokenizer.htok` **first**:

```cpp
for (const std::string& c : {dir2 + "tokenizer.htok", stem2 + ".htok"}) { ... }
```

That name is a *single-model* convention (`model.q4nx + tokenizer.htok` in one directory, added by #2197), but the lookup runs for **every** model. In a shared directory — the normal case, `~/models` holding ~30 artifacts — one model's vocabulary therefore won for all of them, silently.

This makes it the **last resort** instead: `<stem>.htok` beside the artifact, then the existing sibling-GGUF / self-synthesis path (which is what actually serves a GGUF artifact's own vocabulary), and only then `<dir>/tokenizer.htok`.

## Type of Change

- [ ] NPU Engine (`[npu]`)
- [ ] GPU Engine (`[gpu]`)
- [ ] Packaging (`[packaging]`)
- [ ] Documentation (`[docs]`)
- [ ] CI/CD (`[ci]`)
- [ ] Site (`[site]`)

None of the listed boxes apply: this is the engine's server-side tokenizer lookup, not one of the six categories.

## Performance Impact (if engine change)

None. The lookup runs once at model load, before any decode; no decode path is touched and no throughput number is claimed.

## Verification

- [x] Built and ran locally
- [x] Benchmarks pass (if applicable) — not applicable, no decode change
- [x] No regressions in existing model support

### Measured on strixhalo (`~/models` = 31 artifacts; zaya `tokenizer.htok` = 9,045,287 B present)

**Before** — both models in the shared directory loaded the foreign zaya vocabulary, even though each already had its own correct 3,494,480-byte cache beside it:

```
$ ./build/1bit unified --port 8181 -m ~/models/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf
Loaded BPE tokenizer from /home/bcloud/models/tokenizer.htok (BOS=0, EOS=106)
$ ./build/1bit unified --port 8182 -m ~/models/Qwen3-0.6B-Q4_K_M.gguf
Loaded BPE tokenizer from /home/bcloud/models/tokenizer.htok (BOS=0, EOS=106)
```

**After** — same commands, same box:

| # | artifact | tokenizer loaded | note |
|---|---|---|---|
| A | `~/models/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf` | its own `…Q4_K_M.gguf.htok` (`BOS=128000, EOS=151645`) | the case in #2205 |
| B | `~/models/Qwen3-0.6B-Q4_K_M.gguf` | its own `…gguf.htok` (`BOS=128000`) | a second shared-dir model |
| D | `/tmp/2205-foreign/`: GGUF + **foreign** `tokenizer.htok`, no own cache | self-synthesized `…gguf.htok` (3,494,480 B) | the leak class itself |
| C | `/tmp/2205-single/model.q4nx` + `tokenizer.htok` | `/tmp/2205-single/tokenizer.htok` (`BOS=0, EOS=106`) | **#2197 native-container layout still works** |

Case **C** is why the directory-level file is kept rather than dropped: a native container has no GGUF to borrow a vocabulary from, so it remains that layout's only in-directory source. Case **D** is the defect class: a foreign `tokenizer.htok` beside a model with no cache of its own no longer pre-empts the artifact's own vocabulary.

Serving is unaffected: `curl -sf /v1/health` → `200` after ~21 s with `Qwen3-0.6B-Q4_K_M.gguf`, and the log contains no abort/segfault.

### Not changed

- `tokenizer_path()` (the WEIGHTS-DIR fallback), the sibling-GGUF synthesis, the quant-marker stripping and the directory scan are untouched.
- No new naming convention: the per-model candidate uses the same `<gguf>.htok` cache `load_or_synthesize()` already writes, which is why an existing cache is picked up unchanged.
- The "directory contains a single artifact" check that #2205's option 2 suggested is **not** needed once the directory-level file is consulted only after the artifact's own vocabulary has been tried: option 1 plus last-resort gives the same protection with a smaller diff (1 file, +34/−12).

### Gates actually run, and ones that were not

- `ninja onebin` — clean build; no new warnings from this file.
- `clang-format --dry-run --Werror` — **not run**. The only formatter found on the box is `~/rocm-llvm-full/install/bin/clang-format` (LLVM `24.0.0git`), which rejects the repo's `.clang-format` (`Standard: Cpp17` → `error: unknown enumerated scalar`), so it cannot judge this file. CI's formatter is apt `clang-format` on `ubuntu-24.04` and its step is `continue-on-error: true`. Instead, the changed lines were measured to be ≤100 columns (`ColumnLimit: 100`, `ReflowComments: true`).
- No automated test covers `load_model_tokenizer()` (it is a `static` function in the server), so the table above is the behavioural gate.
- The NPU/HIP PPL and model-test gates are unaffected in principle — they consume token ids/logits, not the ids→text mapping — but they were **not** re-run here and this PR does not claim they were.

## Related Issues

Fixes #2205

---
*By submitting this PR, I confirm that any benchmark numbers or status changes accurately reflect real on-device measurements, or are explicitly marked `unvalidated` per the repo's process policy (see #54).*

*Prepared by the local mesh agent `@agent-2ddcfd` (goal `mty494c4`). The branch lives in this repository rather than the `bong-water-water-bong` fork: the repo's post-commit auto-push hook pushes to `origin`, and same-repo branches are how every other PR here is opened.*


___

### **PR Type**
Bug fix


___

### **Description**
- Per-model `<stem>.htok` now wins over directory vocabulary

- Directory-level `tokenizer.htok` demoted to last-resort fallback

- Fixes shared-directory vocab leak across models (#2205)

- Keeps #2197 native container layout working


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["load_model_tokenizer(model_path)"] -- "load_from_gguf" --> B["GGUF vocab?"]
  B -- "no" --> C["Per-model: <stem>.htok beside artifact"]
  C -- "not found" --> D["Sibling GGUF / .htok synthesis"]
  D -- "not found" --> E["Last resort: <dir>/tokenizer.htok"]
  C -- "loaded" --> Z["Tokenizer ready, return"]
  E -- "loaded" --> Z
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>unified_server.cpp</strong><dd><code>Reorders tokenizer lookup so per-model `.htok` wins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/unified_server.cpp

<ul><li>Removes <code><dir>/tokenizer.htok</code> from the artifact-adjacent probe in <br><code>load_model_tokenizer()</code>, leaving only the per-model <code><stem>.htok</code> first.<br> <li> Adds a last-resort block at the end of the function that tries <br><code><dir>/tokenizer.htok</code> only after sibling-GGUF lookup and <code>.htok</code> synthesis <br>have failed.<br> <li> Drops the now-unused <code>slash2</code>/<code>dir2</code> derivation and documents the <br>shared-directory vocabulary leak (#2205) in expanded comments.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2257/files#diff-108a4e5ad06a8667d81e8da41605283a4dff15e0519645becad615fded67977c">+34/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

