### PR TITLE
fix(sigpost): stop the scheduled run scaffolding a post from placeholder inputs

### DIFF
--- a/.github/workflows/significant-post.yml
+++ b/.github/workflows/significant-post.yml
@@ -45,9 +45,23 @@ jobs:
         id: gen
         run: |
           set -euo pipefail
-          ARCH="${{ github.event.inputs.arch || 'deepseek_v4_flash' }}"
-          MODEL="${{ github.event.inputs.model || 'deepseek-ai/DeepSeek-V4-Flash' }}"
-          FAMILY="${{ github.event.inputs.family || '' }}"
+          ARCH="${{ github.event.inputs.arch }}"
+          MODEL="${{ github.event.inputs.model }}"
+          FAMILY="${{ github.event.inputs.family }}"
+          # arch/model are `required: true` on workflow_dispatch, so an empty
+          # value here means the daily schedule fired. Do NOT fall back to the
+          # examples these lines used to carry: on 2026-09-04 a scheduled run
+          # did exactly that and published PR #2095 — a post claiming the engine
+          # maps the placeholder class `deepseek_v4_flash`, which
+          # include/rocm_cpp/bitnet_model.h does not map (DeepSeek-V4-Flash's
+          # real class is `deepseekv4`). A scheduled run has nothing to
+          # scaffold; auto-firing from the census escalation is the follow-up
+          # named in this file's header.
+          if [ -z "$ARCH" ] || [ -z "$MODEL" ]; then
+            echo "no --arch/--model input (scheduled run) — not scaffolding a placeholder post"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           CMD=(python3 Testing/significant_model_post.py --arch "$ARCH" --model "$MODEL")
           [ -n "$FAMILY" ] && CMD+=(--family "$FAMILY")
           "${CMD[@]}"

--- a/site/1bit-post-significant-deepseek-ai-deepseek-v4-flash.html
+++ b/site/1bit-post-significant-deepseek-ai-deepseek-v4-flash.html
@@ -338,7 +338,7 @@
       <h1>The engine now runs DeepSeek V4</h1>
       <p class="lead">A significant new model architecture arrived — DeepSeek V4 (example: deepseek-ai/DeepSeek-V4-Flash) — and the engine now maps it to a token. This post scaffolds the entry; details are a draft.</p>
       <div class="prose">
-        <p><b>DeepSeek V4</b> is a <b>significant architecture arrival</b> — a major-family or vision/multimodal model the engine did not previously map. Example checkpoint on HuggingFace: <span class="mono">deepseek-ai/DeepSeek-V4-Flash</span> (stripped class <span class="mono">deepseek_v4_flash</span>).</p>
+        <p><b>DeepSeek V4</b> is a <b>significant architecture arrival</b> — a major-family or vision/multimodal model the engine did not previously map. Example checkpoint on HuggingFace: <span class="mono">deepseek-ai/DeepSeek-V4-Flash</span> (stripped class <span class="mono">deepseekv4</span>).</p>
         <p>The engine maps it to an architecture token, so the whole class now resolves to one binary — the census claim stays at 100% coverage.</p>
         <p><b>Draft scaffold:</b> fill in what the architecture actually does, kernel/backend support, and decode-validation status before publishing.</p>
         <p>The daily census keeps this live: the new-model watcher catches the arrival, the autopr drafts the alias, and this post is generated so the change is discoverable.</p>


### PR DESCRIPTION
### **User description**
## The daily schedule published a post about a placeholder class

`.github/workflows/significant-post.yml` substituted examples when its inputs were empty:

```yaml
ARCH="${{ github.event.inputs.arch || 'deepseek_v4_flash' }}"
MODEL="${{ github.event.inputs.model || 'deepseek-ai/DeepSeek-V4-Flash' }}"
```

Both inputs are `required: true` on `workflow_dispatch`, so the only caller that can arrive without
them is the daily `schedule` — which is what happened on 2026-09-04: PR #2095 published
`site/1bit-post-significant-deepseek-ai-deepseek-v4-flash.html`, whose body says

> The engine maps it to an architecture token, so the whole class now resolves to one binary — the
> census claim stays at 100% coverage.

for `stripped class deepseek_v4_flash`.

**That class does not exist.** `include/rocm_cpp/bitnet_model.h` maps `deepseekv4` and `deepseek_v4`;
it does not map `deepseek_v4_flash` or `deepseekv4flash` — "flash" is a size, not an architecture. The
family underneath is mapped, so the page is not claiming support for something unsupported; it names
a class that is not a class, and then makes a claim about it.

### Found by checking the family

I walked all 94 covered-mode posts ("The engine now runs X") and read the `stripped class` each one
names, then looked each up in the registry: **93 of 94 name a mapped class.** This is the one
exception.

### Changes

- Empty inputs now refuse to scaffold and report `changed=false`, so the token/PR steps skip. The
  file header already names auto-firing from the census escalation as the follow-up; this stops the
  schedule from filling the gap with an example.
- The published page's class is corrected to `deepseekv4` (mapped), so the claim it makes is true.

### Verification

Ran the step's own script, extracted from the workflow, with the GitHub expressions rendered both
ways and a stubbed generator first on `PATH`:

| case | result |
|---|---|
| schedule (empty inputs) | prints the refusal, `changed=false`, **generator not invoked** |
| dispatch (inputs given) | generator invoked with `--arch rwkv7moe --model win10/RWKV7-G1j-10B-A1B` |

Workflow YAML parses; `detect-changes` reports 3 symbols (none from this change — workflow + content
only), 0 affected processes, risk low.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Guard scheduled runs against placeholder post scaffolding

- Refuse empty `arch`/`model` inputs and set `changed=false`

- Skip token/PR steps when no real inputs exist

- Correct published post's class to mapped `deepseekv4`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["significant-post.yml: Scaffold the post"] -- "empty arch/model (daily schedule)" --> B["Refuse to scaffold"]
  B -- "changed=false" --> C["Token and PR steps skip"]
  A -- "dispatch arch/model provided" --> D["significant_model_post.py runs"]
  D --> E["Blog post draft + significant_posts.json"]
  F["site/1bit-post-...deepseek-v4-flash.html"] -- "class corrected" --> G["deepseekv4 (mapped in bitnet_model.h)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>significant-post.yml</strong><dd><code>Scheduled runs refuse to scaffold placeholder posts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/significant-post.yml

<ul><li>Remove <code>|| 'deepseek_v4_flash'</code> / <code>|| 'deepseek-ai/DeepSeek-V4-Flash'</code> <br>fallbacks for <code>ARCH</code> and <code>MODEL</code>.<br> <li> Add a guard that exits 0 with <code>changed=false</code> when either input is <br>empty.<br> <li> Add an explanatory comment citing PR #2095 and the unmapped <br>placeholder class.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2302/files#diff-c50885d40221740808f022b9603ea1d1dd42f3bdf05cbc1b22a258f4482e47b3">+17/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>1bit-post-significant-deepseek-ai-deepseek-v4-flash.html</strong><dd><code>Correct published post's stripped class to deepseekv4</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

site/1bit-post-significant-deepseek-ai-deepseek-v4-flash.html

<ul><li>Replace the stripped-class span <code>deepseek_v4_flash</code> with <code>deepseekv4</code>.<br> <li> Make the post's coverage claim match an architecture the engine <br>actually maps.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2302/files#diff-0a605e88e41e30175da8f7f9149c57493c8627cac80eae5a258709d1ef33ae00">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

