### PR TITLE
fix(engine): an explicit --weights <dir> wins over the $HOME/models scan root (#2206)

### DIFF
--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -1824,7 +1824,36 @@ int main(int argc, char** argv) {
         }
     }
     if (current_cfg.model_path.empty() && !discovered.empty()) {
+        // Issue #2206, suggested direction (1): an explicitly provided `--weights <dir>` must
+        // not be overridden by an artifact that exists only because the SECONDARY scan root
+        // ($HOME/models) contributed it. Measured on strixhalo: with `--weights models/`
+        // holding one small model and a 35B Q8_0 present in $HOME/models, the 35B outranked
+        // it on quant quality and became [active]; no discovered backend can load that arch,
+        // so the server never came healthy.
+        //
+        // The quality ordering above is deliberately unchanged WITHIN a root: this only stops
+        // the convenience root from outranking the operator's own directory. When the primary
+        // root holds nothing, the fallback below is still `discovered.front()`.
+        //
+        // This does NOT cover the case where `--weights` IS $HOME/models (a symlink): the
+        // artifact is then genuinely inside the weights dir and still wins on quality.
+        // Refusing an unloadable auto-selection is the separate product call in #2206.
+        const char* env_root = getenv("LEMONADE_ENGINE_REGISTRY_ROOT");
+        if (!env_root || !*env_root) env_root = getenv("ZAYA_WEIGHTS_DIR");
+        std::string primary = (env_root && *env_root) ? std::string(env_root) : g_weights_dir;
+        while (primary.size() > 1 && primary.back() == '/') primary.pop_back();
+        auto under_primary = [&primary](const std::string& p) {
+            if (primary.empty()) return false;
+            if (p.compare(0, primary.size(), primary) != 0) return false;
+            return p.size() == primary.size() || p[primary.size()] == '/';
+        };
         current_cfg = discovered.front();
+        for (const auto& m : discovered) {
+            if (under_primary(m.model_path)) {
+                current_cfg = m;
+                break;
+            }
+        }
     }
 
     for (auto& m : discovered) {


### PR DESCRIPTION
### **User description**
## Description

Since #2198 the registry scans a **second** root, `$HOME/models`, unconditionally. With no `-m`, the active model is then `discovered.front()` — sorted by format then quant quality — so an artifact from that convenience root can outrank, and silently replace, the model in the operator's own `--weights <dir>`.

This implements suggested direction **(1)** in #2206: when no `-m` was given, prefer a discovered artifact that lives under the **primary** root (`--weights <dir>`, or `LEMONADE_ENGINE_REGISTRY_ROOT` / `ZAYA_WEIGHTS_DIR` when set) over one that is present only because `$HOME/models` contributed it. The quality ordering is unchanged *within* a root, and the fallback is still `discovered.front()` when the primary root holds nothing.

One `if`-block at the selection site; no other logic moved.

## Type of Change

- [x] NPU Engine (`[npu]`) — not applicable
- [ ] GPU Engine (`[gpu]`)
- [ ] Packaging (`[packaging]`)
- [ ] Documentation (`[docs]`)
- [ ] CI/CD (`[ci]`)
- [ ] Site (`[site]`)

This is the engine's server-side model-selection path, not one of the six listed categories.

## Performance Impact (if engine change)

None. Selection happens once at startup; no decode or load path is touched.

## Verification

- [x] Built and ran locally
- [x] Benchmarks pass (if applicable) — not applicable
- [x] No regressions in existing model support

### Measured on strixhalo

**The case this fixes** — an explicit weights dir that is *not* the shared dir, holding one loadable model, with a 35B Q8_0 present in `$HOME/models`:

```
# before (main)
$ cd /tmp/2206-distinct && ./build/1bit unified --port 8191 --weights models/ --gen-timeout-ms 10000 --quick
[discover] 1 model(s) found in models/
  Registry discovery: 32 artifact(s) as canonical ids, +1 legacy-only
  > qwen3-6-35b-a3b-q8-0.gguf (/home/bcloud/models/Qwen3.6-35B-A3B-Q8_0.gguf) [active]
HEALTH=000          # the operator's own model/dir was overridden; the 35B never comes up

# after
  > Qwen3-0.6B (models//Qwen3-0.6B-Q4_K_M.gguf) [active]
HEALTH=200          # ~21 s
```

**Unchanged, and deliberately so:**

| scenario | before | after |
|---|---|---|
| `--weights` is the shared dir via symlink (`models/ -> ~/models`) | 35B Q8_0 `[active]`, `HEALTH=000` | 35B Q8_0 `[active]`, `HEALTH=000` |
| no `--weights` at all (default weights dir) | default-dir `Qwen3-0.6B-Q8_0` `[active]`, `HEALTH=200` | same, `HEALTH=200` |

The symlink row is the E2E smoke test's actual shape, and it is **not** fixed here: with `models/ -> ~/models` the unloadable 35B is genuinely *inside* the weights dir, so "primary root wins" cannot exclude it. That gate was already unblocked by pinning `-m` in the workflow (#2208), and refusing an unloadable auto-selection is direction **(2)** — the product decision the issue explicitly leaves to the operator ("this changes which model an unconfigured server serves — the operator's call").

### Behaviour change worth naming

For a file reachable through *both* roots, the auto-selected **canonical id** can change form: before, the registry entry won (`qwen3-6-35b-a3b-q8-0.gguf`, absolute path); after, the weights-dir entry wins (`Qwen3.6-35B-A3B`, `models//…`). Same file, same bytes — but the model id an unconfigured server reports as active changes, which is visible in `/v1/models`. Stated rather than glossed over.

### Gates actually run, and ones that were not

- `ninja onebin` — clean build, no new warnings from this file.
- `clang-format --dry-run --Werror` — **not run**: the only formatter found on the box is `~/rocm-llvm-full/install/bin/clang-format` (LLVM `24.0.0git`) and it rejects the repo's `.clang-format` (`Standard: Cpp17` → `error: unknown enumerated scalar`). CI's formatter is apt `clang-format` on `ubuntu-24.04` and its step is `continue-on-error: true`. The changed lines were measured to be ≤100 columns (`ColumnLimit: 100`, `ReflowComments: true`) instead.
- No automated test covers this selection path; the table above is the behavioural gate.
- PPL/model-test gates are unaffected in principle (selection only) and were **not** re-run here — no claim is made that they were.

## Related Issues

References #2206 — implements suggested direction (1). It does **not** close the issue: direction (2) (auto-selecting an artifact no discovered backend can load) remains, and that is the operator's call.

---
*By submitting this PR, I confirm that any benchmark numbers or status changes accurately reflect real on-device measurements, or are explicitly marked `unvalidated` per the repo's process policy (see #54).*

*Prepared by the local mesh agent `@agent-2ddcfd` (goal `mty494c4`).*


___

### **PR Type**
Bug fix


___

### **Description**
- Prefer primary root over `$HOME/models` in selection

- Explicit `--weights <dir>` no longer silently outranked

- Honour `LEMONADE_ENGINE_REGISTRY_ROOT` / `ZAYA_WEIGHTS_DIR` overrides

- Quality ordering and `discovered.front()` fallback unchanged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Startup: no -m, discovered non-empty"] -- "compute primary root" --> B["--weights dir, else LEMONADE_ENGINE_REGISTRY_ROOT / ZAYA_WEIGHTS_DIR"]
  B -- "normalize trailing slashes" --> C["under_primary(path) prefix test"]
  C -- "match found" --> D["current_cfg = artifact under primary root"]
  C -- "no match" --> E["fallback: current_cfg = discovered.front()"]
  D -- "unchanged" --> F["quality ordering kept within a root"]
  E -- "unchanged" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>unified_server.cpp</strong><dd><code>Prefer primary weights root when auto-selecting a model</code>&nbsp; &nbsp; </dd></summary>
<hr>

tools/unified_server.cpp

<ul><li>Adds an <code>under_primary</code> lambda using the primary root <br>(<code>LEMONADE_ENGINE_REGISTRY_ROOT</code>, <code>ZAYA_WEIGHTS_DIR</code>, else <code>g_weights_dir</code>) <br>with trailing-slash normalization.<br> <li> After <code>current_cfg = discovered.front()</code>, loops <code>discovered</code> and selects <br>the first artifact whose <code>model_path</code> lies under the primary root.<br> <li> Documents that the <code>$HOME/models</code> scan root is a convenience and must <br>not override an explicit <code>--weights <dir></code>.<br> <li> Notes explicit limits: quality order unchanged within a root, and a <br><code>--weights</code> symlink to <code>$HOME/models</code> is still not covered.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2259/files#diff-108a4e5ad06a8667d81e8da41605283a4dff15e0519645becad615fded67977c">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

