### PR TITLE
fix(analytics): normalize Taiwan/TW before country aggregation

### DIFF
--- a/.github/workflows/analytics.yml
+++ b/.github/workflows/analytics.yml
@@ -170,13 +170,16 @@ jobs:
             echo "=== Visitors by country (top 10, 7d) ==="
             # httpRequestsAdaptiveGroups supports clientCountryName but only
             # 1-day windows (a 7d range errors out); loop the last 7 days and
-            # aggregate by country (codes are ISO alpha-2).
+            # aggregate by country (codes are ISO alpha-2). Cloudflare returns
+            # "Taiwan" instead of "TW" for this one field, unlike every other
+            # country which comes back as a code — normalized below so it
+            # doesn't split into two rows in the aggregation.
             COUNTRIES=$(for d in $(seq 0 6); do
               DAY=$(date -u -d "$FROM + $d days" +%Y-%m-%d)
               if RESP=$(gql "{ viewer { zones(filter: {zoneTag: \"$ZONE_ID\"}) { httpRequestsAdaptiveGroups(limit: 100, filter: {date: \"$DAY\"}, orderBy: [count_DESC]) { dimensions { clientCountryName } count } } } }"); then
                 ERR=$(printf '%s' "$RESP" | jq -r '.errors[0].message // empty')
                 [ -z "$ERR" ] || echo "country query failed (day $DAY): $ERR" >&2
-                printf '%s' "$RESP" | jq -r 'if .data then [.data.viewer.zones[0].httpRequestsAdaptiveGroups[]? | select(.dimensions.clientCountryName != null) | { country: .dimensions.clientCountryName, requests: .count }] | .[] | "\(.country)	\(.requests)" else empty end'
+                printf '%s' "$RESP" | jq -r 'if .data then [.data.viewer.zones[0].httpRequestsAdaptiveGroups[]? | select(.dimensions.clientCountryName != null) | { country: (.dimensions.clientCountryName | if . == "Taiwan" then "TW" else . end), requests: .count }] | .[] | "\(.country)	\(.requests)" else empty end'
               else
                 echo "country query failed (day $DAY): HTTP error" >&2
               fi


### PR DESCRIPTION
### **User description**
## Summary
- The traffic report's "Visitors by country" section (posted to #traffic-report) was showing Taiwan traffic as two separate rows — Cloudflare's `clientCountryName` returns "Taiwan" instead of the ISO alpha-2 code used for every other country, so the per-country aggregation split its counts across "Taiwan" and "TW" keys.
- Normalized "Taiwan" → "TW" before aggregation so it collapses into a single consistent row.

## Test plan
- [x] Verified the jq normalization against mock GraphQL responses mixing "Taiwan" and "TW" — counts correctly combine into one `TW` row.
- [ ] Confirm next scheduled analytics.yml run shows a single TW row in the country breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeUexV7WAecV5hVHjrSnMq


___

### **PR Type**
Bug fix


___

### **Description**
- Normalize Cloudflare `clientCountryName` "Taiwan" to ISO code "TW"

- Fix split Taiwan rows in traffic report country breakdown

- Extend comment documenting the Cloudflare naming quirk

- jq aggregation now collapses Taiwan traffic into one row


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cloudflare httpRequestsAdaptiveGroups"] -- "clientCountryName" --> B["jq filter in analytics.yml"]
  B -- "if == \"Taiwan\" then \"TW\"" --> C["Normalized country key"]
  C -- "awk aggregation" --> D["Single TW row in #traffic-report"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analytics.yml</strong><dd><code>Normalize Taiwan country code in analytics jq filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/analytics.yml

<ul><li>Map <code>clientCountryName</code> value "Taiwan" to "TW" inside the jq expression <br>before emitting country/requests pairs<br> <li> Ensure the per-day loop's <code>awk</code> aggregation no longer splits Taiwan <br>counts across two keys<br> <li> Expand the inline comment explaining that Cloudflare returns "Taiwan" <br>instead of the ISO alpha-2 code<br> <li> No changes to query window, limits, sorting, or report formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2266/files#diff-607f949b9aca36160cbe6db71570383124fdf743994796f8091bb52cf1cc52a4">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

