### PR TITLE
fix(sigpost): date generated posts from the date they are written, not a literal

### DIFF
--- a/Testing/significant_model_post.py
+++ b/Testing/significant_model_post.py
@@ -50,7 +50,7 @@ def _slug(v: str) -> str:
     return s or "model"
 
 
-def _meta(model_id, arch, family, desc, mode="covered"):
+def _meta(model_id, arch, family, desc, date, mode="covered"):
     fam = family or arch
     if mode == "announcement":
         title = f"A new significant architecture arrived: {fam}"
@@ -65,14 +65,25 @@ def _meta(model_id, arch, family, desc, mode="covered"):
         "url": f"{SITE_URL}/{slug}.html",
         "mainEntityOfPage": f"{SITE_URL}/{slug}.html",
         "image": OG_IMG,
-        "datePublished": "2026-09-02", "dateModified": "2026-09-02",
+        "datePublished": date, "dateModified": date,
         "author": AUTHOR, "publisher": AUTHOR,
     }
     return title, slug, json.dumps(jsonld, separators=(",", ":"))
 
 
 def render(model_id, arch, family, date, desc, body_paras, style, nav, foot, mode="covered"):
-    title, slug, jsonld = _meta(model_id, arch, family, desc, mode=mode)
+    title, slug, jsonld = _meta(model_id, arch, family, desc, date, mode=mode)
+    # The JSON-LD is the machine-readable publication date and the one
+    # gen_rss.py's post_date() reads for the feed, so it must never drift from
+    # the date the caller asked for. It did: _meta() hard-coded 2026-09-02
+    # while the visible <span> used the argument, which is how 100+ generated
+    # posts ended up publishing a date they were not written on. Fail loudly
+    # here instead of writing a page whose two dates disagree.
+    marker = '"datePublished":' + json.dumps(date, separators=(",", ":"))
+    if marker not in jsonld:
+        raise SystemExit(
+            f"[sigpost] refusing to write {slug}.html: requested date {date!r} "
+            f"is not the JSON-LD datePublished ({marker!r} absent)")
     fname = f"{slug}.html"
     body = "\n".join(f"        <p>{p}</p>" for p in body_paras)
     html = f"""<!doctype html>
@@ -143,7 +154,8 @@ def main():
     ap.add_argument("--arch", required=True, help="stripped architecture class, e.g. deepseek_v4_flash")
     ap.add_argument("--model", required=True, help="example HF model id, e.g. deepseek-ai/DeepSeek-V4-Flash")
     ap.add_argument("--family", default=None, help="family name for the title, e.g. DeepSeek V4")
-    ap.add_argument("--date", default="2026-09-02")
+    ap.add_argument("--date", default=datetime.date.today().isoformat(),
+                    help="publication date (YYYY-MM-DD); defaults to today")
     ap.add_argument("--desc", default=None)
     ap.add_argument("--mode", choices=["announcement", "covered"], default="covered",
                     help="announcement = arrival detected, support in progress; "


### PR DESCRIPTION
### **User description**
## The generated-post family publishes a date it was not written on

`Testing/significant_model_post.py` wrote `"datePublished": "2026-09-02"` into every post it
generated. Two independent causes:

1. `_meta()` **hard-coded that literal** in the JSON-LD and ignored the `date` argument it was given,
   while the visible `<span>` in the body *did* use the argument — so the two dates on one page could
   disagree.
2. `--date` defaulted to the same literal, and `significant-post.yml` never passes `--date`, so the
   default is what every generated post received.

**Measured on main: 103 generated posts** (`site/1bit-post-announcement-*.html`,
`site/1bit-post-significant-*.html`) carry `"datePublished":"2026-09-02"`.

### Why it became load-bearing this week

#2296 (merged) made `gen_rss.py`'s `post_date()` read each page's `datePublished` for its feed item.
Any generated post that reaches the listing page would therefore enter `site/blog.xml` dated
2026-09-02. Checked before claiming it: no generated post is on the listing today — the single
`Wed, 02 Sep 2026` feed item is `1bit-post-lemonade-v1190.html`, a hand-written post whose date is
correct. So this is a latent hazard plus 103 wrong pages, not a live feed defect.

### Changes

- `_meta()` takes the date and uses it for `datePublished` **and** `dateModified`.
- `--date` defaults to today.
- `render()` **refuses to write** a page whose JSON-LD `datePublished` is not the requested date, so
  the two dates cannot silently diverge again. This is the invariant that was missing — it would have
  failed on the first generated post.

### Verification

Isolated harness (a copy of the script plus the template, so the real `site/` is untouched):

| run | `datePublished` |
|---|---|
| `--date 2026-09-12` | `2026-09-12` (was `2026-09-02`) |
| no `--date` | `2026-09-12` — today |
| guard: literal reintroduced, `--date 2026-09-12` | `[sigpost] refusing to write …`, **0 files written** |

GitNexus: `impact(_meta)` = **LOW**, epistemic `exact`, 1 direct caller (`render`);
`detect-changes` = 3 changed symbols, **0 affected processes**, risk low.

### Not fixed here

The 103 existing pages keep their wrong date. Re-dating them is a content change — their real date is
the commit that added each file — and it should be its own decision rather than smuggled into a
generator fix.


___

### **PR Type**
Bug fix


___

### **Description**
- `_meta()` uses the requested `date` for both JSON-LD fields

- `--date` now defaults to today instead of a literal

- `render()` refuses to write a page whose JSON-LD date drifts

- Stops 100+ generated posts publishing a stale date


___

### Diagram Walkthrough


```mermaid
flowchart TD
  A["--date argument"] -- "defaults to today" --> B["render()"]
  B -- "passes date into" --> C["_meta()"]
  C -- "writes" --> D["JSON-LD datePublished / dateModified"]
  D -- "marker check" --> E["render() guard"]
  E -- "marker absent" --> F["SystemExit, no file written"]
  E -- "marker present" --> G["site/slug.html written"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>significant_model_post.py</strong><dd><code>Derive generated post dates from requested date, guard divergence</code></dd></summary>
<hr>

Testing/significant_model_post.py

<ul><li>Adds a required <code>date</code> parameter to <code>_meta()</code> and uses it for both <br><code>datePublished</code> and <code>dateModified</code> in the JSON-LD, replacing the <br>hard-coded <code>2026-09-02</code>.<br> <li> <code>render()</code> now passes <code>date</code> through to <code>_meta()</code> and asserts the emitted <br>JSON-LD contains <code>"datePublished":<date></code>, raising <code>SystemExit</code> (writing <br>nothing) if the two dates diverge.<br> <li> <code>--date</code> CLI default changes from the literal <code>"2026-09-02"</code> to <br><code>datetime.date.today().isoformat()</code>, with help text noting the <br><code>YYYY-MM-DD</code> format and today's default.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2300/files#diff-ce5eeb862069bd9e79febd8879e91905ab1e16bd4079ca16455eaf4d5342c100">+16/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

