### PR TITLE
fix(seo): stop the bare-count pattern eating the coverage fraction's denominator

### DIFF
--- a/scripts/seo_sync.py
+++ b/scripts/seo_sync.py
@@ -183,7 +183,7 @@ def _pct_claim(m, covered, with_arch, suffix_groups):
 
 def _build_patterns(tokens, arch, covered, with_arch):
     t, a, c, w = fmt(tokens), fmt(arch), fmt(covered), fmt(with_arch)
-    return [
+    pats = [
         # "552 architecture tokens, 1,774 HF arch strings" (+ "/" variant in posts)
         (re.compile(r"(\d[\d,]*)( architecture tokens[ ,/]+)(\d[\d,]*)( HF arch strings)"),
          lambda m: _pair(m, t, a)),
@@ -225,13 +225,49 @@ def _build_patterns(tokens, arch, covered, with_arch):
         # "321,611 checkpoints map to", "mapping 321,611 checkpoints".
         # Run LAST so the fraction pattern above has already rewritten
         # "X/Y checkpoints mapped" -> "X'/Y' checkpoints mapped" first.
-        (re.compile(r"(\d[\d,]*)( checkpoints mapped)"),
+        #
+        # (?<!/) is load-bearing and its absence was a false-claim bug: after the
+        # fraction pattern has written "323,579/323,682", this bare pattern still
+        # matched the DENOMINATOR — the digits directly in front of
+        # " checkpoints mapped" — and rewrote it to the numerator, publishing
+        # "323,579/323,579 checkpoints mapped", i.e. a fabricated 100% on every
+        # page that states the ratio. main read "323,303/323,303" while the
+        # census said 323,303 of 323,386, and --check could not see it because
+        # the clobbered text IS its idempotent output. A bare count is never
+        # preceded by "/", and a partial match of it is preceded by a digit --
+        # so the lookbehind has to exclude digits and commas too, or the regex
+        # merely starts one character later inside the same number ("323,682" ->
+        # "23,682" -> "3323,579").
+        (re.compile(r"(?<![\d,/])(\d[\d,]*)( checkpoints mapped)"),
          lambda m: _bare(m, c)),
-        (re.compile(r"(\d[\d,]*)( checkpoints map to)"),
+        (re.compile(r"(?<![\d,/])(\d[\d,]*)( checkpoints map to)"),
          lambda m: _bare(m, c)),
         (re.compile(r"(mapping )(\d[\d,]*)( checkpoints)"),
          lambda m: _num_between(m, c)),
+        # Prose percentage sitting immediately beside the ratio it describes:
+        # "The engine's own HF coverage stays at 100%: ... 323,579/323,682
+        # checkpoints mapped." Fixing the ratio alone would leave that page
+        # asserting 100% right next to its own 99.97%. Deliberately narrower
+        # than the generated posts' "the census claim stays at 100% coverage",
+        # which is about CLASS coverage rather than this checkpoint ratio.
+        (re.compile(r"(coverage stays at )(\d+(?:\.\d+)?)(%)"),
+         lambda m: m.group(0) if covered >= with_arch
+         else m.group(1) + _pct(covered, with_arch).rstrip("%") + m.group(3)),
     ]
+    # Invariant, checked on every run: the bare-count patterns must not touch a
+    # fraction's denominator, and the fraction must land on covered/with_arch.
+    # Worth asserting rather than trusting -- the corrupted text was idempotent,
+    # so --check reported "no drift" for months while every page claimed 100%.
+    probe = "1/2 checkpoints mapped"
+    got = probe
+    for pat, repl in pats:
+        got = pat.sub(repl, got)
+    want = f"{c}/{w} checkpoints mapped"
+    if got != want:
+        raise SystemExit(
+            f"[seo_sync] fraction rewrite is wrong: {probe!r} -> {got!r}, "
+            f"expected {want!r} -- a bare-count pattern is eating the denominator")
+    return pats
 
 
 def _pct(covered, with_arch):


### PR DESCRIPTION
### **User description**
## The site has been claiming 100% checkpoint coverage

Every `X/Y checkpoints mapped` on the site is rewritten to `X/X` before it ships, so the ratio always
reads as 100%.

`_build_patterns` rewrites the fraction first and the bare prose forms last, with a comment saying the
fraction must go first. It does — but the bare pattern is `(\d[\d,]*)( checkpoints mapped)`, and once
the fraction is written, the digits directly in front of ` checkpoints mapped` **are the denominator**.
So the bare pattern, running last, replaces it with the numerator.

Measured on main:

| | site says | census says |
|---|---|---|
| before the 09-12 sweep | `323,303/323,303 checkpoints mapped` | 323,303 of 323,386 |
| after (once #2303 lands) | `323,579/323,579 checkpoints mapped` | 323,579 of 323,682 |

The models page states the same ratio as a percentage and correctly says **99.97%** — so the site
contradicts itself, and the 100% is the fabricated side.

**`--check` could not see this.** The clobbered text is exactly what the script produces, so it is the
idempotent fixed point: "no drift" was true of the corrupted text.

## Changes

- Both bare-count patterns now carry `(?<![\d,/])`.
  Digits and commas have to be excluded as well as `/` — with only `(?<!/)` the regex simply restarts
  one character later inside the same number (`323,682` → `23,682` → `3323,579`). That is not
  hypothetical: it is what the first version of this fix did, and the test below is what caught it.
- The prose percentage beside that ratio is synced too, so the blog page cannot assert
  "coverage stays at 100%" immediately next to its own `323,579/323,682`.
- `_build_patterns` now asserts the invariant it exists to maintain — applying the patterns to
  `1/2 checkpoints mapped` must yield `covered/with_arch` — and stops the run with a named error
  otherwise, so this cannot silently return.

## Verification

```
unit   "323,303/323,303 checkpoints mapped" -> "323,579/323,682 checkpoints mapped"
       "323,579/323,682 checkpoints mapped" -> unchanged (idempotent)
       "321,611 checkpoints mapped"         -> "323,579 checkpoints mapped"
e2e    python3 scripts/seo_sync.py on main's tree
         -> site/1bit-blog.html reads "coverage stays at 99.97%: 568 architecture
            tokens, 2,040 HF arch strings, 323,579/323,682 checkpoints mapped."
         -> python3 scripts/seo_sync.py --check then reports "no drift"
guard  the same file with the lookbehind removed stops with
         "fraction rewrite is wrong: '1/2 checkpoints mapped' ->
          '323,579/323,579 checkpoints mapped', expected '323,579/323,682 ...'"
```

Scripts-only, so the pages heal on the next `seo/post-*` run (the same shape as #2290). Ordering with
#2303 is not delicate: it writes the same 100% form, so whichever lands second, the run after it
converges — `--check` will simply keep reporting the drift until it does.

## Deliberately not touched

The static **"100% HuggingFace architecture coverage"** claims (5 on `1bit-monster-v2.html`) and the
generated posts' *"the census claim stays at 100% coverage"* line are about **class** coverage, not
this checkpoint ratio, and they are false for a different reason: one architecture class is currently
unmapped (`deepseekv41`, #2178). That is an editorial and issue-level call, not a number-sync bug, so
this PR does not silently reword it.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Stop bare-count patterns clobbering coverage denominators

- Add `(?<![\d,/])` lookbehind to avoid partial digit rewrites

- Sync adjacent prose "coverage stays at N%" percentage

- Assert fraction-rewrite invariant on every run

- Guard against fabricated 100% checkpoint coverage claims


___

### Diagram Walkthrough


```mermaid
flowchart LR
  P["_build_patterns"] -- "bare counts get (?<![\\d,/])" --> B["denominator no longer clobbered"]
  P -- "new coverage-stays-at pattern" --> C["prose percentage synced"]
  P -- "probe 1/2 checkpoints mapped" --> D["invariant assertion"]
  D -- "mismatch" --> E["SystemExit with named error"]
  B --> F["fraction stays covered/with_arch"]
  C --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>seo_sync.py</strong><dd><code>Fix bare-count rewrite clobbering coverage denominator</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/seo_sync.py

<ul><li><code>_build_patterns</code> now builds a <code>pats</code> list, runs an invariant probe on <br><code>"1/2 checkpoints mapped"</code>, and raises <code>SystemExit</code> if the rewritten text <br>is not <code>covered/with_arch</code>.<br> <li> Both bare prose count patterns gain an <code>(?<![\d,/])</code> lookbehind so they no longer <br>rewrite the denominator of an already-written <code>X/Y checkpoints mapped</code> <br>fraction into the numerator.<br> <li> Add a new pattern syncing <code>"coverage stays at N%"</code> prose to the real <br><code>covered/with_arch</code> percentage, skipping the rewrite when coverage is <br>complete.<br> <li> Extensive comments documenting the lookbehind (digits and commas, not <br>just <code>/</code>) and why the previously idempotent corrupted output hid the bug <br>from <code>--check</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2304/files#diff-19b7c8d8a41e3bbba491ffaaaf2c5e7eb5014e5d4ecccd83a2f3fd315d276a35">+39/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

