### PR TITLE
fix(census): record why a model is unverifiable instead of always blaming gating

### DIFF
--- a/Testing/hf_new_models.py
+++ b/Testing/hf_new_models.py
@@ -202,7 +202,23 @@ def main():
                 seen[mid] = True
             else:
                 if mid not in seen or not seen[mid]:
-                    unverifiable[mid] = "no config / no mapped tag"
+                    # Record WHY it is unverifiable. The listing is fetched with
+                    # full=true, so `gated`/`private` are right here (verified
+                    # against the live API) — and the print used to assert
+                    # "gated repos need a token" for every entry regardless,
+                    # which sends readers after a token that cannot help.
+                    # Issue #2178 listed 7 such models; 5 of 7 checked, all
+                    # gated=false, two of them shipping training-hyperparameter
+                    # files (`batch_size`, `learning_rate`) instead of a model
+                    # config. Only claim gating when the API says so.
+                    if m.get("gated"):
+                        unverifiable[mid] = "gated — a token would let this be checked"
+                    elif m.get("private"):
+                        unverifiable[mid] = "private repo"
+                    elif cfg is None:
+                        unverifiable[mid] = "config fetch failed (404/network)"
+                    else:
+                        unverifiable[mid] = "no config / no mapped tag"
                 seen[mid] = False  # retry next run
             time.sleep(0.2)
             continue
@@ -290,8 +306,9 @@ def main():
         except Exception as _e:
             print(f"[watch] census_autopr failed: {_e}", file=sys.stderr)
     for mid, why in sorted(unverifiable.items()):
-        print(f"  ? UNVERIFIABLE {mid} ({why}) — gated repos need a token; "
-              f"retried next run")
+        # `why` carries the cause now, so no blanket gating claim: only the
+        # entries whose reason is actually gated benefit from a token.
+        print(f"  ? UNVERIFIABLE {mid} ({why}) — retried next run")
 
     # Only uncovered classes are a real alert. Unverifiable (gated/no-config)
     # models are expected — HF gates repos without a token, and a missing


### PR DESCRIPTION
### **User description**
## What

Every `? UNVERIFIABLE` line in the census watcher ended with **"gated repos need a token"** — a
hardcoded claim, printed regardless of cause, while the code recorded only one reason for all of
them. On a live 60-model run, all three unverifiable entries were **404s, not gated**, so the advice
pointed at a token that could not help three times out of three.

Follow-up to #2178, split out of #2291 as agreed there.

## Evidence

`main` @ `cd62877ba`, live run against the HF API:

```
hf_new_models: 60 new models checked, 34 in-scope, 27 covered, 3 uncovered class(es), 3 unverifiable (gated/no-config)
  ? UNVERIFIABLE Kai9987kai/supermix-v89 (no config / no mapped tag) — gated repos need a token; retried next run
  ? UNVERIFIABLE dhanesh-hf/Jarvis-Titan-M4-Calibrated-Adapter (no config / no mapped tag) — gated repos need a token; retried next run
  ? UNVERIFIABLE shiva123782/Kaveri-0.5B-Ollama (no config / no mapped tag) — gated repos need a token; retried next run
```

Checking those two directly:

| repo | `gated` | `private` | `config.json` |
|---|---|---|---|
| `Kai9987kai/supermix-v89` | **false** | false | **HTTP 404** |
| `shiva123782/Kaveri-0.5B-Ollama` | **false** | false | **HTTP 404** |

Not gated. The `gated` field was already in hand: the listing is fetched with `full=true`, and the
API returns `gated`/`private` there (verified against the live endpoint). The code simply never read
it — it had a single reason string, `"no config / no mapped tag"`, for every case, while its own
comment allowed for `gated/fetch-fail, no config`.

## Change

Record the cause, and stop asserting one:

```python
if m.get("gated"):
    unverifiable[mid] = "gated — a token would let this be checked"
elif m.get("private"):
    unverifiable[mid] = "private repo"
elif cfg is None:
    unverifiable[mid] = "config fetch failed (404/network)"
else:
    unverifiable[mid] = "no config / no mapped tag"
...
print(f"  ? UNVERIFIABLE {mid} ({why}) — retried next run")
```

The token hint now appears only on the entries where a token would actually help.

## Verification

Ran the watcher against the **live HF API** with `CENSUS_SKIP_PR=1` (its own guard, so it cannot file
draft PRs), then restored the two state files it writes. Same 60-model batch:

```
  ? UNVERIFIABLE Kai9987kai/supermix-v89 (config fetch failed (404/network)) — retried next run
  ? UNVERIFIABLE dhanesh-hf/Jarvis-Titan-M4-Calibrated-Adapter (config fetch failed (404/network)) — retried next run
  ? UNVERIFIABLE shiva123782/Kaveri-0.5B-Ollama (config fetch failed (404/network)) — retried next run
```

`grep -c 'gated repos need a token'` on that run's output: **0**. `python3 -m py_compile` passes.

The `? UNVERIFIABLE` prefix is unchanged, so the `census-watch` grep (and #2291's per-category note)
still match; no other consumer parses the suffix — checked across workflows and scripts.

## Note on the summary line

The summary still reads `N unverifiable (gated/no-config)`. Left as is because it names the two
categories rather than asserting one, but it could carry the same problem if the causes diverge —
happy to fold it in if you would rather.


___

### **PR Type**
Bug fix


___

### **Description**
- Record cause-specific unverifiable reasons instead of one generic string

- Classify order: gated, private, config fetch failed, no mapped tag

- Read `gated`/`private` fields already present in the `full=true` listing

- Drop hardcoded "gated repos need a token" claim from every printed line


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["probe_tags finds no tag"] -- "read gated / private / cfg" --> B{"classify cause"}
  B -- "gated" --> C["reason: a token would let this be checked"]
  B -- "private" --> D["reason: private repo"]
  B -- "cfg is None" --> E["reason: config fetch failed (404/network)"]
  B -- "otherwise" --> F["reason: no config / no mapped tag"]
  C --> G["print UNVERIFIABLE (why) — retried next run"]
  D --> G
  E --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hf_new_models.py</strong><dd><code>Record cause-specific reason for unverifiable HF models</code>&nbsp; &nbsp; </dd></summary>
<hr>

Testing/hf_new_models.py

<ul><li>Replaces the single <code>unverifiable[mid] = "no config / no mapped tag"</code> <br>assignment with a classification chain: <code>gated</code> -> <code>private</code> -> <code>config </code><br><code>fetch failed (404/network)</code> -> <code>no config / no mapped tag</code>.<br> <li> Reads the <code>gated</code>/<code>private</code> fields from the listing already fetched with <br><code>full=true</code>, with a comment citing issue #2178 and live-API checks (5 of <br>7 models <code>gated=false</code>).<br> <li> Removes the hardcoded <code>— gated repos need a token</code> suffix from the <code>? </code><br><code>UNVERIFIABLE</code> print, since <code>why</code> now carries the cause.<br> <li> Leaves <code>seen[mid] = False</code> retry behavior and the comment that <br>unverifiable models are not a coverage breach unchanged.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2292/files#diff-b2cdcca5305ff83c2aa31abfc2dd476b9458209d9ef12ace923ce85369618ef6">+20/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

