### PR TITLE
feat(engine): opt-in skip for lanes the plan already marked KNOWN-ABORT (#2263)

### DIFF
--- a/include/backend_manager.h
+++ b/include/backend_manager.h
@@ -110,6 +110,14 @@ public:
         probe_timeout_s_ = timeout_s;
     }
 
+    /// #2263: engine ids not to instantiate at all for the next init. Set with
+    /// set_init_budget for auto-selected probes, where the plan has already
+    /// emitted a KNOWN-ABORT verdict (the engine aborts on this artifact rather
+    /// than failing closed, so attempting it is worse than skipping it) and the
+    /// lane would otherwise consume the whole per-lane budget before declining.
+    /// Empty (the default) skips nothing, so a model pinned with -m is unaffected.
+    void set_skip_ids(const std::vector<std::string>& ids) { skip_ids_ = ids; }
+
     BackendManager();
     ~BackendManager();
 
@@ -245,6 +253,7 @@ private:
 private:
     int probe_retries_ = 0;     // #2263: 0 = leave the lane's budget alone
     int probe_timeout_s_ = 0;
+    std::vector<std::string> skip_ids_;  // #2263: empty = skip nothing
 
 };
 

--- a/include/model_router.h
+++ b/include/model_router.h
@@ -23,6 +23,11 @@
 struct BackendRoute {
     std::vector<std::string> backend_ids_in_order;
     std::string reason; // human-readable, for logging
+    // #2263: engine ids the plan put in `blocked` (KNOWN-ABORT). Carried so the
+    // caller can choose not to pay for them; to_backend_route() already emits the
+    // verdict into `reason`, but a string cannot be acted on. Empty when nothing
+    // is blocked, which is the common case.
+    std::vector<std::string> known_abort_ids;
 };
 
 BackendRoute select_backend_route(const ModelConfig& cfg);

--- a/src/backend_manager.cpp
+++ b/src/backend_manager.cpp
@@ -606,6 +606,18 @@ bool BackendManager::init_in_order(const ModelConfig& cfg, const std::string& we
         auto& info = backends_[idx];
         if (!info.available || !info.auto_selectable) continue;
 
+        // #2263: the plan has already put this engine in `blocked` (KNOWN-ABORT)
+        // for THIS artifact — the measured case aborts the process rather than
+        // failing closed, so attempting it cannot succeed, and it costs the full
+        // per-lane budget plus the lane's retry delay before declining (measured:
+        // one such lane was the whole of a 23 s phase). Only populated for
+        // auto-selected probes, so a model pinned with -m keeps its lanes.
+        if (!skip_ids_.empty() &&
+            std::find(skip_ids_.begin(), skip_ids_.end(), info.id) != skip_ids_.end()) {
+            printf("  → skipped (KNOWN-ABORT for this artifact, #2263)\n");
+            continue;
+        }
+
         printf("BackendManager: trying %s (%s)...\n", info.id.c_str(), info.description.c_str());
         // Try to create via dlsym (GPU/NPU backends live in librocm_cpp.so or standalone)
         // CPU backend is linked directly

--- a/src/model_registry_route.cpp
+++ b/src/model_registry_route.cpp
@@ -214,6 +214,10 @@ BackendRoute merge_router_and_registry(const BackendRoute& router, const RoutePl
     }
     if (appended)
         out.reason += " | " + std::to_string(appended) + " lane(s) added";
+    // #2263: `out` is built fresh here, so to_backend_route()'s blocked ids would
+    // be dropped even though their verdict survives inside out.reason. Carry them
+    // so a caller can act on the plan instead of only reading it.
+    out.known_abort_ids = reg.known_abort_ids;
     return out;
 }
 
