### PR TITLE
fix(seo): stop seo_sync prepending the old percentage on every run

### DIFF
--- a/scripts/seo_sync.py
+++ b/scripts/seo_sync.py
@@ -157,10 +157,27 @@ def _meta_pair(m, covered, tokens):
 
 
 def _pct_claim(m, covered, with_arch, suffix_groups):
-    """Percentage claims only move when coverage actually drops below 100%."""
+    """Percentage claims only move when coverage actually drops below 100%.
+
+    suffix_groups is not decoration: the two callers capture the number in different
+    positions, and rebuilding as g[0] + pct + g[-1] is only correct for one of them.
+
+      "N% HuggingFace coverage"        2 groups. Group 0 IS the number, and the '%'
+                                       sits outside the match, so _pct()'s own '%'
+                                       supplies it -- including g[0] as well re-emitted
+                                       the OLD number ahead of the new one, so every
+                                       run prepended another copy and the claim grew
+                                       without bound ("10099.9799.97...% HuggingFace
+                                       coverage"; 12 such spans had accumulated on
+                                       main). No prefix to preserve here.
+      "<span ...>N</span>..."          3 groups. Group 0 is leading MARKUP, which must
+                                       be preserved.
+    """
     if covered >= with_arch:
         return m.group(0)
     g = m.groups()
+    if suffix_groups == 2:
+        return _pct(covered, with_arch) + g[-1]
     return g[0] + _pct(covered, with_arch) + g[-1]
 
 
@@ -194,8 +211,13 @@ def _build_patterns(tokens, arch, covered, with_arch):
         # monster-v2 lead "317,310 arch-bearing checkpoints resolve to 552 tokens"
         (re.compile(r"(\d[\d,]*)( arch-bearing checkpoints resolve to )(\d[\d,]*)( tokens,)"),
          lambda m: _meta_pair(m, covered, tokens)),
-        # percentage claims only move when coverage drops below 100%
-        (re.compile(r"(\d+(?:\.\d+)?)%( HuggingFace coverage)"),
+        # percentage claims only move when coverage drops below 100%.
+        # [0-9][0-9.]* (not \d+(?:\.\d+)?) so the match also swallows the malformed
+        # leading runs this bug already wrote into site/*.html ("10099.9799.97...%") --
+        # with the narrow pattern the regex would match only the trailing "99.97" and
+        # leave the garbage in front of a corrected value. Greedy, but digits and dots
+        # cannot run past the '%' into markup.
+        (re.compile(r"([0-9][0-9.]*)%( HuggingFace coverage)"),
          lambda m: _pct_claim(m, covered, with_arch, 2)),
         (re.compile(r"(<span class=\"n\">)(\d+(?:\.\d+)?)(</span><span class=\"l\">checkpoints mapped</span>)"),
          lambda m: _pct_claim(m, covered, with_arch, 3)),


### PR DESCRIPTION
### **User description**
## What

`scripts/seo_sync.py` corrupted every percentage claim it touched: each run **prepended the old
number ahead of the new one** instead of replacing it. On `main` (`cd62877ba`) this had accumulated
**12 malformed spans across 4 files**, live in the public site's JSON-LD metadata and stat blocks —
e.g. `site/index.html`:

```
"description": "... 568 architecture tokens, 2,040 HF arch strings, 10099.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.9799.97% HuggingFace coverage ..."
```

The script documents itself as **idempotent** ("a second run with nothing changed touches nothing and
exits 0"). It was not: `--check` reported DRIFT and exited 1 forever, on every run.

## Root cause

`_pct_claim` rebuilt the claim as `g[0] + pct + g[-1]`, but its two callers capture the number in
**different positions**:

| pattern | groups | `g[0]` is | `_pct()` supplies |
|---|---|---|---|
| `(\d+(?:\.\d+)?)%( HuggingFace coverage)` | 2 | **the number** | the digits **and** the `%` |
| `(<span …>)(\d+…)(</span>…)` | 3 | leading **markup** | the digits and `%` |

So for the first pattern the old digits came back ahead of the new value. `_pct_claim` already took a
`suffix_groups` argument for exactly this distinction — **it was never read**. Demonstrated directly:

```
input  '99.97% HuggingFace coverage'   ->  '99.9799.97% HuggingFace coverage'
input  '100% HuggingFace coverage'     ->  '10099.97% HuggingFace coverage'   <- also explains the '100' prefix
```

## Changes

1. **`_pct_claim` honours `suffix_groups`.** For the 2-group layout there is no prefix to preserve,
   so it returns `_pct(...) + g[-1]`; the 3-group layout keeps `g[0]`.
2. **Widen the pattern to `([0-9][0-9.]*)%`.** This is what makes the damage *repairable*: with the
   narrow pattern the regex matches only the trailing `99.97` and leaves the garbage in front of a
   corrected value, so re-running could only add more. Digits and dots cannot run past the `%` into
   markup, so the greediness is bounded.
3. **Regenerate `site/*.html`** — 12 insertions / 12 deletions, all of them corrected percentages.

## Verification (offline; `seo_sync.py` derives everything from committed files)

| check | before | after |
|---|---|---|
| `--check` following an apply | `DRIFT (4 change(s))`, exit 1, forever | **`OK … no drift`, exit 0** |
| second apply | changed the files again | **`NO-CHANGES`, site files byte-identical** |
| malformed spans in `site/*.html` | **12** | **0** |

The 3-group pattern is untouched behaviourally, and `--check` passing means the rewriter is now a
fixed point — the property the daily census/seo automation depends on to converge.

## Related

This is why **#2255** (census sweep) cannot be merged by resolving its conflict: its branch conflicts
in exactly these four generated files, and re-running `seo_sync` to resolve them was not safe while
the rewriter was lossy — it appended rather than replaced. With this fix the regeneration is a fixed
point, so #2255's conflict can be resolved by regenerating rather than hand-merging generated HTML.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix `_pct_claim` prepending the old percentage value

- Use previously unread `suffix_groups` to pick rebuild layout

- Widen percentage regex to swallow already-corrupted runs

- Make `seo_sync.py` truly idempotent again (no drift)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["seo_sync percentage pattern"] -- "widen to [0-9][0-9.]*" --> B["swallows corrupt 10099.9799.97 spans"]
  C["_pct_claim rebuild"] -- "honor suffix_groups == 2" --> D["drop leading g[0] number"]
  C -- "suffix_groups == 3" --> E["keep leading markup prefix"]
  B --> F["site/*.html rewritten to fixed point"]
  D --> F
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>seo_sync.py</strong><dd><code>Fix idempotency of percentage claim replacement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/seo_sync.py

<ul><li><code>_pct_claim</code> now returns <code>_pct(...) + g[-1]</code> when <code>suffix_groups == 2</code>, <br>instead of unconditionally rebuilding as <code>g[0] + pct + g[-1]</code>.<br> <li> Wires the previously dead <code>suffix_groups</code> argument to the distinction <br>between the two callers (number-in-group-0 vs <br>leading-markup-in-group-0).<br> <li> Expands the <code>N% HuggingFace coverage</code> pattern from <code>\d+(?:\.\d+)?</code> to <br><code>[0-9][0-9.]*</code> so malformed accumulated runs written by the buggy script <br>are consumed by a single match.<br> <li> Adds explanatory docstring and inline comments on capture-layout <br>asymmetry and regex greediness bounds.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2290/files#diff-19b7c8d8a41e3bbba491ffaaaf2c5e7eb5014e5d4ecccd83a2f3fd315d276a35">+25/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

