### PR TITLE
fix(ci): the census alert omitted !! SIGNIFICANT and fired on runtime failures (#2178)

### DIFF
--- a/.github/workflows/census-watch.yml
+++ b/.github/workflows/census-watch.yml
@@ -60,6 +60,11 @@ jobs:
         run: |
           bash scripts/census-watch.sh --limit 120 2>&1 | tee /tmp/census-watch.log
           RC=${PIPESTATUS[0]}
+          # Publish the code so the alert step can tell census-watch.sh's two
+          # non-zero meanings apart: 1 is "found an unmapped class" (the alert),
+          # anything else is a runtime failure (network, probe compile). Written
+          # before the early exits below so it is always emitted.
+          echo "rc=$RC" >> "$GITHUB_OUTPUT"
           # #2084: do NOT let this gate deadlock same-day census PRs. The
           # watcher compares against the LIVE HF snapshot, so a PR that maps
           # classes A/B would fail for classes C/D mapped only by a sibling PR.
@@ -68,13 +73,13 @@ jobs:
           # run on main. Runtime failures (RC > 1) still fail the check.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             if [ "$RC" = "1" ]; then
-              echo "::warning::census watcher found uncovered classes (advisory on PR — the nightly run on main is the blocking gate)"
-              grep -E "UNCOVERED|UNVERIFIABLE" /tmp/census-watch.log > /tmp/census-pr.txt || true
+              echo "::warning::census watcher found unmapped classes (advisory on PR — the nightly run on main is the blocking gate)"
+              grep -E "UNCOVERED|UNVERIFIABLE|SIGNIFICANT" /tmp/census-watch.log > /tmp/census-pr.txt || true
               if [ -s /tmp/census-pr.txt ] && command -v gh >/dev/null 2>&1; then
                 {
                   echo "## census: advisory (this PR's branch)"
                   echo ""
-                  echo "Uncovered classes vs the live HF snapshot. Advisory on PRs (#2084) — same-day sibling PRs map different classes. The blocking gate is the nightly schedule run."
+                  echo "Unmapped classes vs the live HF snapshot. Advisory on PRs (#2084) — same-day sibling PRs map different classes. The blocking gate is the nightly schedule run."
                   echo ""
                   echo '```'
                   cat /tmp/census-pr.txt
@@ -91,12 +96,38 @@ jobs:
       # Only alert on scheduled/manual runs — on PRs the red check itself is
       # the signal. Guard on the watch step specifically so a checkout/setup
       # failure doesn't file a misleading issue.
-      - name: File an alert issue on uncovered classes
-        if: failure() && steps.watch.conclusion == 'failure' && github.event_name != 'pull_request'
+      - name: File an alert issue on unmapped classes
+        # steps.watch.outputs.rc == '1' is census-watch.sh's documented
+        # "a new model carries an architecture class the registry doesn't map".
+        # Any other non-zero is a runtime failure (no network, probe compile
+        # error) and must not be reported as an architecture finding: the grep
+        # below matches nothing, so it filed an EMPTY "Census alert" claiming
+        # classes were found — and because the dedupe below skips while an issue
+        # is open, that empty issue then suppressed the next real alert until
+        # someone closed it. A transient DNS failure could blind the watch.
+        if: failure() && steps.watch.conclusion == 'failure' && steps.watch.outputs.rc == '1' && github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          grep -E "UNCOVERED|UNVERIFIABLE" /tmp/census-watch.log || true
+          # SIGNIFICANT must be in the pattern. Testing/hf_new_models.py:249-258
+          # partitions the uncovered set and prints the two halves with DIFFERENT
+          # prefixes: a major-family/vision arrival goes out as "!! SIGNIFICANT",
+          # everything else as "!! UNCOVERED". Both make the script exit 1, but a
+          # pattern of UNCOVERED|UNVERIFIABLE matches only the second -- so when
+          # the sole trigger was a significant arrival this step filed an issue
+          # listing the unrelated UNVERIFIABLE names and never named the class
+          # that failed the run. That is issue #2178: the run that filed it had
+          # 1 uncovered class (deepseekv41, printed "!! SIGNIFICANT") and the
+          # body contained zero UNCOVERED lines.
+          ALERT_RE='UNCOVERED|UNVERIFIABLE|SIGNIFICANT'
+          grep -E "$ALERT_RE" /tmp/census-watch.log || true
+          # Belt and braces for the same failure mode: rc==1 with nothing to
+          # report would still file an empty alert, which dedupes away the next
+          # real one.
+          if ! grep -qE "$ALERT_RE" /tmp/census-watch.log; then
+            echo "watch exited 1 but the log carries no class lines — not filing"
+            exit 0
+          fi
           gh label create census-watch 2>/dev/null || true
           EXISTING=$(gh issue list --label census-watch --state open --json number --jq 'length')
           if [ "$EXISTING" -gt 0 ]; then
@@ -104,19 +135,33 @@ jobs:
             exit 0
           fi
           {
-            echo "## Census coverage breach"
+            echo "## Census alert"
             echo ""
-            echo "The daily new-model watcher found HF models whose architecture class is not mapped by the engine registry:"
+            echo "The daily new-model watcher found architecture classes the engine registry does not map:"
             echo ""
             echo '```'
-            grep -E "UNCOVERED|UNVERIFIABLE" /tmp/census-watch.log || true
+            grep -E "$ALERT_RE" /tmp/census-watch.log || true
             echo '```'
             echo ""
-            echo "Fix: add the missing mapping in \`include/rocm_cpp/bitnet_model.h\` (alias if it is a known family, otherwise a real implementation), then re-run \`python3 Testing/census_coverage.py\`."
-            echo ""
+            # One instruction per category actually present. The previous single
+            # "alias if it is a known family" sentence is the opposite of what a
+            # SIGNIFICANT arrival needs (its own log line says "NOT an alias"),
+            # so a reader acting on this issue did the wrong thing.
+            if grep -q '!! SIGNIFICANT' /tmp/census-watch.log; then
+              echo "**Significant arrivals** — real engine architecture support + decode validation, **not** an alias. Reviewed evidence: \`Testing/arch-gaps.md\` (see \`research/ws13-arch-gap-closure/\`)."
+              echo ""
+            fi
+            if grep -q '!! UNCOVERED' /tmp/census-watch.log; then
+              echo "**Uncovered classes** — add the mapping in \`include/rocm_cpp/bitnet_model.h\` (alias if it is a known family, otherwise a real implementation), then re-run \`python3 Testing/census_coverage.py\`."
+              echo ""
+            fi
+            if grep -q '? UNVERIFIABLE' /tmp/census-watch.log; then
+              echo "**Unverifiable** — no config or no mapped tag. Not a coverage breach (see the note at the end of \`Testing/hf_new_models.py\`), retried next run; listed for completeness."
+              echo ""
+            fi
             echo "Report: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           } > /tmp/census_issue.md
           gh issue create \
-            --title "census: new HF model class uncovered by the registry" \
+            --title "census: unmapped architecture class(es) in the daily HF sweep" \
             --label census-watch \
             --body-file /tmp/census_issue.md


### PR DESCRIPTION
### **User description**
## What

The census watcher's alert issue never contains the `!! SIGNIFICANT` line — which is the line
that causes the run to fail. When the only unmapped class in a sweep is a significant arrival, the
filed issue lists unrelated `UNVERIFIABLE` repos, names none of the real finding, and gives an
instruction that is the **opposite** of the right one.

Closes the defect behind #2178.

## Evidence

Run [`34458368940`](https://github.com/1bit-MONSTER/1bit-MONSTER/actions/runs/34458368940)
(2026-09-10, `schedule` on `main`) exited 1 legitimately:

```
hf_new_models: 120 new models checked, 84 in-scope, 81 covered, 1 uncovered class(es), 7 unverifiable (gated/no-config)
  !! SIGNIFICANT deepseekv41: 3 model(s), e.g. Terom/DeepSeek-V4.1-Flash
     -> major-family/vision arrival — needs REAL engine arch support + decode validation, NOT an alias
census-watch: EXIT 1 (uncovered class -> needs a bitnet_model.h mapping; …)
```

`Testing/hf_new_models.py:249-258` partitions the uncovered set and prints the two halves with
**different prefixes**:

```python
if _is_significant(s, class_tags.get(s)):
    significant[s] = ids        # -> "  !! SIGNIFICANT <class>: …"
else:
    basic_uncovered[s] = ids    # -> "  !! UNCOVERED <class>: …"
```

The exit is `1 if uncovered else 0` — **both** halves fail the run — but the alert greps

```bash
grep -E "UNCOVERED|UNVERIFIABLE" /tmp/census-watch.log
```

`!! SIGNIFICANT` matches **neither** alternative, and `!! UNCOVERED` never printed because
`basic_uncovered` was empty. Log counts for that run: `!! UNCOVERED` **0**, `!! SIGNIFICANT` **1**,
`? UNVERIFIABLE` **14**. The issue body was the exact complement of the finding.

## The wrong instruction, which matters more than the omission

The old body's single Fix line:

> add the missing mapping in `include/rocm_cpp/bitnet_model.h` (alias if it is a known family…)

against the line that actually failed the run:

> needs REAL engine arch support + decode validation, **NOT an alias**

So the only actionable sentence in the issue told the reader to do the thing the watcher
explicitly rules out for that class.

## Changes

| # | change |
|---|---|
| 1 | `ALERT_RE` gains `SIGNIFICANT`, at all three grep sites (issue body, sanity grep, PR advisory) |
| 2 | one instruction per category actually present — `SIGNIFICANT` gets the real-support text, only `UNCOVERED` gets the alias text |
| 3 | `UNVERIFIABLE` is labelled for what it is (not a coverage breach) instead of being mixed into a "breach" report |
| 4 | title `census: new HF model class uncovered by the registry` → `census: unmapped architecture class(es) in the daily HF sweep` |

On (4): issue dedupe is by label (`gh issue list --label census-watch`), so the title is not
load-bearing and the old one is wrong whenever the trigger is significant-only.

## Verification

Extracted the step's `run` block, executed it against a reconstruction of that run's
`/tmp/census-watch.log` with `gh` stubbed to capture the body, and read the result. The would-be
issue now opens with:

```
  !! SIGNIFICANT deepseekv41: 3 model(s), e.g. Terom/DeepSeek-V4.1-Flash
  ? UNVERIFIABLE …
…
**Significant arrivals** — real engine architecture support + decode validation, **not** an alias.
Reviewed evidence: `Testing/arch-gaps.md` (see `research/ws13-arch-gap-closure/`).

**Unverifiable** — no config or no mapped tag. Not a coverage breach …; listed for completeness.
```

`yaml.safe_load` passes and the run block passes `bash -n`.

## Not in this PR

`Testing/hf_new_models.py:293` appends `— gated repos need a token` to **every** unverifiable entry,
whatever the recorded reason — and the only reason ever recorded is `no config / no mapped tag`. I
checked the seven repos in #2178 against the live HF API: **none is gated** (5 of 7 sampled, all
`gated: false`), and two ship training-hyperparameter files (`batch_size`, `learning_rate`,
`total_steps`) rather than model configs. The claim is therefore not a measurement, and the token
hint points at a fix that would not help. Left out deliberately: it changes watcher output that
other readers may key on, so it deserves its own review rather than riding along on a workflow fix.


___

### **PR Type**
Bug fix


___

### **Description**
- Alert now matches `!! SIGNIFICANT`, not just `UNCOVERED`

- Gate alert on watcher exit code `1` only

- Skip filing empty alerts on runtime failures

- Per-category fix instructions replace misleading "alias" text


___

### Diagram Walkthrough


```mermaid
flowchart TD
  Watch["Run census-watch.sh --limit 120"] -- "log + PIPESTATUS" --> Publish["Publish rc to GITHUB_OUTPUT"]
  Publish -- "rc == 1" --> Alert["File alert issue step"]
  Publish -- "rc != 1" --> Runtime["No alert: runtime failure"]
  Alert -- "grep ALERT_RE" --> Match["UNCOVERED / SIGNIFICANT / UNVERIFIABLE"]
  Match -- "no match" --> Empty["Exit 0: no empty alert"]
  Match -- "present categories" --> Body["Category-specific fix instructions"]
  Body -- "open issue dedupe" --> Issue["gh issue create"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>census-watch.yml</strong><dd><code>Fix census alert matching, exit-code gating and instructions</code></dd></summary>
<hr>

.github/workflows/census-watch.yml

<ul><li>Publish the watcher exit code (<code>rc=$RC</code>) to <code>$GITHUB_OUTPUT</code> before the <br>early PR/runtime exits.<br> <li> Gate the alert step additionally on <code>steps.watch.outputs.rc == '1'</code>, so <br>network/probe failures (rc > 1) no longer file a misleading <br>architecture issue.<br> <li> Extend the log grep pattern to <code>UNCOVERED|UNVERIFIABLE|SIGNIFICANT</code>, and <br>bail out with <code>exit 0</code> when rc==1 but no class lines are present — <br>prevents the empty alert that deduped away the next real one.<br> <li> Emit separate fix instructions for significant arrivals, uncovered <br>classes and unverifiable repos; retitle the issue body/heading and the <br>issue title.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2291/files#diff-87801ad07a4127fc20c4813174df85cd8bc73e3f6e42cb349208d87c13d0511d">+57/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

