### PR TITLE
chore(deps): disable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5


### PR DESCRIPTION
### **User description**
Owner request: **disable the Dependabot bot** for this repo.

- Removes `.github/dependabot.yml` (the only config — `github-actions` ecosystem, `directory: /`, weekly, `open-pull-requests-limit: 5`), which is what schedules the `dynamic/dependabot/dependabot-updates` runs.
- Motivation on record: run [31833962396](https://github.com/1bit-MONSTER/1bit-MONSTER/actions/runs/31833962396) has been stuck `queued` with 0 jobs since 2026-08-14 and cannot be cancelled (409), force-cancelled (409), re-run (403) or deleted (403 — only *completed* runs are deletable; the same DELETE on a completed run returns 204). It is a GitHub-side scheduler ghost, not a repo problem, and it cannot be purged from here. Removing the version-updates config stops this class of job from being scheduled at all.
- Reversible: re-adding the file (contents below) re-enables version updates.

```yaml
version: 2
updates:
  - package-ecosystem: github-actions
    directory: /
    schedule:
      interval: weekly
    open-pull-requests-limit: 5
```

Dependabot **alerts** and **secret scanning** are untouched.


___

### **PR Type**
Other


___

### **Description**
- Remove `.github/dependabot.yml` to disable Dependabot version updates

- Stops weekly `github-actions` update PRs and scheduler runs

- Re-adding the file restores version updates

- Alerts and secret scanning remain unchanged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[".github/dependabot.yml"] -- "removed" --> B["Dependabot version updates disabled"]
  B -- "no longer scheduled" --> C["Stuck queued workflow runs avoided"]
  B -- "untouched" --> D["Alerts and secret scanning"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Remove Dependabot version-update configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Deletes the entire Dependabot configuration file (7 lines).<br> <li> Removed <code>github-actions</code> ecosystem with <code>directory: /</code>, weekly schedule <br>and <code>open-pull-requests-limit: 5</code>.<br> <li> Disables automatic version-update PRs and the scheduled Dependabot <br>update runs.<br> <li> Fully reversible by re-adding the same file.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2275/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

