### PR TITLE
ci(seo): full-history checkout so sitemap lastmod is per-page, not the run date

### DIFF
--- a/.github/workflows/post-seo.yml
+++ b/.github/workflows/post-seo.yml
@@ -43,6 +43,16 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # seo_meta.py dates each page with `git log -1 --format=%cI origin/main
+          # -- site/<page>` (git_lastmod) to build sitemap.xml. A depth-1 checkout
+          # has no history to walk: at the shallow boundary the tip commit is a
+          # root commit, so every path matches it and EVERY url gets the run
+          # date as <lastmod> — 147/147 on 2026-09-13, 39 of them wrong, and it
+          # re-stamps them to "today" on each run. Do not drop this for speed:
+          # without full history the sitemap silently claims every page changed
+          # today, every day.
+          fetch-depth: 0
 
       - name: Generate post SEO tags
         id: gen


### PR DESCRIPTION
### **User description**
`site/sitemap.xml` dates every URL with the date of the last pipeline run instead of the page's own last change, and it has been doing so since the checkout went shallow.

## The mechanism

`scripts/seo_meta.py:26` dates each page with `git log -1 --format=%cI origin/main -- site/<page>`; `post-seo.yml` checked out with `actions/checkout` defaults, i.e. **depth 1**. At a shallow boundary git treats the tip commit as a **root commit**, so a path-filtered log matches every path and returns the tip commit for all of them.

Reproduced rather than reasoned about — a fresh depth-1 clone answers with the tip's timestamp for files it never touched:

```
$ git clone --depth 1 --no-checkout <repo> shallow && cd shallow
$ git log -1 --format=%cI origin/main -- site/1bit-docs.html
2026-09-13T01:37:44Z      # true last change: 2026-09-07
$ git log -1 --format=%cI origin/main -- site/1bit-post-50t.html
2026-09-13T01:37:44Z      # true last change: 2026-09-09
```

## What that puts on the live site

- `<lastmod>2026-09-13</lastmod>` for **147/147** urls on `main`.
- A full-history run dates **39 of them earlier** (2026-09-05 … 2026-09-12). Compared per-url, not line-by-line.
- It is a **daily mass re-stamp**: PR #2207 moved **124** lastmod lines `2026-09-10` → `2026-09-11`. So the sitemap tells crawlers every page changed today, every day — which is the signal a crawler learns to ignore.

## Why nothing caught it

The artifact is self-consistent: CI regenerates the same values, so `git status` stays clean, and the only diff is the date rolling over — which reads as a routine bump. Nothing asserts per-page lastmod, and the JSON-LD side is shielded by `inject_json_ld`'s deliberate idempotence (`seo_meta.py:164`), so the two never disagree loudly.

## The change

`fetch-depth: 0` on that checkout, plus a comment recording the failure mode so it is not dropped later as a speed optimization. Five other workflows in this repo already check out full history (`pr-agent.yml` documents its own reason for it).

`post-seo.yml` is the only workflow that runs `seo_meta.py`, so this is the whole surface.

## Verification

- `yaml.safe_load` parses the file; the checkout step now carries `with: {fetch-depth: 0}`.
- The corrected output is already known, from a full-history run of the same generator chain: exactly those 39 lastmods change, nothing else in `sitemap.xml`.
- After this lands, the next `Post SEO` run carries the one-time correction; I will confirm on `main` that the 39 urls show their true dates and that the following run does **not** move them again.

## GitNexus

- `impact git_lastmod --direction upstream`: callers are `scripts/seo_meta.py` functions (transitively `main`); no other consumer of the date helpers.
- `detect-changes` cannot run here — a worktree is not a registered repo path (`Repository "/home/bcloud/wt/seo-lastmod" not found`), the same limitation #2308 documented. That is *unseen*, not clean.
- The workflow file itself is not in the graph (`impact post-seo.yml` → `Target not found`), so there is no symbol-level blast radius to report for a `with:` addition.


___

### **PR Type**
Bug fix


___

### **Description**
- `post-seo.yml` checkout now uses `fetch-depth: 0`

- Fixes sitemap `lastmod` stamped with the run date

- Shallow clone made tip commit match every path

- Restores per-page dates for 39 mis-dated urls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["post-seo.yml<br>actions/checkout"] -- "add fetch-depth: 0" --> B["Full history clone"]
  B -- "git log -1 per site/page" --> C["seo_meta.py git_lastmod()"]
  C -- "real commit dates" --> D["sitemap.xml per-page lastmod"]
  A -- "depth 1 (before)" --> E["tip commit = root commit"]
  E -- "same date for all paths" --> F["147/147 urls stamped run date"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>post-seo.yml</strong><dd><code>Full-history checkout so sitemap lastmod stays per-page</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/post-seo.yml

<ul><li>Add <code>fetch-depth: 0</code> to the <code>actions/checkout</code> step in the <code>seo-tags</code> job.<br> <li> Document why shallow checkout breaks <code>seo_meta.py</code>'s <code>git_lastmod()</code>: at <br>the shallow boundary the tip commit is a root commit, so every path <br>matches it.<br> <li> Note the impact — 147/147 urls get the run date as <code><lastmod></code>, 39 of them wrong, <br>re-stamped to "today" on every run.<br> <li> Warn against dropping the setting for speed, since CI cannot detect <br>the self-consistent artifact.</ul>


</details>


  </td>
  <td><a href="https://github.com/1bit-MONSTER/1bit-MONSTER/pull/2310/files#diff-b766a1380327589536026944196fe3bbadcd1d8eb775f27f9785f9efc4e4a014">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