@@ -436,6 +440,16 @@ RoutePlan plan_route(const ModelArtifact& a, uint32_t context_tokens,
 BackendRoute to_backend_route(const RoutePlan& plan) {
     BackendRoute out;
     for (const auto& t : plan.targets) out.backend_ids_in_order.push_back(t.engine_id);
+    // #2263: the blocked capabilities get their verdict into `why` below, but the
+    // caller also needs the engine ids to act on it. backend_for() is the same
+    // translation table used to build `targets`, so the id is the one
+    // init_in_order will compare against.
+    for (const auto& r : plan.blocked) {
+        BackendType bt;
+        std::string id, constraint;
+        if (backend_for(r.first, bt, id, constraint) && !id.empty())
+            out.known_abort_ids.push_back(id);
+    }
 
     std::string why = plan.targets.empty() ? "no backend can serve this artifact"
                                            : "registry plan";

--- a/tools/unified_server.cpp
+++ b/tools/unified_server.cpp
@@ -1939,6 +1939,28 @@ int main(int argc, char** argv) {
         bool ok;
         {
             std::lock_guard<std::mutex> cfg_lock(g_config_mutex);
+            // #2263, OPT-IN: an auto-selected candidate is a probe, so do not pay
+            // for a lane the plan has already put in `blocked` (KNOWN-ABORT) for
+            // this artifact. Measured on the degraded path, that single lane was
+            // the whole of phase 1 — 23 s of a 27 s startup — because it consumes
+            // the per-lane budget plus its own retry delay before declining.
+            //
+            // Off by default. It changes WHICH lanes get how much time, which this
+            // issue leaves as an operator call; ONEBP_SKIP_KNOWN_ABORT=1 enables
+            // it. Deliberately not a deadline: nothing is aborted early, a lane
+            // whose verdict is already known simply is not paid for.
+            static const bool skip_known_abort = [] {
+                const char* v = getenv("ONEBP_SKIP_KNOWN_ABORT");
+                return v && *v && *v != '0';
+            }();
+            if (skip_known_abort && g_model_name.empty()) {
+                if (!out_route.known_abort_ids.empty())
+                    printf("  [select] skipping %zu KNOWN-ABORT lane(s) (#2263, "
+                           "ONEBP_SKIP_KNOWN_ABORT=1)\n", out_route.known_abort_ids.size());
+                mgr.set_skip_ids(out_route.known_abort_ids);
+            } else {
+                mgr.set_skip_ids({});
+            }
             ok = mgr.init(cand, g_weights_dir, out_route.backend_ids_in_order);
         }
         return ok;


### PR DESCRIPTION
### **User description**
## What

An opt-in for #2263's open operator call, implemented and measured — not decided. **Off by default.**

---

feat(engine): opt-in skip for lanes the plan already marked KNOWN-ABORT (#2263)

Measured on the degraded #2263 path: one lane the router had ALREADY declared
KNOWN-ABORT accounted for 23 s of a 27 s startup. It was instantiated anyway and
allowed to consume the full per-lane budget plus its own retry delay before
declining, while every other lane on that artifact declined in under a second:

    Router: ... | KNOWN-ABORT: HRX-GGUF | 1 lane(s) added
       1 BackendManager: trying hrx_gpu ...
      21   → init timed out (>20s) — skipping
      21 HRX: spawn attempt 1/1 failed — retrying in 3s
      24 HRX: failed to start llama-server after 1 attempts

hrx_gpu costs exactly budget + 3 s (20+3=23, 5+3=8 across budgets), so it is the
only budget-scaling term in that shape.

This carries the plan's blocked capabilities out as engine ids and, when opted in,
does not instantiate them for an auto-selected probe.

Deliberately NOT a deadline: nothing is aborted early. A lane whose verdict the
router has already computed simply is not paid for, so the risk raised in #2263 —
a total-deadline aborting before the serving lane is reached — does not apply.

OFF BY DEFAULT. It changes which lanes get how much time on the degraded path,
which #2263 leaves as an operator call. Enable with ONEBP_SKIP_KNOWN_ABORT=1.
A model pinned with -m is unaffected either way (the skip is only applied when
auto-selecting).

Implementation:
  * BackendRoute gains known_abort_ids; to_backend_route() fills it via
    backend_for(), the same capability->engine-id table used to build targets
  * merge_router_and_registry() carries it through — it builds `out` fresh, so
    the ids would otherwise be dropped even though the verdict survives in
    out.reason (this was a real bug in the first cut: the flag did nothing)
  * BackendManager::set_skip_ids(), honoured in init_in_order()
  * unified_server.cpp sets it inside the existing g_config_mutex block, only when
    auto-selecting and the env opt-in is set

A/B on the degraded shape (unloadable artifact in the primary root), same box,
same fixture, differing only by the env var:

    OFF (default)   /v1/health = 200 at 26 s   1 init timeout   hrx_gpu tried 2x
    ON              /v1/health = 200 at  3 s   0 init timeouts  hrx_gpu tried 1x
                    "[select] skipping 1 KNOWN-ABORT lane(s)"

Both reach the same active backend, so the skip does not change which lane serves
the artifact that actually loads — only how long the unloadable candidate costs.

---

## Notes

* Neither the default nor any `-m` path changes; the flag is inert unless `ONEBP_SKIP_KNOWN_ABORT=1`.
* The first cut of this change did nothing — `to_backend_route()` populated the ids but `merge_router_and_registry()` builds its result fresh and dropped them. Caught by measuring rather than by reading the diff, and now carried explicitly.
* A/B numbers were taken with the fixture from #2263 (unloadable artifact in the primary root); the harness is at `.dsh`-scratch level only, not in-tree.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `known_abort_ids` to `BackendRoute`

- Carry blocked engine ids through registry merge

- `init_in_order` skips lanes already KNOWN-ABORT

- Opt-in only: `ONEBP_SKIP_KNOWN_ABORT=1`, off by default


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["plan_route() blocked caps"] -- "backend_for()" --> B["BackendRoute.known_abort_ids"]
  B -- "merge_router_and_registry()" --> C["select_route_with_registry()"]
  C -- "ONEBP_SKIP_KNOWN_ABORT=1 and no -m" --> D["mgr.set_skip_ids()"]
  D -- "init_in_order()" --> E["lane skipped, logged why"]
  C -- "default / model pinned with -m" --> F["set_skip_ids({}), lanes untouched"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model_router.h</strong><dd><code>Add known_abort_ids field to BackendRoute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/model_router.h

<ul><li>Add <code>known_abort_ids</code> vector to <code>BackendRoute</code><br> <li> Documents it holds engine ids the plan put in <code>blocked</code> (KNOWN-ABORT)<br> <li> Notes the verdict already appears in <code>reason</code> but a string cannot be <br>acted on<br> <li> Field stays empty when nothing is blocked (common case)</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2294/files#diff-085d00decd1b6e7af1a3b25a271ca5821c2e61182f492b67c12ffef5ef41a7eb">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backend_manager.h</strong><dd><code>Expose skip-ids setter on BackendManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

include/backend_manager.h

<ul><li>New <code>set_skip_ids()</code> setter for engine ids to not instantiate<br> <li> Documents intent: verdict already KNOWN-ABORT for this artifact<br> <li> New private <code>skip_ids_</code> member, empty by default skips nothing<br> <li> Pinned <code>-m</code> models keep all their lanes</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2294/files#diff-59ff365586c7cb33235cd3786a5f0cc2fa9a0add61d7aa2d109b335b98cc7266">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backend_manager.cpp</strong><dd><code>Skip known-abort lanes during backend init</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/backend_manager.cpp

<ul><li>In <code>init_in_order()</code>, skip any backend whose id is in <code>skip_ids_</code><br> <li> Logs <code>→ skipped (KNOWN-ABORT for this artifact, #2263)</code><br> <li> Avoids paying per-lane budget plus retry delay for a doomed lane<br> <li> Only populated for auto-selected probes, so <code>-m</code> is unaffected</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2294/files#diff-f2ed10bacc975dc1c4ed35af9a62ab967874cf0273695b07cceb6059ed53a1cf">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model_registry_route.cpp</strong><dd><code>Carry plan blocked ids onto the backend route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/model_registry_route.cpp

<ul><li><code>to_backend_route()</code> fills <code>known_abort_ids</code> from <code>plan.blocked</code><br> <li> Translates each blocked capability to an engine id via <code>backend_for()</code><br> <li> <code>merge_router_and_registry()</code> carries the ids through, since <code>out</code> is <br>rebuilt fresh<br> <li> Prevents the blocked verdict from surviving only as text in <code>reason</code></ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2294/files#diff-d8bc724c7d449d6094f72d890f17fd709b757eea9907e700f2e0e7299394b9dd">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>unified_server.cpp</strong><dd><code>Gate known-abort lane skipping behind env var</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tools/unified_server.cpp

<ul><li>Read <code>ONEBP_SKIP_KNOWN_ABORT</code> once into a static bool (default off)<br> <li> When enabled and no <code>-m</code> was given, pass <code>known_abort_ids</code> to <br><code>mgr.set_skip_ids()</code><br> <li> Logs how many KNOWN-ABORT lanes were skipped<br> <li> Otherwise clears skip ids so pinned models keep their lanes</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2294/files#diff-108a4e5ad06a8667d81e8da41605283a4dff15e0519645becad615fded67977c">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

