### PR TITLE
fix(site): date RSS items from the post's own datePublished, not git history (#2295)

### DIFF
--- a/scripts/gen_rss.py
+++ b/scripts/gen_rss.py
@@ -50,6 +50,32 @@ def post_description(site_dir: Path, name: str) -> str:
     return re.sub(r"\s+", " ", m.group(1)).strip() if m else ""
 
 
+def post_date(site_dir: Path, name: str) -> str:
+    """The feed item's date: the post page's OWN datePublished (#2295).
+
+    Preferred over git_firstmod() for two reasons measured on this repo:
+
+      * git_firstmod returns the first commit touching the path AS NAMED TODAY, so
+        the date moves if a post is ever renamed. That is why 2 of the 28 posts
+        carried a page date that disagreed with it (by 1 and 4 days).
+      * in a shallow checkout -- actions/checkout's default fetch-depth: 1 -- the
+        single fetched commit is a graft root with no parent, so EVERY path looks
+        added in it and git_firstmod returns that one commit's date for all of
+        them. site/blog.xml on main had all 28 items stamped with the generation
+        day for exactly this reason.
+
+    The page's datePublished is a snapshot taken when the post was published and is
+    not regenerated afterwards, so it is stable and needs no git history at all.
+    Falls back to git_firstmod only for a page that predates the tag.
+    """
+    try:
+        page = (site_dir / name).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        page = ""
+    m = re.search(r'"datePublished"\s*:\s*"([0-9]{4}-[0-9]{2}-[0-9]{2})"', page)
+    return m.group(1) if m else git_firstmod(f"site/{name}")
+
+
 def gen_blog_rss(site_dir: Path) -> None:
     blog = (site_dir / "1bit-blog.html").read_text(encoding="utf-8")
     posts = collect_posts(blog)
@@ -57,7 +83,7 @@ def gen_blog_rss(site_dir: Path) -> None:
     for name, title in posts:
         url = f"{SITE}/{name}"
         desc = post_description(site_dir, name)
-        pub = rfc2822(git_firstmod(f"site/{name}"))
+        pub = rfc2822(post_date(site_dir, name))
         items.append(
             "    <item>\n"
             f"      <title>{html.escape(title)}</title>\n"


### PR DESCRIPTION
### **User description**
## What

Fixes #2295 (operator chose this option): date each RSS item from the post page's own `datePublished` instead of `git_firstmod()`.

Closes #2295.

---

fix(site): date RSS items from the post's own datePublished, not git history

site/blog.xml on main had all 28 items stamped with the generation day:

  $ git show origin/main:site/blog.xml | grep -oE '<pubDate>[^<]*</pubDate>' | sort | uniq -c
       28 <pubDate>Sat, 12 Sep 2026 00:00:00 +0000</pubDate>

gen_rss.py took each item's date from seo_meta.git_firstmod(), which runs
`git log --diff-filter=A origin/main -- <path>`. In a shallow checkout --
actions/checkout's default fetch-depth: 1, and post-seo.yml passes no `with:` -- the
single fetched commit is a GRAFT ROOT with no parent, so every path in the tree looks
added in it and the lookup returns that one commit's date for all of them. The feed
therefore published the run date for every post, and the date moved on every run.

git_firstmod is also a moving measurement even with full history: it returns the first
commit touching the path AS NAMED TODAY, so a renamed post changes its own publication
date. That is why 2 of the 28 pages carried a datePublished disagreeing with it (by 1
and 4 days).

The post page already carries the date it was published with, as datePublished in its
own JSON-LD, written once and never regenerated. Use that; fall back to git_firstmod
only for a page that predates the tag.

Measured, same script, same site/ tree:

  full clone     : 7 distinct pubDates across 28 items
  --depth 1 clone: 7 distinct pubDates across 28 items   <- identical
  before the fix : 1 distinct  pubDate  (the run date) in BOTH

So the feed is now clone-depth independent, which is the property that was broken.
Against main's committed feed, 28 pubDate lines change (the single run date -> the real
per-post dates) and lastBuildDate moves; nothing else.

Deliberately carries no site/blog.xml change: the SEO automation regenerates that file
and site/llms-full.txt roughly every half hour, so a PR holding them is unmergeable
almost immediately -- the same reason #2290 was reduced to its generator. The next post
run will rewrite the feed with the corrected dates.


___

### **PR Type**
Bug fix


___

### **Description**
- Date RSS items from page `datePublished`, not git history

- Feed no longer stamped with the generation run day

- Stable across shallow and full clones

- Fall back to `git_firstmod` for pre-tag pages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gen_blog_rss loop"] -- "calls instead of git_firstmod" --> B["post_date(site_dir, name)"]
  B -- "read page HTML" --> C["regex datePublished YYYY-MM-DD"]
  C -- "match" --> D["stable per-post pubDate"]
  C -- "no match" --> E["fallback git_firstmod('site/name')"]
  D --> F["site/blog.xml items"]
  E --> F
  G["shallow checkout fetch-depth 1"] -- "no longer affects dates" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gen_rss.py</strong><dd><code>Derive RSS item dates from page datePublished</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/gen_rss.py

<ul><li>Add <code>post_date()</code> helper that reads the post page's own <code>datePublished</code> <br>(JSON-LD) from <code>site/<name></code>, with an <code>OSError</code>-safe read.<br> <li> Fall back to <code>git_firstmod(f"site/{name}")</code> only when the page has no <br><code>datePublished</code> tag.<br> <li> Swap the feed item's <code>pub</code> source in <code>gen_blog_rss</code> from <code>git_firstmod()</code> to <br><code>post_date()</code>, documented as avoiding renamed-post drift and <br>shallow-checkout graft-root behaviour.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2296/files#diff-0fed13557b1d9357c42c78c712722f7ff1a4cf8ff2ac3e11b261b93bf865e965">+27/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

