### PR TITLE
fix(engine): bound the per-candidate backend decline budget (#2263)

### DIFF
--- a/include/backend_manager.h
+++ b/include/backend_manager.h
@@ -100,6 +100,16 @@ struct BackendPlugin {
 // monitors health, and handles failover.
 class BackendManager {
 public:
+
+    /// #2263: narrow the out-of-process spawn/health budget applied to every
+    /// backend this manager creates (0 = leave that lane's own budget alone).
+    /// The server sets this for *auto-selected* candidates, which are probes
+    /// rather than commitments; a model pinned with -m keeps the lane's budget.
+    void set_init_budget(int retries, int timeout_s) {
+        probe_retries_ = retries;
+        probe_timeout_s_ = timeout_s;
+    }
+
     BackendManager();
     ~BackendManager();
 
@@ -231,6 +241,11 @@ private:
     bool pilot_active_ = false;
     bool initialized_ = false;
     mutable std::mutex mtx_;
+
+private:
+    int probe_retries_ = 0;     // #2263: 0 = leave the lane's budget alone
+    int probe_timeout_s_ = 0;
+
 };
 
 // ── Convenience: global singleton ──

--- a/src/backend.h
+++ b/src/backend.h
@@ -154,6 +154,17 @@ struct Backend {
     /// Defaults to true; stub backends that only detect hardware override to false
     /// so BackendManager discovers them but never selects them for inference (#82).
     virtual bool can_infer() const { return true; }
+
+    /// Narrow the out-of-process spawn/health budget: how many times to retry a
+    /// failed spawn and how long to wait for the child to become healthy.
+    ///
+    /// Used by the server for *auto-selected* candidates, which are probes rather
+    /// than commitments. Without it the spawn lanes decline an artifact the
+    /// operator never asked for very slowly — HRX 3 x 120 s, LSE and FLM
+    /// 10 x 120 s, i.e. up to ~20 min per candidate — which a 90 s health window
+    /// cannot tell apart from a dead server (#2263). In-process backends ignore
+    /// this: they have no child to spawn.
+    virtual void set_init_budget(int retries, int timeout_s) { (void)retries; (void)timeout_s; }
 };
 
 // ── Factory: auto-detect and create best available backend ──

--- a/src/backend_hrx.h
+++ b/src/backend_hrx.h
@@ -78,6 +78,11 @@ private:
     int spawn_retries_ = 3;
     int retry_delay_s_ = 3;
     int init_timeout_s_ = 120;
+    // #2263: bounded decline for auto-selected probes (see Backend::set_init_budget).
+    void set_init_budget(int retries, int timeout_s) override {
+        if (retries > 0) spawn_retries_ = retries;
+        if (timeout_s > 0) init_timeout_s_ = timeout_s;
+    }
     double last_decode_tok_s_ = 0.0;
 };
 

--- a/src/backend_lse.h
+++ b/src/backend_lse.h
@@ -55,6 +55,11 @@ private:
     int spawn_retries_ = 10;
     int retry_delay_s_ = 5;
     int init_timeout_s_ = 120;
+    // #2263: bounded decline for auto-selected probes (see Backend::set_init_budget).
+    void set_init_budget(int retries, int timeout_s) override {
+        if (retries > 0) spawn_retries_ = retries;
+        if (timeout_s > 0) init_timeout_s_ = timeout_s;
+    }
     // Per-request statistics from the last /v1/completions call (M3
     // benchmark): decode tok/s reported by lse-server's timings field.
     double last_decode_tok_s_ = 0.0;

--- a/src/backend_manager.cpp
+++ b/src/backend_manager.cpp
@@ -615,6 +615,12 @@ bool BackendManager::init_in_order(const ModelConfig& cfg, const std::string& we
             continue;
         }
         info.instance = std::shared_ptr<Backend>(raw);
+        // #2263: for an auto-selected probe, narrow this lane's decline budget
+        // before we ask it to init (Backend::set_init_budget).
+        if (probe_retries_ > 0 || probe_timeout_s_ > 0) {
+            info.instance->set_init_budget(probe_retries_, probe_timeout_s_);
+        }
+
 
         // Timeout guard: if a backend takes >6s to init (e.g. CPU scanning
         // missing weights), skip it so higher-tier backends like NPU FLM get
@@ -632,7 +638,10 @@ bool BackendManager::init_in_order(const ModelConfig& cfg, const std::string& we
         // seconds on a cold cache). 6s was timing out legit backends so they
         // never came up; still bounded so a hung init can't block forever
         // (issue #1282).
-        if (init_fut.wait_for(std::chrono::seconds(120)) == std::future_status::ready) {
+        // #2263: the outer cap follows the probe budget when one is set (a probe must
+        // not wait 120 s per lane across ~20 lanes).
+        const int init_cap_s = probe_timeout_s_ > 0 ? probe_timeout_s_ : 120;
+        if (init_fut.wait_for(std::chrono::seconds(init_cap_s)) == std::future_status::ready) {
             // init() may THROW (wedged NPU/XRT, driver fault, OOM) — the
             // exception is captured by the future and rethrown here. A
             // broken backend must be skipped, never allowed to terminate
@@ -645,7 +654,7 @@ bool BackendManager::init_in_order(const ModelConfig& cfg, const std::string& we
                 printf("  → ❌ (init threw unknown exception)\n");
             }
         } else {
-            printf("  → ⏱️  init timed out (>120s) — skipping\n");
+            printf("  → ⏱️  init timed out (>%ds) — skipping\n", init_cap_s);
             destroy_instance(info);
             continue;
         }

--- a/src/backend_npu_flm.cpp
+++ b/src/backend_npu_flm.cpp
@@ -113,6 +113,14 @@ class NpuFlmBackend : public Backend {
     int http_port_ = -1;  // FLM serve port (serve mode)
 
 public:
+    // #2263: bounded decline for auto-selected probes (see Backend::set_init_budget).
+    // FLM has no separate health timeout — its per-attempt wait is bounded
+    // internally — so only the retry count is narrowed here.
+    void set_init_budget(int retries, int timeout_s) override {
+        if (retries > 0) spawn_retries_ = retries;
+        (void)timeout_s;
+    }
+
     NpuFlmBackend() {
         type = BackendType::NPU_XRT;
         name = "NPU FLM (MIT, 67.5 tok/s)";

--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -1878,6 +1878,28 @@ int main(int argc, char** argv) {
     // The flip: the registry resolver is consumed here. The merge is a UNION — the
     // registry can demote the head only for a stated exclusion, and never drops a
     // router lane — so this cannot lose a route the engine has today.
+    // Issue #2263 (re-scoped): an auto-selected candidate is a *probe*, not a
+    // commitment, so narrow the budget every lane gets before it is created — the
+    // manager applies it as it instantiates each backend. Without it the spawn
+    // lanes decline an unpinned artifact very slowly (HRX 3 x 120 s, LSE and FLM
+    // 10 x 120 s) and the manager waits up to 120 s per backend across ~20
+    // backends, so a bare server can look dead for many minutes — which a 90 s
+    // health window cannot tell apart from a permanent failure. A model pinned
+    // with -m keeps the lane's full budget: there we ARE committed to it.
+    // Overrides: ONEBP_PROBE_RETRIES (default 1), ONEBP_PROBE_TIMEOUT_S (default 20).
+    if (g_model_name.empty()) {
+        auto probe_env = [](const char* key, int dflt) {
+            const char* v = getenv(key);
+            if (!v || !*v) return dflt;
+            int n = atoi(v);
+            return n > 0 ? n : dflt;
+        };
+        const int probe_retries = probe_env("ONEBP_PROBE_RETRIES", 1);
+        const int probe_timeout = probe_env("ONEBP_PROBE_TIMEOUT_S", 20);
+        mgr.set_init_budget(probe_retries, probe_timeout);
+        printf("  [select] auto-probe budget: %d retry(ies), %ds lane timeout (#2263)\n",
+               probe_retries, probe_timeout);
+    }
     // Route + initialise ONE candidate. Factored out so auto-selection can fall
     // through to the next candidate when no backend can load this one (#2263).
     auto route_and_init = [&](const ModelConfig& cand, BackendRoute& out_route) -> bool {

--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -1878,14 +1878,58 @@ int main(int argc, char** argv) {
     // The flip: the registry resolver is consumed here. The merge is a UNION — the
     // registry can demote the head only for a stated exclusion, and never drops a
     // router lane — so this cannot lose a route the engine has today.
-    BackendRoute route = onebit::select_route_with_registry(cfg, cfg.model_path, &g_registry);
-    printf("  Router: %s\n", route.reason.c_str());
-    // mgr state is read by /v1/health + /v1/models under g_config_mutex —
-    // mutate under the same lock (issue #1271).
-    bool inited;
-    {
-        std::lock_guard<std::mutex> cfg_lock(g_config_mutex);
-        inited = mgr.init(cfg, g_weights_dir, route.backend_ids_in_order);
+    // Route + initialise ONE candidate. Factored out so auto-selection can fall
+    // through to the next candidate when no backend can load this one (#2263).
+    auto route_and_init = [&](const ModelConfig& cand, BackendRoute& out_route) -> bool {
+        out_route = onebit::select_route_with_registry(cand, cand.model_path, &g_registry);
+        printf("  Router: %s\n", out_route.reason.c_str());
+        // mgr state is read by /v1/health + /v1/models under g_config_mutex —
+        // mutate under the same lock (issue #1271).
+        bool ok;
+        {
+            std::lock_guard<std::mutex> cfg_lock(g_config_mutex);
+            ok = mgr.init(cand, g_weights_dir, out_route.backend_ids_in_order);
+        }
+        return ok;
+    };
+    BackendRoute route;
+    bool inited = route_and_init(cfg, route);
+    // Issue #2263 (from #2206 direction 2): with no -m, discovered.front() is
+    // only a guess — it is sorted by container then quant quality, with no
+    // loadability check, so it can be an artifact every discovered backend
+    // refuses (e.g. an arch=21 Qwen3.5 GGUF on a box whose NPU lane is Q4NX-only
+    // and whose HIP lane declines). Chosen behaviour (A): try the remaining
+    // candidates, saying so, instead of leaving /v1/health permanently unusable.
+    if (!inited && g_model_name.empty() && discovered.size() > 1) {
+        for (const auto& cand : discovered) {
+            if (cand.model_path == cfg.model_path) continue;
+            fprintf(stderr,
+                    "  [select] %s (%s) was not initialised by any discovered backend — trying %s\n",
+                    cfg.model_name.c_str(), cfg.model_path.c_str(), cand.model_name.c_str());
+            if (!route_and_init(cand, route)) continue;
+            printf("  ✓  Substituted %s -> %s (#2263)\n",
+                   cfg.model_name.c_str(), cand.model_name.c_str());
+            cfg = cand;
+            {
+                std::lock_guard<std::mutex> cfg_lock(g_config_mutex);
+                current_cfg = cand;
+            }
+            load_model_tokenizer(cfg.model_path);  // the tokenizer follows the model
+            inited = true;
+            break;
+        }
+    }
+    if (!inited && g_model_name.empty() && !discovered.empty()) {
+        // Chosen behaviour (B): refuse loudly. A model named with -m is still
+        // never silently swapped (#1958) and keeps the discovery-only path, but
+        // an unpinned server must not come up pretending to work.
+        fprintf(stderr,
+                "\n  ** ERROR: none of the %zu discovered artifact(s) could be initialised by any backend.\n",
+                discovered.size());
+        for (const auto& m : discovered)
+            fprintf(stderr, "     not loadable: %s (%s)\n", m.model_name.c_str(), m.model_path.c_str());
+        fprintf(stderr, "     Pass -m <name|path> to pin a model, or point --weights at a loadable artifact.\n");
+        return 1;
     }
     if (inited) {
         // Load vision encoder (--mmproj) for real ViT embeddings (issue #1420).


### PR DESCRIPTION
Implements the re-scoped #2263 (see the issue's re-scope comment): **bound the decline budget** so a bare `1bit unified` reaches a verdict in a window an operator will wait for, instead of spending minutes inside a lane that is going to decline anyway.

## The defect, measured on strixhalo

A bare server auto-selects `discovered.front()` and hands it to every backend in turn. The spawn-based lanes decline slowly by default, and the manager waits per lane:

| lane | retries | per-attempt timeout | worst case |
|---|---|---|---|
| `src/backend_hrx.h:78-80` | 3 | 120 s | ~6 min |
| `src/backend_lse.h:55-57` | **10** | 120 s | **~20 min** |
| `src/backend_npu_flm.cpp:110-111` | **10** | (per-attempt health check) | minutes |

plus `src/backend_manager.cpp`'s own **120 s cap per backend across ~20 backends**. Observed on the smoke shape (`models/ -> ~/models`), defaults, no `-m`:

```
health=000 after 303s      # still retrying inside one lane's init; a 90 s health
                           # window cannot tell this apart from a dead server
```

## The fix

1. **`Backend::set_init_budget(int retries, int timeout_s)`** — no-op by default (in-process lanes have no child to spawn).
2. **Overridden by the three spawn lanes** (`HrxBackend`, `LseBackend`, `NpuFlmBackend`).
3. **`BackendManager::set_init_budget(...)`** stores it and applies it to each instance **as it is created** (the backend list is empty before init — narrowing `mgr.backends()` from the server found 0 lanes), and uses it as the **outer `wait_for` cap** instead of the fixed 120 s.
4. **The server sets a probe budget when no `-m` was given**: `ONEBP_PROBE_RETRIES` (default **1**), `ONEBP_PROBE_TIMEOUT_S` (default **20**), logged as `[select] auto-probe budget: 1 retry(ies), 20s lane timeout (#2263)`. A model **pinned with `-m` keeps the lane's full budget** — there we are committed to that artifact and a large model legitimately needs time.
5. The earlier commit on this branch (`179c7473c`) keeps the **A+B safety net**: fall through to the next discovered candidate when the auto-selected one is not initialised, and exit non-zero with the reasons when none are. `-m`-pinned models are never silently swapped (issue #1958).

## Gates run — strixhalo, 2026-09-12

Build: `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=/opt/rocm-therock/bin/amdclang++ …` then `ninja -C build -j32 1bit` — clean (only pre-existing `-Wunused-function` warnings in `src/backend_npu.cpp`).

**A/B on the same box, same configure, same command, same 180 s observation window** — shape `<dir>/models -> /home/bcloud/models`, default budgets, no `-m`:

| build | `/v1/health` | log evidence |
|---|---|---|
| `origin/main` (`71ce970d6`) | **never healthy** — `000` after **181 s** | last line: `HRX: spawn attempt 1/3 failed — retrying in 3s` |
| this branch | **200 after 96 s** (one earlier run: 30 s) | `[select] auto-probe budget: 1 retry(ies), 20s lane timeout (#2263)`, then `✓ Active backend: hip_1bp_gpu`, serving `Qwen3.6-35B-A3B` |

**What this does not yet guarantee (and the issue's revised acceptance asks for).** The bound is **per lane**; the **per-candidate total is still `lanes x probe budget`** (~17 lanes x 20 s ≈ 340 s worst case), and the *order* of lanes decides how much of it is spent before a lane that can actually serve the artifact is reached. Measured range on this box: **30-96 s**, i.e. it usually lands inside the issue's 90 s target but not reliably. A per-candidate *deadline* alone would not fix that — it could abort the search before the winning lane is tried (in the 96 s run, `hip_1bp_gpu` was only reached late). The remaining levers are lane ordering and/or a smaller default probe budget; both want an operator decision, so they are left to the issue rather than chosen here.

**Pinned `-m` keeps the full budget**: with `-m /home/bcloud/models/Qwen3.6-35B-A3B-Q8_0.gguf` the auto-probe line is **absent** (`grep -c` = 0) and selection behaves as before.

## Not run, and why

* **The A+B fall-through could not be exercised on this box.** With the smoke shape the front candidate *is* loadable: `generic` refuses it (`arch=21 — Qwen3.5 Gate-Delta requires NPU (FLM/XRT) or HIP backend`) but the **HIP 1BP lane accepts it**, so `mgr.init()` returns `true`, `[active]` is legitimate and the fall-through is (correctly) never reached. It is a safety net for a genuinely unloadable artifact; the forced-failure harness (a GGUF with a bogus `general.architecture` ahead of a loadable model) is specified on the issue.
* **No CI here** — this was built and exercised on strixhalo only; the merge queue will run the normal gates.
* **clang-format**: not run; the only formatter on this box is a ROCm LLVM 24 `clang-format` that rejects the repo's `.clang-format` (`Standard: Cpp17`). Changed lines are ≤100 columns.

Refs #2263 (re-scoped), #2206, #2208, #2259. The `-m`-pin semantics come from #1958.
